### PR TITLE
Correct ppo_epochs usage

### DIFF
--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -130,6 +130,8 @@ We can then loop over all examples in the dataset and generate a response for ea
 
 ```py
 from tqdm import tqdm
+
+
 epochs = 10
 for epoch in tqdm(range(epochs), "epoch: "):
     for batch in tqdm(ppo_trainer.dataloader): 

--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -130,7 +130,8 @@ We can then loop over all examples in the dataset and generate a response for ea
 
 ```py
 from tqdm import tqdm
-for epoch in tqdm(range(ppo_trainer.config.ppo_epochs), "epoch: "):
+epoch = 10
+for epoch in tqdm(range(epoch), "epoch: "):
     for batch in tqdm(ppo_trainer.dataloader): 
         query_tensors = batch["input_ids"]
     

--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -130,8 +130,8 @@ We can then loop over all examples in the dataset and generate a response for ea
 
 ```py
 from tqdm import tqdm
-epoch = 10
-for epoch in tqdm(range(epoch), "epoch: "):
+epochs = 10
+for epoch in tqdm(range(epochs), "epoch: "):
     for batch in tqdm(ppo_trainer.dataloader): 
         query_tensors = batch["input_ids"]
     


### PR DESCRIPTION
The usage of ppo_epochs is incorrect here. 

In https://github.com/huggingface/trl/blob/8534f0edf8608ad6bcbea9beefae380fa60ded77/trl/trainer/ppo_config.py#L104C8-L104C58

the ppo_epochs was described as the "Number of optimisation epochs per batch of samples". 

However, here it is used as the usual epoch number, in which you do one iteration over the training dataset.