### PR TITLE
benchmark CI fix

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,14 +36,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-              setup.py
-              requirements.txt
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          # cpu version of pytorch
           pip install .[test]
 
       - name: Login


### PR DESCRIPTION
Having weird issues with `pip` caches in self-hosted runners. Taking them off.