### PR TITLE
Adds reward bootstrapping to PPOTrainer

### DIFF
--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -124,6 +124,8 @@ class PPOConfig:
     """Score clipping"""
     whiten_rewards: bool = False
     """Whiten the rewards before compute advantages"""
+    bootstrap_rewards: bool = False
+    """Use the value function to bootstrap the rewards when responses do not end with an EOS token"""
 
     # computed hyperparameters at runtime; we use `tyro.conf.Suppress` to hide them from the help text
     is_encoder_decoder: Optional[tyro.conf.Suppress[bool]] = None


### PR DESCRIPTION
The current return calculations for the PPO trainer assumes that every response terminates without truncation (https://github.com/huggingface/trl/blob/main/trl/trainer/ppo_trainer.py#L1159).

```
nextvalues = values[:, t + 1] if t < gen_len - 1 else 0.0
```

When an episode is truncated early, it is technically correct to either drop the episode, or more commonly, bootstrap the reward with the value of the final state (e.g. `last reward <- last reward + gamma * value of final state`). This change adds a `bootstrap_rewards` option to `PPOConfig` that enables bootstrapping when sequences do not end with an EOS token. An alternative way to implement this is to have the user pass in a list of which responses were terminated early, but I felt the option that was simpler for the user would be better. 