### PR TITLE
[reward_modeling] Cleaning example script

### DIFF
--- a/examples/scripts/reward_modeling.py
+++ b/examples/scripts/reward_modeling.py
@@ -72,10 +72,6 @@ class ScriptArguments:
             modules_to_save=["scores"],
         ),
     )
-    load_in_8bit: bool = False
-    """load the model in 8 bits precision"""
-    load_in_4bit: bool = False
-    """load the model in 4 bits precision"""
 
 
 args = tyro.cli(ScriptArguments)
@@ -116,8 +112,8 @@ def preprocess_function(examples):
         "attention_mask_rejected": [],
     }
     for chosen, rejected in zip(examples["chosen"], examples["rejected"]):
-        tokenized_chosen = tokenizer(chosen, truncation=True)
-        tokenized_rejected = tokenizer(rejected, truncation=True)
+        tokenized_chosen = tokenizer(chosen)
+        tokenized_rejected = tokenizer(rejected)
 
         new_examples["input_ids_chosen"].append(tokenized_chosen["input_ids"])
         new_examples["attention_mask_chosen"].append(tokenized_chosen["attention_mask"])


### PR DESCRIPTION
### Small changes to reward_modeling example script

Script arguments 'load_in_8_bit' and 'load_in_4_bit' were repeated multiple times.

Also removed truncation=True in the preprocess_function as it is already removing samples with higher lengths than reward_config.max_length in the filtering step.
It avoids problems with the scenario when reward_config.max_length is equal to the tokenizer max length. In this scenario, if truncation is set to True, we won't filter samples that have a higher maximum length than reward_config.max_length.