### PR TITLE
save_model -> save_pretrained in ppo_trainer.mdx

### DIFF
--- a/docs/source/ppo_trainer.mdx
+++ b/docs/source/ppo_trainer.mdx
@@ -151,7 +151,7 @@ for epoch in tqdm(range(epochs), "epoch: "):
         ppo_trainer.log_stats(stats, batch, rewards)
 
 #### Save model
-ppo_trainer.save_model("my_ppo_model")
+ppo_trainer.save_pretrained("my_ppo_model")
 ```
 
 ## Logging


### PR DESCRIPTION
This fixes the PPO documentation and replaces `PPOTrainer.save_model` with `PPOTrainer.save_pretrained`, as `save_model` does not exist. I ran the document's code to make sure the save function works. This discrepancy was noted in ticket #1443.