### PR TITLE
Fix padding issue

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -404,7 +404,7 @@ class SFTTrainer(Trainer):
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
                 add_special_tokens=add_special_tokens,
                 truncation=True,
-                padding=True,
+                padding='max_length',
                 max_length=max_seq_length,
                 return_overflowing_tokens=False,
                 return_length=False,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -404,7 +404,7 @@ class SFTTrainer(Trainer):
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
                 add_special_tokens=add_special_tokens,
                 truncation=True,
-                padding=False,
+                padding=True,
                 max_length=max_seq_length,
                 return_overflowing_tokens=False,
                 return_length=False,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -410,7 +410,7 @@ class SFTTrainer(Trainer):
                 element[dataset_text_field] if not use_formatting_func else formatting_func(element),
                 add_special_tokens=add_special_tokens,
                 truncation=True,
-                padding='max_length',
+                padding="max_length",
                 max_length=max_seq_length,
                 return_overflowing_tokens=False,
                 return_length=False,


### PR DESCRIPTION
Been trying to solve this all day and I think I finally found the issue. By default, when `packed=False` samples are not padded, but only truncated.

My dataset has very short prompts (200-400 tokens), when I set `max_seq_length=512` in training what happens is that none of them are truncated and they are not padded either. So I end up getting:
```
Unable to create tensor, you should probably activate truncation and/or padding with 'padding=True' 'truncation=True' to have batched tensors with the same length
```
As the samples are of different length.

When training with `packed=True` my performance deteriorates. So I need to be able to train when my samples are shorter than max length. 

This PR changes the behaviour when packed=False, all samples in dataset is padded to `max_seq_length`