### PR TITLE
Only load data on main process

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -251,7 +251,7 @@ trainer = SFTTrainer(
 
 trainer.train()
 ```
-To preperly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763)
+To properly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763)
 
 ### Packing dataset ([`ConstantLengthDataset`])
 

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -251,7 +251,7 @@ trainer = SFTTrainer(
 
 trainer.train()
 ```
-To properly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763)
+To preperly format your input make sure to process all the examples by looping over them and returning a list of processed text. Check out a full example on how to use SFTTrainer on alpaca dataset [here](https://github.com/huggingface/trl/pull/444#issue-1760952763)
 
 ### Packing dataset ([`ConstantLengthDataset`])
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -35,6 +35,7 @@ from transformers import (
 from transformers.modeling_utils import unwrap_model
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
+from accelerate import PartialState
 
 from ..extras.dataset_formatting import get_formatting_func_from_dataset
 from ..import_utils import is_peft_available
@@ -254,7 +255,7 @@ class SFTTrainer(Trainer):
 
         if dataset_kwargs is None:
             dataset_kwargs = {}
-        if train_dataset is not None:
+        if train_dataset is not None and PartialState().is_main_process:
             train_dataset = self._prepare_dataset(
                 train_dataset,
                 tokenizer,
@@ -267,7 +268,7 @@ class SFTTrainer(Trainer):
                 remove_unused_columns=args.remove_unused_columns if args is not None else True,
                 **dataset_kwargs,
             )
-        if eval_dataset is not None:
+        if eval_dataset is not None and PartialState().is_main_process:
             _multiple = isinstance(eval_dataset, dict)
             _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
             for _eval_dataset_name, _eval_dataset in _eval_datasets.items():

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -253,6 +253,9 @@ class SFTTrainer(Trainer):
             if data_collator is None:
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
+        # Avoid processing the dataset on all processes for multi-GPU training
+        is_main_process = PartialState().is_main_process
+        
         if dataset_kwargs is None:
             dataset_kwargs = {}
         if train_dataset is not None and PartialState().is_main_process:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -254,7 +254,7 @@ class SFTTrainer(Trainer):
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
         # Pre-process the datasets only once per node. The remaining processes will use the cache.
-        with PartialState().is_local_main_process():
+        with PartialState().is_local_main_process:
             if dataset_kwargs is None:
                 dataset_kwargs = {}
             if train_dataset is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -254,7 +254,7 @@ class SFTTrainer(Trainer):
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
         # Pre-process the datasets only once per node. The remaining processes will use the cache.
-        with PartialState().main_process_first():
+        with PartialState().is_local_main_process():
             if dataset_kwargs is None:
                 dataset_kwargs = {}
             if train_dataset is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -253,13 +253,27 @@ class SFTTrainer(Trainer):
             if data_collator is None:
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-        # Pre-process the datasets only once per node. The remaining processes will use the cache.
-        with PartialState().main_process_first():
-            if dataset_kwargs is None:
-                dataset_kwargs = {}
-            if train_dataset is not None:
-                train_dataset = self._prepare_dataset(
-                    train_dataset,
+        if dataset_kwargs is None:
+            dataset_kwargs = {}
+        if train_dataset is not None:
+            train_dataset = self._prepare_dataset(
+                train_dataset,
+                tokenizer,
+                packing,
+                dataset_text_field,
+                max_seq_length,
+                formatting_func,
+                num_of_sequences,
+                chars_per_token,
+                remove_unused_columns=args.remove_unused_columns if args is not None else True,
+                **dataset_kwargs,
+            )
+        if eval_dataset is not None:
+            _multiple = isinstance(eval_dataset, dict)
+            _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
+            for _eval_dataset_name, _eval_dataset in _eval_datasets.items():
+                _eval_datasets[_eval_dataset_name] = self._prepare_dataset(
+                    _eval_dataset,
                     tokenizer,
                     packing,
                     dataset_text_field,
@@ -270,24 +284,8 @@ class SFTTrainer(Trainer):
                     remove_unused_columns=args.remove_unused_columns if args is not None else True,
                     **dataset_kwargs,
                 )
-            if eval_dataset is not None:
-                _multiple = isinstance(eval_dataset, dict)
-                _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
-                for _eval_dataset_name, _eval_dataset in _eval_datasets.items():
-                    _eval_datasets[_eval_dataset_name] = self._prepare_dataset(
-                        _eval_dataset,
-                        tokenizer,
-                        packing,
-                        dataset_text_field,
-                        max_seq_length,
-                        formatting_func,
-                        num_of_sequences,
-                        chars_per_token,
-                        remove_unused_columns=args.remove_unused_columns if args is not None else True,
-                        **dataset_kwargs,
-                    )
-                if not _multiple:
-                    eval_dataset = _eval_datasets["singleton"]
+            if not _multiple:
+                eval_dataset = _eval_datasets["singleton"]
 
         if tokenizer.padding_side is not None and tokenizer.padding_side != "right":
             warnings.warn(
@@ -349,6 +347,7 @@ class SFTTrainer(Trainer):
 
         return super().push_to_hub(commit_message=commit_message, blocking=blocking, **kwargs)
 
+    @PartialState().main_process_first()
     def _prepare_dataset(
         self,
         dataset,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -271,7 +271,7 @@ class SFTTrainer(Trainer):
                 remove_unused_columns=args.remove_unused_columns if args is not None else True,
                 **dataset_kwargs,
             )
-        if eval_dataset is not None and PartialState().is_main_process:
+        if eval_dataset is not None and is_main_process:
             _multiple = isinstance(eval_dataset, dict)
             _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
             for _eval_dataset_name, _eval_dataset in _eval_datasets.items():

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -258,7 +258,7 @@ class SFTTrainer(Trainer):
         
         if dataset_kwargs is None:
             dataset_kwargs = {}
-        if train_dataset is not None and PartialState().is_main_process:
+        if train_dataset is not None and is_main_process:
             train_dataset = self._prepare_dataset(
                 train_dataset,
                 tokenizer,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -254,7 +254,7 @@ class SFTTrainer(Trainer):
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
         # Pre-process the datasets only once per node. The remaining processes will use the cache.
-        with PartialState().is_local_main_process:
+        if PartialState().is_local_main_process:
             if dataset_kwargs is None:
                 dataset_kwargs = {}
             if train_dataset is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -253,27 +253,13 @@ class SFTTrainer(Trainer):
             if data_collator is None:
                 data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-        if dataset_kwargs is None:
-            dataset_kwargs = {}
-        if train_dataset is not None:
-            train_dataset = self._prepare_dataset(
-                train_dataset,
-                tokenizer,
-                packing,
-                dataset_text_field,
-                max_seq_length,
-                formatting_func,
-                num_of_sequences,
-                chars_per_token,
-                remove_unused_columns=args.remove_unused_columns if args is not None else True,
-                **dataset_kwargs,
-            )
-        if eval_dataset is not None:
-            _multiple = isinstance(eval_dataset, dict)
-            _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
-            for _eval_dataset_name, _eval_dataset in _eval_datasets.items():
-                _eval_datasets[_eval_dataset_name] = self._prepare_dataset(
-                    _eval_dataset,
+        # Pre-process the datasets only once per node. The remaining processes will use the cache.
+        with PartialState().main_process_first():
+            if dataset_kwargs is None:
+                dataset_kwargs = {}
+            if train_dataset is not None:
+                train_dataset = self._prepare_dataset(
+                    train_dataset,
                     tokenizer,
                     packing,
                     dataset_text_field,
@@ -284,8 +270,24 @@ class SFTTrainer(Trainer):
                     remove_unused_columns=args.remove_unused_columns if args is not None else True,
                     **dataset_kwargs,
                 )
-            if not _multiple:
-                eval_dataset = _eval_datasets["singleton"]
+            if eval_dataset is not None:
+                _multiple = isinstance(eval_dataset, dict)
+                _eval_datasets = eval_dataset if _multiple else {"singleton": eval_dataset}
+                for _eval_dataset_name, _eval_dataset in _eval_datasets.items():
+                    _eval_datasets[_eval_dataset_name] = self._prepare_dataset(
+                        _eval_dataset,
+                        tokenizer,
+                        packing,
+                        dataset_text_field,
+                        max_seq_length,
+                        formatting_func,
+                        num_of_sequences,
+                        chars_per_token,
+                        remove_unused_columns=args.remove_unused_columns if args is not None else True,
+                        **dataset_kwargs,
+                    )
+                if not _multiple:
+                    eval_dataset = _eval_datasets["singleton"]
 
         if tokenizer.padding_side is not None and tokenizer.padding_side != "right":
             warnings.warn(
@@ -347,7 +349,6 @@ class SFTTrainer(Trainer):
 
         return super().push_to_hub(commit_message=commit_message, blocking=blocking, **kwargs)
 
-    @PartialState().main_process_first()
     def _prepare_dataset(
         self,
         dataset,


### PR DESCRIPTION
This PR address #1249. With the fix, the new data preprocessing times become:

```bash
# Single GPU
accelerate launch \
    --config_file="./conf/accelerate/single_gpu.yaml" \
    --num_processes 1 \
    examples/sft.py
# => data loading reports: 9846/9846 [00:07<00:00, 1340.85 examples/s]

# Multi GPU
accelerate launch \
    --config_file="./conf/accelerate/multi_gpu.yaml" \
    --num_processes 8 \
    examples/sft.py
# => data loading reports: 9846/9846 [00:11<00:00, 878.93 examples/s]
```

So there is still some overhead in the distributed setting, but this is a big improvement over the 10X slowdown I was previously seeing.

My only note is that I wasn't exactly sure where to put the `PartialState().is_main_process` in the `SFTTrainer`, so that could maybe use a second set of eyes @younesbelkada. Thanks!