### PR TITLE
Improve PreTrainedModelWrapper._get_current_device

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 
 import torch
 import torch.nn as nn
-from accelerate import Accelerator
+from accelerate import PartialState
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError, HFValidationError, LocalEntryNotFoundError
 from safetensors.torch import load_file as safe_load_file
@@ -386,18 +386,18 @@ class PreTrainedModelWrapper(nn.Module):
     @classmethod
     def _get_current_device(cls):
         r"""
-        Get the current device. For GPU, we return the local process index using LOCAL_RANK
+        Get the current device. For GPU, we return the local process index using PartialState
         object to handle corner cases when running scripts in distributed environments.
 
         Returns:
             current_device (`Union[int, str]`):
                 The current device.
         """
-        local_rank = int(os.environ.get('LOCAL_RANK', '0'))
+        state = PartialState()
         if is_xpu_available():
-            return f"xpu:{local_rank}"
+            return f"xpu:{state.local_process_index}"
         else:
-            return local_rank if torch.cuda.is_available() else "cpu"
+            return state.local_process_index if torch.cuda.is_available() else "cpu"
 
     @classmethod
     def _split_kwargs(cls, kwargs):

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -386,18 +386,18 @@ class PreTrainedModelWrapper(nn.Module):
     @classmethod
     def _get_current_device(cls):
         r"""
-        Get the current device. For GPU, we return the local process index using the `Accelerator`
+        Get the current device. For GPU, we return the local process index using LOCAL_RANK
         object to handle corner cases when running scripts in distributed environments.
 
         Returns:
             current_device (`Union[int, str]`):
                 The current device.
         """
-        dummy_accelerator = Accelerator()
+        local_rank = int(os.environ.get('LOCAL_RANK', '0'))
         if is_xpu_available():
-            return f"xpu:{dummy_accelerator.local_process_index}"
+            return f"xpu:{local_rank}"
         else:
-            return dummy_accelerator.local_process_index if torch.cuda.is_available() else "cpu"
+            return local_rank if torch.cuda.is_available() else "cpu"
 
     @classmethod
     def _split_kwargs(cls, kwargs):

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -386,7 +386,7 @@ class PreTrainedModelWrapper(nn.Module):
     @classmethod
     def _get_current_device(cls):
         r"""
-        Get the current device. For GPU, we return the local process index using PartialState
+        Get the current device. For GPU, we return the local process index using the `accelerate.PartialState`
         object to handle corner cases when running scripts in distributed environments.
 
         Returns:


### PR DESCRIPTION
If using ```dummy_accelerator = Accelerator()```, it will cause the ```ACCELERATE_USE_DEEPSPEED``` environment variable to be set in advance, resulting in the regeneration of ```DeepSpeedPlugin``` and causing a change in the type of ```trainer.accelerator.state.deepspeed_plugin.hf_ds_config```
 [source code: regeneration DeepSpeedPlugin](https://github.com/huggingface/accelerate/blob/3499cf25aa431ed3eeb7969f1d9b501ef20d0911/src/accelerate/accelerator.py#L284-L292)
[source code: HfTrainerDeepSpeedConfig  -> HfDeepSpeedConfig ](https://github.com/huggingface/accelerate/blob/3499cf25aa431ed3eeb7969f1d9b501ef20d0911/src/accelerate/utils/dataclasses.py#L600)

which may lead to errors similar to https://github.com/microsoft/DeepSpeed/issues/3733, https://github.com/hiyouga/LLaMA-Factory/issues/286. If this situation occurs, it will be difficult to identify the problem. It feels that using the ```LOCAL_RANK``` environment variable may be a better approach.

