### PR TITLE
Fix DPOTrainer + PEFT 

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -556,7 +556,7 @@ class DPOTrainer(Trainer):
         """Generate samples from the model and reference model for the given batch of inputs."""
 
         policy_output = model.generate(
-            batch["prompt_input_ids"],
+            input_ids=batch["prompt_input_ids"],
             attention_mask=batch["prompt_attention_mask"],
             max_length=self.max_length,
             do_sample=True,


### PR DESCRIPTION
Fixes https://github.com/huggingface/trl/issues/877

Indeed as stated in the issue when using `PeftModel` and call `generate` you need to pass explicit positional arguments otherwise generate will fail 

cc @lvwerra 