### PR TITLE
Fixed wrong trigger for warning

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -543,8 +543,7 @@ class ConstantLengthDataset(IterableDataset):
             self.formatting_func = formatting_func
 
         if formatting_func is not None:
-            formatting_func_signature = formatting_func.__code__.co_varnames
-            if len(formatting_func_signature) > 1:
+            if formatting_func.__code__.co_argcount > 1:
                 warnings.warn(
                     "The passed formatting_func has more than one argument. Usually that function should have a single argument `example`"
                     " which corresponds to the dictionary returned by each element of the dataset. Make sure you know what you are doing."


### PR DESCRIPTION
Fixes #972

In `trl/trainer/utils.py` the code `func.__code__.co_varnames` is being used to check if the user passed a **formatting_func** with more than 1 parameter. This code actually counts the function variables rather than function parameters.

For instance
```
def add_v1(a):
  return a + 1

def add_v2(a):
  b = a + 1
  return b

print("Number of parameters for add_v1 is", len(add_v1.__code__.co_varnames))
print("Number of parameters for add_v2 is", len(add_v2.__code__.co_varnames))
```
outputs
```
Number of parameters for add_v1 is 1
Number of parameters for add_v2 is 2
```

The proposed fix is to change the following:

```python
formatting_func_signature = formatting_func.__code__.co_varnames
if len(formatting_func_signature) > 1:
    warnings.warn(
        "The passed formatting_func has more than one argument. Usually that function should have a single argument `example`"
        " which corresponds to the dictionary returned by each element of the dataset. Make sure you know what you are doing."
    )
```
to:
```python
if formatting_func.__code__.co_argcount > 1:
    warnings.warn(
        "The passed formatting_func has more than one argument. Usually that function should have a single argument `example`"
        " which corresponds to the dictionary returned by each element of the dataset. Make sure you know what you are doing."
    )
```

Tested on python Python 2.7.5 and Python 3.6.8