### PR TITLE
Fix misleading variable "epoch" from the training loop from PPOTrainer Doc.

### DIFF
--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -115,22 +115,22 @@ We can then loop over all examples in the dataset and generate a response for ea
 
 ```py
 from tqdm import tqdm
-
-for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader)):
-    query_tensors = batch["input_ids"]
-
-    #### Get response from SFTModel
-    response_tensors = ppo_trainer.generate(query_tensors, **generation_kwargs)
-    batch["response"] = [tokenizer.decode(r.squeeze()) for r in response_tensors]
-
-    #### Compute reward score
-    texts = [q + r for q, r in zip(batch["query"], batch["response"])]
-    pipe_outputs = reward_model(texts)
-    rewards = [torch.tensor(output[1]["score"]) for output in pipe_outputs]
-
-    #### Run PPO step
-    stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
-    ppo_trainer.log_stats(stats, batch, rewards)
+for epoch in tqdm(range(ppo_trainer.config.ppo_epochs), "epoch: "):
+    for batch_id, batch in tqdm(enumerate(ppo_trainer.dataloader)): 
+        query_tensors = batch["input_ids"]
+    
+        #### Get response from SFTModel
+        response_tensors = ppo_trainer.generate(query_tensors, **generation_kwargs)
+        batch["response"] = [tokenizer.decode(r.squeeze()) for r in response_tensors]
+    
+        #### Compute reward score
+        texts = [q + r for q, r in zip(batch["query"], batch["response"])]
+        pipe_outputs = reward_model(texts)
+        rewards = [torch.tensor(output[1]["score"]) for output in pipe_outputs]
+    
+        #### Run PPO step
+        stats = ppo_trainer.step(query_tensors, response_tensors, rewards)
+        ppo_trainer.log_stats(stats, batch, rewards)
 
 #### Save model
 ppo_trainer.save_model("my_ppo_model")

--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -116,7 +116,7 @@ We can then loop over all examples in the dataset and generate a response for ea
 ```py
 from tqdm import tqdm
 for epoch in tqdm(range(ppo_trainer.config.ppo_epochs), "epoch: "):
-    for batch_id, batch in tqdm(enumerate(ppo_trainer.dataloader)): 
+    for batch in tqdm(ppo_trainer.dataloader): 
         query_tensors = batch["input_ids"]
     
         #### Get response from SFTModel


### PR DESCRIPTION
**The usage of the variable “epoch” is misleading (incorrect) in the original Doc:**
the dataloader does not contain the data for ALL epochs, but 1 epoch only, thus  
`"for epoch, batch in tqdm(enumerate(ppo_trainer.dataloader))" ` is misleading and does not actually stores the epoch #. 

The correct version comes from the TRL PPO notebook tutorial  (https://github.com/huggingface/trl/blob/main/examples/notebooks/gpt2-sentiment-control.ipynb), which uses an outer loop to capture the epochs.

I posted also the question on forum: https://discuss.huggingface.co/t/confusing-and-possibly-misleading-ppo-trainer-code-from-trl-api-doc-tutorial/67531
<img width="362" alt="image" src="https://github.com/huggingface/trl/assets/67591670/c13f5c86-e954-49fa-8ece-9655deb538fd">

<img width="657" alt="image" src="https://github.com/huggingface/trl/assets/67591670/be4d0491-a9f9-4263-a31c-27b5a5c4cda0">