### PR TITLE
[`NEFTune`] Make use of forward hooks instead

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -580,6 +580,8 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
+            trainer.model = trainer._activate_neftune(trainer.model)
+
             device = trainer.model.get_input_embeddings().weight.device
             trainer.model.train()
 
@@ -591,6 +593,8 @@ class SFTTrainerTester(unittest.TestCase):
 
             self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
             self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
+
+            trainer.neftune_hook_handle.remove()
 
             trainer.train()
 
@@ -670,6 +674,8 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
+            trainer.model = trainer._activate_neftune(trainer.model)
+
             self.assertTrue(isinstance(trainer.model, PeftModel))
 
             device = trainer.model.get_input_embeddings().weight.device
@@ -683,6 +689,8 @@ class SFTTrainerTester(unittest.TestCase):
 
             self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
             self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
+
+            trainer.neftune_hook_handle.remove()
 
             trainer.train()
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import inspect
 import os
 import tempfile
 import unittest
@@ -581,25 +580,23 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
-            # inspect input embeddings forward code source
-            input_embeddings_forward_code_source = inspect.getsource(trainer.model.get_input_embeddings().forward)
+            device = trainer.model.get_input_embeddings().weight.device
+            trainer.model.train()
 
-            self.assertTrue(
-                "mag_norm = self.neftune_noise_alpha / torch.sqrt(dims)" in input_embeddings_forward_code_source
-            )
+            torch.random.manual_seed(42)
+            embeds_neftune = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
 
-            # training should work fine
+            torch.random.manual_seed(24)
+            embeds_neftune_2 = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
+
+            self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
+            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
+
             trainer.train()
 
-            # inspect input embeddings forward code source - this time it should not contain any code from NEFTune.
-            input_embeddings_forward_code_source = inspect.getsource(trainer.model.get_input_embeddings().forward)
-
-            self.assertFalse(
-                "mag_norm = self.neftune_noise_alpha / torch.sqrt(dims)" in input_embeddings_forward_code_source
-            )
-
             # Make sure forward pass works fine
-            _ = trainer.model(torch.LongTensor([[1, 0, 1]]))
+            _ = trainer.model(torch.LongTensor([[1, 0, 1]]).to(device))
+            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) == 0)
 
     @require_peft
     def test_peft_sft_trainer(self):
@@ -675,25 +672,19 @@ class SFTTrainerTester(unittest.TestCase):
 
             self.assertTrue(isinstance(trainer.model, PeftModel))
 
-            # inspect input embeddings forward code source
-            input_embeddings_forward_code_source = inspect.getsource(
-                trainer.model.base_model.get_input_embeddings().forward
-            )
+            device = trainer.model.get_input_embeddings().weight.device
+            trainer.model.train()
 
-            self.assertTrue(
-                "mag_norm = self.neftune_noise_alpha / torch.sqrt(dims)" in input_embeddings_forward_code_source
-            )
+            torch.random.manual_seed(42)
+            embeds_neftune = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
+
+            torch.random.manual_seed(24)
+            embeds_neftune_2 = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
+
+            self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
+            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
 
             trainer.train()
-
-            # inspect input embeddings forward code source - this time it should not contain any code from NEFTune.
-            input_embeddings_forward_code_source = inspect.getsource(
-                trainer.model.base_model.get_input_embeddings().forward
-            )
-
-            self.assertFalse(
-                "mag_norm = self.neftune_noise_alpha / torch.sqrt(dims)" in input_embeddings_forward_code_source
-            )
 
             self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
             self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
@@ -703,4 +694,5 @@ class SFTTrainerTester(unittest.TestCase):
             self.assertTrue("pytorch_model.bin" not in os.listdir(tmp_dir + "/checkpoint-2"))
 
             # Make sure forward pass works fine to check if embeddings forward is not broken.
-            _ = trainer.model(torch.LongTensor([[1, 0, 1]]))
+            _ = trainer.model(torch.LongTensor([[1, 0, 1]]).to(device))
+            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) == 0)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -260,7 +260,14 @@ class SFTTrainer(Trainer):
         # After training we make sure to retrieve back the original forward pass method
         # for the embedding layer by removing the forward post hook.
         if self.neftune_noise_alpha is not None:
+            if isinstance(self.model, PreTrainedModel):
+                embeddings = self.model.get_input_embeddings()
+            elif isinstance(self.model, PeftModel):
+                embeddings = self.model.base_model.get_input_embeddings()
+
             self.neftune_hook_handle.remove()
+            del embeddings.neftune_noise_alpha
+
         return output
 
     def _prepare_dataset(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -228,9 +228,6 @@ class SFTTrainer(Trainer):
                 "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
             )
 
-        if self.neftune_noise_alpha is not None:
-            model = self._activate_neftune(model)
-
         super().__init__(
             model=model,
             args=args,
@@ -255,6 +252,10 @@ class SFTTrainer(Trainer):
 
     @wraps(Trainer.train)
     def train(self, *args, **kwargs):
+        # Activate neftune right before training.
+        if self.neftune_noise_alpha is not None:
+            self.model = self._activate_neftune(self.model)
+
         output = super().train(*args, **kwargs)
 
         # After training we make sure to retrieve back the original forward pass method


### PR DESCRIPTION
As per title, this looks indeed much cleaner than monkey patching the forward pass of the embedding layer

No changes on the API are required

Stronger checks added on the CI 

cc @BenjaminBossan @lewtun @lvwerra 