### PR TITLE
docs: add missing Trainer classes and sort alphabetically

### DIFF
--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -4,6 +4,47 @@ At TRL we support PPO (Proximal Policy Optimisation) with an implementation that
 The Trainer and model classes are largely inspired from `transformers.Trainer` and `transformers.AutoModel` classes and adapted for RL.
 We also support a `RewardTrainer` that can be used to train a reward model.
 
+
+## CPOConfig
+
+[[autodoc]] CPOConfig
+
+## CPOTrainer
+
+[[autodoc]] CPOTrainer
+
+## DDPOConfig
+
+[[autodoc]] DDPOConfig
+
+## DDPOTrainer
+
+[[autodoc]] DDPOTrainer
+
+## DPOTrainer
+
+[[autodoc]] DPOTrainer
+
+## IterativeSFTTrainer
+
+[[autodoc]] IterativeSFTTrainer
+
+## KTOConfig
+
+[[autodoc]] KTOConfig
+
+## KTOTrainer
+
+[[autodoc]] KTOTrainer
+
+## ORPOConfig
+
+[[autodoc]] ORPOConfig
+
+## ORPOTrainer
+
+[[autodoc]] ORPOTrainer
+
 ## PPOConfig
 
 [[autodoc]] PPOConfig
@@ -23,22 +64,6 @@ We also support a `RewardTrainer` that can be used to train a reward model.
 ## SFTTrainer
 
 [[autodoc]] SFTTrainer
-
-## DPOTrainer
-
-[[autodoc]] DPOTrainer
-
-## DDPOConfig
-
-[[autodoc]] DDPOConfig
-
-## DDPOTrainer
-
-[[autodoc]] DDPOTrainer
-
-## IterativeSFTTrainer
-
-[[autodoc]] IterativeSFTTrainer
 
 ## set_seed
 


### PR DESCRIPTION
Hey! Thanks for this great project...

I noticed that several Trainer/Config classes are missing here: https://huggingface.co/docs/trl/main/en/trainer

I'm adding them and introducing alphabetical order.