### PR TITLE
Simplify immutable TrainingArgs fix using `dataclasses.replace`

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, replace
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -133,14 +133,7 @@ class RewardTrainer(Trainer):
                 try:  # for bc before https://github.com/huggingface/transformers/pull/25435
                     args.remove_unused_columns = False
                 except FrozenInstanceError:
-                    args_dict = args.to_dict()
-                    args_dict["remove_unused_columns"] = False
-
-                    new_args = TrainingArguments(
-                        **args_dict,
-                    )
-
-                    args = new_args
+                    args = replace(args, remove_unused_columns=False)
                 # warn users
                 warnings.warn(
                     "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"


### PR DESCRIPTION
Related: #676

Hello!

## Pull Request overview
* Use built-in fix for immutable dataclass rather than the workaround.

## Details
`dataclasses` has a little known [`replace`](https://docs.python.org/3/library/dataclasses.html#dataclasses.replace) function, which creates a new object of the same type as the first argument, but replacing fields with the values from the kwargs.

So, 
```python
args_dict = args.to_dict()
args_dict["remove_unused_columns"] = False

new_args = TrainingArguments(
    **args_dict,
)

args = new_args
```
becomes equivalent to
```python
args = replace(args, remove_unused_columns=False)
```

See also https://github.com/tomaarsen/SpanMarkerNER/pull/27 where I implement the same.

cc: @younesbelkada for implementing the original fix

- Tom Aarsen