### PR TITLE
[SFTTrainer] Support logging response in wandb

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import dataclasses
 import warnings
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -208,6 +209,15 @@ class SFTTrainer(Trainer):
                 infinite,
                 num_of_sequences,
                 chars_per_token,
+            )
+            # create a `sample_dataset` in which we give half of the
+            # token in the dataset to predict the rest
+            self.sample_dataset = copy.deepcopy(eval_dataset)
+            self.sample_dataset = self.sample_dataset.map(
+                lambda x: {"remaining_input_ids": x["input_ids"][len(x["input_ids"]) // 2 :]}
+            )
+            self.sample_dataset = self.sample_dataset.map(
+                lambda x: {key: x[key][: len(x[key]) // 2] for key in x.keys()}
             )
 
         if tokenizer.padding_side is not None and tokenizer.padding_side != "right":


### PR DESCRIPTION
# What does this PR do?

This PR attempts to log some sample and reference responses in wandb, which gives concrete examples for our inspection and also makes training more informative. Basically, it's going to log something as follows:

<img width="940" alt="image" src="https://github.com/huggingface/trl/assets/5555347/885b9fb0-ad4f-4303-a904-b1da640efaf0">


Some datasets such as `timdettmers/openassistant-guanaco` do not really have a query/response structure, so I basically give the model the first half of the token in the dataset and let it generate the remaining tokens; I also added the second half of the token as the reference response to test out the SFT policy.


## Question:

I wasn't quite sure how to get the batching working with dataset and generate, though... The `dataloader` complains

```
ValueError: Unable to create tensor, you should probably activate truncation and/or padding with 'padding=True' 'truncation=True' to have batched tensors with the same length. Perhaps your features (`remaining_input_ids` in this case) have excessive nesting (inputs type `list` where type `int` is expected).
```

if I try to use a `batch_size > 1` for the dataloader.
