### PR TITLE
Imrpove benchmark ci

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
 
     name: Benchmark
     # Only run if it#s a PR and the comment contains /Benchmark
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/Benchmark') && contains('["vwxyzjn", "younesbelkada", "lvwerra"]', github.actor)
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/benchmark-core-trl-experiments') && contains('["vwxyzjn", "younesbelkada", "lvwerra"]', github.actor)
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION

https://github.com/huggingface/trl/pull/754#issuecomment-1715990325 actually triggered an infinite loop — this is because the comment contained "Here are the benchmark results" which somehow triggered the `contains(github.event.comment.body, '/Benchmark')` condition. This PR tighten things up further with `/benchmark-core-trl-experiments` command, making accidentally triggering the CI less likely.

<img width="1192" alt="Screenshot 2023-09-12 at 4 00 16 PM" src="https://github.com/huggingface/trl/assets/5555347/a8ab0739-b6c1-4888-becd-5c094de33f52">
