### PR TITLE
hackey update to ModelConfig to allow lora_target_modules="all-linear"

### DIFF
--- a/trl/trainer/model_config.py
+++ b/trl/trainer/model_config.py
@@ -85,3 +85,6 @@ class ModelConfig:
     def __post_init__(self):
         if self.load_in_8bit and self.load_in_4bit:
             raise ValueError("You can't use 8 bit and 4 bit precision at the same time")
+
+        if self.lora_target_modules == ["all-linear"]:
+            self.lora_target_modules = "all-linear"


### PR DESCRIPTION
the type hint forces a list which raises a "all-linear" layer not found. forcing a string makes it work. updating the type hint to `Union[str, list[str]]` also raise a parsing error

looks like peft handles this by making the arg a str and using comma delimited values 
https://github.com/huggingface/peft/blob/main/examples/sft/train.py#L30