### PR TITLE
Allow pre-tokenized datasets in SFTTrainer

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -401,7 +401,16 @@ class SFTTrainer(Trainer):
         if dataset is None:
             raise ValueError("The dataset should not be None")
 
+        # If the dataset is already preprocessed (tokenized), return as-is. Only works if dataset is
+        # a datasets.Dataset or datasets.IterableDataset -- not for torch Dataset
+        column_names = (
+            dataset.column_names if isinstance(dataset, (datasets.Dataset, datasets.IterableDataset)) else None
+        )
+        if column_names and "input_ids" in column_names:
+            return dataset
+
         # check if torch dataset / dataloader and do nothing
+        # see https://github.com/huggingface/trl/pull/1468 for why datasets.IterableDataset needs a separate check
         if isinstance(
             dataset, (torch.utils.data.IterableDataset, torch.utils.data.Dataset, ConstantLengthDataset)
         ) and not isinstance(dataset, datasets.IterableDataset):


### PR DESCRIPTION
This tiny PR makes it so that datasets that are already tokenized (have an `input_ids` column) can be used as-is. This greatly improves flexibility, especially in larger training runs: we can do data preprocessing (tokenization) one one CPU-heavy server and save the tokenized dataset to disk, and transfer it to a GPU server to use it directly as a dataset.

Note: this only works for `datasets` datasets, not for PyTorch datasets.