### PR TITLE
[`DPOTrainer`] Fix DPO trainer + mistral + FA2

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -964,6 +964,7 @@ class DPOTrainer(Trainer):
         all_logits = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
+            use_cache=False,
             **model_kwargs,
         ).logits
 


### PR DESCRIPTION
Fixes: https://github.com/huggingface/trl/issues/1217 
Fixes: https://github.com/huggingface/transformers/issues/26877
Fixes: https://github.com/huggingface/trl/issues/1266

Simply setting `use_cache=False` circumvents all issues with FA-2 + DPO + Mistral. in fact we should bypass that check since we are not in text generation mode when computing the loss function. `use_cache` is retrieved from the model config by default which falls back always to `True`. The cache is not used anyway when purely computing the logits so this change is fully BC

cc @kashif @vwxyzjn 

To test that, I managed to repro the issue by adding `--attn_implementation "flash_attention_2"` in the dpo shell script on a A100 machine, and I confirm this PR fixes it. Unfortunately our CI runners are not compatible with FA2 so we cannot add a slow test to test that