### PR TITLE
[SFT Trainer] precompute packed iterable into a dataset

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -178,6 +178,7 @@ class SFTTrainerTester(unittest.TestCase):
                 args=training_args,
                 train_dataset=self.dummy_dataset,
                 formatting_func=formatting_prompts_func,
+                max_seq_length=32, # make sure there is at least 1 packed sequence
                 packing=True,
             )
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -189,7 +189,7 @@ class SFTTrainerTester(unittest.TestCase):
                     args=training_args,
                     train_dataset=self.dummy_dataset,
                     formatting_func=formatting_prompts_func,
-                    max_seq_length=1024,  # make sure there is at least 1 packed sequence
+                    max_seq_length=1024,  # make sure there is NOT at least 1 packed sequence
                     packing=True,
                 )
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -191,7 +191,7 @@ class SFTTrainerTester(unittest.TestCase):
                     packing=False,
                 )
 
-            # but this shpuld work
+            # but this should work
             _ = SFTTrainer(
                 model=self.model,
                 args=training_args,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -178,7 +178,7 @@ class SFTTrainerTester(unittest.TestCase):
                 args=training_args,
                 train_dataset=self.dummy_dataset,
                 formatting_func=formatting_prompts_func,
-                max_seq_length=32, # make sure there is at least 1 packed sequence
+                max_seq_length=32,  # make sure there is at least 1 packed sequence
                 packing=True,
             )
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -182,6 +182,17 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
+            with self.assertRaises(ValueError):
+                # This should not work because not enough data for one sample
+                _ = SFTTrainer(
+                    model=self.model,
+                    args=training_args,
+                    train_dataset=self.dummy_dataset,
+                    formatting_func=formatting_prompts_func,
+                    max_seq_length=1024,  # make sure there is at least 1 packed sequence
+                    packing=True,
+                )
+
             # This should not work as well
             with self.assertRaises(ValueError):
                 _ = SFTTrainer(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn as nn
 from datasets import Dataset
 from datasets.arrow_writer import SchemaInferenceError
+from datasets.builder import DatasetGenerationError
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -404,7 +405,7 @@ class SFTTrainer(Trainer):
                 packed_dataset = Dataset.from_generator(
                     data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator}
                 )
-            except SchemaInferenceError:
+            except (DatasetGenerationError, SchemaInferenceError):
                 raise ValueError(
                     "Error occurred while packing the dataset. Make sure that your dataset has enough samples to at least yield one packed sequence."
                 )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -334,7 +334,11 @@ class SFTTrainer(Trainer):
                 chars_per_token=chars_per_token,
                 eos_token_id=tokenizer.eos_token_id,
             )
-            return Dataset.from_generator(constant_length_iterator)
+
+            def data_generator(constant_length_iterator):
+                for i in constant_length_iterator:
+                    yield i
+            return Dataset.from_generator(data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator})
 
         raise ValueError(
             "You need to pass a `dataset_text_field` or `formatting_func` argument to the SFTTrainer if you want to use the `ConstantLengthDataset`."

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -381,9 +381,7 @@ class SFTTrainer(Trainer):
     ):
         if dataset_text_field is not None or formatting_func is not None:
             if tokenizer is None:
-                raise ValueError(
-                    "You need to pass a tokenizer when using `dataset_text_field` with `SFTTrainer`."
-                )
+                raise ValueError("You need to pass a tokenizer when using `dataset_text_field` with `SFTTrainer`.")
 
             constant_length_iterator = ConstantLengthDataset(
                 tokenizer,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -20,6 +20,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from datasets import Dataset
+from datasets.arrow_writer import SchemaInferenceError
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -339,9 +340,15 @@ class SFTTrainer(Trainer):
                 for i in constant_length_iterator:
                     yield i
 
-            return Dataset.from_generator(
-                data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator}
-            )
+            try:
+                packed_dataset = Dataset.from_generator(
+                    data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator}
+                )
+            except SchemaInferenceError:
+                raise ValueError(
+                    "Error occurred while packing the dataset. Make sure that your dataset has enough samples to at least yield one packed sequence."
+                )
+            return packed_dataset
 
         raise ValueError(
             "You need to pass a `dataset_text_field` or `formatting_func` argument to the SFTTrainer if you want to use the `ConstantLengthDataset`."

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -145,7 +145,7 @@ class SFTTrainer(Trainer):
 
         if infinite is not None:
             warnings.warn(
-                "The `infinite` argument is deprecated. Use `TrainingArgument.max_steps` or `TrainingArgument.num_epochs` instead to control training length."
+                "The `infinite` argument is deprecated and will be removed in a future version of TRL. Use `TrainingArguments.max_steps` or `TrainingArguments.num_train_epochs` instead to control training length."
             )
 
         if isinstance(model, str):
@@ -382,7 +382,7 @@ class SFTTrainer(Trainer):
         if dataset_text_field is not None or formatting_func is not None:
             if tokenizer is None:
                 raise ValueError(
-                    "You need to pass a tokenizer when using the SFT Trainer when passing a `dataset_text_field`."
+                    "You need to pass a tokenizer when using `dataset_text_field` with `SFTTrainer`."
                 )
 
             constant_length_iterator = ConstantLengthDataset(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -338,7 +338,10 @@ class SFTTrainer(Trainer):
             def data_generator(constant_length_iterator):
                 for i in constant_length_iterator:
                     yield i
-            return Dataset.from_generator(data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator})
+
+            return Dataset.from_generator(
+                data_generator, gen_kwargs={"constant_length_iterator": constant_length_iterator}
+            )
 
         raise ValueError(
             "You need to pass a `dataset_text_field` or `formatting_func` argument to the SFTTrainer if you want to use the `ConstantLengthDataset`."

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -323,17 +323,18 @@ class SFTTrainer(Trainer):
                     "You need to pass a tokenizer when using the SFT Trainer when passing a `dataset_text_field`."
                 )
 
-            return ConstantLengthDataset(
+            constant_length_iterator = ConstantLengthDataset(
                 tokenizer,
                 dataset,
                 dataset_text_field=dataset_text_field,
                 formatting_func=formatting_func,
                 seq_length=max_seq_length,
-                infinite=infinite,
+                infinite=False,
                 num_of_sequences=num_of_sequences,
                 chars_per_token=chars_per_token,
                 eos_token_id=tokenizer.eos_token_id,
             )
+            return Dataset.from_generator(constant_length_iterator)
 
         raise ValueError(
             "You need to pass a `dataset_text_field` or `formatting_func` argument to the SFTTrainer if you want to use the `ConstantLengthDataset`."


### PR DESCRIPTION
With this PR we'll precompute the packed iterable dataloader and push it into a dataset. That will make sure the epoch estimate is right and we have a working progress bar. 

Fixes #1008 #1004