### PR TITLE
`peft_module_casting_to_bf16` util method, `append_concat_token` flag, remove callback `PeftSavingCallback`

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -279,33 +279,6 @@ trainer = SFTTrainer(
 trainer.train()
 ```
 
-Note that in case of training adapters, we manually add a saving callback to automatically save the adapters only:
-```python
-class PeftSavingCallback(TrainerCallback):
-    def on_save(self, args, state, control, **kwargs):
-        checkpoint_path = os.path.join(args.output_dir, f"checkpoint-{state.global_step}")
-        kwargs["model"].save_pretrained(checkpoint_path)
-
-        if "pytorch_model.bin" in os.listdir(checkpoint_path):
-            os.remove(os.path.join(checkpoint_path, "pytorch_model.bin"))
-```
-If you want to add more callbacks, make sure to add this one as well to properly save the adapters only during training.
-```python
-...
-
-callbacks = [YourCustomCallback(), PeftSavingCallback()]
-
-trainer = SFTTrainer(
-    "EleutherAI/gpt-neo-125m",
-    train_dataset=dataset,
-    dataset_text_field="text",
-    peft_config=peft_config,
-    callbacks=callbacks
-)
-
-trainer.train()
-```
-
 You can also continue training your `PeftModel`. For that, first load a `PeftModel` outside `SFTTrainer` and pass it directly to the trainer without the `peft_config` argument being passed.
 
 ### Training adapters with base 8 bit models 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ __version__ = "0.7.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 
 REQUIRED_PKGS = [
     "torch>=1.4.0",
-    "transformers>=4.18.0",
+    "transformers>=4.30.0",
     "numpy>=1.18.2",
     "accelerate",
     "datasets",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ __version__ = "0.7.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 
 REQUIRED_PKGS = [
     "torch>=1.4.0",
-    "transformers>=4.30.0",
+    "transformers>=4.31.0",
     "numpy>=1.18.2",
     "accelerate",
     "datasets",

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -23,6 +23,7 @@ from .utils import (
     DataCollatorForCompletionOnlyLM,
     RunningMoments,
     disable_dropout_in_model,
+    peft_module_casting_to_bf16,
 )
 
 # isort: on

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -26,7 +26,7 @@ from transformers.trainer_utils import EvalPrediction
 
 from ..import_utils import is_peft_available
 from .training_configs import RewardConfig
-from .utils import PeftSavingCallback, RewardDataCollatorWithPadding, compute_accuracy
+from .utils import RewardDataCollatorWithPadding, compute_accuracy
 
 
 if is_peft_available():
@@ -146,12 +146,6 @@ class RewardTrainer(Trainer):
                     model = prepare_model_for_kbit_training(model, **preprare_model_kwargs)
 
                 model = get_peft_model(model, peft_config)
-
-        if is_peft_available() and isinstance(model, PeftModel):
-            if callbacks is None:
-                callbacks = [PeftSavingCallback()]
-            else:
-                callbacks += [PeftSavingCallback()]
 
         if compute_metrics is None:
             compute_metrics = compute_accuracy

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -42,6 +42,7 @@ from .utils import (
     DataCollatorForCompletionOnlyLM,
     PeftSavingCallback,
     neftune_post_forward_hook,
+    peft_module_casting_to_bf16,
 )
 
 
@@ -201,6 +202,8 @@ class SFTTrainer(Trainer):
                         model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
                 model = get_peft_model(model, peft_config)
+                if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
+                    peft_module_casting_to_bf16(model)
 
             if callbacks is None:
                 callbacks = [PeftSavingCallback]

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -40,7 +40,6 @@ from ..import_utils import is_peft_available
 from .utils import (
     ConstantLengthDataset,
     DataCollatorForCompletionOnlyLM,
-    PeftSavingCallback,
     neftune_post_forward_hook,
     peft_module_casting_to_bf16,
 )
@@ -204,9 +203,6 @@ class SFTTrainer(Trainer):
                 model = get_peft_model(model, peft_config)
                 if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
                     peft_module_casting_to_bf16(model)
-
-            if callbacks is None:
-                callbacks = [PeftSavingCallback]
 
         if tokenizer is None:
             tokenizer = AutoTokenizer.from_pretrained(model.config._name_or_path)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import random
 import warnings
 from collections import deque
@@ -22,7 +21,7 @@ import numpy as np
 import torch
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import IterableDataset
-from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerBase, TrainerCallback
+from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerBase
 
 
 class AdaptiveKLController:
@@ -446,16 +445,6 @@ class ConstantLengthDataset(IterableDataset):
                     "input_ids": torch.LongTensor(example),
                     "labels": torch.LongTensor(example),
                 }
-
-
-class PeftSavingCallback(TrainerCallback):
-    def on_save(self, args, state, control, **kwargs):
-        if args.should_save:
-            checkpoint_path = os.path.join(args.output_dir, f"checkpoint-{state.global_step}")
-            kwargs["model"].save_pretrained(checkpoint_path)
-
-            if "pytorch_model.bin" in os.listdir(checkpoint_path):
-                os.remove(os.path.join(checkpoint_path, "pytorch_model.bin"))
 
 
 class RunningMoments:


### PR DESCRIPTION
### What does this PR do?
1. Inline with QLoRA code when using bf16 [here](https://github.com/artidoro/qlora/blob/main/qlora.py#L396-L405), added `peft_module_casting_to_bf16`.
2. Added `append_concat_token` flag so that datasets which already have `eos_token` at the end of each sample can skip appending the eos/concat token
3. Removes the callback `PeftSavingCallback` and bumps the minimum transformers version to `4.31.0` which handles this by default. The current `PeftSavingCallback` would fail when using PEFT+DeepSpeed and the trainer handles this properly.