### PR TITLE
Make prepending of bos token configurable.

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -243,7 +243,8 @@ class SFTTrainer(Trainer):
             if data_collator is None:
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-        dataset_kwargs = dataset_kwargs or {}
+        if dataset_kwargs is None:
+            dataset_kwargs = {}
         if train_dataset is not None:
             train_dataset = self._prepare_dataset(
                 train_dataset,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -243,6 +243,7 @@ class SFTTrainer(Trainer):
             if data_collator is None:
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
+        dataset_kwargs = dataset_kwargs or {}
         if train_dataset is not None:
             train_dataset = self._prepare_dataset(
                 train_dataset,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -111,6 +111,8 @@ class SFTTrainer(Trainer):
             fine-tuning. Check out the original paper here: https://arxiv.org/abs/2310.05914 and the original code here: https://github.com/neelsjain/NEFTune
         model_init_kwargs: (`Optional[Dict]`, *optional*):
             Dict of Optional kwargs to pass when instantiating the model from a string
+        dataset_kwargs: (`Optional[Dict]`, *optional*):
+            Dict of Optional kwargs to pass when creating packed or non-packed datasets
     """
 
     def __init__(
@@ -138,6 +140,7 @@ class SFTTrainer(Trainer):
         dataset_batch_size: int = 1000,
         neftune_noise_alpha: Optional[float] = None,
         model_init_kwargs: Optional[Dict] = None,
+        dataset_kwargs: Optional[Dict] = None,
     ):
         if model_init_kwargs is None:
             model_init_kwargs = {}
@@ -250,6 +253,7 @@ class SFTTrainer(Trainer):
                 formatting_func,
                 num_of_sequences,
                 chars_per_token,
+                **dataset_kwargs,
             )
         if eval_dataset is not None:
             _multiple = isinstance(eval_dataset, dict)
@@ -264,6 +268,7 @@ class SFTTrainer(Trainer):
                     formatting_func,
                     num_of_sequences,
                     chars_per_token,
+                    **dataset_kwargs,
                 )
             if not _multiple:
                 eval_dataset = _eval_datasets["singleton"]
@@ -328,6 +333,8 @@ class SFTTrainer(Trainer):
         formatting_func,
         num_of_sequences,
         chars_per_token,
+        append_concat_token=True,
+        add_special_tokens=True,
     ):
         if dataset is None:
             raise ValueError("The dataset should not be None")
@@ -338,7 +345,7 @@ class SFTTrainer(Trainer):
 
         if not packing:
             return self._prepare_non_packed_dataloader(
-                tokenizer, dataset, dataset_text_field, max_seq_length, formatting_func
+                tokenizer, dataset, dataset_text_field, max_seq_length, formatting_func, add_special_tokens
             )
 
         else:
@@ -350,10 +357,12 @@ class SFTTrainer(Trainer):
                 num_of_sequences,
                 chars_per_token,
                 formatting_func,
+                append_concat_token,
+                add_special_tokens,
             )
 
     def _prepare_non_packed_dataloader(
-        self, tokenizer, dataset, dataset_text_field, max_seq_length, formatting_func=None
+        self, tokenizer, dataset, dataset_text_field, max_seq_length, formatting_func=None, add_special_tokens=True
     ):
         use_formatting_func = formatting_func is not None and dataset_text_field is None
         self._dataset_sanity_checked = False
@@ -362,6 +371,7 @@ class SFTTrainer(Trainer):
         def tokenize(element):
             outputs = tokenizer(
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
+                add_special_tokens=add_special_tokens,
                 truncation=True,
                 padding=False,
                 max_length=max_seq_length,
@@ -398,6 +408,8 @@ class SFTTrainer(Trainer):
         num_of_sequences,
         chars_per_token,
         formatting_func=None,
+        append_concat_token=True,
+        add_special_tokens=True,
     ):
         if dataset_text_field is not None or formatting_func is not None:
             if tokenizer is None:
@@ -413,6 +425,8 @@ class SFTTrainer(Trainer):
                 num_of_sequences=num_of_sequences,
                 chars_per_token=chars_per_token,
                 eos_token_id=tokenizer.eos_token_id,
+                append_concat_token=append_concat_token,
+                add_special_tokens=add_special_tokens,
             )
 
             def data_generator(constant_length_iterator):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -361,6 +361,8 @@ class ConstantLengthDataset(IterableDataset):
                 Shuffle the examples before they are returned
             append_concat_token ('bool', *optional*, defaults to True)
                 If true, appends `eos_token_id` at the end of each sample being packed.
+            add_special_tokens ('bool', *optional*, defaults to True)
+                If true, tokenizers adds special tokens to each sample being packed.
     """
 
     def __init__(

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -376,6 +376,7 @@ class ConstantLengthDataset(IterableDataset):
         eos_token_id=0,
         shuffle=True,
         append_concat_token=True,
+        add_special_tokens=True,
     ):
         self.tokenizer = tokenizer
 
@@ -393,6 +394,7 @@ class ConstantLengthDataset(IterableDataset):
         self.max_buffer_size = seq_length * chars_per_token * num_of_sequences
         self.shuffle = shuffle
         self.append_concat_token = append_concat_token
+        self.add_special_tokens = add_special_tokens
         if formatting_func is None:
             self.formatting_func = lambda x: x[dataset_text_field]
         else:
@@ -426,7 +428,9 @@ class ConstantLengthDataset(IterableDataset):
                     else:
                         more_examples = False
                         break
-            tokenized_inputs = self.tokenizer(buffer, truncation=False)["input_ids"]
+            tokenized_inputs = self.tokenizer(buffer, add_special_tokens=self.add_special_tokens, truncation=False)[
+                "input_ids"
+            ]
             all_token_ids = []
             for tokenized_input in tokenized_inputs:
                 if self.append_concat_token:


### PR DESCRIPTION
### What does this PR do?
1. Tokenization using chat template doesn't add special tokens such as bos_token by default. https://github.com/huggingface/transformers/blob/17506d1256c1780efc9e2a5898a828c10ad4ea69/src/transformers/tokenization_utils_base.py#L1750
2. Related issue elsewhere: https://github.com/vllm-project/vllm/issues/2012
3. This leads to redundant bos/special tokens being added by the tokenizer in SFT training here: 

https://github.com/huggingface/trl/blob/f100ca34cca92e3a09a04b0f07950703b0aa7fd0/trl/trainer/utils.py#L429

This PR makes it configurable while retaining backwards compatibility. 