### PR TITLE
Fix reported KL in PPO trainer

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -579,7 +579,7 @@ class PPOTrainerTester(unittest.TestCase):
         logits = torch.exp(all_logprobs)
         vpreds = values + 0.1
 
-        score, non_score = ppo_trainer.compute_rewards(dummy_scores, all_logprobs, ref_logprobs, mask)
+        score, non_score, kls = ppo_trainer.compute_rewards(dummy_scores, all_logprobs, ref_logprobs, mask)
         values, advantages, returns = ppo_trainer.compute_advantages(values, score, mask)
 
         # just make sure a dummy loss is computed


### PR DESCRIPTION
PPO trainer currently separately calculates the KL that's reported in the stats and to wandb, and always uses the estimated KL for this. That's fine when the estimated KL is also used for training (`kl_penalty = 'kl'`), but leads to a mismatch when using `kl_penalty = 'abs'`, `kl_penalty = 'mse'`, or `kl_penalty = 'full'`. Additionally, this can lead to a warning about negative KL being triggered even in cases where the KL used in training is not and cannot be negative.

This PR changes it so that instead the KL that is calculated during training is kept and used for stats and reporting.

Tested using the PPO example script in both single-GPU and Deepspeed stage 2 training, leading to identical results in the `kl_penalty = 'kl'`case. Verified also that `kl_penalty = 'abs'` now does not trigger the negative KL warning anymore.

Closes #1161.