### PR TITLE
Fix `DPOTrainer` docstrings

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -123,11 +123,11 @@ class DPOTrainer(Trainer):
         precompute_ref_log_probs (`bool`, defaults to `False`):
             Flag to precompute reference model log probabilities and evaluation datasets. This is useful if you want to train
             without the reference model and reduce the total GPU memory needed.
-        dataset_num_proc (`Optional[int]`):
+        dataset_num_proc (`Optional[int]`, *optional*):
             The number of workers to use to tokenize the data. Defaults to None.
-        model_init_kwargs: (`Optional[Dict]`, *optional*):
+        model_init_kwargs (`Optional[Dict]`, *optional*):
             Dict of Optional kwargs to pass when instantiating the model from a string
-        ref_model_init_kwargs: (`Optional[Dict]`, *optional*):
+        ref_model_init_kwargs (`Optional[Dict]`, *optional*):
             Dict of Optional kwargs to pass when instantiating the ref model from a string
         model_adapter_name (`str`, defaults to `None`):
             Name of the train target PEFT adapter, when using LoRA with multiple adapters.


### PR DESCRIPTION
## Description

Some issues were leading the auto-generation of the API reference to fail and the args were overlapped in the documentation page, see screenshot below:

<img width="896" alt="Screenshot 2024-01-31 at 12 40 20" src="https://github.com/huggingface/trl/assets/36760800/fb6a3ddd-f22e-45b6-a73b-86dde081d9e6">

*Note that the issue was most likely due to a duplicated colon (:) within the args `model_init_kwargs` and `ref_model_init_kwargs`.*