### PR TITLE
[ORPO] Update NLL loss to use `input_ids` instead

### DIFF
--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -705,7 +705,11 @@ class ORPOTrainer(Trainer):
             loss = loss_fct(logits, labels)
             return loss
 
-        labels = concatenated_batch["concatenated_input_ids"].clone()
+        if self.is_encoder_decoder:
+            labels = concatenated_batch["concatenated_labels"].clone()
+        else:
+            labels = concatenated_batch["concatenated_input_ids"].clone()
+
         chosen_nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
 
         all_logps = self.get_batch_logps(

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -705,7 +705,7 @@ class ORPOTrainer(Trainer):
             loss = loss_fct(logits, labels)
             return loss
 
-        labels = concatenated_batch["concatenated_labels"].clone()
+        labels = concatenated_batch["concatenated_input_ids"].clone()
         chosen_nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
 
         all_logps = self.get_batch_logps(


### PR DESCRIPTION
## Description

This PR updates how the NLL loss in ORPO is being calculated so as to use the `input_ids` for the chosen response i.e. the whole conversation, instead of only the labels i.e. the ids for the chosen response only.

As mentioned by @nlee-208, calculating the full prompt loss instead of solely the loss on the chosen response leads to better results in MT-Bench, leading then to a more faithful reproduction of the original codebase at https://github.com/xfactlab/orpo.git (see the screenshot shared by Noah below where the `wo-pl`, standing for without prompt loss, fine-tune performs worst on MT-Bench)

![image](https://github.com/huggingface/trl/assets/36760800/203d4c21-0df7-43e6-8efa-7c56c041b392)

Kudos to @nlee-208, @jiwooya1000 and @lewtun 