### PR TITLE
Logs metrics on all distributed processes when using DPO & FSDP

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -989,8 +989,7 @@ class DPOTrainer(Trainer):
         loss, metrics = self.get_batch_loss_metrics(model, inputs, train_eval="train")
 
         # force log the metrics
-        if self.accelerator.is_main_process:
-            self.store_metrics(metrics, train_eval="train")
+        self.store_metrics(metrics, train_eval="train")
 
         if return_outputs:
             return (loss, metrics)
@@ -1059,8 +1058,7 @@ class DPOTrainer(Trainer):
             loss, metrics = self.get_batch_loss_metrics(model, inputs, train_eval="eval")
 
         # force log the metrics
-        if self.accelerator.is_main_process:
-            self.store_metrics(metrics, train_eval="eval")
+        self.store_metrics(metrics, train_eval="eval")
 
         if prediction_loss_only:
             return (loss.detach(), None, None)


### PR DESCRIPTION
Logs metrics on all distributed processes when using FSDP. 

All processes need access to the metrics in order for things like "Early Stopping" / "Load Best Model At End" to work. You get a `KeyError` on workers #1 - #N, otherwise.

There is no need for this guard as the logging callbacks themselves check if they are the main process before printing metrics to the terminal.
