### PR TITLE
fix const-length-dataset information leak

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -554,9 +554,11 @@ class ConstantLengthDataset(IterableDataset):
                 random.shuffle(examples)
             for example in examples:
                 self.current_size += 1
+                input_example = example[:-1]
+                label_example = example[1:]
                 yield {
-                    "input_ids": torch.LongTensor(example),
-                    "labels": torch.LongTensor(example),
+                    "input_ids": torch.LongTensor(input_example),
+                    "labels": torch.LongTensor(label_example),
                 }
 
 


### PR DESCRIPTION
To fix the information leakage in autoregressive language models with ConstantLengthDataset, we can fix the problem by separating input from labels. When training an autoregressive model, we typically want the model to predict the next token. Thus, there should be a one-position offset between the input and the labels. For example ,in the sentence "The cat is on bed.", if the input is [The, cat, is], then the labels should be [cat, is, on]. After shift the example array, the labels are the next token of input_ids.