### PR TITLE
Fix sft trainer when args is None

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -710,6 +710,24 @@ class SFTTrainerTester(unittest.TestCase):
             self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) == 0)
 
     @require_peft
+    def test_peft_sft_trainer_str(self):
+        peft_config = LoraConfig(
+            r=16,
+            lora_alpha=32,
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+
+        _ = SFTTrainer(
+            model=self.model_id,
+            args=None,
+            train_dataset=self.train_dataset,
+            eval_dataset=self.eval_dataset,
+            peft_config=peft_config,
+        )
+
+    @require_peft
     def test_peft_sft_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -725,6 +725,7 @@ class SFTTrainerTester(unittest.TestCase):
             train_dataset=self.train_dataset,
             eval_dataset=self.eval_dataset,
             peft_config=peft_config,
+            packing=True,
         )
 
     @require_peft

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -209,7 +209,7 @@ class SFTTrainer(Trainer):
                         model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
                 model = get_peft_model(model, peft_config)
-                if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
+                if args is not None and args.bf16 and getattr(model, "is_loaded_in_4bit", False):
                     peft_module_casting_to_bf16(model)
 
         if tokenizer is None:


### PR DESCRIPTION
Happens when one passes a str model + peft_config

cc @lvwerra 