### PR TITLE
[ORPO] use log1p for loss

### DIFF
--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -610,7 +610,7 @@ class ORPOTrainer(Trainer):
 
         # Derived from Eqs. (4) and (7) from https://arxiv.org/abs/2403.07691 by using log identities and exp(log(P(y|x)) = P(y|x)
         log_odds = (policy_chosen_logps - policy_rejected_logps) - (
-            torch.log(1 - torch.exp(policy_chosen_logps)) - torch.log(1 - torch.exp(policy_rejected_logps))
+            torch.log1p(-torch.exp(policy_chosen_logps)) - torch.log1p(-torch.exp(policy_rejected_logps))
         )
         sig_ratio = F.sigmoid(log_odds)
         ratio = torch.log(sig_ratio)


### PR DESCRIPTION
torch.log1p is more accurate for smaller values