### PR TITLE
Allow for ref_model=None in DPOTrainer

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -16,9 +16,12 @@ import unittest
 
 import torch
 from datasets import Dataset
+from pytest import mark
 from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
 
 from trl import DPOTrainer
+
+from .testing_utils import require_peft
 
 
 class DPOTrainerTester(unittest.TestCase):
@@ -29,6 +32,40 @@ class DPOTrainerTester(unittest.TestCase):
         cls.ref_model = AutoModelForCausalLM.from_pretrained(cls.model_id)
         cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_id)
         cls.tokenizer.pad_token = cls.tokenizer.eos_token
+
+    def _init_dummy_dataset(self):
+        # fmt: off
+        dummy_dataset_dict = {
+            "prompt": [
+                "hello",
+                "how are you",
+                "What is your name?",
+                "What is your name?",
+                "Which is the best programming language?",
+                "Which is the best programming language?",
+                "Which is the best programming language?",
+            ],
+            "chosen": [
+                "hi nice to meet you",
+                "I am fine",
+                "My name is Mary",
+                "My name is Mary",
+                "Python",
+                "Python",
+                "Python",
+            ],
+            "rejected": [
+                "leave me alone",
+                "I am not fine",
+                "Whats it to you?",
+                "I dont have a name",
+                "Javascript",
+                "C++",
+                "Java",
+            ],
+        }
+        # fmt: on
+        return Dataset.from_dict(dummy_dataset_dict)
 
     def test_dpo_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -42,38 +79,7 @@ class DPOTrainerTester(unittest.TestCase):
                 evaluation_strategy="steps",
             )
 
-            # fmt: off
-            dummy_dataset_dict = {
-                "prompt": [
-                    "hello",
-                    "how are you",
-                    "What is your name?",
-                    "What is your name?",
-                    "Which is the best programming language?",
-                    "Which is the best programming language?",
-                    "Which is the best programming language?",
-                ],
-                "chosen": [
-                    "hi nice to meet you",
-                    "I am fine",
-                    "My name is Mary",
-                    "My name is Mary",
-                    "Python",
-                    "Python",
-                    "Python",
-                ],
-                "rejected": [
-                    "leave me alone",
-                    "I am not fine",
-                    "Whats it to you?",
-                    "I dont have a name",
-                    "Javascript",
-                    "C++",
-                    "Java",
-                ],
-            }
-            # fmt: on
-            dummy_dataset = Dataset.from_dict(dummy_dataset_dict)
+            dummy_dataset = self._init_dummy_dataset()
 
             trainer = DPOTrainer(
                 model=self.model,
@@ -97,3 +103,91 @@ class DPOTrainerTester(unittest.TestCase):
                 # check the params have changed - ignore 0 biases
                 if param.sum() != 0:
                     self.assertFalse(torch.equal(param, new_param))
+
+    def test_dpo_trainer_without_providing_ref_model(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=3,
+                remove_unused_columns=False,
+                gradient_accumulation_steps=4,
+                learning_rate=9e-1,
+                evaluation_strategy="steps",
+            )
+
+            dummy_dataset = self._init_dummy_dataset()
+
+            trainer = DPOTrainer(
+                model=self.model,
+                ref_model=None,
+                beta=0.1,
+                args=training_args,
+                tokenizer=self.tokenizer,
+                train_dataset=dummy_dataset,
+                eval_dataset=dummy_dataset,
+            )
+
+            previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+            # check the params have changed
+            for n, param in previous_trainable_params.items():
+                new_param = trainer.model.get_parameter(n)
+                # check the params have changed - ignore 0 biases
+                if param.sum() != 0:
+                    self.assertFalse(torch.equal(param, new_param))
+
+    @require_peft
+    @mark.peft_test
+    def test_dpo_trainer_without_providing_ref_model_with_lora(self):
+        from peft import LoraConfig
+
+        lora_config = LoraConfig(
+            r=16,
+            lora_alpha=32,
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=3,
+                remove_unused_columns=False,
+                gradient_accumulation_steps=4,
+                learning_rate=9e-1,
+                evaluation_strategy="steps",
+            )
+
+            dummy_dataset = self._init_dummy_dataset()
+
+            trainer = DPOTrainer(
+                model=self.model,
+                ref_model=None,
+                beta=0.1,
+                args=training_args,
+                tokenizer=self.tokenizer,
+                train_dataset=dummy_dataset,
+                eval_dataset=dummy_dataset,
+                peft_config=lora_config,
+            )
+
+            previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+            trainer.train()
+
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+            # check the params have changed
+            for n, param in previous_trainable_params.items():
+                if "lora" in n:
+                    new_param = trainer.model.get_parameter(n)
+                    # check the params have changed - ignore 0 biases
+                    if param.sum() != 0:
+                        self.assertFalse(torch.equal(param, new_param))

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -167,7 +167,8 @@ class DPOTrainer(Trainer):
 
         if disable_dropout:
             disable_dropout_in_model(model)
-            disable_dropout_in_model(ref_model)
+            if self.ref_model:
+                disable_dropout_in_model(self.ref_model)
 
         self.label_pad_token_id = label_pad_token_id
         self.padding_value = padding_value

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -167,7 +167,7 @@ class DPOTrainer(Trainer):
 
         if disable_dropout:
             disable_dropout_in_model(model)
-            if self.ref_model:
+            if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
 
         self.label_pad_token_id = label_pad_token_id

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -40,7 +40,8 @@ class DPOTrainer(Trainer):
         model (`transformers.PreTrainedModel`):
             The model to train, preferably an `AutoModelForSequenceClassification`.
         ref_model (`PreTrainedModelWrapper`):
-            Hugging Face transformer model with a casual language modelling head. Used for implicit reward computation and loss. If no `ref_model` is provided, `model` without adapters is used as the reference model (only possible if peft_config is provided).
+            Hugging Face transformer model with a casual language modelling head. Used for implicit reward computation and loss. If no
+            reference model is provided, the trainer will create a reference model with the same architecture as the model to be optimized.
         beta (`float`, defaults to 0.1):
             The beta factor in DPO loss. Higher beta means less divergence from the initial policy.
         args (`transformers.TrainingArguments`):


### PR DESCRIPTION
PR for #624. The goal is to allow DPOTrainer to allow for `ref_model=None`. If the model to be trained is a `peft` model, or a `peft_config` is provided, we use the base model for improved memory consumption. Otherwise, a reference model is created on the fly by copying the `model`.