### PR TITLE
Changed the default value of the `log_with` argument

### DIFF
--- a/examples/scripts/sft_trainer.py
+++ b/examples/scripts/sft_trainer.py
@@ -40,7 +40,7 @@ class ScriptArguments:
         default="timdettmers/openassistant-guanaco", metadata={"help": "the dataset name"}
     )
     dataset_text_field: Optional[str] = field(default="text", metadata={"help": "the text field of the dataset"})
-    log_with: Optional[str] = field(default=None, metadata={"help": "use 'wandb' to log with wandb"})
+    log_with: Optional[str] = field(default="none", metadata={"help": "use 'wandb' to log with wandb"})
     learning_rate: Optional[float] = field(default=1.41e-5, metadata={"help": "the learning rate"})
     batch_size: Optional[int] = field(default=64, metadata={"help": "the batch size"})
     seq_length: Optional[int] = field(default=512, metadata={"help": "Input sequence length"})


### PR DESCRIPTION
This change avoids setting report_to="all" (the default behavior in transformers v4), which could lead to unexpected error messages for inexperienced users. Note that the default value of report_to will change anyway to "none" in transformers v5.

Fixes https://github.com/huggingface/trl/issues/788