### PR TITLE
Refactor RewardTrainer hyperparameters into dedicated dataclass

### DIFF
--- a/docs/source/reward_trainer.mdx
+++ b/docs/source/reward_trainer.mdx
@@ -32,8 +32,8 @@ Just pass a `peft_config` in the key word arguments of `RewardTrainer`, and the 
 
 ```python
 from peft import LoraConfig, task_type
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, TrainingArguments
-from trl import RewardTrainer
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from trl import RewardTrainer, RewardTrainingArguments
 
 model = AutoModelForSequenceClassification.from_pretrained("gpt2")
 peft_config = LoraConfig(
@@ -57,6 +57,10 @@ trainer = RewardTrainer(
 trainer.train()
 
 ```
+
+## RewardTrainingArguments
+
+[[autodoc]] RewardTrainingArguments
 
 ## RewardTrainer
 

--- a/docs/source/reward_trainer.mdx
+++ b/docs/source/reward_trainer.mdx
@@ -33,7 +33,7 @@ Just pass a `peft_config` in the key word arguments of `RewardTrainer`, and the 
 ```python
 from peft import LoraConfig, task_type
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
-from trl import RewardTrainer, RewardTrainingArguments
+from trl import RewardTrainer, RewardConfig
 
 model = AutoModelForSequenceClassification.from_pretrained("gpt2")
 peft_config = LoraConfig(
@@ -58,9 +58,9 @@ trainer.train()
 
 ```
 
-## RewardTrainingArguments
+## RewardConfig
 
-[[autodoc]] RewardTrainingArguments
+[[autodoc]] RewardConfig
 
 ## RewardTrainer
 

--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -12,9 +12,9 @@ We also support a `RewardTrainer` that can be used to train a reward model.
 
 [[autodoc]] PPOTrainer
 
-## RewardTrainingArguments
+## RewardConfig
 
-[[autodoc]] RewardTrainingArguments
+[[autodoc]] RewardConfig
 
 ## RewardTrainer
 

--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -12,6 +12,10 @@ We also support a `RewardTrainer` that can be used to train a reward model.
 
 [[autodoc]] PPOTrainer
 
+## RewardTrainingArguments
+
+[[autodoc]] RewardTrainingArguments
+
 ## RewardTrainer
 
 [[autodoc]] RewardTrainer

--- a/examples/scripts/reward_trainer.py
+++ b/examples/scripts/reward_trainer.py
@@ -15,7 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-from accelerate import Accelerator
 from datasets import load_dataset
 from peft import LoraConfig
 from tqdm import tqdm
@@ -67,7 +66,7 @@ elif script_args.load_in_8bit or script_args.load_in_4bit:
         load_in_8bit=script_args.load_in_8bit, load_in_4bit=script_args.load_in_4bit
     )
     # This means: fit the entire model on the GPU:0
-    device_map = {"": Accelerator().local_process_index}
+    device_map = {"": 0}
 else:
     device_map = None
     quantization_config = None

--- a/examples/scripts/reward_trainer.py
+++ b/examples/scripts/reward_trainer.py
@@ -20,7 +20,7 @@ from peft import LoraConfig
 from tqdm import tqdm
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, BitsAndBytesConfig, HfArgumentParser
 
-from trl import RewardTrainer, RewardTrainingArguments
+from trl import RewardConfig, RewardTrainer
 
 
 tqdm.pandas()
@@ -136,7 +136,7 @@ else:
 
 
 # Step 3: Define the training arguments
-training_args = RewardTrainingArguments(
+training_args = RewardConfig(
     output_dir=script_args.output_dir,
     per_device_train_batch_size=script_args.batch_size,
     num_train_epochs=script_args.num_train_epochs,

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -18,7 +18,7 @@ import torch
 from datasets import Dataset
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction
 
-from trl import RewardTrainer, RewardTrainingArguments
+from trl import RewardConfig, RewardTrainer
 from trl.trainer import compute_accuracy
 
 from .testing_utils import require_peft
@@ -39,7 +39,7 @@ class RewardTrainerTester(unittest.TestCase):
 
     def test_reward_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = RewardTrainingArguments(
+            training_args = RewardConfig(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=3,
@@ -119,7 +119,7 @@ class RewardTrainerTester(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = RewardTrainingArguments(
+            training_args = RewardConfig(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=6,
@@ -199,7 +199,7 @@ class RewardTrainerTester(unittest.TestCase):
 
     def test_reward_trainer_assert_value_error(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = RewardTrainingArguments(
+            training_args = RewardConfig(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=1,
@@ -246,7 +246,7 @@ class RewardTrainerTester(unittest.TestCase):
             with self.assertRaises(ValueError):
                 trainer.train()
 
-            training_args = RewardTrainingArguments(
+            training_args = RewardConfig(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=1,

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -16,9 +16,9 @@ import unittest
 
 import torch
 from datasets import Dataset
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction, TrainingArguments
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction
 
-from trl import RewardTrainer
+from trl import RewardTrainer, RewardTrainingArguments
 from trl.trainer import compute_accuracy
 
 from .testing_utils import require_peft
@@ -39,7 +39,7 @@ class RewardTrainerTester(unittest.TestCase):
 
     def test_reward_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = TrainingArguments(
+            training_args = RewardTrainingArguments(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=3,
@@ -119,7 +119,7 @@ class RewardTrainerTester(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = TrainingArguments(
+            training_args = RewardTrainingArguments(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=6,
@@ -199,7 +199,7 @@ class RewardTrainerTester(unittest.TestCase):
 
     def test_reward_trainer_assert_value_error(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            training_args = TrainingArguments(
+            training_args = RewardTrainingArguments(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=1,
@@ -246,7 +246,7 @@ class RewardTrainerTester(unittest.TestCase):
             with self.assertRaises(ValueError):
                 trainer.train()
 
-            training_args = TrainingArguments(
+            training_args = RewardTrainingArguments(
                 output_dir=tmp_dir,
                 per_device_train_batch_size=2,
                 max_steps=1,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -12,7 +12,15 @@ from .models import (
     PreTrainedModelWrapper,
     create_reference_model,
 )
-from .trainer import DataCollatorForCompletionOnlyLM, DPOTrainer, PPOConfig, PPOTrainer, RewardTrainer, SFTTrainer
+from .trainer import (
+    DataCollatorForCompletionOnlyLM,
+    DPOTrainer,
+    PPOConfig,
+    PPOTrainer,
+    RewardTrainer,
+    RewardTrainingArguments,
+    SFTTrainer,
+)
 
 
 if is_diffusers_available():

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -17,8 +17,8 @@ from .trainer import (
     DPOTrainer,
     PPOConfig,
     PPOTrainer,
+    RewardConfig,
     RewardTrainer,
-    RewardTrainingArguments,
     SFTTrainer,
 )
 

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -40,3 +40,4 @@ from .ppo_config import PPOConfig
 from .ppo_trainer import PPOTrainer
 from .reward_trainer import RewardTrainer, compute_accuracy
 from .sft_trainer import SFTTrainer
+from .training_args import RewardTrainingArguments

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -40,4 +40,4 @@ from .ppo_config import PPOConfig
 from .ppo_trainer import PPOTrainer
 from .reward_trainer import RewardTrainer, compute_accuracy
 from .sft_trainer import SFTTrainer
-from .training_args import RewardTrainingArguments
+from .training_configs import RewardConfig

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -18,12 +18,13 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from datasets import Dataset
-from transformers import DataCollator, PreTrainedModel, PreTrainedTokenizerBase, Trainer, TrainingArguments
+from transformers import DataCollator, PreTrainedModel, PreTrainedTokenizerBase, Trainer
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_pt_utils import nested_detach
 from transformers.trainer_utils import EvalPrediction
 
 from ..import_utils import is_peft_available
+from .training_args import RewardTrainingArguments
 from .utils import PeftSavingCallback, RewardDataCollatorWithPadding, compute_accuracy
 
 
@@ -51,7 +52,7 @@ class RewardTrainer(Trainer):
     def __init__(
         self,
         model: Union[PreTrainedModel, nn.Module] = None,
-        args: TrainingArguments = None,
+        args: RewardTrainingArguments = None,
         data_collator: Optional[DataCollator] = None,
         train_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
@@ -73,7 +74,7 @@ class RewardTrainer(Trainer):
         Args:
             model (`transformers.PreTrainedModel`):
                 The model to train, preferably an `AutoModelForSequenceClassification`.
-            args (`transformers.TrainingArguments`):
+            args (`RewardTrainingArguments`):
                 The arguments to use for training.
             data_collator (`transformers.DataCollator`):
                 The data collator to use for training. If None is specified, the default data collator (`RewardDataCollatorWithPadding`) will be used
@@ -94,18 +95,21 @@ class RewardTrainer(Trainer):
                 The optimizer and scheduler to use for training.
             preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
                 The function to use to preprocess the logits before computing the metrics.
-            max_length (`int`, defaults to `None`):
-                The maximum length of the sequences in the batch. This argument is required if you want to use the default data collator.
             peft_config (`Dict`, defaults to `None`):
                 The PEFT configuration to use for training. If you pass a PEFT configuration, the model will be wrapped in a PEFT model.
         """
+        if max_length is not None:
+            warnings.warn(
+                "The `max_length` argument is deprecated and will be removed in a future version. Please use the `RewardTrainingArguments` to set `max_length` instead.",
+                FutureWarning,
+            )
         if not is_peft_available() and peft_config is not None:
             raise ValueError(
                 "PEFT is not installed and you passed a `peft_config` in the trainer's kwargs, please install it to use the PEFT models"
             )
         elif is_peft_available() and peft_config is not None:
             if getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_quantized", False):
-                model = prepare_model_for_int8_training(model)
+                model = prepare_model_for_int8_training(model, use_gradient_checkpointing=args.gradient_checkpointing)
 
             model = get_peft_model(model, peft_config)
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -24,7 +24,7 @@ from transformers.trainer_pt_utils import nested_detach
 from transformers.trainer_utils import EvalPrediction
 
 from ..import_utils import is_peft_available
-from .training_args import RewardTrainingArguments
+from .training_configs import RewardConfig
 from .utils import PeftSavingCallback, RewardDataCollatorWithPadding, compute_accuracy
 
 
@@ -52,7 +52,7 @@ class RewardTrainer(Trainer):
     def __init__(
         self,
         model: Union[PreTrainedModel, nn.Module] = None,
-        args: RewardTrainingArguments = None,
+        args: RewardConfig = None,
         data_collator: Optional[DataCollator] = None,
         train_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
@@ -74,7 +74,7 @@ class RewardTrainer(Trainer):
         Args:
             model (`transformers.PreTrainedModel`):
                 The model to train, preferably an `AutoModelForSequenceClassification`.
-            args (`RewardTrainingArguments`):
+            args (`RewardConfig`):
                 The arguments to use for training.
             data_collator (`transformers.DataCollator`):
                 The data collator to use for training. If None is specified, the default data collator (`RewardDataCollatorWithPadding`) will be used
@@ -100,7 +100,7 @@ class RewardTrainer(Trainer):
         """
         if max_length is not None:
             warnings.warn(
-                "The `max_length` argument is deprecated and will be removed in a future version. Please use the `RewardTrainingArguments` to set `max_length` instead.",
+                "The `max_length` argument is deprecated and will be removed in a future version. Please use the `RewardConfig` to set `max_length` instead.",
                 FutureWarning,
             )
         if not is_peft_available() and peft_config is not None:
@@ -126,14 +126,14 @@ class RewardTrainer(Trainer):
                 )
             if max_length is None:
                 warnings.warn(
-                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardTrainingArguments."
+                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardConfig."
                     " It will be set to `512` by default, but you should do it yourself in the future.",
                     UserWarning,
                 )
                 max_length = 512
             elif args.max_length is None:
                 warnings.warn(
-                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardTrainingArguments."
+                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardConfig."
                     " It will be set to `512` by default, but you should do it yourself in the future.",
                     UserWarning,
                 )
@@ -149,7 +149,7 @@ class RewardTrainer(Trainer):
                     args = replace(args, remove_unused_columns=False)
                 # warn users
                 warnings.warn(
-                    "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your RewardTrainingArguments"
+                    "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your RewardConfig"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
                 )

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -124,13 +124,15 @@ class RewardTrainer(Trainer):
                 raise ValueError(
                     "max_length or a tokenizer must be specified when using the default RewardDataCollatorWithPadding"
                 )
-            if max_length is None:
+            if args.max_length is None:
                 warnings.warn(
-                    "When using RewardDataCollatorWithPadding, you should set `max_length` in the RewardTrainer's init"
-                    " it will be set to `512` by default, but you should do it yourself in the future.",
+                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardTrainingArguments."
+                    " It will be set to `512` by default, but you should do it yourself in the future.",
                     UserWarning,
                 )
                 max_length = 512
+            else:
+                max_length = args.max_length
             data_collator = RewardDataCollatorWithPadding(tokenizer, max_length=max_length)
 
             if args.remove_unused_columns:
@@ -140,7 +142,7 @@ class RewardTrainer(Trainer):
                     args = replace(args, remove_unused_columns=False)
                 # warn users
                 warnings.warn(
-                    "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"
+                    "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your RewardTrainingArguments"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
                 )

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -109,7 +109,7 @@ class RewardTrainer(Trainer):
             )
         elif is_peft_available() and peft_config is not None:
             if getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_quantized", False):
-                model = prepare_model_for_int8_training(model, use_gradient_checkpointing=args.gradient_checkpointing)
+                model = prepare_model_for_int8_training(model)
 
             model = get_peft_model(model, peft_config)
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -124,7 +124,14 @@ class RewardTrainer(Trainer):
                 raise ValueError(
                     "max_length or a tokenizer must be specified when using the default RewardDataCollatorWithPadding"
                 )
-            if args.max_length is None:
+            if max_length is None:
+                warnings.warn(
+                    "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardTrainingArguments."
+                    " It will be set to `512` by default, but you should do it yourself in the future.",
+                    UserWarning,
+                )
+                max_length = 512
+            elif args.max_length is None:
                 warnings.warn(
                     "When using RewardDataCollatorWithPadding, you should set `max_length` in RewardTrainingArguments."
                     " It will be set to `512` by default, but you should do it yourself in the future.",

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -98,7 +98,6 @@ class RewardTrainer(Trainer):
             peft_config (`Dict`, defaults to `None`):
                 The PEFT configuration to use for training. If you pass a PEFT configuration, the model will be wrapped in a PEFT model.
         """
-        print(args)
         if max_length is not None and args.max_length is not None:
             raise ValueError(
                 "You cannot specify both `max_length` and `args.max_length`. Please use the `RewardConfig` to set `max_length` once."

--- a/trl/trainer/training_args.py
+++ b/trl/trainer/training_args.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass, field
+from typing import Optional
+
+from transformers import TrainingArguments
+
+
+@dataclass
+class RewardTrainingArguments(TrainingArguments):
+    max_length: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "The maximum length of the sequences in the batch. This argument is required if you want to use the default data collator."
+        },
+    )

--- a/trl/trainer/training_args.py
+++ b/trl/trainer/training_args.py
@@ -21,6 +21,19 @@ from transformers import TrainingArguments
 
 @dataclass
 class RewardTrainingArguments(TrainingArguments):
+    """
+    RewardTrainingArguments is the subset of the arguments we use in our example scripts **which relate to the training loop
+    itself**.
+
+    Using [`HfArgumentParser`] we can turn this class into
+    [argparse](https://docs.python.org/3/library/argparse#module-argparse) arguments that can be specified on the
+    command line.
+
+    Parameters:
+        max_length (`int`, *optional*, defaults to `None`):
+            The maximum length of the sequences in the batch. This argument is required if you want to use the default data collator.
+    """
+
     max_length: Optional[int] = field(
         default=None,
         metadata={

--- a/trl/trainer/training_configs.py
+++ b/trl/trainer/training_configs.py
@@ -22,8 +22,7 @@ from transformers import TrainingArguments
 @dataclass
 class RewardConfig(TrainingArguments):
     """
-    RewardConfig is the subset of the arguments we use in our example scripts **which relate to the training loop
-    itself**.
+    RewardConfig collects all training arguments related to the [`RewardTrainer`] class.
 
     Using [`HfArgumentParser`] we can turn this class into
     [argparse](https://docs.python.org/3/library/argparse#module-argparse) arguments that can be specified on the

--- a/trl/trainer/training_configs.py
+++ b/trl/trainer/training_configs.py
@@ -20,9 +20,9 @@ from transformers import TrainingArguments
 
 
 @dataclass
-class RewardTrainingArguments(TrainingArguments):
+class RewardConfig(TrainingArguments):
     """
-    RewardTrainingArguments is the subset of the arguments we use in our example scripts **which relate to the training loop
+    RewardConfig is the subset of the arguments we use in our example scripts **which relate to the training loop
     itself**.
 
     Using [`HfArgumentParser`] we can turn this class into


### PR DESCRIPTION
This PR migrates the `max_length` arg of the `RewardTrainer` into a dedicated `RewardTrainingArguments` class that can also be used for storing future hyperparameters.

To be backwards compatible, I've left the variable in the trainer's init, with a warning that this will be removed in some future version.

Tested with:

```shell
accelerate launch --multi_gpu --num_processes 2 examples/scripts/reward_trainer.py --batch_size 1
```