### PR TITLE
[`PPOTrainer`] Print query tokens and associated KL

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -788,12 +788,12 @@ class PPOTrainer(BaseTrainer):
     def _kl_warning(self, non_score_reward, responses, masks):
         avg_kl = masked_mean(non_score_reward, masks, axis=-1)
         for i, kl in enumerate(avg_kl):
-            if kl<-10:
+            if kl < -10:
                 warning_str = f"The average KL for sequence is below threshold ({kl.item():.2f}). Per token KL: "
                 for token_index in range(non_score_reward.shape[1]):
-                    if masks[i, token_index]==1:
+                    if masks[i, token_index] == 1:
                         # TODO: a bug adds an unnecessary masked token at position 0 which is why we offset -1
-                        token = self.tokenizer.convert_ids_to_tokens([responses[i][token_index-1]])[0]
+                        token = self.tokenizer.convert_ids_to_tokens([responses[i][token_index - 1]])[0]
                         per_token_kl = non_score_reward[i, token_index]
                         warning_str += f"[{token}, {per_token_kl:.2f}] "
                 warnings.warn(warning_str)

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1139,7 +1139,7 @@ class PPOTrainer(BaseTrainer):
         if mean_kl.item() < -10.0:
             warnings.warn(
                 f"KL divergence is becoming very negative: {mean_kl.item():.2f} - this might be a precursor for failed training."
-                f" Here is the kl penalty score per token - tokens : {data['queries']} | kl {kl_list}."
+                f" Here is the mea, kl penalty score per token {kl_list}."
             )
 
         stats = {

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1136,6 +1136,12 @@ class PPOTrainer(BaseTrainer):
                 " that the generation kwargs are set correctly, or review your training hyperparameters."
             )
 
+        if mean_kl.item() < -10.0:
+            warnings.warn(
+                f"KL divergence is becoming very negative: {mean_kl.item():.2f} - this might be a precursor for failed training."
+                f" Here is the kl penalty score per token - tokens : {data['queries']} | kl {kl_list}."
+            )
+
         stats = {
             "objective/kl": mean_kl,
             "objective/kl_dist": kl_list,


### PR DESCRIPTION
As discussed offline, we can add an utility logging to log the kl per token when the mean_kl is quite negative (we can also make that value modulable).

cc @lvwerra 