### PR TITLE
[`core`] Fix import of `randn_tensor`

### DIFF
--- a/trl/models/modeling_sd_base.py
+++ b/trl/models/modeling_sd_base.py
@@ -24,7 +24,7 @@ from diffusers import DDIMScheduler, StableDiffusionPipeline, UNet2DConditionMod
 from diffusers.loaders import AttnProcsLayers
 from diffusers.models.attention_processor import LoRAAttnProcessor
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg
-from diffusers.utils import randn_tensor
+from diffusers.utils.torch_utils import randn_tensor
 
 
 @dataclass


### PR DESCRIPTION
Fixes https://github.com/huggingface/autotrain-advanced/issues/259

With https://github.com/huggingface/diffusers/pull/4829 being merged it changed a bit the structure of diffusers lib. the method `randn_tensor` which always lives inside `diffusers.utils.torch_utils` has been removed from `diffusers.utils`' init. Therefore causes import issues for users that are using the latest diffusers or in the next release. This PR fixes this

cc @kashif @vwxyzjn 