### PR TITLE
Fix DPO Unsloth example in Docs

### DIFF
--- a/docs/source/dpo_trainer.mdx
+++ b/docs/source/dpo_trainer.mdx
@@ -161,7 +161,7 @@ training_args = TrainingArguments(output_dir="./output")
 
 dpo_trainer = DPOTrainer(
     model,
-    model_ref=None,
+    ref_model=None,
     args=training_args,
     beta=0.1,
     train_dataset=train_dataset,


### PR DESCRIPTION
The argument for the trainer is `ref_model` instead of `model_ref`