### PR TITLE
[dpo_trainer] Fixed a compatibility bug with deepspeed when initializing reference_model

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -398,6 +398,7 @@ class DPOTrainer(Trainer):
         # Otherwise, we assume the reference model fits in memory and is initialized on each device with ZeRO disabled (stage 0)
         if config_kwargs["zero_optimization"]["stage"] != 3:
             config_kwargs["zero_optimization"]["stage"] = 0
+        config_kwargs.pop('scheduler', None)
         model, *_ = deepspeed.initialize(model=model, config=config_kwargs)
         model.eval()
         return model


### PR DESCRIPTION
When training a model using DeepSpeed + DPO (with Warmup), the following error occurs:
(This issue has also been mentioned in [#955](https://github.com/huggingface/trl/issues/955)).

`File "xxx/deepspeed/runtime/lr_schedules.py", line 661, in __init__ self.warmup_num_steps = max(2, warmup_num_steps) TypeError: '>' not supported between instances of 'str' and 'int'`

The dpo_trainer initializes both the model and the reference_model using the same deepspeed config. Training hyperparameters are set through TrainingArguments & Trainer, but the reference_model only requires deepspeed for forward computation. Scheduler-related parameters not only cause issues but are also redundant, they should be removed.