### PR TITLE
Fix: RuntimeError: 'weight' must be 2-D issue

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -206,7 +206,8 @@ class DPOTrainer(Trainer):
                 )
         else:
             if self.is_deepspeed_enabled:
-                (self.ref_model,) = self.accelerator._prepare_deepspeed(self.ref_model)
+                # Read more about the issue in https://github.com/huggingface/trl/pull/687
+                self.ref_model = self.accelerator._prepare_deepspeed(self.ref_model)
                 self.ref_model.eval()
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -205,7 +205,7 @@ class DPOTrainer(Trainer):
                     "You are using a `peft` version that does not support `disable_adapter`. Please update your `peft` version to the latest version."
                 )
         else:
-            if self.args.deepspeed != "":
+            if self.is_deepspeed_enabled:
                 (self.ref_model,) = self.accelerator._prepare_deepspeed(self.ref_model)
                 self.ref_model.eval()
             else:

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -205,7 +205,11 @@ class DPOTrainer(Trainer):
                     "You are using a `peft` version that does not support `disable_adapter`. Please update your `peft` version to the latest version."
                 )
         else:
-            self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
+            if self.args.deepspeed != "":
+                (self.ref_model,) = self.accelerator._prepare_deepspeed(self.ref_model)
+                self.ref_model.eval()
+            else:
+                self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
 
     def concatenated_inputs(self, batch: Dict[str, Union[List, torch.LongTensor]]) -> Dict[str, torch.LongTensor]:
         """Concatenate the chosen and rejected inputs into a single tensor.


### PR DESCRIPTION
Fix #669

# Problem description

In ZeRO3, issues like #669 are caused by running `deepspeed.initialize` on only one of the two models passed to DPO_Trainer.

Most users use `.from_pretrained` to get the weight of the model, and inside from_pretrained is the code below.
```python
    if is_deepspeed_zero3_enabled():
        import deepspeed

        logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
        init_contexts = [deepspeed.zero.Init(config_dict_or_path=deepspeed_config())] + init_contexts
    elif load_in_8bit or low_cpu_mem_usage:
        init_contexts.append(init_empty_weights())

    with ContextManagers(init_contexts):
        model = cls(config, *model_args, **model_kwargs)
```
Models that don't use ZeRO3 don't matter, 
But most of the heavier models like LLM are run using ZeRO3, so `from_pretrained`, `is_deepspeed_zero3_enabled()` becomes True, it have to use the if statement.

But since ZeRO3 is parameter partitioning, does this mean that it need to use the `_partition_param` in `deepspeed.zero.Init` to divide the parameters in one layer by the number of GPUs?

At this time, the partitioned parameter is put into a `.ds_tensor`, and `parameter.data`(or weight, bias), where the original parameter was, is filled with a zero tensor of size 0.

So far, so good

The problem is that we need to do a `deepspeed.initialize` when training to load the partitioned parameters in `.ds_tensor`,
But ref_model didn't do `deepspeed.initialize`, so it can't load the `.ds_tensor`.

This causes an error like `RuntimeError: 'weight' must be {n}-D` because ref_model's `parameter.data` does not contain weight, as shown in the issue.

So to solve the issue, it need to `deepspeed.initialize` ref_model as well as model.

However, since `prepare_model` does not have a deepspeed wrapper, 
so it need to add the process of wrapping the model with deepspeed using `_prepare_deepspeed` to the init.