### PR TITLE
[`SFTTrainer`] Add warning in SFTTrainer when dataset already processed 

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -468,6 +468,11 @@ class SFTTrainer(Trainer):
             dataset.column_names if isinstance(dataset, (datasets.Dataset, datasets.IterableDataset)) else None
         )
         if column_names and "input_ids" in column_names:
+            if formatting_func is not None:
+                warnings.warn(
+                    "You passed a dataset that is already processed (contains an `input_ids` field) together with a valid formatting function. Therefore `formatting_func` will be ignored."
+                )
+
             return dataset
 
         # check if torch dataset / dataloader and do nothing


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/blog/issues/2005

This PR throws a warning to users that use `SFTTrainer` with a non-`None` `formatting_func` if the dataset is already processed
