### PR TITLE
[`core`] Fix peft config typehint

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -123,7 +123,7 @@ class SFTTrainer(Trainer):
         callbacks: Optional[List[TrainerCallback]] = None,
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
-        peft_config: Optional[PeftConfig] = None,
+        peft_config: Optional["PeftConfig"] = None,
         dataset_text_field: Optional[str] = None,
         packing: Optional[bool] = False,
         formatting_func: Optional[Callable] = None,


### PR DESCRIPTION
# What does this PR do?

Currently TRL==0.7.3 is broken (a simple `from trl import SFTTrainer` fails) for users that do not have PEFT installed because of the typehint. This PR fixes it and I can confirm everything works fine on a fresh new enviornment on Google Colab

cc @lvwerra 