### PR TITLE
Add `PackedIterableDataset`, `peft_module_casting_to_bf16` util method and `append_concat_token` flag

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -449,3 +449,8 @@ Pay attention to the following best practices when training a model with that tr
 ## ConstantLengthDataset
 
 [[autodoc]] trainer.ConstantLengthDataset
+
+
+## PackedIterableDataset
+
+[[autodoc]] trainer.PackedIterableDataset

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -20,9 +20,13 @@ from .utils import (
     AdaptiveKLController,
     FixedKLController,
     ConstantLengthDataset,
+    PackedIterableDataset,
     DataCollatorForCompletionOnlyLM,
     RunningMoments,
     disable_dropout_in_model,
+    peft_module_casting_to_bf16,
+    SaveDeepSpeedPeftModelCallback,
+    save_peft_deepspeed_ckpt,
 )
 
 # isort: on

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -25,8 +25,6 @@ from .utils import (
     RunningMoments,
     disable_dropout_in_model,
     peft_module_casting_to_bf16,
-    SaveDeepSpeedPeftModelCallback,
-    save_peft_deepspeed_ckpt,
 )
 
 # isort: on

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -40,6 +40,7 @@ from .utils import (
     DataCollatorForCompletionOnlyLM,
     PeftSavingCallback,
     neftune_post_forward_hook,
+    peft_module_casting_to_bf16,
 )
 
 
@@ -188,6 +189,8 @@ class SFTTrainer(Trainer):
                         model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
                 model = get_peft_model(model, peft_config)
+                if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
+                    peft_module_casting_to_bf16(model)
 
             if callbacks is None:
                 callbacks = [PeftSavingCallback]

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -518,6 +518,8 @@ class PackedIterableDataset(IterableDataset):
                 Id of the end of sequence token if the passed tokenizer does not have an EOS token.
             shuffle ('bool', *optional*, defaults to True)
                 Shuffle the examples before they are returned
+            append_concat_token ('bool', *optional*, defaults to True)
+                If true, appends `eos_token_id` at the end of each sample being packed.
     """
 
     def __init__(
@@ -629,6 +631,8 @@ class ConstantLengthDataset(PackedIterableDataset):
                 Id of the end of sequence token if the passed tokenizer does not have an EOS token.
             shuffle ('bool', *optional*, defaults to True)
                 Shuffle the examples before they are returned
+            append_concat_token ('bool', *optional*, defaults to True)
+                If true, appends `eos_token_id` at the end of each sample being packed.
     """
 
     def __len__(self):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -22,12 +22,7 @@ import numpy as np
 import torch
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import IterableDataset
-from transformers import (
-    DataCollatorForLanguageModeling,
-    PreTrainedModel,
-    PreTrainedTokenizerBase,
-    TrainerCallback,
-)
+from transformers import DataCollatorForLanguageModeling, PreTrainedModel, PreTrainedTokenizerBase, TrainerCallback
 
 
 class AdaptiveKLController:


### PR DESCRIPTION
### What does this PR do?
1. Fixes https://github.com/huggingface/trl/issues/746 by introducing `PackedIterableDataset`
2. Inline with QLoRA code when using bf16 [here](https://github.com/artidoro/qlora/blob/main/qlora.py#L396-L405), added `peft_module_casting_to_bf16`.
3. Added `append_concat_token` flag so that datasets which already have eos_token at the end of each sample can skip appending the eos/concat token.

Details:
Issues with `ConstantLengthDataset`: 
1. Learning rate schedulers like Cosine, linear_decay ... will run improperly because the length of the dataset is set to the initial dataset while an epoch will have much fewer steps because of packing.
For example, I've the below code which uses the existing `ConstantLengthDataset` and epoch=1. The logs show that epoch only has 207 steps instead of the original 1360 steps due to packing. Because of this, cosine lr_scheduler doesn't go down to 0 at the end of the epoch.
Code: https://github.com/pacman100/DHS-LLM-Workshop/pull/14
Commnad:
```
cd /DHS-LLM-Workshop/chat_assistant/training

accelerate launch --config_file configs/fsdp_config.yaml \
train.py \
--model_name_or_path "meta-llama/Llama-2-7b-chat-hf" \
--dataset_name "smangrul/code-chat-assistant-v1" \
--max_seq_len 4096 \
--num_train_epochs 1 \
--save_strategy "epoch" \
--logging_steps 25 \
--eval_steps 100 \
--bf16 True \
--packing True \
--output_dir "experiments/full-finetune-llama7B-fullshard" \
--per_device_train_batch_size 1 \
--gradient_accumulation_steps 1 \
--dataset_text_field "content" \
--learning_rate 5e-5  \
--lr_scheduler_type "cosine" \
--weight_decay 0.01 \
--warmup_ratio 0.03 \
--use_flash_attn True
```

Output logs:
```
15%|█▌        | 207/1360 [04:09<22:52,  1.19s/it]
```

wandb_plots:
<img width="962" alt="Screenshot 2023-11-23 at 3 17 58 PM" src="https://github.com/huggingface/trl/assets/13534540/e0191a7f-52ba-498a-a902-1c07eef65e94">

So, epoch based training using `ConstantLengthDataset` is not preferable with decay based lr_scheduler and packing=True.

2. When `max_steps` is passed which has more steps than the initial `len(dataset)`, it results in https://github.com/huggingface/trl/issues/746. `PackedIterableDataset` is meant to fix this issue as it doesn't contain the length attribute and works as expected when passing `max_steps`. 