### PR TITLE
Log ddpo reward as float to fix numpy conversion during bf16 training

### DIFF
--- a/examples/scripts/ddpo.py
+++ b/examples/scripts/ddpo.py
@@ -175,7 +175,7 @@ def image_outputs_logger(image_data, global_step, accelerate_logger):
     for i, image in enumerate(images):
         prompt = prompts[i]
         reward = rewards[i].item()
-        result[f"{prompt:.25} | {reward:.2f}"] = image.unsqueeze(0)
+        result[f"{prompt:.25} | {reward:.2f}"] = image.unsqueeze(0).float()
 
     accelerate_logger.log_images(
         result,


### PR DESCRIPTION
Fixes `TypeError: Got unsupported ScalarType BFloat16` when logging the reward during bf16 finetuning with ddpo