### PR TITLE
[`DataCollatorForCompletionOnlyLM`] Add more clarification / guidance in the case `tokenizer.pad_token_id == tokenizer.eos_token_id`

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -111,6 +111,8 @@ trainer = SFTTrainer(
 trainer.train() 
 ```
 
+Make sure to have a `pad_token_id` which is different from `eos_token_id` which can result in the model not properly predicting EOS (End of Sentence) tokens during generation. 
+
 #### Using token_ids directly for `response_template`
 
 Some tokenizers like Llama 2 (`meta-llama/Llama-2-XXb-hf`) tokenize sequences differently depending whether they have context or not. For example:


### PR DESCRIPTION
Linked issue: https://github.com/huggingface/trl/issues/976 

While finding a proper fix, I propose to first clarifiy the docs a bit

As a follow up work, one needs to propose a proper fix for the case where `tokenizer.pad_token_id == tokenizer.eos_token_id`. 

cc @lvwerra 