### PR TITLE
FIX [`RewardModeling`] Fix RM script for PEFT

### DIFF
--- a/examples/scripts/reward_modeling.py
+++ b/examples/scripts/reward_modeling.py
@@ -27,6 +27,7 @@ python examples/scripts/reward_modeling.py \
     --evaluation_strategy="steps" \
     --max_length=512 \
 """
+import warnings
 
 import torch
 from datasets import load_dataset
@@ -63,6 +64,12 @@ if __name__ == "__main__":
     model = AutoModelForSequenceClassification.from_pretrained(
         model_config.model_name_or_path, num_labels=1, **model_kwargs
     )
+
+    if model_config.lora_task_type != "SEQ_CLS":
+        warnings.warn(
+            "You are using a `task_type` that is different than `SEQ_CLS` for PEFT. This will lead to silent bugs"
+            " Make sure to pass --lora_task_type SEQ_CLS when using this script."
+        )
 
     ################
     # Dataset

--- a/trl/trainer/model_config.py
+++ b/trl/trainer/model_config.py
@@ -61,6 +61,9 @@ class ModelConfig:
         default=None,
         metadata={"help": ("Model layers to unfreeze & train")},
     )
+    lora_task_type: str = field(
+        default="CAUSAL_LM", metadata={"help": "The task_type to pass for LoRA (use SEQ_CLS for reward modeling)"}
+    )
     load_in_8bit: bool = field(
         default=False, metadata={"help": "use 8 bit precision for the base model - works only with LoRA"}
     )

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -726,7 +726,7 @@ def get_peft_config(model_config: ModelConfig) -> "Optional[PeftConfig]":
         lora_alpha=model_config.lora_alpha,
         lora_dropout=model_config.lora_dropout,
         bias="none",
-        task_type="CAUSAL_LM",
+        task_type=model_config.lora_task_type,
         target_modules=model_config.lora_target_modules,
         modules_to_save=model_config.lora_modules_to_save,
     )


### PR DESCRIPTION
Fixes https://github.com/huggingface/trl/issues/1379

Indeed, `task_type` is always hard-coded to `CAUSAL_LM` which should be modulable for other scripts such as `reward_modeling.py` to be able to pass other `task_type`.

cc @lewtun @kashif WDYT?