### PR TITLE
[`CI`] Add tests on transformers peft main on push main

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,0 +1,34 @@
+name: tests on transformers PEFT main
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"
+        cache-dependency-path: |
+            setup.py
+            requirements.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # install PEFT & transformers from source
+        pip install -U git+https://github.com/huggingface/peft.git
+        pip install -U git+https://github.com/huggingface/transformers.git 
+        # cpu version of pytorch
+        pip install -e ".[test, diffusers]"
+    - name: Test with pytest
+      run: |
+        make test


### PR DESCRIPTION
As per title and similar PR as https://github.com/huggingface/peft/pull/1461 - let's test also on transformers / PEFT main whenever we push a commit on main to make sure we can catch early bugs on transformers main before the releases

cc @lvwerra 