### PR TITLE
Pin bnb to <=0.41.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ EXTRAS = {
     "diffusers": ["diffusers>=0.18.0"],
     "deepspeed": ["deepspeed>=0.9.5"],
     "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed"],
-    "quantization": ["bitsandbytes>=0.41.0"],
+    "quantization": ["bitsandbytes==0.41.0"],
 }
 EXTRAS["dev"] = []
 for reqs in EXTRAS.values():

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ EXTRAS = {
     "diffusers": ["diffusers>=0.18.0"],
     "deepspeed": ["deepspeed>=0.9.5"],
     "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed"],
-    "quantization": ["bitsandbytes==0.41.0"],
+    "quantization": ["bitsandbytes==0.41.1"],
 }
 EXTRAS["dev"] = []
 for reqs in EXTRAS.values():

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ EXTRAS = {
     "diffusers": ["diffusers>=0.18.0"],
     "deepspeed": ["deepspeed>=0.9.5"],
     "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed"],
-    "quantization": ["bitsandbytes==0.41.1"],
+    "quantization": ["bitsandbytes<=0.41.1"],
 }
 EXTRAS["dev"] = []
 for reqs in EXTRAS.values():


### PR DESCRIPTION
Currently the doc builder job fails because of the issue described in https://github.com/TimDettmers/bitsandbytes/pull/859

The fix should be to pin bnb to the previous working version - 0.41.1

cc @lvwerra @mishig25 