### PR TITLE
Fix wrong variable name in DPOTrainer documentation example

### DIFF
--- a/docs/source/dpo_trainer.mdx
+++ b/docs/source/dpo_trainer.mdx
@@ -142,7 +142,7 @@ model = FastLanguageModel.get_peft_model(
     random_state = 3407,
 )
 
-args = TrainingArguments(output_dir="./output")
+training_args = TrainingArguments(output_dir="./output")
 
 dpo_trainer = DPOTrainer(
     model,


### PR DESCRIPTION
In the [Accelerate DPO fine-tuning using unsloth](https://huggingface.co/docs/trl/dpo_trainer#dpo-trainer) code example, `args` receives a variable named `training_args`, while the variable created is called `args`.