### PR TITLE
[DPO] Refactor eval logging of dpo trainer

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -294,6 +294,8 @@ class DPOTrainer(Trainer):
                 )
 
             self.use_dpo_data_collator = True
+
+            args.label_names = ["chosen_labels", "rejected_labels"]
         else:
             self.use_dpo_data_collator = False
 
@@ -685,7 +687,7 @@ class DPOTrainer(Trainer):
         return initial_output
 
 
-def compute_dpo_metrics(self, eval_preds: EvalPrediction):
+def compute_dpo_metrics(eval_preds: EvalPrediction):
     preds, labels = eval_preds
     chosen_rewards = preds["chosen_rewards"]
     rejected_rewards = preds["rejected_rewards"]

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -648,24 +648,8 @@ class DPOTrainer(Trainer):
                 "prediction_step is only implemented for DPODataCollatorWithPadding, and you passed a datacollator that is different than "
                 "DPODataCollatorWithPadding - you might see unexpected behavior. Alternatively, you can implement your own prediction_step method if you are using a custom data collator"
             )
-        if ignore_keys is None:
-            if hasattr(model, "config"):
-                ignore_keys = getattr(model.config, "keys_to_ignore_at_inference", [])
-            else:
-                ignore_keys = []
 
-        with torch.no_grad():
-            loss, outputs = self.compute_loss(model, inputs, return_outputs=True)
-
-        if prediction_loss_only:
-            return (loss.detach(), None, None)
-
-        # select the preferred sequence
-        # 0 for position 0 (chosen)
-        # 1 for position 1 (rejected)
-        labels = torch.int(outputs["chosen_rewards"] < outputs["rejected_rewards"])
-
-        return (loss.detach(), outputs, labels)
+        return super().prediction_step(model, inputs, prediction_loss_only, ignore_keys)
 
     def evaluation_loop(
         self,


### PR DESCRIPTION
Address part 1 of #952 by removing `store_metrics` and switching to more standard `compute_metrics` letting `Trainer` handle logging