### PR TITLE
Support fork in benchmark CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,10 +28,13 @@ jobs:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Checkout `main` branch
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Checkout PR branch
+        run: gh pr checkout $PR_NUMBER
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Basically just use `gh pr checkout xx` to support dealing with fork in the benchmark CI