### PR TITLE
fix: remove useless token

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -15,5 +15,4 @@ jobs:
       package: trl
       version_tag_suffix: ""
     secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
This token is not used by your action.
Secret is removed from the repository.