### PR TITLE
hotfix for dpo trainer

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -638,6 +638,7 @@ class DPOTrainer(Trainer):
                     )
                 }
             )
+            self.state.log_history.pop()
 
         # Base evaluation
         initial_output = super().evaluation_loop(


### PR DESCRIPTION
addresses #914

DPO trainer logs a `wandb.Table` which gets added to the trainer's `state.log_history` and then can't be converted to a json when the trainer is trying to save the state.

This removes the `wandb.Table` from the log history, in a kind of ugly way.