### PR TITLE
PPO variant -  Add KL loss as regularization

### DIFF
--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -89,6 +89,8 @@ class PPOConfig:
     cliprange_value: float = 0.2
     """Range for clipping values in loss calculation"""
     vf_coef: float = 0.1
+    """KL loss between policy and reference in loss computation"""
+    kl_loss_coef: float = 0
     """Scaling factor for value loss"""
     batch_size: int = 256
     """Number of samples per optimisation step"""

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -1069,6 +1069,7 @@ class PPOTrainer(BaseTrainer):
             old_logprobs, values, logits, vpreds, logprobs, mask, advantages, returns
         )
         loss_kl = masked_mean(ref_logprobs - logprobs, mask)
+        train_stats["loss/kl"] = loss_kl.detach()
         loss = loss_p + loss_v + self.config.kl_loss_coef * loss_kl
         self.accelerator.backward(loss)
         if self.config.max_grad_norm is not None:


### PR DESCRIPTION
This is inspired by the PPO variant implementation from:
https://github.com/ContextualAI/HALOs/blob/f9f78263cb7aa70809a87f9f74482dfd09f8c60b/trainers.py#L942.

According to the paper, https://arxiv.org/pdf/2309.16240.pdf, the KL loss acts as a regularization term to prevent the policy model to drift too much away from the reference model, and according to the paper, it is relatively stable when applying different divergence functions.

![Picture1](https://github.com/huggingface/trl/assets/140311653/0e14ceeb-d0f1-4f52-9bfb-175a355a5bd6)


Will attach wandb graph later.


