### PR TITLE
[`CI`] Fix unmutable `TrainingArguments` issue

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
+from dataclasses import FrozenInstanceError
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -129,7 +130,17 @@ class RewardTrainer(Trainer):
             data_collator = RewardDataCollatorWithPadding(tokenizer, max_length=max_length)
 
             if args.remove_unused_columns:
-                args.remove_unused_columns = False
+                try:  # for bc before https://github.com/huggingface/transformers/pull/25435
+                    args.remove_unused_columns = False
+                except FrozenInstanceError:
+                    args_dict = args.to_dict()
+                    args_dict["remove_unused_columns"] = False
+
+                    new_args = TrainingArguments(
+                        **args_dict,
+                    )
+
+                    args = new_args
                 # warn users
                 warnings.warn(
                     "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"


### PR DESCRIPTION
Currently the CI is failing on main due to the new release of transformers that included https://github.com/huggingface/transformers/pull/25435

Now `TrainingArguments` are unmutable, meaning to change a value in a `TrainingArguments` object one needs to create a copy of that object with the desired change

Fixes the failing CI in https://github.com/huggingface/trl/pull/649

cc @lvwerra 