### PR TITLE
Add missing `loss_type` in `ValueError` message

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -466,7 +466,7 @@ class DPOTrainer(Trainer):
             # eqn (17) of the paper where beta is the regularization parameter for the IPO loss, denoted by tau in the paper.
             losses = (logits - 1 / (2 * self.beta)) ** 2
         else:
-            raise ValueError(f"Unknown loss type: {self.loss_type}. Should be one of ['sigmoid', 'hinge']")
+            raise ValueError(f"Unknown loss type: {self.loss_type}. Should be one of ['sigmoid', 'hinge', 'ipo']")
 
         chosen_rewards = self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
         rejected_rewards = self.beta * (policy_rejected_logps - reference_rejected_logps).detach()


### PR DESCRIPTION
Hi to whoever is reading this! 🤗

## Description

This PR only adds the IPO loss within the available ones within the exception message of `ValueError` when `self.loss_type` is neither `hinge`, `sigmoid` or `ipo`.