### PR TITLE
Allow passing the token_ids as instruction_template in DataCollatorForCompletionOnlyLM

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -82,14 +82,14 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         **kwargs,
     ):
         super().__init__(*args, mlm=mlm, **kwargs)
-        
+
         self.instruction_template = instruction_template
         if isinstance(instruction_template, str):
             # The user provides a string, must tokenize
             self.instruction_token_ids = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
         else:
             # The user already provides the token ids
-            self.instruction_token_ids = instruction_template            
+            self.instruction_token_ids = instruction_template
 
         self.response_template = response_template
         if isinstance(response_template, str):
@@ -98,7 +98,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         else:
             # The user already provides the token ids
             self.response_token_ids = response_template
-        
+
         self.ignore_index = ignore_index
 
     def torch_call(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -75,26 +75,31 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     def __init__(
         self,
         response_template: Union[str, List[int]],
-        instruction_template: Optional[str] = None,
+        instruction_template: Union[str, List[int]] = None,
         *args,
         mlm: bool = False,
         ignore_index: int = -100,
         **kwargs,
     ):
         super().__init__(*args, mlm=mlm, **kwargs)
-        self.ignore_index = ignore_index
+        
         self.instruction_template = instruction_template
-        self.response_template = response_template
-        if type(instruction_template) == list:
-            # The user already provides the token ids
-            self.instruction_token_ids = instruction_template
-        else:
+        if isinstance(instruction_template, str):
+            # The user provides a string, must tokenize
             self.instruction_token_ids = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
-        if type(response_template) == list:
+        else:
+            # The user already provides the token ids
+            self.instruction_token_ids = instruction_template            
+
+        self.response_template = response_template
+        if isinstance(response_template, str):
+            # The user provides a string, must tokenize
+            self.response_token_ids = self.tokenizer.encode(self.response_template, add_special_tokens=False)
+        else:
             # The user already provides the token ids
             self.response_token_ids = response_template
-        else:
-            self.response_token_ids = self.tokenizer.encode(self.response_template, add_special_tokens=False)
+        
+        self.ignore_index = ignore_index
 
     def torch_call(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:
         batch = super().torch_call(examples)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -82,12 +82,10 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         **kwargs,
     ):
         super().__init__(*args, mlm=mlm, **kwargs)
-        self.instruction_template = instruction_template
-        self.response_template = response_template
         self.ignore_index = ignore_index
         if type(instruction_template) == list:
             # The user already provides the token ids
-            self.instruction_template = response_template
+            self.instruction_template = instruction_template
         else:
             self.instruction_template = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
         if type(response_template) == list:
@@ -95,7 +93,6 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
             self.response_token_ids = response_template
         else:
             self.response_token_ids = self.tokenizer.encode(self.response_template, add_special_tokens=False)
-        
 
     def torch_call(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:
         batch = super().torch_call(examples)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -85,11 +85,17 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
         self.instruction_template = instruction_template
         self.response_template = response_template
         self.ignore_index = ignore_index
+        if type(instruction_template) == list:
+            # The user already provides the token ids
+            self.instruction_template = response_template
+        else:
+            self.instruction_template = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
         if type(response_template) == list:
             # The user already provides the token ids
             self.response_token_ids = response_template
         else:
             self.response_token_ids = self.tokenizer.encode(self.response_template, add_special_tokens=False)
+        
 
     def torch_call(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:
         batch = super().torch_call(examples)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -83,11 +83,13 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     ):
         super().__init__(*args, mlm=mlm, **kwargs)
         self.ignore_index = ignore_index
+        self.instruction_template = instruction_template
+        self.response_template = response_template
         if type(instruction_template) == list:
             # The user already provides the token ids
-            self.instruction_template = instruction_template
+            self.instruction_token_ids = instruction_template
         else:
-            self.instruction_template = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
+            self.instruction_token_ids = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
         if type(response_template) == list:
             # The user already provides the token ids
             self.response_token_ids = response_template
@@ -145,7 +147,7 @@ class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
                     )
                     batch["labels"][i, :] = self.ignore_index
 
-                human_token_ids = self.tokenizer.encode(self.instruction_template, add_special_tokens=False)
+                human_token_ids = self.instruction_token_ids
                 for human_idx in np.where(batch["labels"][i] == human_token_ids[0])[0]:
                     # find the indexes of the start of a human answer.
                     if human_token_ids == batch["labels"][i][human_idx : human_idx + len(human_token_ids)].tolist():


### PR DESCRIPTION
This is to make multi-turn chat conversation training work -

```python
instruction_template_with_context = "\n### Human:"  # We added context here: "\n". This is enough for this tokenizer
instruction_template_ids = tokenizer.encode(instruction_template_with_context, add_special_tokens=False)[2:]  # Now we have it like in the dataset texts: `[2277, 29937, 4007, 22137, 29901]`


response_template_with_context = "\n### Assistant:"  # We added context here: "\n". This is enough for this tokenizer
response_template_ids = tokenizer.encode(response_template_with_context, add_special_tokens=False)[2:]  # Now we have it like in the dataset texts: `[2277, 29937, 4007, 22137, 29901]`

data_collator = DataCollatorForCompletionOnlyLM(
	instruction_template=response_template_ids,
	response_template=response_template_ids,  
	tokenizer=tokenizer
)
```