### PR TITLE
[`PPOTrainer`] A workaround for failing log_stats

### DIFF
--- a/examples/research_projects/tools/calculator.py
+++ b/examples/research_projects/tools/calculator.py
@@ -115,5 +115,5 @@ for step in range(100):
     response_texts = [tokenizer.decode(response) for response in responses]
     query_texts = [tokenizer.decode(query) for query in queries]
     texts = {"query": [qt.split("<submit>")[-1].strip() for qt in query_texts], "response": response_texts}
-    ppo_trainer.log_stats(train_stats, texts, rewards)
+    ppo_trainer.log_stats(train_stats, texts, rewards, columns_to_log=["query", "response", "answer"])
 ppo_trainer.save_pretrained(model_id + "-calculator")

--- a/examples/research_projects/tools/python_interpreter.py
+++ b/examples/research_projects/tools/python_interpreter.py
@@ -188,7 +188,7 @@ for epoch in range(args.n_epochs):
             "response": [tokenizer.decode(response) for response in responses],
             "answer": batch["answer"],
         }
-        ppo_trainer.log_stats(train_stats, texts, rewards)
+        ppo_trainer.log_stats(train_stats, texts, rewards, columns_to_log=["query", "response", "answer"])
 
 reward_mean_test = evaluate(test_dataloader, text_env, ppo_trainer)
 ppo_trainer.save_pretrained(f"model/{args.model_name}-gsm8k")

--- a/examples/research_projects/tools/triviaqa.py
+++ b/examples/research_projects/tools/triviaqa.py
@@ -184,6 +184,8 @@ for i in range(args.iterations):
         "answer": [", ".join(item) for item in answers],
     }
     all_rewards = ppo_trainer.accelerator.gather(torch.tensor(rewards, device=ppo_trainer.accelerator.device))
-    ppo_trainer.log_stats(train_stats, texts, [item for item in all_rewards])
+    ppo_trainer.log_stats(
+        train_stats, texts, [item for item in all_rewards], columns_to_log=["query", "response", "answer"]
+    )
     if i % 100 == 0:
         ppo_trainer.save_pretrained(f"models/{args.model_name}_{args.seed}_{i}_triviaqa")


### PR DESCRIPTION
Currently in the 0.7.0 version `ppo_trainer.log_stats` fails with the error

```bash
KeyError                                  Traceback (most recent call last)
<ipython-input-6-aac057b11b52> in <cell line: 138>()
    155     #### Run PPO step
    156     stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
--> 157     ppo_trainer.log_stats(stats, batch, rewards)

/usr/local/lib/python3.10/dist-packages/trl/trainer/ppo_trainer.py in log_stats(self, stats, batch, rewards)
   1297 
   1298                 table_rows = [
-> 1299                     list(r) for r in zip(batch["query"], batch["response"], batch["answer"], rewards.cpu().tolist())
   1300                 ]
   1301                 logs.update(
KeyError: ‘answer’
```

Introduced in #424 the fix is to create a new parameters `columns_to_log`, to let users have control on which column name to log in wandb. We set that value to the default so that it would work for the current PPOTrainer related code, and adapted the current code examples for textenvs

cc @lvwerra @vwxyzjn 