### PR TITLE
Handle last token from generation prompt

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -593,35 +593,28 @@ class DPOTrainer(Trainer):
                 raise ValueError(f"rejected should be an str but got {type(rejected)}")
             rejected_tokens = self.build_tokenized_answer(prompt, rejected)
 
-            # Last prompt token might get merged by tokenizer
+            # Last prompt token might get merged by tokenizer and
             # it should not be included for generation if that happens
             prompt_len_input_ids = len(prompt_tokens['prompt_input_ids'])
-
-            # print(prompt_len_input_ids)
-            # print(len(chosen_tokens["prompt_input_ids"]))
-            # print(len(rejected_tokens["prompt_input_ids"]))
 
             chosen_prompt_len_input_ids = len(chosen_tokens["prompt_input_ids"])
             rejected_prompt_len_input_ids = len(rejected_tokens["prompt_input_ids"])
             prompt_len_input_ids = min(chosen_prompt_len_input_ids, rejected_prompt_len_input_ids)
 
             for k, v in prompt_tokens.items():
-                # print(len(v), prompt_len_input_ids)
-                # print(prompt_tokens[k])
                 prompt_tokens[k] = v[:prompt_len_input_ids]
-                # print(prompt_tokens[k])
-                # print()
 
             # Make sure prompts only have one different token at most an
             # and length only differs by 1 at most
             num_diff_tokens = sum([a != b
-                for a,b in zip(
-                    chosen_tokens['prompt_input_ids'], rejected_tokens['prompt_input_ids']
-                )
+                for a,b in zip(chosen_tokens['prompt_input_ids'], rejected_tokens['prompt_input_ids'])
             ])
             num_diff_len = abs(chosen_prompt_len_input_ids - rejected_prompt_len_input_ids)
             if num_diff_tokens > 1 or num_diff_len > 1:
-                raise ValueError("Chosen and rejected prompt_input_ids might only differ on the last token due to tokenizer merge ops.")
+                raise ValueError(
+                    "Chosen and rejected prompt_input_ids might only differ on the "
+                    "last token due to tokenizer merge ops."
+                )
 
             # add BOS token to head of prompt
             prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -595,7 +595,7 @@ class DPOTrainer(Trainer):
 
             # Last prompt token might get merged by tokenizer and
             # it should not be included for generation if that happens
-            prompt_len_input_ids = len(prompt_tokens['prompt_input_ids'])
+            prompt_len_input_ids = len(prompt_tokens["prompt_input_ids"])
 
             chosen_prompt_len_input_ids = len(chosen_tokens["prompt_input_ids"])
             rejected_prompt_len_input_ids = len(rejected_tokens["prompt_input_ids"])
@@ -606,9 +606,9 @@ class DPOTrainer(Trainer):
 
             # Make sure prompts only have one different token at most an
             # and length only differs by 1 at most
-            num_diff_tokens = sum([a != b
-                for a,b in zip(chosen_tokens['prompt_input_ids'], rejected_tokens['prompt_input_ids'])
-            ])
+            num_diff_tokens = sum(
+                [a != b for a, b in zip(chosen_tokens["prompt_input_ids"], rejected_tokens["prompt_input_ids"])]
+            )
             num_diff_len = abs(chosen_prompt_len_input_ids - rejected_prompt_len_input_ids)
             if num_diff_tokens > 1 or num_diff_len > 1:
                 raise ValueError(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -593,6 +593,36 @@ class DPOTrainer(Trainer):
                 raise ValueError(f"rejected should be an str but got {type(rejected)}")
             rejected_tokens = self.build_tokenized_answer(prompt, rejected)
 
+            # Last prompt token might get merged by tokenizer
+            # it should not be included for generation if that happens
+            prompt_len_input_ids = len(prompt_tokens['prompt_input_ids'])
+
+            # print(prompt_len_input_ids)
+            # print(len(chosen_tokens["prompt_input_ids"]))
+            # print(len(rejected_tokens["prompt_input_ids"]))
+
+            chosen_prompt_len_input_ids = len(chosen_tokens["prompt_input_ids"])
+            rejected_prompt_len_input_ids = len(rejected_tokens["prompt_input_ids"])
+            prompt_len_input_ids = min(chosen_prompt_len_input_ids, rejected_prompt_len_input_ids)
+
+            for k, v in prompt_tokens.items():
+                # print(len(v), prompt_len_input_ids)
+                # print(prompt_tokens[k])
+                prompt_tokens[k] = v[:prompt_len_input_ids]
+                # print(prompt_tokens[k])
+                # print()
+
+            # Make sure prompts only have one different token at most an
+            # and length only differs by 1 at most
+            num_diff_tokens = sum([a != b
+                for a,b in zip(
+                    chosen_tokens['prompt_input_ids'], rejected_tokens['prompt_input_ids']
+                )
+            ])
+            num_diff_len = abs(chosen_prompt_len_input_ids - rejected_prompt_len_input_ids)
+            if num_diff_tokens > 1 or num_diff_len > 1:
+                raise ValueError("Chosen and rejected prompt_input_ids might only differ on the last token due to tokenizer merge ops.")
+
             # add BOS token to head of prompt
             prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
             chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]


### PR DESCRIPTION
Some tokenizers, like Llama BPE tokenizer, might merge tokens into one such as the case where there is a space follow by some characters like `$`. 

In a previous PR we handled the case for chosen/rejected but one small improvement is to remove the extra space token from the end of the prompt used for generation in `get_batch_samples`. It should left to the model if the next generated token is just the space token or one such that it combines the space with other token into one. To do so, we need to manually check `prompt_ids` for chosen/rejected and by itself and chose the shortest knowing that they can only differ by 1 token. 

Given the following example, `prompt + chosen` will leave the space after `[\INST]` unchanged but it wont be the case for `prompt+rejected` since it starts with `$`.    

```
"prompt": "[INST] How is the stock price? [/INST] "
"chosen": "46 as of 10am EST"
"rejected":  "$46 as of 10am EST"
```

@kashif 