### PR TITLE
[`PEFT` + `DPO`] Raise value error if one passes a ref_model and a peft_config

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -209,6 +209,12 @@ class DPOTrainer(Trainer):
             if isinstance(model, PeftModel):
                 model = model.merge_and_unload()
 
+            if ref_model is not None:
+                raise ValueError(
+                    "You passed both a ref_model and a peft_config. For training PEFT adapters with DPO there is no need to pass a reference"
+                    " model. Please pass `ref_model=None` in case you want to train PEFT adapters."
+                )
+
             if getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False):
                 _support_gc_kwargs = hasattr(
                     args, "gradient_checkpointing_kwargs"


### PR DESCRIPTION
Recently I have seen many tutorials that passes both the ref_model and a peft_config, this should be not allowed as it is very memory inefficient. This PR enhances the UX by raising a value error if peft_config if passed together with a ref_model and guiding the user on what should be the best practice.

cc @kashif 