### PR TITLE
Add epsilon to score normalization

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -604,10 +604,12 @@ class PPOTrainer(BaseTrainer):
         if self.config.use_score_scaling:
             # Score scaling
             scores_mean, scores_std = self.running.update(scores)
+            tensor_to_kwargs = dict(dtype=scores.dtype, device=scores.device)
+            score_scaling_factor = self.running.std.to(**tensor_to_kwargs) + torch.finfo(scores.dtype).eps
             if self.config.use_score_norm:
-                scores = (scores - self.running.mean) / self.running.std
+                scores = (scores - self.running.mean.to(**tensor_to_kwargs)) / score_scaling_factor
             else:
-                scores /= self.running.std
+                scores /= score_scaling_factor
 
         if self.config.score_clip is not None:
             # Score clipping


### PR DESCRIPTION
## Summary
- Add epsilon to score normalization for numerical stability;
- Call `Tensor.to` on running mean and std

## Test
Running
```commandline
python examples/scripts/sentiment_tuning.py --log_with wandb --use_score_scaling --use_score_norm --score_clip 0.5
```
![Screenshot 2023-09-01 at 9 20 03 PM](https://github.com/huggingface/trl/assets/780646/fc1c80d2-71c9-47d6-b655-f342b1d888a9)

