### PR TITLE
propagating eval_batch_size to TrainingArguments

### DIFF
--- a/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
+++ b/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
@@ -164,6 +164,7 @@ if __name__ == "__main__":
     # 4. initialize training arguments:
     training_args = TrainingArguments(
         per_device_train_batch_size=script_args.per_device_train_batch_size,
+        per_device_eval_batch_size=script_args.per_device_eval_batch_size,
         max_steps=script_args.max_steps,
         logging_steps=script_args.logging_steps,
         save_steps=script_args.save_steps,


### PR DESCRIPTION
The script missed copying `per_device_eval_batch_size` to `training_args`, which makes it use the default size of 8 for eval_batch_size instead of 1 as set in this script. This PR fixes the issue by copying the `per_device_eval_batch_size` from `script_args` to `training_args`.

fixes #671