### PR TITLE
Fix transformers version checking for Python < 3.8

### DIFF
--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -41,9 +41,16 @@ def is_accelerate_greater_20_0() -> bool:
     return accelerate_version >= "0.20.0"
 
 
-def is_transformers_greater_than(version: str) -> bool:
-    _transformers_version = importlib.metadata.version("transformers")
-    return _transformers_version > version
+def is_transformers_greater_than(current_version: str) -> bool:
+    if _is_python_greater_3_8:
+        from importlib.metadata import version
+
+        _transformers_version = version("transformers")
+    else:
+        import pkg_resources
+
+        _transformers_version = pkg_resources.get_distribution("transformers").version
+    return _transformers_version > current_version
 
 
 def is_torch_greater_2_0() -> bool:


### PR DESCRIPTION
To be consistent with the existing code and maintain compatibility for environments running Python versions earlier than 3.8, this pull request includes a minor adjustment to the `is_transformers_greater_than` function.