### PR TITLE
Add option to check dataset labels in SFTTrainer

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -307,9 +307,6 @@ class SFTTrainer(Trainer):
                 "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
             )
 
-        # set the correct log level depending on the node
-        log_level = args.get_process_log_level()
-        logger.setLevel(log_level)
 
         if check_dataset_labels:
             if train_dataset is not None and len(train_dataset) > 0:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -149,6 +149,7 @@ class SFTTrainer(Trainer):
         model_init_kwargs: Optional[Dict] = None,
         dataset_kwargs: Optional[Dict] = None,
         eval_packing: Optional[bool] = None,
+        check_dataset_labels: Optional[bool] = None,
     ):
         if model_init_kwargs is None:
             model_init_kwargs = {}
@@ -301,6 +302,16 @@ class SFTTrainer(Trainer):
                 "You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to "
                 "overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code."
             )
+
+        if check_dataset_labels:
+            if train_dataset is not None and len(train_dataset) > 0:
+                input_ids, attention_mask, labels = data_collator([train_dataset[0]]).values()
+                # print is obviously the wrong choice but no logger
+                print(f"check_dataset_labels:")
+                print(tokenizer.decode(input_ids[0]))
+                for token, label in zip(input_ids[0], labels[0]):
+                    logger.info(token.item(), f"'{tokenizer.decode(token)}'", label.item())
+                    print(token.item(), f"'{tokenizer.decode(token)}'", label.item())
 
         super().__init__(
             model=model,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -309,10 +309,10 @@ class SFTTrainer(Trainer):
             if train_dataset is not None and len(train_dataset) > 0:
                 input_ids, attention_mask, labels = data_collator([train_dataset[0]]).values()
 
-                print("check_dataset_labels:")
-                print(tokenizer.decode(input_ids[0]))
+                print("check_dataset_labels:") # noqa
+                print(tokenizer.decode(input_ids[0])) # noqa
                 for token, label in zip(input_ids[0], labels[0]):
-                    print(f"{token.item()}, '{tokenizer.decode(token)}' {label.item()}")
+                    print(f"{token.item()}, '{tokenizer.decode(token)}' {label.item()}") # noqa
 
         super().__init__(
             model=model,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -36,7 +36,7 @@ from transformers import (
 from transformers.modeling_utils import unwrap_model
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
-from transformers.utils import logging 
+from transformers.utils import logging
 
 from ..extras.dataset_formatting import get_formatting_func_from_dataset
 from ..import_utils import is_peft_available

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -310,7 +310,6 @@ class SFTTrainer(Trainer):
                 print(f"check_dataset_labels:")
                 print(tokenizer.decode(input_ids[0]))
                 for token, label in zip(input_ids[0], labels[0]):
-                    logger.info(token.item(), f"'{tokenizer.decode(token)}'", label.item())
                     print(token.item(), f"'{tokenizer.decode(token)}'", label.item())
 
         super().__init__(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -309,10 +309,10 @@ class SFTTrainer(Trainer):
             if train_dataset is not None and len(train_dataset) > 0:
                 input_ids, attention_mask, labels = data_collator([train_dataset[0]]).values()
 
-                print("check_dataset_labels:") # noqa
-                print(tokenizer.decode(input_ids[0])) # noqa
+                print("check_dataset_labels:")  # noqa
+                print(tokenizer.decode(input_ids[0]))  # noqa
                 for token, label in zip(input_ids[0], labels[0]):
-                    print(f"{token.item()}, '{tokenizer.decode(token)}' {label.item()}") # noqa
+                    print(f"{token.item()}, '{tokenizer.decode(token)}' {label.item()}")  # noqa
 
         super().__init__(
             model=model,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -118,6 +118,8 @@ class SFTTrainer(Trainer):
             Dict of Optional kwargs to pass when creating packed or non-packed datasets
         eval_packing: (`Optional[bool]`, *optional*):
             Whether to pack the eval dataset as well. Defaults to `packing` if `None` is passed.
+        check_dataset_labels (`Optional[bool]`):
+            Flag to enable debugging of dataset labels and tokenization. If set to True, the trainer will print the tokens, decoded tokens, and their corresponding labels for the first item in the training dataset during initialization. Defaults to False.
     """
 
     _tag_names = ["trl", "sft"]
@@ -149,7 +151,7 @@ class SFTTrainer(Trainer):
         model_init_kwargs: Optional[Dict] = None,
         dataset_kwargs: Optional[Dict] = None,
         eval_packing: Optional[bool] = None,
-        check_dataset_labels: Optional[bool] = None,
+        check_dataset_labels: Optional[bool] = False,
     ):
         if model_init_kwargs is None:
             model_init_kwargs = {}
@@ -306,11 +308,11 @@ class SFTTrainer(Trainer):
         if check_dataset_labels:
             if train_dataset is not None and len(train_dataset) > 0:
                 input_ids, attention_mask, labels = data_collator([train_dataset[0]]).values()
-                # print is obviously the wrong choice but no logger
-                print(f"check_dataset_labels:")
+
+                print("check_dataset_labels:")
                 print(tokenizer.decode(input_ids[0]))
                 for token, label in zip(input_ids[0], labels[0]):
-                    print(token.item(), f"'{tokenizer.decode(token)}'", label.item())
+                    print(f"{token.item()}, '{tokenizer.decode(token)}' {label.item()}")
 
         super().__init__(
             model=model,


### PR DESCRIPTION
Hi everyone!

This PR introduces a new option `check_dataset_labels` in `SFTTrainer`. When enabled, the trainer calls the collator on the first sample from the training set and logs `token_id`, decoded `token_id`, and the corresponding `label`. This helps to uncover mistakes early, such as setting the tokenizer's `pad_token` to`eos_token`. The idea is taken from axolotl where such an option exists already. 

**Problem(s)**:
It's common practice to set the tokenizer's pad_token to eos_token. This is problematic because `DataCollatorForCompletionOnlyLM` sets the `label` for all occurrences of `pad_token` to `-100`. If `pad=eos`, then **the model will never learn to output eos**. This issue can be hard to debug and many people struggle with it.

Additionally, when using `instruction_template` and `response_template`, logging the tokens and labels would be helpful to ensure that all the labels are correctly set to only train on output and ignore the instruction. Furthermore, tokenizers can be complex and the output would aid in spotting tokenization issues like handling of special tokens quickly

**Solution**:
* Add a new option `check_dataset_labels` to the trainer.
* When check_dataset_labels is enabled, the trainer calls the collator on the first sample from the training set and logs token_id, decoded token_id, and the corresponding label.
* This creates transparency and helps to uncover mistakes early.

**Usage**:
```python
# load model and tokenizer 
...

messages = [
    {"role": "user", "content": "Hello who are you?"},
    {"role": "assistant", "content": "Luke, I am your father"},
    {"role": "user", "content": "WTF"},
]
dataset = Dataset.from_list([dict(messages=messages)])

trainer = SFTTrainer(
    model = model,
    tokenizer = tokenizer,
    train_dataset = dataset,
    data_collator = DataCollatorForCompletionOnlyLM(
        instruction_template = "<|im_start|>user", 
        response_template = "<|im_start|>assistant", 
        tokenizer = tokenizer, 
        mlm = False),
    check_dataset_labels = True,
    dataset_kwargs=dict(add_special_tokens=False),
    args = TrainingArguments(output_dir = "out")
)
```

output:
```
check_dataset_labels:
<|im_start|> user
Hello who are you? <|im_end|> 
 <|im_start|> assistant
Luke, I am your father <|im_end|> 
 <|im_start|> user
WTF <|im_end|> 

32000 '<|im_start|>' -100
1792 'user' -100
13 '<0x0A>' -100
10994 'Hello' -100
1058 'who' -100
526 'are' -100
366 'you' -100
29973 '?' -100
32001 '<|im_end|>' -100
13 '<0x0A>' -100
32000 '<|im_start|>' -100
465 'ass' -100
22137 'istant' -100
13 '<0x0A>' 13
24126 'Lu' 24126
446 'ke' 446
29892 ',' 29892
306 'I' 306
626 'am' 626
596 'your' 596
4783 'father' 4783
32001 '<|im_end|>' 32001
13 '<0x0A>' 13
32000 '<|im_start|>' -100
1792 'user' -100
13 '<0x0A>' -100
29956 'W' -100
8969 'TF' -100
32001 '<|im_end|>' -100
13 '<0x0A>' -100
```

**Related issues**:
* https://github.com/huggingface/trl/issues/1384
* https://github.com/huggingface/trl/issues/976
* https://github.com/huggingface/trl/issues/1191
* https://github.com/huggingface/trl/issues/916
* https://github.com/huggingface/transformers/issues/22794
* https://stackoverflow.com/questions/76446228/setting-padding-token-as-eos-token-when-using-datacollatorforlanguagemodeling-fr
