### PR TITLE
Token-level rewards

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -459,7 +459,6 @@ class PPOTrainerTester(unittest.TestCase):
         for query_tensor, response_tensor in dummy_dataloader:
             # define a reward for response
             # (this could be any reward such as human feedback or output from another model)
-            # reward = [torch.tensor([[1.0]]), torch.tensor([[0.0]])]
             reward = [torch.tensor([1.0, 2.0, 3.0]), torch.tensor([[0.0, 1.0]])]
             # train model - this should raise an error
             with self.assertRaises(ValueError):
@@ -575,7 +574,6 @@ class PPOTrainerTester(unittest.TestCase):
 
         dummy_queries = [torch.tensor([1, 2, 3, 4]), torch.tensor([1, 2, 3, 4, 5, 6, 7])]
         dummy_responses = [torch.tensor([5, 6, 7, 8, 9]), torch.tensor([8, 9, 10, 11, 12, 13])]
-        # dummy_scores = torch.Tensor([1, 2])
         dummy_scores = [
             torch.tensor([0, 0, 0, 0, 1], device=ppo_trainer.current_device),
             torch.tensor([0, 0, 0, 0, 0, 2], device=ppo_trainer.current_device),

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -142,10 +142,10 @@ class PPOTrainer(BaseTrainer):
 
     def __init__(
         self,
-        config: PPOConfig = None,
-        model: PreTrainedModelWrapper = None,
+        config: Optional[PPOConfig] = None,
+        model: Optional[PreTrainedModelWrapper] = None,
         ref_model: Optional[PreTrainedModelWrapper] = None,
-        tokenizer: PreTrainedTokenizerBase = None,
+        tokenizer: Optional[PreTrainedTokenizerBase] = None,
         dataset: Optional[Union[torch.utils.data.Dataset, Dataset]] = None,
         optimizer: Optional[torch.optim.Optimizer] = None,
         data_collator: Optional[typing.Callable] = None,
@@ -431,7 +431,7 @@ class PPOTrainer(BaseTrainer):
     def generate(
         self,
         query_tensor: Union[torch.Tensor, List[torch.Tensor]],
-        length_sampler: Callable = None,
+        length_sampler: Optional[Callable] = None,
         batch_size: int = 4,
         return_prompt: bool = True,
         generate_ref_response: bool = False,
@@ -508,10 +508,10 @@ class PPOTrainer(BaseTrainer):
         self,
         model: PreTrainedModelWrapper,
         query_tensors: List[torch.Tensor],
-        length_sampler: Callable = None,
+        length_sampler: Optional[Callable] = None,
         batch_size: int = 4,
         return_prompt: bool = True,
-        pad_to_multiple_of: int = None,
+        pad_to_multiple_of: Optional[int] = None,
         remove_padding: bool = True,
         **generation_kwargs,
     ):

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -854,7 +854,9 @@ class PPOTrainer(BaseTrainer):
         train_stats["policy/advantages"] = torch.nan_to_num(train_stats["policy/advantages"], WANDB_PADDING)
         train_stats["policy/ratio"] = torch.flatten(train_stats["policy/ratio"]).unsqueeze(0)
 
-        total_scores = torch.tensor([score[score != padding_value].sum() for score in scores]).to(self.current_device)
+        total_scores = torch.tensor([score[score != padding_value].sum() for score in padded_scores]).to(
+            self.current_device
+        )
 
         stats = self.record_step_stats(
             scores=total_scores,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -854,7 +854,11 @@ class PPOTrainer(BaseTrainer):
         train_stats["policy/advantages"] = torch.nan_to_num(train_stats["policy/advantages"], WANDB_PADDING)
         train_stats["policy/ratio"] = torch.flatten(train_stats["policy/ratio"]).unsqueeze(0)
 
-        total_scores = torch.tensor([score[score != padding_value].sum() for score in padded_scores]).to(
+        discount = torch.tensor(
+            [self.config.gamma**i for i in range(padded_scores.shape[1])], device=padded_scores.device
+        ).unsqueeze(0)
+        discounted_scores = padded_scores * discount
+        total_scores = torch.tensor([score[score != padding_value].sum() for score in discounted_scores]).to(
             self.current_device
         )
 


### PR DESCRIPTION
Allow passing rewards to step that are List[`torch.FloatTensor`] but each either of shape 1 (i.e. same as existing functionality) or (`response_length`) so that we can give reward to individual tokens. Important for more fine-grained feedback.