### PR TITLE
CI: Fix CI on main

### DIFF
--- a/tests/test_no_peft.py
+++ b/tests/test_no_peft.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import sys
 import unittest
+from functools import partial
 from unittest.mock import patch
 
 import pytest
@@ -134,6 +135,7 @@ class TestPeftDependancy(unittest.TestCase):
                 tokenizer=tokenizer,
                 dataset=dummy_dataset,
             )
+            ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
             dummy_dataloader = ppo_trainer.dataloader
 
             for query_tensor, response_tensor in dummy_dataloader:

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -17,6 +17,7 @@ import gc
 import re
 import tempfile
 import unittest
+from functools import partial
 
 import pytest
 import torch
@@ -193,6 +194,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -220,6 +222,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -252,6 +255,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
 
         assert isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD)
@@ -291,6 +295,7 @@ class PPOTrainerTester(unittest.TestCase):
             dataset=dummy_dataset,
             lr_scheduler=lr_scheduler,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
 
         assert isinstance(ppo_trainer.optimizer.optimizer, torch.optim.SGD)
@@ -332,6 +337,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -382,6 +388,7 @@ class PPOTrainerTester(unittest.TestCase):
             dataset=dummy_dataset,
             num_shared_layers=num_shared_layers,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -449,6 +456,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -486,6 +494,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:
@@ -526,6 +535,7 @@ class PPOTrainerTester(unittest.TestCase):
                 ref_model=self.gpt2_model_ref,
                 tokenizer=self.gpt2_tokenizer,
             )
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         # train model with ppo
         reward = [torch.tensor([1.0])]
         # train model - this should work fine
@@ -692,7 +702,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
 
         # train model with ppo
@@ -879,7 +889,7 @@ class PPOTrainerTester(unittest.TestCase):
             tokenizer=self.gpt2_tokenizer,
             dataset=dummy_dataset,
         )
-
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         assert ppo_trainer.ref_model is None
 
         dummy_dataloader = ppo_trainer.dataloader
@@ -967,7 +977,7 @@ class PPOTrainerTester(unittest.TestCase):
                 tokenizer=self.gpt2_tokenizer,
                 dataset=dummy_dataset,
             )
-
+            ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
             assert ppo_trainer.ref_model is None
 
             dummy_dataloader = ppo_trainer.dataloader
@@ -1213,6 +1223,7 @@ class PPOTrainerTester(unittest.TestCase):
             dataset=dummy_dataset,
         )
 
+        ppo_trainer.optimizer.zero_grad = partial(ppo_trainer.optimizer.zero_grad, set_to_none=False)
         dummy_dataloader = ppo_trainer.dataloader
         # train model with ppo
         for query_tensor, response_tensor in dummy_dataloader:


### PR DESCRIPTION
The recent accelerate release includes: https://github.com/huggingface/accelerate/pull/2472 that sets `set_to_none` to `True` by default for optimizers, leads to our tests failing since we explictly check for `param.grad` after the optimization step. The fix is to patch the `optimizer.zero_grad` method to expliclty call it with `set_to_none=False`

cc @lvwerra 