### PR TITLE
Upcast log probs in fp32 to avoid `NaN` reward

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -402,8 +402,8 @@ class DPOTrainer(Trainer):
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}. Should be one of ['sigmoid', 'hinge']")
 
-        chosen_rewards = self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
-        rejected_rewards = self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
+        chosen_rewards = self.beta * (policy_chosen_logps.float() - reference_chosen_logps.float()).detach()
+        rejected_rewards = self.beta * (policy_rejected_logps.float() - reference_rejected_logps.float()).detach()
 
         return losses, chosen_rewards, rejected_rewards
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/trl/issues/878

As stated by the contributors, it seems the NaN issues disappears when training the model in bf16 / fp32 - hence I believe the fix is to upcast the logprobs in fp32 before computing the rewards to avoid underflow/overflow issues

This should have no effect on training as the reward is not used for backprop

cc @lvwerra 