### PR TITLE
fix padding in dpo trainer

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -144,7 +144,7 @@ class DPOTrainer(Trainer):
         args: TrainingArguments = None,
         data_collator: Optional[DataCollator] = None,
         label_pad_token_id: int = -100,
-        padding_value: int = 0,
+        padding_value: Optional[int] = None,
         truncation_mode: str = "keep_end",
         train_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,


### PR DESCRIPTION
### What does this PR do?
1. The padding token in DPO trainer is wrongly set to 0 when tokenizer uses a different token id for padding and tokenizer is passed. This happens because the conditional statement is checking if padding value is `None` but if the default is 0, it is never `None`.