### PR TITLE
[`Docs`] Fix sft mistakes

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -238,7 +238,6 @@ trainer = SFTTrainer(
     "facebook/opt-350m",
     train_dataset=dataset,
     dataset_text_field="text",
-    torch_dtype=torch.bfloat16,
 )
 
 trainer.train()
@@ -294,7 +293,6 @@ trainer = SFTTrainer(
     "EleutherAI/gpt-neo-125m",
     train_dataset=dataset,
     dataset_text_field="text",
-    torch_dtype=torch.bfloat16,
     peft_config=peft_config,
     callbacks=callbacks
 )
@@ -327,7 +325,6 @@ trainer = SFTTrainer(
     model,
     train_dataset=dataset,
     dataset_text_field="text",
-    torch_dtype=torch.bfloat16,
     peft_config=peft_config,
 )
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/trl/issues/714

Fixes issues here and there regarding docs about SFTTrainer, in fact, the trainer does not support some args such as `torch_dtype`

cc @lvwerra @vwxyzjn 