### PR TITLE
Update dpo_llama2.py to fix 8-bit multi-gpu training bug

### DIFF
--- a/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
+++ b/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
@@ -129,6 +129,7 @@ if __name__ == "__main__":
         low_cpu_mem_usage=True,
         torch_dtype=torch.float16,
         load_in_4bit=True,
+        device_map={"": Accelerator().local_process_index}
     )
     model.config.use_cache = False
 
@@ -176,6 +177,7 @@ if __name__ == "__main__":
         remove_unused_columns=False,
         run_name="dpo_llama2",
     )
+    training_args.gradient_checkpointing_kwargs = dict(use_reentrant=False)
 
     peft_config = LoraConfig(
         r=script_args.lora_r,

--- a/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
+++ b/examples/research_projects/stack_llama_2/scripts/dpo_llama2.py
@@ -9,7 +9,7 @@ from peft import LoraConfig
 from transformers import AutoModelForCausalLM, AutoTokenizer, HfArgumentParser, TrainingArguments
 
 from trl import DPOTrainer
-
+from accelerate import Accelerator
 
 # Define and parse arguments.
 @dataclass


### PR DESCRIPTION
fix "ValueError: You can't train a model that has been loaded in 8-bit precision on a different device than the one you're training on." see https://github.com/huggingface/trl/issues/1348