### PR TITLE
[PPOTrainer] - add comment of zero masking (from second query token)

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -962,7 +962,7 @@ class PPOTrainer(BaseTrainer):
                     start = 1
                     end = attention_mask[j, :].sum() - 1
                 else:
-                    start = len(query_batch[j]) - 1
+                    start = len(query_batch[j]) - 1  # logprobs starts from the second query token
                     if attention_mask[j, 0] == 0:  # offset left padding
                         start += attention_mask[j, :].nonzero()[0]
                     end = start + len(response_batch[j])


### PR DESCRIPTION
It took a while to understand why zero-masked tokens are one less than the length of query tokens. 

If I got it correctly, it is because the first logit (and state-value) from the outputs refers to the second token in the query. 

Hope this comment can be helpful to others who may encounter a similar question in the first-pass reading of the code :)