### PR TITLE
[`SFTrainer`] Allow users to pass a simple `formatting_func` when `packing=False` at their own risk

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -183,7 +183,29 @@ trainer = SFTTrainer(
 
 trainer.train()
 ```
-To preperly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763)
+To preperly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763).
+
+Note for formatting prompts with `packing=False` your `formatting_prompts_func` needs to process a dict of lists and return a list. This is because `dataset.map(xxx, batched=True)` is called under the hood. To disable this behaviour and use a simple `formatting_prompts_func` e.g.:
+```python
+def formatting_func(example):
+    text = f"### Question: {example['question']}\n ### Answer: {example['answer']}"
+    return text
+```
+You can pass `process_batched_dataset=False` at `SFTTrainer`'s `__init__` method:
+
+```python
+def formatting_func(example):
+    text = f"### Question: {example['question']}\n ### Answer: {example['answer']}"
+    return text
+
+trainer = SFTTrainer(
+    model,
+    train_dataset=dataset,
+    formatting_func=formatting_func,
+    process_batched_dataset=False,
+)
+```
+However processing the dataset will be slower.
 
 ### Packing dataset ([`ConstantLengthDataset`])
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -200,6 +200,15 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=False,
             )
 
+            _ = SFTTrainer(
+                model=self.model,
+                args=training_args,
+                train_dataset=self.dummy_dataset,
+                formatting_func=formatting_prompts_func,
+                packing=False,
+                process_batched_dataset=False,
+            )
+
     def test_sft_trainer_with_model_num_train_epochs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(


### PR DESCRIPTION
Fixes #944 

Currently the API for using `formatting_func` is not consistent across `packing=True` and `packing=False`. The reason behind forcing users to use a function that processes a batched input and returns a list is because for non-packed dataset we call `dataset.map(xxx, batched=True)` under the hood, that returns a dict of list for each element.

As changing the API will be breaking for users that already use this setup, I propose to offer users the possibility to use a simpler prompt formatting function at their own risk (slower pre-tokenization step) - by passing `process_batched_dataset=False` at the trainer's init. 

Updated the documentation with more clarification and added a test

cc @lvwerra 
