### PR TITLE
Fix shape descriptions in calculate_loss method

### DIFF
--- a/trl/trainer/ddpo_trainer.py
+++ b/trl/trainer/ddpo_trainer.py
@@ -343,11 +343,11 @@ class DDPOTrainer(BaseTrainer):
 
         Args:
             latents (torch.Tensor):
-                The latents sampled from the diffusion model, shape: [batch_size, num_steps, ...]
+                The latents sampled from the diffusion model, shape: [batch_size, num_channels_latents, height, width]
             timesteps (torch.Tensor):
                 The timesteps sampled from the diffusion model, shape: [batch_size]
             next_latents (torch.Tensor):
-                The next latents sampled from the diffusion model, shape: [batch_size, num_steps, ...]
+                The next latents sampled from the diffusion model, shape: [batch_size, num_channels_latents, height, width]
             log_probs (torch.Tensor):
                 The log probabilities of the latents, shape: [batch_size]
             advantages (torch.Tensor):


### PR DESCRIPTION
The content of `latents` is defined in the following code in `modeling_sd_base.py`:

```python
latents = self.prepare_latents(
    batch_size * num_images_per_prompt,
    num_channels_latents,
    height,
    width,
    prompt_embeds.dtype,
    device,
    generator,
    latents,
)
```

As a result, the shape of `latents` and `next_latents` mentioned in the description of the `calculate_loss` method in the `DDPOTrainer` class should be `[batch_size, num_channels_latents, height, width]`.