### PR TITLE
Fix version check in import_utils.py

### DIFF
--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -15,7 +15,7 @@ import importlib
 import sys
 
 
-if sys.version_info[0] < 3.8:
+if sys.version_info < (3, 8):
     _is_python_greater_3_8 = False
 else:
     _is_python_greater_3_8 = True


### PR DESCRIPTION
IIUC, the check is currently comparing 3 to 3.8 and so is always true. I noticed this because Pyright [crashes](https://github.com/microsoft/pyright/issues/6116) because it special cases the version check.