### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,35 +3,14 @@ line-length = 119
 target-version = ['py38']
 
 [tool.ruff]
-ignore = ["C901", "E501", "E741", "W605"]
-select = ["C", "E", "F", "I", "W"]
+ignore = ["E501", "E741", "W605"]
+select = ["E", "F", "I", "W"]
 line-length = 119
+
+# Ignore import violations in all `__init__.py` files.
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402", "F401", "F403", "F811"]
 
 [tool.ruff.isort]
 lines-after-imports = 2
 known-first-party = ["trl"]
-
-[isort]
-default_section = "FIRSTPARTY"
-known_first_party = "trl"
-known_third_party = [
-    "numpy",
-    "torch",
-    "accelerate",
-    "transformers",
-    "peft",
-]
-line_length = 119
-lines_after_imports = 2
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-
-[tool.pytest]
-doctest_optionflags = [
-    "NORMALIZE_WHITESPACE",
-    "ELLIPSIS",
-    "NUMBER",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 119
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.ruff]
 ignore = ["C901", "E501", "E741", "W605"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.black]
+line-length = 119
+target-version = ['py37']
+
+[tool.ruff]
+ignore = ["C901", "E501", "E741", "W605"]
+select = ["C", "E", "F", "I", "W"]
+line-length = 119
+
+[tool.ruff.isort]
+lines-after-imports = 2
+known-first-party = ["trl"]
+
+[isort]
+default_section = "FIRSTPARTY"
+known_first_party = "trl"
+known_third_party = [
+    "numpy",
+    "torch",
+    "accelerate",
+    "transformers",
+    "peft",
+]
+line_length = 119
+lines_after_imports = 2
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
+[tool.pytest]
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "ELLIPSIS",
+    "NUMBER",
+]


### PR DESCRIPTION
Other huggingface projects such as [transformers](https://github.com/huggingface/transformers/blob/main/pyproject.toml), [peft](https://github.com/huggingface/peft/blob/main/pyproject.toml), and [accelerate](https://github.com/huggingface/accelerate/blob/main/pyproject.toml) all have `pyproject.toml` files that allow different editors to standardize formatting during editing. Although there is already a pre-commit `setup.cfg` it becomes a bit annoying when the style is overridden during editing.

I've added a simple default `pyproject.toml` mostly mimicking peft's and keeping the same parameters as the `setup.cfg`. Happy to add / remove any parameters. 