### PR TITLE
Adds `requires_grad` to input for non-quantized peft models

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -176,6 +176,16 @@ class SFTTrainer(Trainer):
                     model = prepare_model_for_kbit_training(model, **preprare_model_kwargs)
 
                     args = dataclasses.replace(args, gradient_checkpointing=False)
+                elif getattr(args, "gradient_checkpointing", False):
+                    # For backward compatibility with older versions of transformers
+                    if hasattr(model, "enable_input_require_grads"):
+                        model.enable_input_require_grads()
+                    else:
+    
+                        def make_inputs_require_grad(module, input, output):
+                            output.requires_grad_(True)
+    
+                        model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
                 model = get_peft_model(model, peft_config)
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -181,10 +181,10 @@ class SFTTrainer(Trainer):
                     if hasattr(model, "enable_input_require_grads"):
                         model.enable_input_require_grads()
                     else:
-    
+
                         def make_inputs_require_grad(module, input, output):
                             output.requires_grad_(True)
-    
+
                         model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
                 model = get_peft_model(model, peft_config)


### PR DESCRIPTION
# What does this PR do?

As flagged internally by @regisss

This fixes the case where the base model is not quantized and one uses gradient checkpointing

cc @lvwerra 