### PR TITLE
Codemod Unittest assertions to bare asserts

### DIFF
--- a/tests/slow/test_dpo_slow.py
+++ b/tests/slow/test_dpo_slow.py
@@ -145,8 +145,8 @@ class DPOTrainerSlowTester(unittest.TestCase):
                 max_length=self.max_length,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
-            self.assertTrue(trainer.ref_model is None)
+            assert isinstance(trainer.model, PeftModel)
+            assert trainer.ref_model is None
 
             # train the model
             trainer.train()
@@ -209,8 +209,8 @@ class DPOTrainerSlowTester(unittest.TestCase):
                 max_length=self.max_length,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
-            self.assertTrue(trainer.ref_model is None)
+            assert isinstance(trainer.model, PeftModel)
+            assert trainer.ref_model is None
 
             # train the model
             trainer.train()

--- a/tests/slow/test_sft_slow.py
+++ b/tests/slow/test_sft_slow.py
@@ -146,7 +146,7 @@ class SFTTrainerSlowTester(unittest.TestCase):
                 peft_config=self.peft_config,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 
@@ -256,7 +256,7 @@ class SFTTrainerSlowTester(unittest.TestCase):
                 peft_config=self.peft_config,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 
@@ -340,7 +340,7 @@ class SFTTrainerSlowTester(unittest.TestCase):
                 peft_config=self.peft_config,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 
@@ -383,7 +383,7 @@ class SFTTrainerSlowTester(unittest.TestCase):
                 peft_config=self.peft_config,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 

--- a/tests/test_best_of_n_sampler.py
+++ b/tests/test_best_of_n_sampler.py
@@ -59,7 +59,7 @@ class BestOfNSamplerTester(unittest.TestCase):
 
         for q, expected_length in various_queries_formats:
             results = best_of_n.generate(q)
-            self.assertIsInstance(results, list)
+            assert isinstance(results, list)
             assert len(results) == expected_length
 
     def test_different_sample_sizes_and_n_candidates_values(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,13 +30,13 @@ class CoreTester(unittest.TestCase):
         cls.test_input_unmasked = cls.test_input[1:3]
 
     def test_masked_mean(self):
-        self.assertEqual(torch.mean(self.test_input_unmasked), masked_mean(self.test_input, self.test_mask))
+        assert torch.mean(self.test_input_unmasked) == masked_mean(self.test_input, self.test_mask)
 
     def test_masked_var(self):
-        self.assertEqual(torch.var(self.test_input_unmasked), masked_var(self.test_input, self.test_mask))
+        assert torch.var(self.test_input_unmasked) == masked_var(self.test_input, self.test_mask)
 
     def test_masked_whiten(self):
         whiten_unmasked = whiten(self.test_input_unmasked)
         whiten_masked = masked_whiten(self.test_input, self.test_mask)[1:3]
         diffs = (whiten_unmasked - whiten_masked).sum()
-        self.assertAlmostEqual(diffs, 0)
+        assert round(diffs - 0, 7) >= 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,4 +39,4 @@ class CoreTester(unittest.TestCase):
         whiten_unmasked = whiten(self.test_input_unmasked)
         whiten_masked = masked_whiten(self.test_input, self.test_mask)[1:3]
         diffs = (whiten_unmasked - whiten_masked).sum()
-        assert round(diffs - 0, 7) >= 0
+        assert abs(diffs.item()) < 0.00001

--- a/tests/test_data_collator_completion_only.py
+++ b/tests/test_data_collator_completion_only.py
@@ -45,7 +45,7 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
         self.tokenized_response_w_context = self.tokenizer.encode(self.response_template, add_special_tokens=False)[2:]
 
         # Plain check on string
-        self.assertIn(self.response_template, self.instruction)
+        assert self.response_template in self.instruction
         self.tokenized_instruction = self.tokenizer.encode(self.instruction, add_special_tokens=False)
 
         # Test the fix for #598
@@ -80,7 +80,7 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
             collator_output["labels"][torch.where(collator_output["labels"] != -100)]
         )
         expected_text = " First response\n\n Second response" ""
-        self.assertEqual(collator_text, expected_text)
+        assert collator_text == expected_text
 
     def test_data_collator_handling_of_long_sequences(self):
         self.tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/dummy-GPT2-correct-vocab")
@@ -94,7 +94,7 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
         self.collator = DataCollatorForCompletionOnlyLM(self.response_template, tokenizer=self.tokenizer)
         encoded_instance = self.collator.torch_call([self.tokenized_instruction])
         result = torch.all(encoded_instance["labels"] == -100)
-        self.assertTrue(result, "Not all values in the tensor are -100.")
+        assert result, "Not all values in the tensor are -100."
 
         # check DataCollatorForCompletionOnlyLM using response template and instruction template
         self.instruction_template = "\n### User:"
@@ -103,4 +103,4 @@ class DataCollatorForCompletionOnlyLMTester(unittest.TestCase):
         )
         encoded_instance = self.collator.torch_call([self.tokenized_instruction])
         result = torch.all(encoded_instance["labels"] == -100)
-        self.assertTrue(result, "Not all values in the tensor are -100.")
+        assert result, "Not all values in the tensor are -100."

--- a/tests/test_dataset_formatting.py
+++ b/tests/test_dataset_formatting.py
@@ -28,32 +28,28 @@ class DatasetFormattingTestCase(unittest.TestCase):
 
         # Llama tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
-        self.assertTrue(isinstance(formatting_func, Callable))
+        assert isinstance(formatting_func, Callable)
         formatted_text = formatting_func(dataset[0])
-        self.assertEqual(
-            formatted_text,
-            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>",
+        assert (
+            formatted_text
+            == "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
         )
         formatted_text = formatting_func(dataset[0:1])
-        self.assertEqual(
-            formatted_text,
-            ["<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"],
-        )
+        assert formatted_text == [
+            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
+        ]
 
         # ChatML tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.chatml_tokenizer)
         formatted_text = formatting_func(dataset[0])
-        self.assertEqual(
-            formatted_text,
-            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n",
+        assert (
+            formatted_text
+            == "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
         )
         formatted_text = formatting_func(dataset[0:1])
-        self.assertEqual(
-            formatted_text,
-            [
-                "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-            ],
-        )
+        assert formatted_text == [
+            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
+        ]
 
     def test_get_formatting_func_from_dataset_with_chatml_conversations(self):
         dataset = Dataset.from_dict(
@@ -69,60 +65,56 @@ class DatasetFormattingTestCase(unittest.TestCase):
         )
         # Llama tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
-        self.assertTrue(isinstance(formatting_func, Callable))
+        assert isinstance(formatting_func, Callable)
         formatted_text = formatting_func(dataset[0])
-        self.assertEqual(
-            formatted_text,
-            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>",
+        assert (
+            formatted_text
+            == "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
         )
         formatted_text = formatting_func(dataset[0:1])
-        self.assertEqual(
-            formatted_text,
-            ["<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"],
-        )
+        assert formatted_text == [
+            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
+        ]
 
         # ChatML tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.chatml_tokenizer)
         formatted_text = formatting_func(dataset[0])
-        self.assertEqual(
-            formatted_text,
-            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n",
+        assert (
+            formatted_text
+            == "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
         )
         formatted_text = formatting_func(dataset[0:1])
-        self.assertEqual(
-            formatted_text,
-            [
-                "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-            ],
-        )
+        assert formatted_text == [
+            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
+        ]
 
     def test_get_formatting_func_from_dataset_with_instruction(self):
         dataset = Dataset.from_list(
             [{"prompt": "What is 2+2?", "completion": "4"}, {"prompt": "What is 3+3?", "completion": "6"}]
         )
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
-        self.assertIsNotNone(formatting_func)
-        self.assertTrue(isinstance(formatting_func, Callable))
+        assert formatting_func is not None
+        assert isinstance(formatting_func, Callable)
         formatted_text = formatting_func(dataset[0])
-        self.assertEqual(formatted_text, "<s>[INST] What is 2+2? [/INST] 4 </s>")
+        assert formatted_text == "<s>[INST] What is 2+2? [/INST] 4 </s>"
         formatted_text = formatting_func(dataset[0:1])
-        self.assertEqual(formatted_text, ["<s>[INST] What is 2+2? [/INST] 4 </s>"])
+        assert formatted_text == ["<s>[INST] What is 2+2? [/INST] 4 </s>"]
 
     def test_get_formatting_func_from_dataset_from_hub(self):
         ds_1 = load_dataset("philschmid/trl-test-instruction", split="train")
         ds_2 = load_dataset("philschmid/dolly-15k-oai-style", split="train")
         for ds in [ds_1, ds_2]:
             formatting_func = get_formatting_func_from_dataset(ds, self.llama_tokenizer)
-            self.assertIsNotNone(formatting_func)
-            self.assertTrue(isinstance(formatting_func, Callable))
+            assert formatting_func is not None
+            assert isinstance(formatting_func, Callable)
         ds_3 = load_dataset("philschmid/guanaco-sharegpt-style", split="train")
         formatting_func = get_formatting_func_from_dataset(ds_3, self.llama_tokenizer)
-        self.assertIsNone(formatting_func)
+        assert formatting_func is None
 
     def test_get_formatting_func_from_dataset_with_unknown_format(self):
         dataset = Dataset.from_dict({"text": "test"})
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
-        self.assertIsNone(formatting_func)
+        assert formatting_func is None
 
 
 class SetupChatFormatTestCase(unittest.TestCase):
@@ -138,15 +130,15 @@ class SetupChatFormatTestCase(unittest.TestCase):
 
         _chatml = ChatMlSpecialTokens()
         # Check if special tokens are correctly set
-        self.assertTrue(modified_tokenizer.eos_token == "<|im_end|>")
-        self.assertTrue(modified_tokenizer.pad_token == "<|im_end|>")
-        self.assertTrue(modified_tokenizer.bos_token == "<|im_start|>")
-        self.assertTrue(modified_tokenizer.eos_token == _chatml.eos_token)
-        self.assertTrue(modified_tokenizer.pad_token == _chatml.pad_token)
-        self.assertTrue(modified_tokenizer.bos_token == _chatml.bos_token)
-        self.assertTrue(len(modified_tokenizer) == original_tokenizer_len + 2)
-        self.assertTrue(self.model.get_input_embeddings().weight.shape[0] % 64 == 0)
-        self.assertTrue(self.model.get_input_embeddings().weight.shape[0] == original_tokenizer_len + 64)
+        assert modified_tokenizer.eos_token == "<|im_end|>"
+        assert modified_tokenizer.pad_token == "<|im_end|>"
+        assert modified_tokenizer.bos_token == "<|im_start|>"
+        assert modified_tokenizer.eos_token == _chatml.eos_token
+        assert modified_tokenizer.pad_token == _chatml.pad_token
+        assert modified_tokenizer.bos_token == _chatml.bos_token
+        assert len(modified_tokenizer) == (original_tokenizer_len + 2)
+        assert (self.model.get_input_embeddings().weight.shape[0] % 64) == 0
+        assert self.model.get_input_embeddings().weight.shape[0] == (original_tokenizer_len + 64)
 
     def test_example_with_setup_model(self):
         modified_model, modified_tokenizer = setup_chat_format(
@@ -160,7 +152,7 @@ class SetupChatFormatTestCase(unittest.TestCase):
         ]
         prompt = modified_tokenizer.apply_chat_template(messages, tokenize=False)
 
-        self.assertEqual(
-            prompt,
-            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n",
+        assert (
+            prompt
+            == "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
         )

--- a/tests/test_dataset_formatting.py
+++ b/tests/test_dataset_formatting.py
@@ -30,26 +30,18 @@ class DatasetFormattingTestCase(unittest.TestCase):
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
         assert isinstance(formatting_func, Callable)
         formatted_text = formatting_func(dataset[0])
-        assert (
-            formatted_text
-            == "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
-        )
+        expected = "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
+        assert formatted_text == expected
         formatted_text = formatting_func(dataset[0:1])
-        assert formatted_text == [
-            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
-        ]
+        assert formatted_text == [expected]
 
         # ChatML tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.chatml_tokenizer)
         formatted_text = formatting_func(dataset[0])
-        assert (
-            formatted_text
-            == "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-        )
+        expected = "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
+        assert formatted_text == expected
         formatted_text = formatting_func(dataset[0:1])
-        assert formatted_text == [
-            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-        ]
+        assert formatted_text == [expected]
 
     def test_get_formatting_func_from_dataset_with_chatml_conversations(self):
         dataset = Dataset.from_dict(
@@ -67,26 +59,18 @@ class DatasetFormattingTestCase(unittest.TestCase):
         formatting_func = get_formatting_func_from_dataset(dataset, self.llama_tokenizer)
         assert isinstance(formatting_func, Callable)
         formatted_text = formatting_func(dataset[0])
-        assert (
-            formatted_text
-            == "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
-        )
+        expected = "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
+        assert formatted_text == expected
         formatted_text = formatting_func(dataset[0:1])
-        assert formatted_text == [
-            "<s>[INST] <<SYS>>\nYou are helpful\n<</SYS>>\n\nHello [/INST] Hi, how can I help you? </s>"
-        ]
+        assert formatted_text == [expected]
 
         # ChatML tokenizer
         formatting_func = get_formatting_func_from_dataset(dataset, self.chatml_tokenizer)
         formatted_text = formatting_func(dataset[0])
-        assert (
-            formatted_text
-            == "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-        )
+        expected = "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
+        assert formatted_text == expected
         formatted_text = formatting_func(dataset[0:1])
-        assert formatted_text == [
-            "<|im_start|>system\nYou are helpful<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\nHi, how can I help you?<|im_end|>\n"
-        ]
+        assert formatted_text == [expected]
 
     def test_get_formatting_func_from_dataset_with_instruction(self):
         dataset = Dataset.from_list(

--- a/tests/test_ddpo_trainer.py
+++ b/tests/test_ddpo_trainer.py
@@ -68,13 +68,13 @@ class DDPOTrainerTester(unittest.TestCase):
         clip_range = 0.0001
         ratio = torch.tensor([1.0])
         loss = self.trainer.loss(advantage, clip_range, ratio)
-        self.assertEqual(loss.item(), 1.0)
+        assert loss.item() == 1.0
 
     def test_generate_samples(self):
         samples, output_pairs = self.trainer._generate_samples(1, 2)
-        self.assertEqual(len(samples), 1)
-        self.assertEqual(len(output_pairs), 1)
-        self.assertEqual(len(output_pairs[0][0]), 2)
+        assert len(samples) == 1
+        assert len(output_pairs) == 1
+        assert len(output_pairs[0][0]) == 2
 
     def test_calculate_loss(self):
         samples, _ = self.trainer._generate_samples(1, 2)
@@ -87,16 +87,16 @@ class DDPOTrainerTester(unittest.TestCase):
         prompt_embeds = sample["prompt_embeds"]
         advantage = torch.tensor([1.0], device=prompt_embeds.device)
 
-        self.assertEqual(latents.shape, (1, 4, 64, 64))
-        self.assertEqual(next_latents.shape, (1, 4, 64, 64))
-        self.assertEqual(log_probs.shape, (1,))
-        self.assertEqual(timesteps.shape, (1,))
-        self.assertEqual(prompt_embeds.shape, (2, 77, 32))
+        assert latents.shape == (1, 4, 64, 64)
+        assert next_latents.shape == (1, 4, 64, 64)
+        assert log_probs.shape == (1,)
+        assert timesteps.shape == (1,)
+        assert prompt_embeds.shape == (2, 77, 32)
         loss, approx_kl, clipfrac = self.trainer.calculate_loss(
             latents, timesteps, next_latents, log_probs, advantage, prompt_embeds
         )
 
-        self.assertTrue(torch.isfinite(loss.cpu()))
+        assert torch.isfinite(loss.cpu())
 
 
 @require_diffusers

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -129,14 +129,14 @@ class DPOTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[-1]["train_loss"] is not None
 
             # check the params have changed
             for n, param in previous_trainable_params.items():
                 new_param = trainer.model.get_parameter(n)
                 # check the params have changed - ignore 0 biases
                 if param.sum() != 0:
-                    self.assertFalse(torch.equal(param, new_param))
+                    assert not torch.equal(param, new_param)
 
     def test_dpo_trainer_without_providing_ref_model(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -167,14 +167,14 @@ class DPOTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[-1]["train_loss"] is not None
 
             # check the params have changed
             for n, param in previous_trainable_params.items():
                 new_param = trainer.model.get_parameter(n)
                 # check the params have changed - ignore 0 biases
                 if param.sum() != 0:
-                    self.assertFalse(torch.equal(param, new_param))
+                    assert not torch.equal(param, new_param)
 
     @require_peft
     @mark.peft_test
@@ -218,7 +218,7 @@ class DPOTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[-1]["train_loss"] is not None
 
             # check the params have changed
             for n, param in previous_trainable_params.items():
@@ -226,7 +226,7 @@ class DPOTrainerTester(unittest.TestCase):
                     new_param = trainer.model.get_parameter(n)
                     # check the params have changed - ignore 0 biases
                     if param.sum() != 0:
-                        self.assertFalse(torch.equal(param, new_param))
+                        assert not torch.equal(param, new_param)
 
     def test_dpo_trainer_padding_token_is_none(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -38,12 +38,12 @@ class TextHistoryTest(unittest.TestCase):
         tokens = torch.tensor([1, 2, 3])
 
         history = TextHistory(text, tokens)
-        self.assertEqual(history.text, text)
-        self.assertTrue(torch.equal(history.tokens, tokens))
-        self.assertTrue(torch.equal(history.token_masks, torch.zeros_like(tokens)))
+        assert history.text == text
+        assert torch.equal(history.tokens, tokens)
+        assert torch.equal(history.token_masks, torch.zeros_like(tokens))
 
         history = TextHistory(text, tokens, system=False)
-        self.assertTrue(torch.equal(history.token_masks, torch.ones_like(tokens)))
+        assert torch.equal(history.token_masks, torch.ones_like(tokens))
 
     def test_text_history_append_segment(self):
         text = "Hello there!"
@@ -51,26 +51,26 @@ class TextHistoryTest(unittest.TestCase):
 
         history = TextHistory(text, tokens)
         history.append_segment("General Kenobi!", torch.tensor([4, 5, 6]), system=False)
-        self.assertEqual(history.text, text + "General Kenobi!")
-        self.assertTrue(torch.equal(history.tokens, torch.tensor([1, 2, 3, 4, 5, 6])))
-        self.assertTrue(torch.equal(history.token_masks, torch.tensor([0, 0, 0, 1, 1, 1])))
+        assert history.text == (text + "General Kenobi!")
+        assert torch.equal(history.tokens, torch.tensor([1, 2, 3, 4, 5, 6]))
+        assert torch.equal(history.token_masks, torch.tensor([0, 0, 0, 1, 1, 1]))
 
         history.append_segment("You are a bold one!", torch.tensor([7, 8, 9]))
-        self.assertEqual(history.text, text + "General Kenobi!" + "You are a bold one!")
-        self.assertTrue(torch.equal(history.tokens, torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9])))
-        self.assertTrue(torch.equal(history.token_masks, torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0])))
+        assert history.text == ((text + "General Kenobi!") + "You are a bold one!")
+        assert torch.equal(history.tokens, torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+        assert torch.equal(history.token_masks, torch.tensor([0, 0, 0, 1, 1, 1, 0, 0, 0]))
 
     def test_text_history_complete(self):
         text = "Hello there!"
         tokens = torch.tensor([1, 2, 3])
         history = TextHistory(text, tokens)
         history.complete()
-        self.assertTrue(history.completed)
-        self.assertFalse(history.truncated)
+        assert history.completed
+        assert not history.truncated
 
         history.complete(truncated=True)
-        self.assertTrue(history.completed)
-        self.assertTrue(history.truncated)
+        assert history.completed
+        assert history.truncated
 
     def test_text_history_last_segment(self):
         text = "Hello there!"
@@ -78,7 +78,7 @@ class TextHistoryTest(unittest.TestCase):
         history = TextHistory(text, tokens)
         history.append_segment("General Kenobi!", torch.tensor([4, 5, 6]))
         history.append_segment("You are a bold one!", torch.tensor([7, 8, 9]))
-        self.assertEqual(history.last_text_segment, "You are a bold one!")
+        assert history.last_text_segment == "You are a bold one!"
 
     def test_text_history_split_query_response(self):
         text = "Hello there!"
@@ -88,9 +88,9 @@ class TextHistoryTest(unittest.TestCase):
         history.append_segment("You are a bold one!", torch.tensor([7, 8, 9]), system=True)
         query, response, mask = history.split_query_response_tokens()
 
-        self.assertTrue(torch.equal(query, torch.tensor([1, 2, 3])))
-        self.assertTrue(torch.equal(response, torch.tensor([4, 5, 6, 7, 8, 9])))
-        self.assertTrue(torch.equal(mask, torch.tensor([1, 1, 1, 0, 0, 0])))
+        assert torch.equal(query, torch.tensor([1, 2, 3]))
+        assert torch.equal(response, torch.tensor([4, 5, 6, 7, 8, 9]))
+        assert torch.equal(mask, torch.tensor([1, 1, 1, 0, 0, 0]))
 
 
 class TextEnvironmentTester(unittest.TestCase):
@@ -112,10 +112,10 @@ class TextEnvironmentTester(unittest.TestCase):
             reward_fn=lambda x: torch.tensor(1),
             prompt="I am a prompt!\n",
         )
-        self.assertEqual(env.prompt, "I am a prompt!\n")
-        self.assertEqual(list(env.tools.keys()), ["DummyTool"])
-        self.assertTrue(isinstance(env.tools["DummyTool"], DummyTool))
-        self.assertEqual(env.reward_fn("Hello there!"), 1)
+        assert env.prompt == "I am a prompt!\n"
+        assert list(env.tools.keys()) == ["DummyTool"]
+        assert isinstance(env.tools["DummyTool"], DummyTool)
+        assert env.reward_fn("Hello there!") == 1
 
     def test_text_environment_generate(self):
         generation_kwargs = {"do_sample": False, "max_new_tokens": 4, "pad_token_id": self.gpt2_tokenizer.eos_token_id}
@@ -138,7 +138,7 @@ class TextEnvironmentTester(unittest.TestCase):
         generations_single = [env._generate_batched([inputs], batch_size=1)[0] for inputs in model_inputs]
         generations_single = self.gpt2_tokenizer.batch_decode(generations_single)
 
-        self.assertEqual(generations_single, generations_batched)
+        assert generations_single == generations_batched
 
     def test_text_environment_tool_call_parsing(self):
         string_valid = "Something something <request><Tool1>Hello there!<call>"
@@ -155,24 +155,24 @@ class TextEnvironmentTester(unittest.TestCase):
             prompt="I am a prompt!\n",
         )
         tool, response = env.parse_tool_call(string_valid)
-        self.assertEqual(tool, "Tool1")
-        self.assertEqual(response, "Hello there!")
+        assert tool == "Tool1"
+        assert response == "Hello there!"
 
         tool, response = env.parse_tool_call(string_invalid_request)
-        self.assertEqual(tool, None)
-        self.assertEqual(response, None)
+        assert tool is None
+        assert response is None
 
         tool, response = env.parse_tool_call(string_invalid_call)
-        self.assertEqual(tool, None)
-        self.assertEqual(response, None)
+        assert tool is None
+        assert response is None
 
         tool, response = env.parse_tool_call(string_invalid_tool)
-        self.assertEqual(tool, None)
-        self.assertEqual(response, None)
+        assert tool is None
+        assert response is None
 
         tool, response = env.parse_tool_call(string_invalid_random)
-        self.assertEqual(tool, None)
-        self.assertEqual(response, None)
+        assert tool is None
+        assert response is None
 
     def test_text_environment_tool_truncation(self):
         env = TextEnvironment(
@@ -185,19 +185,19 @@ class TextEnvironmentTester(unittest.TestCase):
 
         env.max_tool_response = 100
         history = env.step(TextHistory("<request><dummy>Hello there!<call>", torch.tensor([1, 2, 3])))
-        self.assertEqual(len(history.last_text_segment) - len(env.response_token), 100)
+        assert (len(history.last_text_segment) - len(env.response_token)) == 100
 
         env.max_tool_response = 500
         history = env.step(TextHistory("<request><dummy>Hello there!<call>", torch.tensor([1, 2, 3])))
-        self.assertEqual(len(history.last_text_segment) - len(env.response_token), 500)
+        assert (len(history.last_text_segment) - len(env.response_token)) == 500
 
         env.max_tool_response = 1001
         history = env.step(TextHistory("<request><dummy>Hello there!<call>", torch.tensor([1, 2, 3])))
-        self.assertEqual(len(history.last_text_segment) - len(env.response_token), 1000)
+        assert (len(history.last_text_segment) - len(env.response_token)) == 1000
 
         env.max_tool_response = 2000
         history = env.step(TextHistory("<request><dummy>Hello there!<call>", torch.tensor([1, 2, 3])))
-        self.assertEqual(len(history.last_text_segment) - len(env.response_token), 1000)
+        assert (len(history.last_text_segment) - len(env.response_token)) == 1000
 
     @patch.object(TextEnvironment, "generate", side_effect=dummy_generate)
     def test_text_environment_max_calls(self, mock_generate):
@@ -211,20 +211,20 @@ class TextEnvironmentTester(unittest.TestCase):
 
         env.max_turns = 1
         _, _, _, _, histories = env.run(["test"])
-        self.assertEqual(
-            histories[0].text, "I am a prompt!\n" + "test" + 1 * "<request><DummyTool>test<call>test<response>"
+        assert histories[0].text == (
+            ("I am a prompt!\n" + "test") + (1 * "<request><DummyTool>test<call>test<response>")
         )
 
         env.max_turns = 2
         _, _, _, _, histories = env.run(["test"])
-        self.assertEqual(
-            histories[0].text, "I am a prompt!\n" + "test" + 2 * "<request><DummyTool>test<call>test<response>"
+        assert histories[0].text == (
+            ("I am a prompt!\n" + "test") + (2 * "<request><DummyTool>test<call>test<response>")
         )
 
         env.max_turns = 4
         _, _, _, _, histories = env.run(["test"])
-        self.assertEqual(
-            histories[0].text, "I am a prompt!\n" + "test" + 4 * "<request><DummyTool>test<call>test<response>"
+        assert histories[0].text == (
+            ("I am a prompt!\n" + "test") + (4 * "<request><DummyTool>test<call>test<response>")
         )
 
     def test_text_environment_compute_rewards(self):
@@ -240,7 +240,7 @@ class TextEnvironmentTester(unittest.TestCase):
         histories = env.compute_reward(histories)
 
         for i in range(8):
-            self.assertEqual(histories[i].reward, i)
+            assert histories[i].reward == i
 
     @patch.object(TextEnvironment, "generate", side_effect=dummy_generate)
     def test_text_environment_run(self, mock_generate):
@@ -256,18 +256,20 @@ class TextEnvironmentTester(unittest.TestCase):
         task_2 = "Hello there! General Kenobi!"
 
         query, response, response_mask, reward, histories = env.run([task_1, task_2])
-        self.assertEqual(len(query[0]), 9)
-        self.assertEqual(len(query[1]), 12)
-        self.assertEqual(len(response[0]), 14)
-        self.assertEqual(len(response[1]), 14)
-        self.assertEqual(response_mask[0].sum(), 2 * 3)  # mocked generate always adds 3 toknes
-        self.assertEqual(response_mask[1].sum(), 2 * 3)  # mocked generate always adds 3 toknes
-        self.assertEqual(reward[0], 0)
-        self.assertEqual(reward[1], 1)
-        self.assertEqual(
-            histories[0].text, "I am a prompt!\n" + "Hello there!" + 2 * "<request><DummyTool>test<call>test<response>"
+        assert len(query[0]) == 9
+        assert len(query[1]) == 12
+        assert len(response[0]) == 14
+        assert len(response[1]) == 14
+        assert response_mask[0].sum() == (2 * 3)
+        # mocked generate always adds 3 toknes
+        assert response_mask[1].sum() == (2 * 3)
+        # mocked generate always adds 3 toknes
+        assert reward[0] == 0
+        assert reward[1] == 1
+        assert histories[0].text == (
+            ("I am a prompt!\n" + "Hello there!") + (2 * "<request><DummyTool>test<call>test<response>")
         )
-        self.assertEqual(
-            histories[1].text,
-            "I am a prompt!\n" + "Hello there! General Kenobi!" + 2 * "<request><DummyTool>test<call>test<response>",
+        assert histories[1].text == (
+            ("I am a prompt!\n" + "Hello there! General Kenobi!")
+            + (2 * "<request><DummyTool>test<call>test<response>")
         )

--- a/tests/test_no_peft.py
+++ b/tests/test_no_peft.py
@@ -15,6 +15,7 @@ import sys
 import unittest
 from unittest.mock import patch
 
+import pytest
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -93,7 +94,7 @@ class TestPeftDependancy(unittest.TestCase):
             from trl import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValueHead
 
             # Check that loading a model with `peft` will raise an error
-            with self.assertRaises(ModuleNotFoundError):
+            with pytest.raises(ModuleNotFoundError):
                 import peft  # noqa
 
             trl_model = AutoModelForCausalLMWithValueHead.from_pretrained(self.causal_lm_model_id)  # noqa
@@ -146,8 +147,8 @@ class TestPeftDependancy(unittest.TestCase):
             # check gradients are not None
             for _, param in trl_model.named_parameters():
                 if param.requires_grad:
-                    self.assertIsNotNone(param.grad)
+                    assert param.grad is not None
 
             # check expected stats
             for stat in EXPECTED_STATS:
-                self.assertIn(stat, train_stats)
+                assert stat in train_stats

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -594,8 +594,8 @@ class PPOTrainerTester(unittest.TestCase):
             returns[idx].unsqueeze(0),
         )
 
-        assert round(pg_loss.item() - 2.0494, 7) >= 0, 4
-        assert round(v_loss.item() - 0.0711, 7) >= 0, 4
+        assert abs(pg_loss.item() - 2.0494) < 0.0001
+        assert abs(v_loss.item() - 0.0711) < 0.0001
 
         # check if we get same results with masked parts removed
         pg_loss_unmasked, v_loss_unmasked, _ = ppo_trainer.loss(
@@ -608,8 +608,8 @@ class PPOTrainerTester(unittest.TestCase):
             apply_mask(advantages[idx], mask[idx]).unsqueeze(0),
             apply_mask(returns[idx], mask[idx]).unsqueeze(0),
         )
-        assert round(pg_loss_unmasked.item() - 2.0494, 7) >= 0, 4
-        assert round(v_loss_unmasked.item() - 0.0711, 7) >= 0, 4
+        assert abs(pg_loss_unmasked.item() - 2.0494) < 0.0001
+        assert abs(v_loss_unmasked.item() - 0.0711) < 0.0001
 
     @parameterized.expand(
         [

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -180,7 +180,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
         dummy_dataloader = ppo_trainer.dataloader
 
-        self.assertEqual(len(dummy_dataloader), 0)
+        assert len(dummy_dataloader) == 0
 
     def test_ppo_step(self):
         # initialize dataset
@@ -256,7 +256,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
         dummy_dataloader = ppo_trainer.dataloader
 
-        self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
+        assert isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD)
 
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -268,11 +268,11 @@ class PPOTrainerTester(unittest.TestCase):
             break
 
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
         # Finally check stats
         for stat in EXPECTED_STATS:
@@ -295,8 +295,8 @@ class PPOTrainerTester(unittest.TestCase):
         )
         dummy_dataloader = ppo_trainer.dataloader
 
-        self.assertTrue(isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD))
-        self.assertTrue(isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR))
+        assert isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD)
+        assert isinstance(ppo_trainer.lr_scheduler.scheduler, torch.optim.lr_scheduler.ExponentialLR)
 
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -309,18 +309,18 @@ class PPOTrainerTester(unittest.TestCase):
             break
 
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
         # Finally check stats
         for stat in EXPECTED_STATS:
             assert stat in train_stats.keys()
 
         # assert that the LR has increased for exponential decay
-        self.assertTrue(train_stats["ppo/learning_rate"] > self.ppo_config.learning_rate)
+        assert train_stats["ppo/learning_rate"] > self.ppo_config.learning_rate
 
     def test_ppo_step_with_no_ref(self):
         # initialize dataset
@@ -345,11 +345,11 @@ class PPOTrainerTester(unittest.TestCase):
             break
 
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
         # initialize a new gpt2 model:
         model = AutoModelForCausalLMWithValueHead.from_pretrained(self.model_id)
@@ -357,10 +357,9 @@ class PPOTrainerTester(unittest.TestCase):
             if "v_head" not in name:
                 name = name.replace("pretrained_model.", "")
 
-                self.assertTrue(
-                    torch.allclose(param.cpu(), model.state_dict()[name].cpu()),
-                    f"Parameter {name} has changed from the original model",
-                )
+                assert torch.allclose(
+                    param.cpu(), model.state_dict()[name].cpu()
+                ), f"Parameter {name} has changed from the original model"
 
         # Finally check stats
         for stat in EXPECTED_STATS:
@@ -402,15 +401,15 @@ class PPOTrainerTester(unittest.TestCase):
             if re.match(pattern, name):
                 layer_number = int(re.match(pattern, name).groups(0)[0])
                 if layer_number < num_shared_layers:
-                    self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+                    assert param.grad is None, f"Parameter {name} has a gradient"
                 else:
-                    self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+                    assert param.grad is not None, f"Parameter {name} has no gradient"
             elif any([layer in name for layer in final_layers]):
-                self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+                assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
         for stat in EXPECTED_STATS:
             assert stat in train_stats.keys()
@@ -459,7 +458,7 @@ class PPOTrainerTester(unittest.TestCase):
             # (this could be any reward such as human feedback or output from another model)
             reward = [torch.tensor([[1.0]]), torch.tensor([[0.0]])]
             # train model - this should raise an error
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 _ = ppo_trainer.step([q for q in query_tensor], [r for r in response_tensor], reward)
 
             reward = [torch.tensor([1.0]), torch.tensor([0.0])]
@@ -469,11 +468,11 @@ class PPOTrainerTester(unittest.TestCase):
 
         # check if the gradients are computed for the model
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
     def test_ppo_step_input_shape(self):
         """
@@ -502,13 +501,13 @@ class PPOTrainerTester(unittest.TestCase):
                 bs, [q for q in query_tensor], [r for r in response_tensor], reward
             )
 
-            self.assertTrue(isinstance(queries, list), f"queries should be a list, got {type(queries)}")
-            self.assertTrue(isinstance(responses, list), f"responses should be a list, got {type(responses)}")
+            assert isinstance(queries, list), f"queries should be a list, got {type(queries)}"
+            assert isinstance(responses, list), f"responses should be a list, got {type(responses)}"
 
             # check the shapes
             for i in range(bs):
-                self.assertEqual(queries[i].shape, torch.Size([7]))
-                self.assertEqual(responses[i].size(), torch.Size([7]))
+                assert queries[i].shape == torch.Size([7])
+                assert responses[i].size() == torch.Size([7])
             break
 
     def test_ppo_step_no_dataset(self):
@@ -536,15 +535,15 @@ class PPOTrainerTester(unittest.TestCase):
 
         # check gradients
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
+            assert param.grad is not None, f"Parameter {name} has no gradient"
 
         # ref model should not be trained
         for name, param in ppo_trainer.ref_model.named_parameters():
-            self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+            assert param.grad is None, f"Parameter {name} has a gradient"
 
         # check train stats
         for stat in EXPECTED_STATS:
-            self.assertTrue(stat in train_stats, f"Train stats should contain {stat}")
+            assert stat in train_stats, f"Train stats should contain {stat}"
 
     def test_loss_trainer(self):
         """
@@ -595,8 +594,8 @@ class PPOTrainerTester(unittest.TestCase):
             returns[idx].unsqueeze(0),
         )
 
-        self.assertAlmostEqual(pg_loss.item(), 2.0494, 4)
-        self.assertAlmostEqual(v_loss.item(), 0.07110, 4)
+        assert round(pg_loss.item() - 2.0494, 7) >= 0, 4
+        assert round(v_loss.item() - 0.0711, 7) >= 0, 4
 
         # check if we get same results with masked parts removed
         pg_loss_unmasked, v_loss_unmasked, _ = ppo_trainer.loss(
@@ -609,8 +608,8 @@ class PPOTrainerTester(unittest.TestCase):
             apply_mask(advantages[idx], mask[idx]).unsqueeze(0),
             apply_mask(returns[idx], mask[idx]).unsqueeze(0),
         )
-        self.assertAlmostEqual(pg_loss_unmasked.item(), 2.0494, 4)
-        self.assertAlmostEqual(v_loss_unmasked.item(), 0.07110, 4)
+        assert round(pg_loss_unmasked.item() - 2.0494, 7) >= 0, 4
+        assert round(v_loss_unmasked.item() - 0.0711, 7) >= 0, 4
 
     @parameterized.expand(
         [
@@ -674,11 +673,11 @@ class PPOTrainerTester(unittest.TestCase):
             model, dummy_queries, dummy_responses, model_inputs
         )
 
-        self.assertLessEqual(abs_diff_masked_tensors(logprobs_1, logprobs_2, mask_1, mask_2), 1e-4)
-        self.assertLessEqual(abs_diff_masked_tensors(values_1, values_2, mask_1, mask_2), 1e-4)
+        assert abs_diff_masked_tensors(logprobs_1, logprobs_2, mask_1, mask_2) <= 0.0001
+        assert abs_diff_masked_tensors(values_1, values_2, mask_1, mask_2) <= 0.0001
 
-        self.assertLessEqual(abs_diff_masked_tensors(logprobs_0, logprobs_2[:1], mask_0, mask_2[:1]), 1e-4)
-        self.assertLessEqual(abs_diff_masked_tensors(values_0, values_2[:1], mask_0, mask_2[:1]), 1e-4)
+        assert abs_diff_masked_tensors(logprobs_0, logprobs_2[:1], mask_0, mask_2[:1]) <= 0.0001
+        assert abs_diff_masked_tensors(values_0, values_2[:1], mask_0, mask_2[:1]) <= 0.0001
 
     def test_ppo_trainer_max_grad_norm(self):
         """
@@ -709,11 +708,10 @@ class PPOTrainerTester(unittest.TestCase):
 
         # check gradients
         for name, param in ppo_trainer.model.named_parameters():
-            self.assertTrue(param.grad is not None, f"Parameter {name} has no gradient")
-            self.assertTrue(
-                torch.all(param.grad.abs() <= self.ppo_config.max_grad_norm),
-                f"Parameter {name} has a gradient larger than max_grad_norm",
-            )
+            assert param.grad is not None, f"Parameter {name} has no gradient"
+            assert torch.all(
+                param.grad.abs() <= self.ppo_config.max_grad_norm
+            ), f"Parameter {name} has a gradient larger than max_grad_norm"
 
     def test_ppo_trainer_kl_penalty(self):
         dummy_dataset = self._init_dummy_dataset()
@@ -730,7 +728,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
 
         expected_output = torch.Tensor([[0.1000, -0.1000, 0.1000], [-0.1000, 0.1000, -0.2000]])
-        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        assert torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output)
 
         self.ppo_config.kl_penalty = "abs"
         ppo_trainer = PPOTrainer(
@@ -742,7 +740,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
 
         expected_output = torch.Tensor([[0.1000, 0.1000, 0.1000], [0.1000, 0.1000, 0.2000]])
-        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        assert torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output)
 
         self.ppo_config.kl_penalty = "mse"
         ppo_trainer = PPOTrainer(
@@ -754,7 +752,7 @@ class PPOTrainerTester(unittest.TestCase):
         )
 
         expected_output = torch.Tensor([[0.0050, 0.0050, 0.0050], [0.0050, 0.0050, 0.0200]])
-        self.assertTrue(torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output))
+        assert torch.allclose(ppo_trainer._kl_penalty(log_probs, ref_log_probs), expected_output)
 
     def test_ppo_trainer_full_kl_penalty(self):
         # a few more extensive tests for the full kl option as it is more involved
@@ -793,8 +791,8 @@ class PPOTrainerTester(unittest.TestCase):
             [[0.0, 0.0]],
         )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1, 2))
-        self.assertTrue(torch.allclose(output, expected_output))
+        assert output.shape == (1, 2)
+        assert torch.allclose(output, expected_output)
 
         # test for when the two dists are almost not overlapping
         log_probs = torch.Tensor(
@@ -819,8 +817,8 @@ class PPOTrainerTester(unittest.TestCase):
             [[4.4474, 4.4474]],
         )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1, 2))
-        self.assertTrue(torch.allclose(output, expected_output))
+        assert output.shape == (1, 2)
+        assert torch.allclose(output, expected_output)
 
         # test for when the two dists are almost not overlapping
         log_probs = torch.Tensor(
@@ -845,8 +843,8 @@ class PPOTrainerTester(unittest.TestCase):
             [[3.7361, 0.0]],
         )
         output = ppo_trainer._kl_penalty(log_probs, ref_log_probs)
-        self.assertTrue(output.shape == (1, 2))
-        self.assertTrue(torch.allclose(output, expected_output, atol=1e-4))
+        assert output.shape == (1, 2)
+        assert torch.allclose(output, expected_output, atol=0.0001)
 
     @require_peft
     @mark.peft_test
@@ -884,7 +882,7 @@ class PPOTrainerTester(unittest.TestCase):
             dataset=dummy_dataset,
         )
 
-        self.assertTrue(ppo_trainer.ref_model is None)
+        assert ppo_trainer.ref_model is None
 
         dummy_dataloader = ppo_trainer.dataloader
 
@@ -904,9 +902,9 @@ class PPOTrainerTester(unittest.TestCase):
         # check gradients
         for name, param in model.named_parameters():
             if "lora" in name or "v_head" in name:
-                self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
+                assert param.grad is not None, f"Parameter {name} has a no gradient"
             else:
-                self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+                assert param.grad is None, f"Parameter {name} has a gradient"
 
     @require_peft
     @mark.peft_test
@@ -972,7 +970,7 @@ class PPOTrainerTester(unittest.TestCase):
                 dataset=dummy_dataset,
             )
 
-            self.assertTrue(ppo_trainer.ref_model is None)
+            assert ppo_trainer.ref_model is None
 
             dummy_dataloader = ppo_trainer.dataloader
 
@@ -990,15 +988,15 @@ class PPOTrainerTester(unittest.TestCase):
                 break
 
             new_logits = ppo_trainer.model.compute_reward_score(dummy_inputs)
-            self.assertTrue(not torch.allclose(previous_rm_logits, new_logits[:, -1, :]))
-            self.assertTrue(torch.allclose(original_rm_logits, new_logits[:, -1, :]))
+            assert not torch.allclose(previous_rm_logits, new_logits[:, -1, :])
+            assert torch.allclose(original_rm_logits, new_logits[:, -1, :])
 
             # check gradients
             for name, param in model.named_parameters():
                 if ("lora" in name or "v_head" in name) and ("reward" not in name):
-                    self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
+                    assert param.grad is not None, f"Parameter {name} has a no gradient"
                 else:
-                    self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+                    assert param.grad is None, f"Parameter {name} has a gradient"
 
     @unittest.skip("Fix by either patching `whomai()` to work in the staging endpoint or use a dummy prod user.")
     def test_push_to_hub(self):
@@ -1016,10 +1014,10 @@ class PPOTrainerTester(unittest.TestCase):
             url = ppo_trainer.push_to_hub(repo_id=repo_id, token=self._token, api_endpoint=CI_HUB_ENDPOINT)
             # Extract repo_name from the url
             re_search = re.search(CI_HUB_ENDPOINT + r"/([^/]+/[^/]+)/", url)
-            self.assertTrue(re_search is not None)
+            assert re_search is not None
             hub_repo_id = re_search.groups()[0]
             # Check we created a Hub repo
-            self.assertEqual(hub_repo_id, repo_id)
+            assert hub_repo_id == repo_id
             # Ensure all files are present
             files = sorted(self._api.list_repo_files(hub_repo_id))
             assert all(
@@ -1057,7 +1055,7 @@ class PPOTrainerTester(unittest.TestCase):
             "gpt2", device_map="balanced", max_memory={0: "500MB", 1: "500MB"}
         )
 
-        self.assertTrue(set(gpt2_model.hf_device_map.values()) == {0, 1})
+        assert set(gpt2_model.hf_device_map.values()) == {0, 1}
 
         # this line is very important
         def make_inputs_require_grad(module, input, output):
@@ -1068,7 +1066,7 @@ class PPOTrainerTester(unittest.TestCase):
         peft_model = get_peft_model(gpt2_model, lora_config)
         model = AutoModelForCausalLMWithValueHead.from_pretrained(peft_model)
 
-        self.assertTrue(model.is_sequential_parallel)
+        assert model.is_sequential_parallel
 
         dummy_dataset = self._init_dummy_dataset()
         self.ppo_config.batch_size = 2
@@ -1082,7 +1080,7 @@ class PPOTrainerTester(unittest.TestCase):
             dataset=dummy_dataset,
         )
 
-        self.assertTrue(ppo_trainer.ref_model is None)
+        assert ppo_trainer.ref_model is None
 
         dummy_dataloader = ppo_trainer.dataloader
 
@@ -1102,9 +1100,9 @@ class PPOTrainerTester(unittest.TestCase):
         # check gradients
         for name, param in model.named_parameters():
             if "lora" in name or "v_head" in name:
-                self.assertTrue(param.grad is not None, f"Parameter {name} has a no gradient")
+                assert param.grad is not None, f"Parameter {name} has a no gradient"
             else:
-                self.assertTrue(param.grad is None, f"Parameter {name} has a gradient")
+                assert param.grad is None, f"Parameter {name} has a gradient"
 
     def test_generation(self):
         dummy_dataset = self._init_dummy_dataset()
@@ -1134,7 +1132,7 @@ class PPOTrainerTester(unittest.TestCase):
         generations_single = [ppo_trainer.generate(inputs, **generation_kwargs).squeeze() for inputs in model_inputs]
         generations_single = tokenizer.batch_decode(generations_single)
 
-        self.assertEqual(generations_single, generations_batched)
+        assert generations_single == generations_batched
 
     def test_grad_accumulation(self):
         dummy_dataset = self._init_dummy_dataset()
@@ -1190,7 +1188,7 @@ class PPOTrainerTester(unittest.TestCase):
             break
 
         model_grad_acc = gpt2_model_clone.v_head.summary.weight
-        self.assertTrue(torch.allclose(model_grad_acc, model_grad, rtol=1e-3, atol=1e-3))
+        assert torch.allclose(model_grad_acc, model_grad, rtol=0.001, atol=0.001)
 
     @unittest.skip("Fix by either patching `whomai()` to work in the staging endpoint or use a dummy prod user.")
     def test_push_to_hub_if_best_reward(self):

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -52,9 +52,9 @@ class RewardTrainerTester(unittest.TestCase):
             # fmt: off
             dummy_dataset_dict = {
                 "input_ids_chosen": [
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
                 ],
                 "attention_mask_chosen": [
@@ -64,9 +64,9 @@ class RewardTrainerTester(unittest.TestCase):
                     torch.LongTensor([1, 0]),
                 ],
                 "input_ids_rejected": [
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
                 ],
                 "attention_mask_rejected": [
@@ -132,9 +132,9 @@ class RewardTrainerTester(unittest.TestCase):
             # fmt: off
             dummy_dataset_dict = {
                 "input_ids_chosen": [
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
                 ],
                 "attention_mask_chosen": [
@@ -144,9 +144,9 @@ class RewardTrainerTester(unittest.TestCase):
                     torch.LongTensor([1, 0]),
                 ],
                 "input_ids_rejected": [
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
                 ],
                 "attention_mask_rejected": [
@@ -206,12 +206,12 @@ class RewardTrainerTester(unittest.TestCase):
                 remove_unused_columns=False,
             )
 
+            # fmt: off
             dummy_dataset_dict = {
-                # fmt: off
                 "input_ids_b": [
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                     torch.LongTensor([1, 2]),
                 ],
                 "attention_mask_c": [
@@ -221,9 +221,9 @@ class RewardTrainerTester(unittest.TestCase):
                     torch.LongTensor([1, 0]),
                 ],
                 "input_ids_f": [
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                     torch.LongTensor([1, 2, 0]),
                 ],
                 "attention_mask_g": [
@@ -232,8 +232,8 @@ class RewardTrainerTester(unittest.TestCase):
                     torch.LongTensor([1, 1]),
                     torch.LongTensor([1, 1, 1]),
                 ],
-                # fmt: on
             }
+            # fmt: on
             dummy_dataset = Dataset.from_dict(dummy_dataset_dict)
 
             trainer = RewardTrainer(
@@ -276,13 +276,13 @@ class RewardTrainerTester(unittest.TestCase):
             # fmt: off
             dummy_dataset_dict = {
                 "input_ids_chosen": [
-                    torch.LongTensor([0, 1, 2,]),
+                    torch.LongTensor([0, 1, 2]),
                 ],
                 "attention_mask_chosen": [
                     torch.LongTensor([1, 1, 1]),
                 ],
                 "input_ids_rejected": [
-                    torch.LongTensor([0, 2,]),
+                    torch.LongTensor([0, 2]),
                 ],
                 "attention_mask_rejected": [
                     torch.LongTensor([1, 1]),

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -307,15 +307,8 @@ class RewardTrainerTester(unittest.TestCase):
             batch = trainer.data_collator(batch)
             loss, outputs = trainer.compute_loss(trainer.model, batch, return_outputs=True)
 
-            assert (
-                round(
-                    loss
-                    - (
-                        -torch.nn.functional.logsigmoid(
-                            (outputs["rewards_chosen"] - outputs["rewards_rejected"]) - batch["margin"]
-                        ).mean()
-                    ),
-                    7,
-                )
-                >= 0
-            )
+            l_val = -torch.nn.functional.logsigmoid(
+                outputs["rewards_chosen"] - outputs["rewards_rejected"] - batch["margin"]
+            ).mean()
+
+            assert abs(loss - l_val) < 1e-6

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import pytest
 import torch
 from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
@@ -148,18 +149,18 @@ class SFTTrainerTester(unittest.TestCase):
             formatting_func=formatting_prompts_func,
         )
 
-        self.assertTrue(len(formatted_dataset) == len(self.dummy_dataset))
-        self.assertTrue(len(formatted_dataset) > 0)
+        assert len(formatted_dataset) == len(self.dummy_dataset)
+        assert len(formatted_dataset) > 0
 
         for example in formatted_dataset:
-            self.assertTrue("input_ids" in example)
-            self.assertTrue("labels" in example)
+            assert "input_ids" in example
+            assert "labels" in example
 
-            self.assertTrue(len(example["input_ids"]) == formatted_dataset.seq_length)
-            self.assertTrue(len(example["labels"]) == formatted_dataset.seq_length)
+            assert len(example["input_ids"]) == formatted_dataset.seq_length
+            assert len(example["labels"]) == formatted_dataset.seq_length
 
             decoded_text = self.tokenizer.decode(example["input_ids"])
-            self.assertTrue(("Question" in decoded_text) and ("Answer" in decoded_text))
+            assert ("Question" in decoded_text) and ("Answer" in decoded_text)
 
     def test_sft_trainer(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -183,10 +184,10 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
     def test_sft_trainer_uncorrect_data(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -200,7 +201,7 @@ class SFTTrainerTester(unittest.TestCase):
                 per_device_train_batch_size=2,
             )
 
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 _ = SFTTrainer(
                     model=self.model,
                     args=training_args,
@@ -246,7 +247,7 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 # This should not work because not enough data for one sample
                 _ = SFTTrainer(
                     model=self.model,
@@ -258,7 +259,7 @@ class SFTTrainerTester(unittest.TestCase):
                 )
 
             # This should not work as well
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 _ = SFTTrainer(
                     model=self.model,
                     args=training_args,
@@ -299,10 +300,10 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
@@ -327,9 +328,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
@@ -352,9 +353,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1")
 
     def test_sft_trainer_with_model(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -378,10 +379,10 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
@@ -405,9 +406,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         # with formatting_func + packed
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -432,9 +433,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         # with formatting_func + packed
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -457,9 +458,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
@@ -481,9 +482,9 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1")
 
     def test_sft_trainer_with_multiple_eval_datasets(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -510,11 +511,11 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_data1_loss"])
-            self.assertIsNotNone(trainer.state.log_history[1]["eval_data2_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_data1_loss"] is not None
+            assert trainer.state.log_history[1]["eval_data2_loss"] is not None
 
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1")
 
     def test_data_collator_completion_lm(self):
         response_template = "### Response:\n"
@@ -529,7 +530,7 @@ class SFTTrainerTester(unittest.TestCase):
         labels = batch["labels"]
         last_pad_idx = np.where(labels == -100)[1][-1]
         result_text = self.tokenizer.decode(batch["input_ids"][0, last_pad_idx + 1 :])
-        self.assertEqual(result_text, "I have not been masked correctly.")
+        assert result_text == "I have not been masked correctly."
 
     def test_data_collator_completion_lm_with_multiple_text(self):
         tokenizer = copy.deepcopy(self.tokenizer)
@@ -552,7 +553,7 @@ class SFTTrainerTester(unittest.TestCase):
             labels = batch["labels"][i]
             last_pad_idx = np.where(labels == -100)[0][-1]
             result_text = tokenizer.decode(batch["input_ids"][i, last_pad_idx + 1 :])
-            self.assertEqual(result_text, "I have not been masked correctly.")
+            assert result_text == "I have not been masked correctly."
 
     def test_data_collator_chat_completion_lm(self):
         instruction_template = "### Human:"
@@ -573,7 +574,7 @@ class SFTTrainerTester(unittest.TestCase):
         labels = batch["labels"]
         non_masked_tokens = batch["input_ids"][labels != -100]
         result_text = self.tokenizer.decode(non_masked_tokens)
-        self.assertEqual(result_text, " I should not be masked. I should not be masked too.")
+        assert result_text == " I should not be masked. I should not be masked too."
 
     def test_data_collator_chat_completion_lm_with_multiple_text(self):
         tokenizer = copy.deepcopy(self.tokenizer)
@@ -601,11 +602,11 @@ class SFTTrainerTester(unittest.TestCase):
 
         non_masked_tokens1 = input_ids[0][labels[0] != -100]
         result_text1 = tokenizer.decode(non_masked_tokens1)
-        self.assertEqual(result_text1, " I should not be masked.")
+        assert result_text1 == " I should not be masked."
 
         non_masked_tokens2 = input_ids[1][labels[1] != -100]
         result_text2 = tokenizer.decode(non_masked_tokens2)
-        self.assertEqual(result_text2, " I should not be masked. I should not be masked too.")
+        assert result_text2 == " I should not be masked. I should not be masked too."
 
     def test_sft_trainer_infinite_with_model(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -628,15 +629,15 @@ class SFTTrainerTester(unittest.TestCase):
                 max_seq_length=500,
             )
 
-            self.assertTrue(trainer.train_dataset.infinite)
+            assert trainer.train_dataset.infinite
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
             # make sure the trainer did 5 steps
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-5"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-5")
 
     def test_sft_trainer_infinite_with_model_epochs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -657,14 +658,14 @@ class SFTTrainerTester(unittest.TestCase):
                 max_seq_length=500,
             )
 
-            self.assertFalse(trainer.train_dataset.infinite)
+            assert not trainer.train_dataset.infinite
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
 
             # make sure the trainer did 5 steps
-            self.assertTrue("model.safetensors" in os.listdir(tmp_dir + "/checkpoint-4"))
+            assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-4")
 
     def test_sft_trainer_with_model_neftune(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -698,8 +699,8 @@ class SFTTrainerTester(unittest.TestCase):
             torch.random.manual_seed(24)
             embeds_neftune_2 = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
 
-            self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
-            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
+            assert not torch.allclose(embeds_neftune, embeds_neftune_2)
+            assert len(trainer.model.get_input_embeddings()._forward_hooks) > 0
 
             trainer.neftune_hook_handle.remove()
 
@@ -707,7 +708,7 @@ class SFTTrainerTester(unittest.TestCase):
 
             # Make sure forward pass works fine
             _ = trainer.model(torch.LongTensor([[1, 0, 1]]).to(device))
-            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) == 0)
+            assert len(trainer.model.get_input_embeddings()._forward_hooks) == 0
 
     @require_peft
     def test_peft_sft_trainer_str(self):
@@ -758,16 +759,16 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2")
 
     @require_peft
     def test_peft_sft_trainer_gc(self):
@@ -800,16 +801,16 @@ class SFTTrainerTester(unittest.TestCase):
                 packing=True,
             )
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2")
 
     @require_peft
     def test_peft_sft_trainer_neftune(self):
@@ -844,7 +845,7 @@ class SFTTrainerTester(unittest.TestCase):
 
             trainer.model = trainer._trl_activate_neftune(trainer.model)
 
-            self.assertTrue(isinstance(trainer.model, PeftModel))
+            assert isinstance(trainer.model, PeftModel)
 
             device = trainer.model.get_input_embeddings().weight.device
             trainer.model.train()
@@ -855,20 +856,20 @@ class SFTTrainerTester(unittest.TestCase):
             torch.random.manual_seed(24)
             embeds_neftune_2 = trainer.model.get_input_embeddings()(torch.LongTensor([[1, 0, 1]]).to(device))
 
-            self.assertFalse(torch.allclose(embeds_neftune, embeds_neftune_2))
-            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) > 0)
+            assert not torch.allclose(embeds_neftune, embeds_neftune_2)
+            assert len(trainer.model.get_input_embeddings()._forward_hooks) > 0
 
             trainer.neftune_hook_handle.remove()
 
             trainer.train()
 
-            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
+            assert trainer.state.log_history[(-1)]["train_loss"] is not None
+            assert trainer.state.log_history[0]["eval_loss"] is not None
 
-            self.assertTrue("adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2"))
-            self.assertTrue("model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2"))
+            assert "adapter_model.safetensors" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "adapter_config.json" in os.listdir(tmp_dir + "/checkpoint-2")
+            assert "model.safetensors" not in os.listdir(tmp_dir + "/checkpoint-2")
 
             # Make sure forward pass works fine to check if embeddings forward is not broken.
             _ = trainer.model(torch.LongTensor([[1, 0, 1]]).to(device))
-            self.assertTrue(len(trainer.model.get_input_embeddings()._forward_hooks) == 0)
+            assert len(trainer.model.get_input_embeddings()._forward_hooks) == 0


### PR DESCRIPTION
This PR runs https://github.com/akx/codemod-unittest-to-pytest-asserts to rewrite Unittest `self.assert...` assertions as plain assertions that can be introspected by Pytest's [assert rewriting](https://docs.pytest.org/en/7.1.x/how-to/assert.html).