### PR TITLE
Fix doc snippet PPOTrainer argument train_dataset -> dataset

### DIFF
--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -90,7 +90,7 @@ from trl import PPOTrainer
 ppo_trainer = PPOTrainer(
     model=model,
     config=config,
-    train_dataset=train_dataset,
+    dataset=dataset,
     tokenizer=tokenizer,
 )
 ```


### PR DESCRIPTION
Both the argument's name and the value need to be renamed in the code snippet. Otherwise we get both

`NameError: name 'train_dataset' is not defined`
and
`TypeError: PPOTrainer.__init__() got an unexpected keyword argument 'train_dataset'`