### PR TITLE
Fix FSDP error

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -220,11 +220,11 @@ class RewardTrainer(Trainer):
         rewards_chosen = model(
             input_ids=inputs["input_ids_chosen"],
             attention_mask=inputs["attention_mask_chosen"],
-        )[0]
+        )["logits"]
         rewards_rejected = model(
             input_ids=inputs["input_ids_rejected"],
             attention_mask=inputs["attention_mask_rejected"],
-        )[0]
+        )["logits"]
         # calculate loss, optionally modulate with margin
         if "margin" in inputs:
             loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected - inputs["margin"]).mean()

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -220,10 +220,12 @@ class RewardTrainer(Trainer):
         rewards_chosen = model(
             input_ids=inputs["input_ids_chosen"],
             attention_mask=inputs["attention_mask_chosen"],
+            return_dict=True,
         )["logits"]
         rewards_rejected = model(
             input_ids=inputs["input_ids_rejected"],
             attention_mask=inputs["attention_mask_rejected"],
+            return_dict=True,
         )["logits"]
         # calculate loss, optionally modulate with margin
         if "margin" in inputs:


### PR DESCRIPTION
This fixes an error in reward training when the `loss` field of model output is non-empty, and `model(...)[0]` returns loss instead of logits. That can happen with FSDP. This PR changes it so the trainer explicitly grabs `model(...)["logits"]` instead.

Closes #1195