### PR TITLE
FIX: fix doc build on main

### DIFF
--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -124,4 +124,10 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        _import_structure,
+        module_spec=__spec__,
+        extra_objects={"__version__": __version__},
+    )


### PR DESCRIPTION
This PR fixes the current failing doc build on main: https://github.com/huggingface/trl/actions/runs/8325681030/job/22779801587 

When implementing the lazy import, I forgot to add `__version__` in `extra_objects`. This PR fixes it

cc @lvwerra 