### PR TITLE
Bump minimum `tyro` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIRED_PKGS = [
     "numpy>=1.18.2",
     "accelerate",
     "datasets",
-    "tyro>=0.5.7",
+    "tyro>=0.5.11",
 ]
 EXTRAS = {
     "test": ["parameterized", "pytest", "pytest-xdist", "accelerate", "peft>=0.4.0", "diffusers>=0.18.0"],


### PR DESCRIPTION
https://github.com/huggingface/trl/pull/897 uses `tyro.conf.arg(constructor=...)`, which is only available in `0.5.11`!

@vwxyzjn