### PR TITLE
[Document] Minor fixes of sft_trainer document

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -232,6 +232,7 @@ You can directly pass the kwargs of the `from_pretrained()` method to the [`SFTT
 
 ```python
 model = AutoModelForCausalLM.from_pretrained("facebook/opt-350m", torch_dtype=torch.bfloat16)
+```
 
 ```python
 ...
@@ -240,6 +241,9 @@ trainer = SFTTrainer(
     "facebook/opt-350m",
     train_dataset=dataset,
     dataset_text_field="text",
+    model_init_kwargs={
+        "torch_dtype": torch.bfloat16,
+    },
 )
 
 trainer.train()


### PR DESCRIPTION
I noticed this minor bug while reading through the documentation. Please see the screenshot below or [visit the document page](https://huggingface.co/docs/trl/sft_trainer#trl.SFTTrainer).

![screenshot](https://github.com/huggingface/trl/assets/37547640/b79bf4a3-7471-4588-a6c9-fd0ff8e395fb)

Notice the additional ```` ```python ````. In addition, the `PretrainedModel` kwargs in the `SFTTrainer` is missing.

To resolve the issue, the following changes were made:

- Add the missing backticks.
- Add `model_init_kwargs` to `SFTTrainer` initialization to demonstrate its usage.