### PR TITLE
fix_ddpo_demo

### DIFF
--- a/examples/scripts/ddpo.py
+++ b/examples/scripts/ddpo.py
@@ -99,7 +99,7 @@ class AestheticScorer(torch.nn.Module):
             cached_path = hf_hub_download(model_id, model_filename)
         except EntryNotFoundError:
             cached_path = os.path.join(model_id, model_filename)
-        state_dict = torch.load(cached_path)
+        state_dict = torch.load(cached_path, map_location=torch.device("cpu"))
         self.mlp.load_state_dict(state_dict)
         self.dtype = dtype
         self.eval()


### PR DESCRIPTION
In `examples/scripts/ddpo.py` , the `AestheticScorer.mlp` loads weights to cuda device by default 
```python
self.mlp.load_state_dict(state_dict)
state_dict = torch.load(cached_path)
```
which throws an error for non-cuda devices, so loading weights on cpu first 

```python
self.mlp.load_state_dict(state_dict, map_location=torch.device('cpu'))
state_dict = torch.load(cached_path)
```
and then copy to target device 
```python
if is_npu_available():
    scorer = scorer.npu()
elif is_xpu_available():
    scorer = scorer.xpu()
else:
    scorer = scorer.cuda()
```

