### PR TITLE
Add `use_cache=False` in `{ORPO,CPO}Trainer.concatenated_forward`

### DIFF
--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import inspect
 import random
 import warnings
@@ -665,6 +666,7 @@ class CPOTrainer(Trainer):
         outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
+            use_cache=False,
             **model_kwargs,
         )
         all_logits = outputs.logits

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import inspect
 import random
 import warnings
@@ -685,6 +686,7 @@ class ORPOTrainer(Trainer):
         outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
+            use_cache=False,
             **model_kwargs,
         )
         all_logits = outputs.logits


### PR DESCRIPTION
## Description

This PR fixes the bug described in #1477, similarly to the former issue within the `DPOTrainer` solved by @younesbelkada  (so kudos to him!).

Adding `use_cache=False` when running the forward pass during training is not needed, because we're not in an inference use case, only computing the logits, and it runs into conflicts with Flash Attention 2, so disabling it has no other impact than fixing the collision bug with FA2.

Closes #1477 

cc @kashif @younesbelkada 