### PR TITLE
Update custom eval loop to aid DPO debugging

### DIFF
--- a/examples/dpo.py
+++ b/examples/dpo.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         max_length=script_args.max_length,
         max_target_length=script_args.max_target_length,
         max_prompt_length=script_args.max_prompt_length,
-        sample_during_eval=True,
+        generate_during_eval=True,
     )
 
     # 6. train

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -22,7 +22,7 @@ from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokeni
 
 from trl import DPOTrainer
 
-from .testing_utils import require_peft
+from .testing_utils import require_no_wandb, require_peft
 
 
 class DPOTrainerTester(unittest.TestCase):
@@ -213,3 +213,34 @@ class DPOTrainerTester(unittest.TestCase):
                     # check the params have changed - ignore 0 biases
                     if param.sum() != 0:
                         self.assertFalse(torch.equal(param, new_param))
+
+    @require_no_wandb
+    def test_dpo_trainer_generate_during_eval_no_wandb(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=3,
+                remove_unused_columns=False,
+                gradient_accumulation_steps=1,
+                learning_rate=9e-1,
+                evaluation_strategy="steps",
+            )
+
+            dummy_dataset = self._init_dummy_dataset()
+
+            with self.assertRaisesRegex(
+                ValueError,
+                expected_regex="`generate_during_eval=True` requires Weights and Biases to be installed."
+                " Please install `wandb` to resolve.",
+            ):
+                DPOTrainer(
+                    model=self.model,
+                    ref_model=None,
+                    beta=0.1,
+                    args=training_args,
+                    tokenizer=self.tokenizer,
+                    train_dataset=dummy_dataset,
+                    eval_dataset=dummy_dataset,
+                    generate_during_eval=True,
+                )

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -15,7 +15,7 @@ import unittest
 
 import torch
 
-from trl import is_peft_available
+from trl import is_peft_available, is_wandb_available
 
 
 def require_peft(test_case):
@@ -25,6 +25,25 @@ def require_peft(test_case):
     if not is_peft_available():
         test_case = unittest.skip("test requires peft")(test_case)
     return test_case
+
+
+def require_wandb(test_case, required: bool = True):
+    """
+    Decorator marking a test that requires wandb. Skips the test if wandb is not available.
+    """
+    # XOR, i.e.:
+    # skip if available and required = False and
+    # skip if not available and required = True
+    if is_wandb_available() ^ required:
+        test_case = unittest.skip("test requires wandb")(test_case)
+    return test_case
+
+
+def require_no_wandb(test_case):
+    """
+    Decorator marking a test that requires no wandb. Skips the test if wandb is available.
+    """
+    return require_wandb(test_case, required=False)
 
 
 def require_bitsandbytes(test_case):

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -5,7 +5,7 @@ __version__ = "0.7.2.dev0"
 from .core import set_seed
 from .environment import TextEnvironment, TextHistory
 from .extras import BestOfNSampler
-from .import_utils import is_diffusers_available, is_peft_available
+from .import_utils import is_diffusers_available, is_peft_available, is_wandb_available
 from .models import (
     AutoModelForCausalLMWithValueHead,
     AutoModelForSeq2SeqLMWithValueHead,

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -21,11 +21,11 @@ else:
     _is_python_greater_3_8 = True
 
 
-def is_peft_available():
+def is_peft_available() -> bool:
     return importlib.util.find_spec("peft") is not None
 
 
-def is_torch_greater_2_0():
+def is_torch_greater_2_0() -> bool:
     if _is_python_greater_3_8:
         from importlib.metadata import version
 
@@ -37,17 +37,21 @@ def is_torch_greater_2_0():
     return torch_version >= "2.0"
 
 
-def is_diffusers_available():
+def is_diffusers_available() -> bool:
     return importlib.util.find_spec("diffusers") is not None
 
 
-def is_bitsandbytes_available():
+def is_bitsandbytes_available() -> bool:
     return importlib.util.find_spec("bitsandbytes") is not None
 
 
-def is_torchvision_available():
+def is_torchvision_available() -> bool:
     return importlib.util.find_spec("torchvision") is not None
 
 
-def is_rich_available():
+def is_rich_available() -> bool:
     return importlib.util.find_spec("rich") is not None
+
+
+def is_wandb_available() -> bool:
+    return importlib.util.find_spec("wandb") is not None

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -86,7 +86,7 @@ class DPOTrainer(Trainer):
             If no model is provided, we need to know if the model_init returns an encoder-decoder.
         disable_dropout (`bool`, defaults to `True`):
             Whether or not to disable dropouts in `model` and `ref_model`.
-        sample_during_eval (`bool`, defaults to `False`):
+        generate_during_eval (`bool`, defaults to `False`):
             Whether to sample and log generations during evaluation step.
     """
 
@@ -116,7 +116,7 @@ class DPOTrainer(Trainer):
         peft_config: Optional[Dict] = None,
         is_encoder_decoder: Optional[bool] = None,
         disable_dropout: bool = True,
-        sample_during_eval: bool = False,
+        generate_during_eval: bool = False,
     ):
         if not is_peft_available() and peft_config is not None:
             raise ValueError(
@@ -202,7 +202,7 @@ class DPOTrainer(Trainer):
             if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
 
-        self.sample_during_eval = sample_during_eval
+        self.generate_during_eval = generate_during_eval
         self.label_pad_token_id = label_pad_token_id
         self.padding_value = padding_value
 
@@ -562,7 +562,7 @@ class DPOTrainer(Trainer):
         """
 
         # Sample and save to game log if requested (for one batch to save time)
-        if self.sample_during_eval:
+        if self.generate_during_eval:
             logs = {}
 
             # Generate a random index within the range of the total number of batches

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import itertools
 import random
 import warnings
 from collections import defaultdict
@@ -571,11 +570,14 @@ class DPOTrainer(Trainer):
         if self.generate_during_eval:
             logs = {}
 
-            # Generate a random index within the range of the total number of batches
-            num_batches = len(dataloader)
-            random_index = random.randint(0, num_batches - 1)
-            # Use itertools.islice to get the random batch without iterating over the DataLoader
-            random_batch = next(itertools.islice(dataloader, random_index, None))
+            # Generate random indices within the range of the total number of samples
+            num_samples = len(dataloader.dataset)
+            random_indices = random.sample(range(num_samples), k=self.args.eval_batch_size)
+
+            # Use dataloader.dataset.select to get the random batch without iterating over the DataLoader
+            random_batch_dataset = dataloader.dataset.select(random_indices)
+            random_batch = self.data_collator(random_batch_dataset)
+            random_batch = self._prepare_inputs(random_batch)
 
             policy_output_decoded, ref_output_decoded = self.get_batch_samples(self.model, random_batch)
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -568,8 +568,6 @@ class DPOTrainer(Trainer):
 
         # Sample and save to game log if requested (for one batch to save time)
         if self.generate_during_eval:
-            logs = {}
-
             # Generate random indices within the range of the total number of samples
             num_samples = len(dataloader.dataset)
             random_indices = random.sample(range(num_samples), k=self.args.eval_batch_size)
@@ -581,7 +579,7 @@ class DPOTrainer(Trainer):
 
             policy_output_decoded, ref_output_decoded = self.get_batch_samples(self.model, random_batch)
 
-            logs.update(
+            self.log(
                 {
                     "game_log": wandb.Table(
                         columns=["Prompt", "Policy", "Ref Model"],
@@ -594,9 +592,6 @@ class DPOTrainer(Trainer):
                     )
                 }
             )
-
-            # log game log
-            self.log(logs)
 
         # Base evaluation
         initial_output = super().evaluation_loop(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -463,7 +463,7 @@ class DPOTrainer(Trainer):
             return (loss, metrics)
         return loss
 
-    def get_batch_samples(self, model, batch: Dict[str, torch.LongTensor], return_tokens=False) -> Tuple[str, str]:
+    def get_batch_samples(self, model, batch: Dict[str, torch.LongTensor]) -> Tuple[str, str]:
         """Generate samples from the model and reference model for the given batch of inputs."""
 
         policy_output = model.generate(
@@ -498,10 +498,7 @@ class DPOTrainer(Trainer):
         reference_output = pad_to_length(reference_output, self.max_length, self.tokenizer.pad_token_id)
         reference_output_decoded = self.tokenizer.batch_decode(reference_output, skip_special_tokens=True)
 
-        if return_tokens:
-            return policy_output_decoded, reference_output_decoded, policy_output, reference_output
-        else:
-            return policy_output_decoded, reference_output_decoded
+        return policy_output_decoded, reference_output_decoded
 
     def prediction_step(
         self,
@@ -571,9 +568,7 @@ class DPOTrainer(Trainer):
             # Use itertools.islice to get the random batch without iterating over the DataLoader
             random_batch = next(itertools.islice(dataloader, random_index, None))
 
-            policy_output_decoded, ref_output_decoded, policy_output, reference_output = self.get_batch_samples(
-                self.model, random_batch, return_tokens=True
-            )
+            policy_output_decoded, ref_output_decoded = self.get_batch_samples(self.model, random_batch)
 
             logs.update(
                 {

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -584,8 +584,13 @@ class DPOTrainer(Trainer):
             logs.update(
                 {
                     "game_log": wandb.Table(
-                        columns=["Policy", "Ref Model"],
-                        rows=[[pol, ref] for pol, ref in zip(policy_output_decoded, ref_output_decoded)],
+                        columns=["Prompt", "Policy", "Ref Model"],
+                        rows=[
+                            [prompt, pol[len(prompt) :], ref[len(prompt) :]]
+                            for prompt, pol, ref in zip(
+                                random_batch["prompt"], policy_output_decoded, ref_output_decoded
+                            )
+                        ],
                     )
                 }
             )


### PR DESCRIPTION
Hello!

This is intended to be pushed directly on top of [dpo_custom_eval](https://github.com/huggingface/trl/tree/dpo_custom_eval) i.e. on top of #766, but I don't have the permissions for that.

## Pull Request overview
* `sample_during_eval` is now `generate_during_eval` - I think `sample` is a bit too vague.
* `return_tokens` was unused, so I removed it.
* Prevent test failures due to `wandb` import without having `wandb` as a mandatory dependency. I added import utils for W&B & a test.
* Optimize random batch selection.
* Separate prompt and Policy/Reference responses in game log table.

This PR is a WIP.

- Tom Aarsen