### PR TITLE
Update benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         os: [self-hosted]
 
     name: Benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cleanup pip packages (specific to self-hosted runners)
+        run: |
+          pip freeze | xargs pip uninstall -y
+      - name: Print python depdenencies
+        run: pip freeze
       - name: Install dependencies
         run: |
           pip install .[test,benchmark]


### PR DESCRIPTION
Had the weridest issues:

```
costa@ip-10-52-17-32:/fsx/costa/slurm_tmpdir/tmp.Uz5n3VUbRw$ which python
/fsx/costa/all-action-runners/trl/actions-runner/_work/_tool/Python/3.8.18/x64/bin/python
costa@ip-10-52-17-32:/fsx/costa/slurm_tmpdir/tmp.Uz5n3VUbRw$ python
Python 3.8.10 (default, May 26 2023, 14:05:08) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```

For some reason `/fsx/costa/all-action-runners/trl/actions-runner/_work/_tool/Python/3.8.18/x64/bin/python` is the python 3.8.10 on the cluster. I tried bumping the python version which seems to resolve the issue.