### PR TITLE
Benchmark CI fix

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cleanup pip packages (specific to self-hosted runners)
         run: |
-          pip_list=$(pip freeze)
+          pip_list=$(pip list --format=freeze)
           if [ ! -z "$pip_list" ]; then
               echo "$pip_list" | xargs pip uninstall -y
           fi


### PR DESCRIPTION
<img width="771" alt="image" src="https://github.com/huggingface/trl/assets/5555347/89660fe1-f074-47e4-a04b-54750746ab18">


`pip freeze` gives `trl @ file:///fsx/costa/all-action-runners/trl/actions-runner/_work/trl/trl` which breaks CI. This PR fixes it. 