### PR TITLE
Correct shapes in docstring of PPOTrainer's train_minibatch method

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1045,15 +1045,15 @@ class PPOTrainer(BaseTrainer):
 
         Args:
             logprobs (`torch.FloatTensor`):
-                Log probabilities of the model, shape [batch_size, response_length]
+                Log probabilities of the model, shape [mini_batch_size, response_length]
             values (`torch.FloatTensor`):
-                Values of the value head, shape [batch_size, response_length]
+                Values of the value head, shape [mini_batch_size, response_length]
             query (`torch.LongTensor`):
-                Encoded queries, shape [batch_size, query_length]
+                Encoded queries, shape [mini_batch_size, query_length]
             response (`torch.LongTensor`):
-                Encoded responses, shape [batch_size, response_length]
+                Encoded responses, shape [mini_batch_size, response_length]
             model_input (`torch.LongTensor`):
-                Concatenated queries and responses, shape [batch_size, query_length+response_length]
+                Concatenated queries and responses, shape [mini_batch_size, query_length+response_length]
 
         Returns:
             train_stats (dict[str, `torch.Tensor`]):


### PR DESCRIPTION
`train_minibatch` is called by `step` [here](https://github.com/huggingface/trl/blob/20428c48ba651b2bc11b2a73e9eb9568b1af3f96/trl/trainer/ppo_trainer.py#L795) (and only there), with minibatches of first dimension size `self.config.mini_batch_size`. To match this, the docstring in `train_minibatch` should say that the inputs are of shape `[mini_batch_size, XXX_length]`, not `[batch_size, XXX_length]`. Alternatively, to be very precise, one could instead say that they are of size `[self.config.mini_batch_size, XXX_length]`.