### PR TITLE
[`DPO`] Revert "Add default Optim to DPO example (#759)"

### DIFF
--- a/examples/dpo.py
+++ b/examples/dpo.py
@@ -67,13 +67,6 @@ class ScriptArguments:
         },
     )
 
-    # optimizer settings
-    warmup_steps: Optional[int] = field(default=150, metadata={"help": "Number of warmup steps for optimizer"})
-    optim: Optional[str] = field(
-        default="RMSprop",
-        metadata={"help": "Optimizer to use. Default is RMSprop, if none" "passed defaults to Transformers trainer."},
-    )
-
 
 def extract_anthropic_prompt(prompt_and_response):
     """Extract the anthropic prompt from a prompt and response pair."""
@@ -138,19 +131,6 @@ if __name__ == "__main__":
     eval_dataset = get_hh("test", sanity_check=script_args.sanity_check)
 
     # 4. initialize training arguments:
-
-    warmup_steps = script_args.warmup_steps
-    if script_args.optim == "RMSprop":  # Trainer to match original paper
-        optimizer = torch.optim.RMSprop(model.parameters(), lr=script_args.learning_rate)
-        scheduler = torch.optim.lr_scheduler.LambdaLR(
-            optimizer, lr_lambda=lambda step: min(1.0, (step + 1) / (warmup_steps + 1))
-        )
-        optim = None
-    else:
-        optimizer = None
-        scheduler = None
-        optim = script_args.optim
-
     training_args = TrainingArguments(
         per_device_train_batch_size=script_args.per_device_train_batch_size,
         max_steps=script_args.max_steps,
@@ -163,8 +143,6 @@ if __name__ == "__main__":
         eval_steps=500,
         output_dir="./test",
         report_to=script_args.report_to,
-        optim=optim,
-        warmup_steps=warmup_steps,
     )
 
     # 5. initialize the DPO trainer
@@ -179,7 +157,6 @@ if __name__ == "__main__":
         max_length=script_args.max_length,
         max_target_length=script_args.max_target_length,
         max_prompt_length=script_args.max_prompt_length,
-        optimizers=(optimizer, scheduler),
     )
 
     # 6. train


### PR DESCRIPTION
This reverts commit d603e7c52704054a9e7f306ae63acdafaa3d179a.

Temporarly reverts #759 as the example script seems to fail on main, making it not usable for users, flagged in https://github.com/huggingface/trl/commit/d603e7c52704054a9e7f306ae63acdafaa3d179a#commitcomment-127787118

Let's revert the PR until we find a better fix 

cc @natolambert 