### PR TITLE
fix: improve error message when `pad_token_id` is not configured

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -259,7 +259,6 @@ class DPOTrainerTester(unittest.TestCase):
                     tokenizer=tokenizer,
                     train_dataset=dummy_dataset,
                     eval_dataset=dummy_dataset,
-                    generate_during_eval=True,
                 )
 
                 trainer.train()

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -228,6 +228,44 @@ class DPOTrainerTester(unittest.TestCase):
                     if param.sum() != 0:
                         self.assertFalse(torch.equal(param, new_param))
 
+    def test_dpo_trainer_padding_token_is_none(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = TrainingArguments(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                max_steps=3,
+                remove_unused_columns=False,
+                gradient_accumulation_steps=1,
+                learning_rate=9e-1,
+                evaluation_strategy="steps",
+            )
+
+            dummy_dataset = self._init_dummy_dataset()
+
+            tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+            tokenizer.pad_token = None
+
+            with self.assertRaisesRegex(
+                ValueError,
+                expected_regex="Padding is enabled, but the tokenizer is not configured with a padding token."
+                    " Explicitly set `tokenizer.pad_token` \(e.g. `tokenizer.pad_token = tokenizer.eos_token`\)"
+                    " before calling the trainer.",
+            ):
+                trainer = DPOTrainer(
+                    model=self.model,
+                    ref_model=None,
+                    beta=0.1,
+                    args=training_args,
+                    tokenizer=tokenizer,
+                    train_dataset=dummy_dataset,
+                    eval_dataset=dummy_dataset,
+                    generate_during_eval=True,
+                )
+
+                previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+                trainer.train()
+
     @require_no_wandb
     def test_dpo_trainer_generate_during_eval_no_wandb(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -247,9 +247,9 @@ class DPOTrainerTester(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 ValueError,
-                expected_regex="Padding is enabled, but the tokenizer is not configured with a padding token."
-                    " Explicitly set `tokenizer.pad_token` \(e.g. `tokenizer.pad_token = tokenizer.eos_token`\)"
-                    " before calling the trainer.",
+                expected_regex=r"Padding is enabled, but the tokenizer is not configured with a padding token."
+                r" Explicitly set `tokenizer.pad_token` \(e.g. `tokenizer.pad_token = tokenizer.eos_token`\)"
+                r" before calling the trainer.",
             ):
                 trainer = DPOTrainer(
                     model=self.model,
@@ -261,8 +261,6 @@ class DPOTrainerTester(unittest.TestCase):
                     eval_dataset=dummy_dataset,
                     generate_during_eval=True,
                 )
-
-                previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
                 trainer.train()
 

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -297,6 +297,11 @@ class DPODataCollatorWithPadding:
                     to_pad = [torch.LongTensor(ex[k]) for ex in features]
 
                     if (k.startswith("prompt")) and (k.endswith("input_ids")):
+                        if self.pad_token_id is None:
+                            raise ValueError(
+                                "Padding is enabled, but the tokenizer is not configured with a padding token."
+                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
+                                " before calling the trainer.")
                         padding_value = self.pad_token_id
                     elif k.endswith("_attention_mask"):
                         padding_value = 0
@@ -312,6 +317,11 @@ class DPODataCollatorWithPadding:
                     else:
                         to_pad = [torch.LongTensor(ex[k]) for ex in features]
                     if k.endswith("_input_ids"):
+                        if self.pad_token_id is None:
+                            raise ValueError(
+                                "Padding is enabled, but the tokenizer is not configured with a padding token."
+                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
+                                " before calling the trainer.")
                         padding_value = self.pad_token_id
                     elif k.endswith("_labels"):
                         padding_value = self.label_pad_token_id

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -308,7 +308,8 @@ class DPODataCollatorWithPadding:
                             raise ValueError(
                                 "Padding is enabled, but the tokenizer is not configured with a padding token."
                                 " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
-                                " before calling the trainer.")
+                                " before calling the trainer."
+                            )
                         padding_value = self.pad_token_id
                     elif k.endswith("_attention_mask"):
                         padding_value = 0
@@ -328,7 +329,8 @@ class DPODataCollatorWithPadding:
                             raise ValueError(
                                 "Padding is enabled, but the tokenizer is not configured with a padding token."
                                 " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
-                                " before calling the trainer.")
+                                " before calling the trainer."
+                            )
                         padding_value = self.pad_token_id
                     elif k.endswith("_labels"):
                         padding_value = self.label_pad_token_id


### PR DESCRIPTION
## Description

Fixes #1149. Improves the error message when `tokenizer.pad_token` is `None` by providing the cause of the error and suggesting the next step to take.

## Current behaviour (before the PR)

```python
> tokenizer = AutoTokenizer.from_pretrained(...)
> print(tokenizer.pad_token)
None

> dpo_trainer = DPOTrainer(...)
> dpo_trainer.train()
...
TypeError: pad_sequence(): argument 'padding_value' (position 3) must be float, not NoneType
```

## New behaviour (after the PR)

```python
> tokenizer = AutoTokenizer.from_pretrained(...)
> print(tokenizer.pad_token)
None

> dpo_trainer = DPOTrainer(...)
> dpo_trainer.train()
...
ValueError: Padding is enabled, but the tokenizer is not configured with a padding token. Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`) before calling the trainer.
```

Thanks in advance!