### PR TITLE
Handle potentially long sequences with DataCollatorForCompletionOnlyLM

### DIFF
--- a/tests/test_data_collator_completion_only.py
+++ b/tests/test_data_collator_completion_only.py
@@ -49,15 +49,14 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
 ### User: How much is 2+2? I'm asking because I'm not sure. And I'm not sure because I'm not good at math.
 """
         self.response_template = "\n### Assistant:"
-
-        # check DataCollatorForCompletionOnlyLM with response template only
+        # check DataCollatorForCompletionOnlyLM using response template only
         self.tokenized_instruction = self.tokenizer.encode(self.instruction, add_special_tokens=False)
         self.collator = DataCollatorForCompletionOnlyLM(self.response_template, tokenizer=self.tokenizer)
         encoded_instance = self.collator.torch_call([self.tokenized_instruction])
         result = torch.all(encoded_instance["labels"] == -100)
         self.assertTrue(result, "Not all values in the tensor are -100.")
 
-        # check DataCollatorForCompletionOnlyLM with response template and instruction template
+        # check DataCollatorForCompletionOnlyLM using response template and instruction template
         self.instruction_template = "\n### User:"
         self.collator = DataCollatorForCompletionOnlyLM(
             self.response_template, self.instruction_template, tokenizer=self.tokenizer

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -132,7 +132,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     ):
                         response_token_ids_idxs.append(assistant_idx + len(self.response_token_ids))
 
-                if len(self.response_token_ids) == 0:
+                if len(response_token_ids_idxs) == 0:
                     warnings.warn(
                         f"Could not find response key `{self.response_template}` in the "
                         f'following instance: {self.tokenizer.decode(batch["input_ids"][i])} '


### PR DESCRIPTION
This PR resolves #643 and provides a patch in `DataCollatorForCompletionOnlyLM` for handling long sequences which may or may not contain a valid `response_template` or a valid `instruction_template`.

For problematic instances where no `response_template` or `instruction_template` is found, we set the labels to the `ignore_idx`. As a result, problematic instances are ignored in the loss computation, but still allow for training to continue.
