### PR TITLE
Fixed ref model not used in PPO generation

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -498,7 +498,7 @@ class PPOTrainer(BaseTrainer):
 
             if generate_ref_response:
                 with unwrap_model_for_generation(
-                    self.model, self.accelerator, is_peft_model=self.is_peft_model
+                    ref_model, self.accelerator, is_peft_model=self.is_peft_model
                 ) as unwrapped_model:
                     ref_response = unwrapped_model.generate(
                         input_ids=query_tensor.unsqueeze(dim=0), **generation_kwargs


### PR DESCRIPTION
In the PPOTrainer.generate function, the primary model was being used instead of the reference model to generate reference responses for single samples. This change uses the correct  model and introduces a test to check for this. The new test was failing with the previous codebase.