### PR TITLE
Typo fixed: "scores" should be "score"

### DIFF
--- a/examples/scripts/reward_modeling.py
+++ b/examples/scripts/reward_modeling.py
@@ -68,7 +68,7 @@ class ScriptArguments:
             lora_alpha=16,
             bias="none",
             task_type="SEQ_CLS",
-            modules_to_save=["scores"],
+            modules_to_save=["score"],  # Typo fixed: scores -> score
         ),
     )
     load_in_8bit: bool = False


### PR DESCRIPTION
## Description

For XXXForSequenceClassification, we should define the correct classification head module name:
modules_to_save=["score"]