### PR TITLE
[WIP] Unify Policy Trainers

### DIFF
--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union, Dict
 
 import torch.nn as nn
 from accelerate.utils import is_deepspeed_available

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -1,8 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union, Dict
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
-import torch.nn as nn
 from accelerate.utils import is_deepspeed_available
 from transformers import PreTrainedModel, PreTrainedTokenizer
 
@@ -155,105 +154,3 @@ def unwrap_model_for_generation(
             add_hooks(model)
     else:
         yield unwrapped_model
-
-
-def prepare_model_and_ref_model(
-        model: Optional[Union[PreTrainedModel, nn.Module, str]],
-        ref_model: Optional[Union[PreTrainedModel, nn.Module, str]],
-        model_init_kwargs: Optional[Dict],
-        ref_model_init_kwargs: Optional[Dict],
-        peft_config: Optional[Dict],
-        force_use_ref_model: bool,
-        args: Optional[TrainingArguments],
-):
-    """
-    Adapted from dpo_trainer.py
-    Allow user to pass a model or model URI + init kwargs + optional peft_config
-    Return a fully initialized model and ref_model
-    """
-    if model_init_kwargs is None:
-        model_init_kwargs = {}
-    elif not isinstance(model, str):
-        raise ValueError("You passed model_init_kwargs to the trainer. But model is already instantiated.")
-
-    if ref_model_init_kwargs is None:
-        ref_model_init_kwargs = {}
-    elif not isinstance(ref_model, str):
-        raise ValueError(
-            "You passed ref_model_init_kwargs to the trainer. But your ref_model is already instantiated."
-        )
-
-    if isinstance(model, str):
-        warnings.warn(
-            "You passed a model_id to the trainer. This will automatically create an "
-            "`AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you."
-        )
-        model = AutoModelForCausalLM.from_pretrained(model, **model_init_kwargs)
-
-    if isinstance(ref_model, str):
-        warnings.warn(
-            "You passed a ref model_id to the trainer. This will automatically create an "
-            "`AutoModelForCausalLM`"
-        )
-        ref_model = AutoModelForCausalLM.from_pretrained(ref_model, **ref_model_init_kwargs)
-
-    if not is_peft_available() and peft_config is not None:
-        raise ValueError(
-            "PEFT is not installed and you passed a `peft_config` in the trainer's kwargs, please install it to use the PEFT models"
-        )
-    elif is_peft_available() and peft_config is not None:
-        # if model is a peft model and we have a peft_config, we merge and unload it first
-        if isinstance(model, PeftModel):
-            model = model.merge_and_unload()
-
-        if ref_model is not None and not force_use_ref_model:
-            raise ValueError(
-                "You passed both a ref_model and a peft_config. For training PEFT adapters there is no need to pass a reference"
-                " model. Please pass `ref_model=None` in case you want to train PEFT adapters, or pass a ref_model with `force_use_ref_model=True` in trainer's init."
-                " if you want to use a different ref_model."
-            )
-
-        if getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False):
-            _support_gc_kwargs = hasattr(
-                args, "gradient_checkpointing_kwargs"
-            ) and "gradient_checkpointing_kwargs" in list(
-                inspect.signature(prepare_model_for_kbit_training).parameters
-            )
-
-            prepare_model_kwargs = {"use_gradient_checkpointing": args.gradient_checkpointing}
-
-            if _support_gc_kwargs:
-                prepare_model_kwargs["gradient_checkpointing_kwargs"] = args.gradient_checkpointing_kwargs
-
-            model = prepare_model_for_kbit_training(model, **prepare_model_kwargs)
-        elif getattr(args, "gradient_checkpointing", False):
-            # For backward compatibility with older versions of transformers
-            if hasattr(model, "enable_input_require_grads"):
-                model.enable_input_require_grads()
-            else:
-
-                def make_inputs_require_grad(module, input, output):
-                    output.requires_grad_(True)
-
-                model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
-
-        # get peft model with the given config
-        model = get_peft_model(model, peft_config)
-        if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
-            peft_module_casting_to_bf16(model)
-
-    # For models that use gradient_checkpointing, we need to attach a hook that enables input
-    # to explicitly have `requires_grad=True`, otherwise training will either silently
-    # fail or completely fail.
-    elif getattr(args, "gradient_checkpointing", False):
-        # For backward compatibility with older versions of transformers
-        if hasattr(model, "enable_input_require_grads"):
-            model.enable_input_require_grads()
-        else:
-
-            def make_inputs_require_grad(module, input, output):
-                output.requires_grad_(True)
-
-            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
-
-    return model, ref_model

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
+import torch.nn as nn
 from accelerate.utils import is_deepspeed_available
 from transformers import PreTrainedModel, PreTrainedTokenizer
 

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union, Callable, Any
 import warnings
 from contextlib import nullcontext
 from tqdm import tqdm
+import gc
 
 import numpy as np
 import torch

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -459,6 +459,7 @@ class PolicyTrainerBase(Trainer):
     @cuda_gc
     def generate_batch_extras(self, model, input_ids):
         # PR TODO: generation_batch_size
+        print("(generate) self.model.active_adapters", self.model.active_adapters)
         queries = input_ids.to(self.accelerator.device)
         context_length = queries.shape[1]
         with torch.no_grad(), self.cast_model_ctx():

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -322,7 +322,7 @@ class ReferenceModelManager:
         if self.ref_model is not None:
             return self.ref_model
         elif self.is_peft_model:
-            self.optional_peft_ctx = self.accelerator.unwrap_model(self.model).disable_adapter().__enter__()
+            self.optional_peft_ctx = self.model.disable_adapter().__enter__()
             return self.model
         else:
             raise ValueError

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -57,7 +57,7 @@ class PolicyTrainerArguments(TrainingArguments):
     non_eos_penalty: bool = False
     """whether to penalize responses that do not contain `truncate_token_id`"""
 
-    update_generation_model_step: Optional[int] = None
+    update_generation_steps: Optional[int] = None
     """Number of steps between updating the generation model. If None, once per epoch"""
 
 
@@ -445,7 +445,7 @@ class PolicyTrainerBase(Trainer):
         update_train_gen_cb = UpdateTrainGenerationSamplesCallback(
             model=self.model,
             steps=(
-                self.args.update_generation_step or
+                self.args.update_generation_steps or
                 len(self.get_train_dataloader()) / self.args.gradient_accumulation_steps
             ),
             batch_size=self._train_batch_size

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -407,8 +407,8 @@ class PolicyTrainerBase(Trainer):
 
         # force disable `pad_token_id` and `eos_token_id` because we just want to
         # generate tokens without truncation / padding
-        self.train_generation_config.eos_token_id = None
-        self.train_generation_config.pad_token_id = None
+        model.generation_config.eos_token_id = None
+        model.generation_config.pad_token_id = None
 
         if args.truncate_token and args.truncate_token == "eos":
             args.truncate_token_id = tokenizer.eos_token_id

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -235,9 +235,6 @@ class ModelManager:
             base_model: Optional[PreTrainedModelWrapper] = None,
     ):
         self.base_model = base_model
-        self.ref_adapter_name =  ref_adapter_name
-
-        self._unwrap_model_ctx = None
 
         # PR TODO: we assume the model is a peft model by default, needs some tweaking for other use cases
         """

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -416,7 +416,7 @@ class PolicyTrainerBase(Trainer):
 
         # handle casting self.model
         if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
-            self.cast_model_ctx = torch.cuda.amp.autocast#lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
+            self.cast_model_ctx = lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
         else:
             self.cast_model_ctx = nullcontext
 

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -487,9 +487,8 @@ class PolicyTrainerBase(Trainer):
         return_outputs=False,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
 
-        with self.time_metric_ctx("get_batch_loss"):
-            with self.cast_model_ctx():
-                loss, metrics = self.get_batch_loss_metrics(model, inputs)
+        with self.cast_model_ctx():
+            loss, metrics = self.get_batch_loss_metrics(model, inputs)
 
         loss = loss.to(self.args.device)
 
@@ -583,6 +582,7 @@ class PolicyTrainerBase(Trainer):
             attention_mask=attention_mask,
             return_dict=True,
             output_hidden_states=True,
+            use_cache=False,
         )
 
     @cuda_gc

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -322,15 +322,15 @@ class ReferenceModelManager:
         if self.ref_model is not None:
             return self.ref_model
         elif self.is_peft_model:
-            self.optional_peft_ctx = self.accelerator.unwrap_model(self.model).disable_adapter()
+            self.optional_peft_ctx = self.accelerator.unwrap_model(self.model).disable_adapter().__enter__()
             return self.model
         else:
             raise ValueError
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.optional_peft_ctx is not None:
-            with self.optional_peft_ctx:
-                pass  # teardown
+            # exit the disabled adapter context
+            self.optional_peft_ctx.__exit__(exc_type, exc_value, traceback)
             # reset adapter back to being the active model
             self.model.set_adapter("default")
 

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -454,7 +454,7 @@ class PolicyTrainerBase(Trainer):
 
 
     def get_batch_responses_and_logprobs(self, model, input_ids):
-        queries = inputs["input_ids"].to(self.accelerator.device)
+        queries = input_ids.to(self.accelerator.device)
         context_length = queries.shape[1]
         query_responses = self.generate(
             model,

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -436,6 +436,7 @@ class PolicyTrainerBase(Trainer):
 
         self._stored_metrics = defaultdict(lambda: defaultdict(list))
 
+    @cuda_gc
     def compute_loss(
         self,
         model: Union[PreTrainedModel, nn.Module],

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -237,7 +237,7 @@ def _prepare_multigpu(model, accelerator, is_deepspeed_enabled: bool):
         )
 
 # PR TODO: Implement original workflow as follows
--"""
+"""
 -There are three models forwards() considered in each step
 -- ref_model: Never changes
 -- update_model: changes every update step (originally was after multiple epochs, I expect fractions of an epoch to work better. Will have to validate to ensure this is true.)

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -567,6 +567,7 @@ class PolicyTrainerBase(Trainer):
                 attention_mask=attention_mask,
                 generation_config=generation_config,
                 return_dict_in_generate=True,
+                use_cache=False,
                 # PR TODO: https://github.com/huggingface/trl/pull/1540/files#r1588004580
             )
         query_responses = torch.cat((queries, output.sequences[:, context_length:]), dim=1)

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -261,13 +261,10 @@ class ModelManager:
             )
         """
 
-    def __enter__(self, adapter_name):
+    def __call__(self, adapter_name):
         self.base_model.set_adapter(adapter_name)
-        return self.base_model
-
-    def __exit__(self, exc_type, exc_value, traceback):
+        yield self.base_model
         self.base_model.disable_adapters()
-
 
 
 # PR TODO: Implement original workflow as follows

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -355,6 +355,8 @@ class ReferenceModelManager:
         if self.optional_peft_ctx is not None:
             with self.optional_peft_ctx:
                 pass  # teardown
+            # reset adapter back to being the active model
+            self.ref_model.set_adapter("default")
 
 
 class PolicyTrainerBase(Trainer):
@@ -382,7 +384,7 @@ class PolicyTrainerBase(Trainer):
 
         model, ref_model = prepare_model_and_ref_model(
             model=model,
-            ref_model=ref_model,
+            ref_model=ref_model,re
             model_init_kwargs=model_init_kwargs,
             ref_model_init_kwargs=ref_model_init_kwargs,
             peft_config=peft_config,
@@ -620,7 +622,6 @@ class PolicyTrainerBase(Trainer):
         train_eval = "train" if "loss" in logs else "eval"
         # Add averaged stored metrics to logs
         for key, metrics in self._stored_metrics[train_eval].items():
-            print(key)
             logs[key] = torch.tensor(metrics).to(dtype=torch.float32).mean().item()
         del self._stored_metrics[train_eval]
         return super().log(logs)

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -462,7 +462,7 @@ class PolicyTrainerBase(Trainer):
         context_length = queries.shape[1]
         with torch.no_grad(), self.cast_model_ctx():
             query_responses = self.generate(
-                model,
+                self.model,
                 queries,
                 self.train_generation_config,
             )

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -548,13 +548,12 @@ class PolicyTrainerBase(Trainer):
     def forward(self, model, query_responses):
         attention_mask = query_responses != self.tokenizer.pad_token_id
         input_ids = torch.masked_fill(query_responses, ~attention_mask, 0)
-        with disable_caching(model):
-            return model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                return_dict=True,
-                output_hidden_states=True,
-            )
+        return model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True,
+            output_hidden_states=True,
+        )
 
     def get_reward(self, reward_model, query_responses, context_length):
         attention_mask = query_responses != self.tokenizer.pad_token_id
@@ -656,6 +655,9 @@ class PolicyTrainerBase(Trainer):
         with self.time_metric_ctx("training_step"):
             return super().training_step(*args, **kwargs)
 
+    def train(self, *args, **kwargs):
+        with disable_caching(self.model):
+            super().train(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -384,7 +384,7 @@ class PolicyTrainerBase(Trainer):
 
         model, ref_model = prepare_model_and_ref_model(
             model=model,
-            ref_model=ref_model,re
+            ref_model=ref_model,
             model_init_kwargs=model_init_kwargs,
             ref_model_init_kwargs=ref_model_init_kwargs,
             peft_config=peft_config,

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -452,7 +452,6 @@ class PolicyTrainerBase(Trainer):
     @cuda_gc
     def generate_batch_extras(self, model, input_ids):
         # PR TODO: generation_batch_size
-        print("(generate) self.model.active_adapters", self.model.active_adapters)
         queries = input_ids.to(self.accelerator.device)
         context_length = queries.shape[1]
         with torch.no_grad(), self.cast_model_ctx():

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -234,7 +234,6 @@ class ModelManager:
             self,
             base_model: Optional[PreTrainedModelWrapper] = None,
     ):
-        self.accelerator = accelerator
         self.base_model = base_model
         self.ref_adapter_name =  ref_adapter_name
 
@@ -386,10 +385,7 @@ class PolicyTrainerBase(Trainer):
             **kwargs,
         )
 
-        self.model_manager = ModelManager(
-            self.accelerator,
-            model=model,
-        )
+        self.model_manager = ModelManager(model)
 
 
         """

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -446,14 +446,10 @@ class PolicyTrainerBase(Trainer):
 
 
         # handle casting self.model
-        """
         if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
-            self.cast_model_ctx = lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
+            self.cast_model_ctx = torch.cuda.amp.autocast#lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
         else:
             self.cast_model_ctx = nullcontext
-        """
-        # PR TODO: remove temporary hack
-        self.cast_model_ctx = lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
 
         super().__init__(
             model=model,

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -339,7 +339,6 @@ class ReferenceModelManager:
             )
 
         if self.ref_model is not None and not self.is_peft_model:
-            print(type(self.ref_model))
             self.ref_model = _prepare_multigpu(self.ref_model, self.accelerator, is_deepspeed_enabled)
 
     def __enter__(self):
@@ -488,7 +487,7 @@ class PolicyTrainerBase(Trainer):
     def get_train_dataloader(self):
         dataloader = super().get_train_dataloader()
         def mutate_fn(batches):
-            for batch in tqdm(batches, desc="mutating batch"):
+            for batch in tqdm(batches, desc="mutating batches"):
                 batch_extras = self.generate_batch_extras(
                     self.model, batch["input_ids"]
                 )
@@ -496,8 +495,7 @@ class PolicyTrainerBase(Trainer):
                 # PR TODO: clean this
                 gc.collect()
                 torch.cuda.empty_cache()
-                print("batch keys", batch.keys())
-            return batch
+            return batches
         return DynamicDataLoader(
             dataloader,
             mutate_fn,

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from contextlib import contextmanager
 from copy import deepcopy
 import os
 import time
@@ -261,6 +262,7 @@ class ModelManager:
             )
         """
 
+    @contextmanager
     def __call__(self, adapter_name):
         self.base_model.set_adapter(adapter_name)
         yield self.base_model

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -29,7 +29,7 @@ from transformers import (
     PreTrainedTokenizerBase
 )
 
-from trl.models.utils import unwrap_model_for_generation, prepare_model_and_ref_model
+from trl.models.utils import unwrap_model_for_generation
 
 
 from ..models import SUPPORTED_ARCHITECTURES, create_reference_model, PreTrainedModelWrapper
@@ -81,6 +81,108 @@ class fast_eval_mode:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.was_training:
             self.model.train()
+
+
+def prepare_model_and_ref_model(
+        model: Optional[Union[PreTrainedModel, nn.Module, str]],
+        ref_model: Optional[Union[PreTrainedModel, nn.Module, str]],
+        model_init_kwargs: Optional[Dict],
+        ref_model_init_kwargs: Optional[Dict],
+        peft_config: Optional[Dict],
+        force_use_ref_model: bool,
+        args: Optional[TrainingArguments],
+):
+    """
+    Adapted from dpo_trainer.py
+    Allow user to pass a model or model URI + init kwargs + optional peft_config
+    Return a fully initialized model and ref_model
+    """
+    if model_init_kwargs is None:
+        model_init_kwargs = {}
+    elif not isinstance(model, str):
+        raise ValueError("You passed model_init_kwargs to the trainer. But model is already instantiated.")
+
+    if ref_model_init_kwargs is None:
+        ref_model_init_kwargs = {}
+    elif not isinstance(ref_model, str):
+        raise ValueError(
+            "You passed ref_model_init_kwargs to the trainer. But your ref_model is already instantiated."
+        )
+
+    if isinstance(model, str):
+        warnings.warn(
+            "You passed a model_id to the trainer. This will automatically create an "
+            "`AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you."
+        )
+        model = AutoModelForCausalLM.from_pretrained(model, **model_init_kwargs)
+
+    if isinstance(ref_model, str):
+        warnings.warn(
+            "You passed a ref model_id to the trainer. This will automatically create an "
+            "`AutoModelForCausalLM`"
+        )
+        ref_model = AutoModelForCausalLM.from_pretrained(ref_model, **ref_model_init_kwargs)
+
+    if not is_peft_available() and peft_config is not None:
+        raise ValueError(
+            "PEFT is not installed and you passed a `peft_config` in the trainer's kwargs, please install it to use the PEFT models"
+        )
+    elif is_peft_available() and peft_config is not None:
+        # if model is a peft model and we have a peft_config, we merge and unload it first
+        if isinstance(model, PeftModel):
+            model = model.merge_and_unload()
+
+        if ref_model is not None and not force_use_ref_model:
+            raise ValueError(
+                "You passed both a ref_model and a peft_config. For training PEFT adapters there is no need to pass a reference"
+                " model. Please pass `ref_model=None` in case you want to train PEFT adapters, or pass a ref_model with `force_use_ref_model=True` in trainer's init."
+                " if you want to use a different ref_model."
+            )
+
+        if getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False):
+            _support_gc_kwargs = hasattr(
+                args, "gradient_checkpointing_kwargs"
+            ) and "gradient_checkpointing_kwargs" in list(
+                inspect.signature(prepare_model_for_kbit_training).parameters
+            )
+
+            prepare_model_kwargs = {"use_gradient_checkpointing": args.gradient_checkpointing}
+
+            if _support_gc_kwargs:
+                prepare_model_kwargs["gradient_checkpointing_kwargs"] = args.gradient_checkpointing_kwargs
+
+            model = prepare_model_for_kbit_training(model, **prepare_model_kwargs)
+        elif getattr(args, "gradient_checkpointing", False):
+            # For backward compatibility with older versions of transformers
+            if hasattr(model, "enable_input_require_grads"):
+                model.enable_input_require_grads()
+            else:
+
+                def make_inputs_require_grad(module, input, output):
+                    output.requires_grad_(True)
+
+                model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+        # get peft model with the given config
+        model = get_peft_model(model, peft_config)
+        if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
+            peft_module_casting_to_bf16(model)
+
+    # For models that use gradient_checkpointing, we need to attach a hook that enables input
+    # to explicitly have `requires_grad=True`, otherwise training will either silently
+    # fail or completely fail.
+    elif getattr(args, "gradient_checkpointing", False):
+        # For backward compatibility with older versions of transformers
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+        else:
+
+            def make_inputs_require_grad(module, input, output):
+                output.requires_grad_(True)
+
+            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+    return model, ref_model
 
 
 # PR TODO: maybe this isn't necessary? This may be handled already by the accelerator, as it prepares

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -558,7 +558,7 @@ class PolicyTrainerBase(Trainer):
         )
         reward_logits = reward_model.score(output.hidden_states[-1])
         sequence_lengths = (
-            first_true_indices(
+            self.first_true_indices(
                 query_responses[:, context_length:] == self.tokenizer.pad_token_id
             ) - 1 + context_length
         )

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -35,7 +35,7 @@ from trl.models.utils import unwrap_model_for_generation
 
 from ..core import logprobs_from_logits
 from ..models import SUPPORTED_ARCHITECTURES, create_reference_model, PreTrainedModelWrapper
-from .utils import disable_dropout_in_model, peft_module_casting_to_bf16, peft_module_casting_to_fp16
+from .utils import disable_dropout_in_model, peft_module_casting_to_bf16
 
 
 from ..import_utils import is_peft_available

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -359,21 +359,6 @@ class ReferenceModelManager:
             self.model.set_adapter("default")
 
 
-class disable_caching(ContextDecorator):  # noqa: N801
-    def __init__(self, model):
-        self.model = model
-        self.prev_value: Any = "UNSET"  # config values may be T/F/None
-
-    def __enter__(self):
-        self.prev_value = self.model.config.use_cache
-        self.model.config.use_cache = False
-
-    def __exit__(self, *exc):
-        if self.prev_value != "UNSET":
-            self.model.config.use_cache = self.prev_value
-        self.prev_value = "UNSET"
-
-
 class PolicyTrainerBase(Trainer):
     """
     Base class for implementing a policy training algorithm.
@@ -654,10 +639,6 @@ class PolicyTrainerBase(Trainer):
         """time logged training step"""
         with self.time_metric_ctx("training_step"):
             return super().training_step(*args, **kwargs)
-
-    def train(self, *args, **kwargs):
-        with disable_caching(self.model):
-            super().train(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -446,10 +446,14 @@ class PolicyTrainerBase(Trainer):
 
 
         # handle casting self.model
+        """
         if args.bf16 and getattr(model, "is_loaded_in_4bit", False):
             self.cast_model_ctx = lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
         else:
             self.cast_model_ctx = nullcontext
+        """
+        # PR TODO: remove temporary hack
+        self.cast_model_ctx = lambda: torch.cuda.amp.autocast(dtype=torch.bfloat16)
 
         super().__init__(
             model=model,

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional, Tuple, Union, Callable, Any
 import warnings
 from contextlib import nullcontext
+from tqdm import tqdm
 
 import numpy as np
 import torch

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -508,11 +508,9 @@ class PolicyTrainerBase(Trainer):
                     generation_config=generation_config,
                     return_dict_in_generate=True,
                     # PR TODO: https://github.com/huggingface/trl/pull/1540/files#r1588004580
-                    output_logits=True,
                 )
-        logits = torch.stack(output.logits, 1)
         query_responses = torch.cat((queries, output.sequences[:, context_length:]), dim=1)
-        return query_responses, logits
+        return query_responses
 
     def forward(self, model, query_responses):
         attention_mask = query_responses != self.tokenizer.pad_token_id

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -620,6 +620,7 @@ class PolicyTrainerBase(Trainer):
         train_eval = "train" if "loss" in logs else "eval"
         # Add averaged stored metrics to logs
         for key, metrics in self._stored_metrics[train_eval].items():
+            print(key)
             logs[key] = torch.tensor(metrics).to(dtype=torch.float32).mean().item()
         del self._stored_metrics[train_eval]
         return super().log(logs)

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -1,3 +1,4 @@
+from accelerate.utils import is_deepspeed_available
 from collections import defaultdict
 from contextlib import nullcontext
 from copy import deepcopy
@@ -26,7 +27,7 @@ from transformers import (
 from ..core import logprobs_from_logits
 from ..models import SUPPORTED_ARCHITECTURES, create_reference_model, PreTrainedModelWrapper
 from .utils import disable_dropout_in_model, peft_module_casting_to_bf16
-from ..import_utils import is_peft_available, is_deepspeed_available
+from ..import_utils import is_peft_available
 
 
 if is_peft_available():

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -1,6 +1,6 @@
 from accelerate.utils import is_deepspeed_available
 from collections import defaultdict
-from contextlib import nullcontext
+from contextlib import nullcontext, contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from tqdm import tqdm
@@ -317,6 +317,7 @@ class ReferenceModelManager:
         if self.ref_model is not None and not self.is_peft_model:
             self.ref_model = _prepare_multigpu(self.ref_model, self.accelerator, is_deepspeed_enabled)
 
+    @contextmanager
     def __call__(self):
         if self.ref_model is not None:
             yield self.ref_model

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -33,7 +33,7 @@ from transformers import (
 
 from trl.models.utils import unwrap_model_for_generation
 
-
+from ..core import logprobs_from_logits
 from ..models import SUPPORTED_ARCHITECTURES, create_reference_model, PreTrainedModelWrapper
 from .utils import disable_dropout_in_model, peft_module_casting_to_bf16, peft_module_casting_to_fp16
 

--- a/trl/trainer/policy_trainer_base.py
+++ b/trl/trainer/policy_trainer_base.py
@@ -356,7 +356,7 @@ class ReferenceModelManager:
             with self.optional_peft_ctx:
                 pass  # teardown
             # reset adapter back to being the active model
-            self.ref_model.set_adapter("default")
+            self.model.set_adapter("default")
 
 
 class PolicyTrainerBase(Trainer):

--- a/trl/trainer/ppov2_trainer.py
+++ b/trl/trainer/ppov2_trainer.py
@@ -1,0 +1,313 @@
+from accelerate.utils import gather_object
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple, Union, Any
+
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import PreTrainedModel, GenerationConfig
+from trl.models.utils import unwrap_model_for_generation
+
+from . import PolicyTrainerBase, PolicyTrainerArguments
+
+
+INVALID_LOGPROB = 1.0
+
+
+@dataclass
+class PPOConfig(PolicyTrainerArguments):
+    vf_coef: float = 0.1
+    """the value function coefficient"""
+    cliprange: float = 0.2
+    """the clip range"""
+    cliprange_value: float = 0.2
+    """the clip range for the value function"""
+    gamma: float = 1
+    """the discount factor"""
+    lam: float = 0.95
+    """the lambda value for GAE"""
+    whiten_rewards: bool = False
+    """whether to whiten the rewards"""
+    kl_coef: float = 0.05
+    """the KL coefficient"""
+
+
+def masked_mean(values, mask, axis=None):
+    """Compute mean of tensor with a masked values."""
+    if axis is not None:
+        return (values * mask).sum(axis=axis) / mask.sum(axis=axis)
+    else:
+        return (values * mask).sum() / mask.sum()
+
+
+def masked_var(values, mask, unbiased=True):
+    """Compute variance of tensor with masked values."""
+    mean = masked_mean(values, mask)
+    centered_values = values - mean
+    variance = masked_mean(centered_values**2, mask)
+    if unbiased:
+        mask_sum = mask.sum()
+        if mask_sum == 0:
+            raise ValueError(
+                "The sum of the mask is zero, which can happen when `mini_batch_size=1`;"
+                "try increase the `mini_batch_size` or `gradient_accumulation_steps`"
+            )
+        # note that if mask_sum == 1, then there is a division by zero issue
+        # to avoid it you just need to use a larger minibatch_size
+        bessel_correction = mask_sum / (mask_sum - 1)
+        variance = variance * bessel_correction
+    return variance
+
+
+def masked_whiten(values, mask, shift_mean=True):
+    """Whiten values with masked values."""
+    mean, var = masked_mean(values, mask), masked_var(values, mask, False)
+    whitened = (values - mean) * torch.rsqrt(var + 1e-8)
+    if not shift_mean:
+        whitened += mean
+    return whitened
+
+
+# taken from https://github.com/OpenLMLab/MOSS-RLHF/blob/40b91eb2f2b71b16919addede0341d2bef70825d/ppo/ppo_trainer.py#L29
+# we did this we can do a single `model = accelerator.prepare(model)`
+class PolicyAndValueWrapper(nn.Module):
+    def __init__(self, policy, value_model) -> None:
+        super().__init__()
+        self.policy = policy
+        self.value_model = value_model
+        self.critic_backbone = getattr(value_model, value_model.base_model_prefix)
+
+    def forward(self, **kwargs):
+        output = self.critic_backbone(
+            **kwargs,
+        )
+        logits = self.value_model.score(output.hidden_states[-1])
+        return self.policy(**kwargs), logits
+
+
+class PPOTrainer(PolicyTrainerBase):
+
+    def push_to_hub(self, **kwargs):
+        """Modified from `Trainer.save_model` to only save the policy a1nd not the value network."""
+        self.backup_model = self.model
+        self.model = self.accelerator.unwrap_model(self.model).policy  # save only the policy
+        super().push_to_hub(**kwargs)
+        self.model = self.backup_model
+
+    def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
+        """Modified from `Trainer.save_model` to only save the policy and not the value network."""
+        # PR TODO: can we simplify this?
+        # PR TODO:
+        if not _internal_call:  # `push_to_hub` already swaps out the self.model with policy
+            self.backup_model = self.model
+            self.model = self.accelerator.unwrap_model(self.model).policy  # save only the policy
+        if output_dir is None:
+            output_dir = self.args.output_dir
+        state_dict = self.accelerator.get_state_dict(self.backup_model)
+        policy_state_dict = state_dict
+        if self.accelerator.is_main_process:
+            policy_state_dict = OrderedDict({k[len("policy."):]: v for k, v in state_dict.items() if k.startswith("policy.")})
+        if self.args.should_save:
+            self._save(output_dir, state_dict=policy_state_dict)
+        if not _internal_call:
+            self.model = self.backup_model
+
+    def get_batch_loss_metrics(
+        self,
+        model: Union[PreTrainedModel, nn.Module],
+        inputs: Dict[str, Union[torch.Tensor, Any]],
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        """
+        PR TODO: appropriate docstring
+        """
+
+        # load inputs created by the generation model in generate_batch_extras()
+        queries = inputs["queries"].to(self.accelerator.device)
+        query_responses = inputs["query_responses"].to(self.accelerator.device)
+        responses = inputs["responses"].to(self.accelerator.device)
+        gen_logprobs = inputs["generation_logprobs"].to(self.accelerator.device)
+        context_length = queries.shape[1]
+
+        with torch.no_grad():
+
+            with self.ref_model_mgr as ref_model:
+                _, ref_logprobs = self.calc_logprobs(
+                    ref_model, query_responses, context_length
+                )
+
+            # Response Processing 1. truncate response after the first occurrence of `truncate_token_id`
+            postprocessed_responses = responses
+            if self.args.truncate_token_id:
+                postprocessed_responses = self.truncate_response(responses)
+
+            # Response Processing 2. run reward model on the truncated responses
+            postprocessed_query_responses = torch.cat((queries, postprocessed_responses), 1)
+            sequence_lengths = self.first_true_indices(
+                postprocessed_responses == self.tokenizer.pad_token_id
+            ) - 1
+
+            full_values, _, _ = self.get_reward(
+                self.accelerator.unwrap_model(self.model).value_model,
+                query_responses,
+                context_length
+            )
+            values = full_values[:, context_length - 1: -1].squeeze(-1)
+            _, scores, _ = self.get_reward(
+                self.reward_model,
+                postprocessed_query_responses,
+                context_length
+            )
+
+            # Response Processing 3. filter response. Ensure that the sample contains truncate_token_id
+            # responses not passing that filter will receive a low (fixed) score
+            if self.args.non_eos_penalty:
+                contain_eos_token = torch.any(postprocessed_responses == self.tokenizer.eos_token_id, dim=-1)
+                non_eos_penalty_rewards = torch.full_like(scores, self.args.penalty_reward_value)
+                scores = torch.where(contain_eos_token, scores, non_eos_penalty_rewards)
+
+            # be very careful with `padding_mask`;
+            # see https://excalidraw.com/#json=LWnzG4w2k5DjF_EOL_xPt,e2w3a-hFJ_gX5vOfeyXGTw
+            response_idxs = torch.arange(responses.shape[1], device=responses.device).repeat(
+                responses.shape[0], 1)
+            padding_mask = response_idxs > sequence_lengths.unsqueeze(1)
+
+            sequence_lengths_p1 = sequence_lengths + 1
+            padding_mask_p1 = response_idxs > (sequence_lengths_p1.unsqueeze(1))
+            values = torch.masked_fill(values, padding_mask_p1, 0)
+
+            gen_logprobs = torch.masked_fill(gen_logprobs, padding_mask, INVALID_LOGPROB)
+            ref_logprobs = torch.masked_fill(ref_logprobs, padding_mask, INVALID_LOGPROB)
+
+            # 4. compute rewards
+            kl = gen_logprobs - ref_logprobs
+            non_score_reward = -self.args.kl_coef * kl
+            rewards = non_score_reward.clone()
+            actual_start = torch.arange(rewards.size(0), device=rewards.device)
+            actual_end = torch.where(sequence_lengths_p1 < rewards.size(1), sequence_lengths_p1, sequence_lengths)
+            rewards[[actual_start, actual_end]] += scores
+
+            # 5. whiten rewards
+            if self.args.whiten_rewards:
+                rewards = masked_whiten(rewards, mask=~padding_mask_p1, shift_mean=False)
+                rewards = torch.masked_fill(rewards, padding_mask_p1, 0)
+
+            # 6. compute advantages and returns
+            lastgaelam = 0
+            advantages_reversed = []
+            gen_length = responses.shape[1]
+            for t in reversed(range(gen_length)):
+                nextvalues = values[:, t + 1] if t < gen_length - 1 else 0.0
+                delta = rewards[:, t] + self.args.gamma * nextvalues - values[:, t]
+                lastgaelam = delta + self.args.gamma * self.args.lam * lastgaelam
+                advantages_reversed.append(lastgaelam)
+            advantages = torch.stack(advantages_reversed[::-1], axis=1)
+            returns = advantages + values
+            advantages = masked_whiten(advantages, ~padding_mask)
+
+        # calculate gradients and loss
+        output, vpred_temp = self.forward(self.model, query_responses)
+        logits = output.logits[:, context_length - 1: -1]
+        logits /= self.args.temperature + 1e-7
+        new_all_logprobs = F.log_softmax(logits, dim=-1)
+        new_logprobs = torch.gather(new_all_logprobs, 2, responses.unsqueeze(-1)).squeeze(-1)
+        new_logprobs = torch.masked_fill(
+            new_logprobs, padding_mask, INVALID_LOGPROB
+        )
+        vpred = vpred_temp[:, context_length - 1: -1].squeeze(-1)
+        vpred = torch.masked_fill(vpred, padding_mask_p1, 0)
+        vpredclipped = torch.clamp(
+            vpred,
+            values - self.args.cliprange_value,
+            values + self.args.cliprange_value,
+        )
+
+        vf_losses1 = torch.square(vpred - returns)
+        vf_losses2 = torch.square(vpredclipped - returns)
+        vf_loss_max = torch.max(vf_losses1, vf_losses2)
+        vf_loss = 0.5 * masked_mean(vf_loss_max, ~padding_mask_p1)
+        vf_clipfrac = masked_mean(
+            (vf_losses2 > vf_losses1).float(), ~padding_mask_p1
+        )
+        logprobs_diff = new_logprobs - gen_logprobs
+        ratio = torch.exp(logprobs_diff)
+        pg_losses = -advantages * ratio
+        pg_losses2 = -advantages * torch.clamp(
+            ratio,
+            1.0 - self.args.cliprange,
+            1.0 + self.args.cliprange
+        )
+        pg_loss_max = torch.max(pg_losses, pg_losses2)
+        pg_loss = masked_mean(pg_loss_max, ~padding_mask)
+        pg_clipfrac = masked_mean(
+            (pg_losses2 > pg_losses).float(), ~padding_mask
+        )
+        loss = pg_loss + self.args.vf_coef * vf_loss
+
+        # calculate metrics
+        with torch.no_grad():
+            mean_non_score_reward = non_score_reward.sum(1).mean()
+
+            metrics = {
+                "objective/kl": kl.sum(1).mean(),
+                "objective/entropy": (-gen_logprobs).sum(1).mean(),
+                "objective/non_score_reward": non_score_reward.mean(),
+                "objective/rlhf_reward": mean_non_score_reward + scores.mean(),
+                "objective/scores": self.accelerator.gather(scores.mean()).mean().item(),
+                "policy/approxkl_avg": 0.5 * (logprobs_diff**2).mean(),
+                "policy/clipfrac_avg": pg_clipfrac.mean(),
+                "loss/policy_avg": self.accelerator.gather(pg_loss).mean().item(),
+                "loss/value_avg": vf_loss.mean(),
+                "val/clipfrac_avg": vf_clipfrac.mean(),
+                # "policy/entropy_avg":
+                # "val/ratio":
+                # "val/ratio_var":
+                "val/num_eos_tokens": (responses == self.tokenizer.eos_token_id).sum().item(),
+            }
+
+        return loss, metrics
+
+    def generate_completions(self, sampling: bool = False):
+        # PR TODO: move this to eval step maybe?
+        """for eval"""
+        args = self.args
+        generation_config = GenerationConfig(
+            max_new_tokens=self.args.response_length,
+            temperature=(0.01 + 1e-7),
+            top_k=0.0,
+            top_p=1.0,
+            do_sample=True,
+        )
+
+        table = defaultdict(list)
+        for batch in self.eval_dataloader:
+            query = batch["input_ids"]
+            name = f"trained {args.base_model}"
+            with torch.no_grad():
+                context_length = query.shape[1]
+                with unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model:
+                    query_response, _ = self.generate(
+                        unwrapped_model.policy,
+                        query,
+                        generation_config,
+                    )
+                response = query_response[:, context_length:]
+                postprocessed_response = response
+                if args.truncate_token_id:
+                    postprocessed_response = self.truncate_response(args, self.tokenizer, response)
+                table["query"].extend(gather_object(self.tokenizer.batch_decode(query, skip_special_tokens=True)))
+                table[name].extend(gather_object(self.tokenizer.batch_decode(postprocessed_response)))
+
+                postprocessed_query_response = torch.cat((query, postprocessed_response), 1)
+                _, score, _ = self.get_reward(self.reward_model, postprocessed_query_response, context_length)
+                table["score"].extend(self.accelerator.gather(score).float().cpu().numpy())
+
+            if sampling:
+                break
+        df = pd.DataFrame(table)
+        # PR TODO: write df to pickle if not using wandb
+        if "wandb" in args.report_to:
+            import wandb
+            if wandb.run is not None:
+                wandb.log({"completions": wandb.Table(dataframe=df)})

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -106,7 +106,7 @@ class RLOOTrainer(PolicyTrainerBase):
             torch.cuda.empty_cache()
 
             with self.time_metric_ctx("get_reward"):
-                2_, scores, _ = self.get_reward(
+                _, scores, _ = self.get_reward(
                     self.reward_model,
                     postprocessed_query_responses,
                     context_length

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -238,7 +238,7 @@ class RLOOTrainer(PolicyTrainerBase):
 
         self.store_metrics(metrics)
 
-        loss = pg_loss.to(self.args.device) * 1e5
+        loss = pg_loss.to(self.args.device) * 1e2
         print("loss", loss)
         print("pg_loss", pg_loss)
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -166,7 +166,7 @@ class RLOOTrainer(PolicyTrainerBase):
             # a response by the average rewards of other `rloo_k - 1` responses
             rlhf_sum = rlhf_reward.sum(dim=0, keepdim=True)
             n = rlhf_reward.size(0)
-            mean_other = (total_sum - rlhf_reward) / (n - 1)
+            mean_other = (rlhf_sum - rlhf_reward) / (n - 1)
             advantages = rlhf_reward - mean_other
 
             _advantages = torch.zeros_like(rlhf_reward)

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -166,7 +166,7 @@ class RLOOTrainer(PolicyTrainerBase):
             # a response by the average rewards of other `rloo_k - 1` responses
             rlhf_mean = rlhf_reward.mean()
             n = rlhf_reward.size(0)
-            mean_other = (total_mean * n - rlhf_reward) / (n - 1)
+            mean_other = (rlhf_mean * n - rlhf_reward) / (n - 1)
             _advantages = rlhf_reward - mean_other
 
             advantages = torch.zeros_like(rlhf_reward)

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -106,7 +106,7 @@ class RLOOTrainer(PolicyTrainerBase):
             torch.cuda.empty_cache()
 
             with self.time_metric_ctx("get_reward"):
-                _, scores, _ = self.get_reward(
+                2_, scores, _ = self.get_reward(
                     self.reward_model,
                     postprocessed_query_responses,
                     context_length
@@ -181,7 +181,10 @@ class RLOOTrainer(PolicyTrainerBase):
         # log metrics
         with torch.no_grad():
             prob_dist = torch.nn.functional.softmax(active_logits, dim=-1)
-            entropy_avg = torch.logsumexp(active_logits, dim=-1) - torch.sum(prob_dist * logits, dim=-1)
+            entropy_avg = (
+                torch.logsumexp(active_logits, dim=-1)
+                - torch.sum(prob_dist * active_logits, dim=-1)
+            )
 
             self.store_metrics({
                 "objective/kl": kl.sum(1).mean(),

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -61,7 +61,7 @@ class RLOOTrainer(PolicyTrainerBase):
     def calc_logprobs(self, model, query_responses, context_length):
         responses = query_responses[:, context_length:]
         output_logits = self.forward(model, query_responses).logits
-        response_logits = gen_output_logits[:, context_length - 1 : -1]
+        response_logits = output_logits[:, context_length - 1 : -1]
         response_logits /= max(self.args.temperature, 1e-7)
         response_logprobs = logprobs_from_logits(response_logits, responses, gather=True)
         return response_logits, response_logprobs

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -60,7 +60,7 @@ class RLOOTrainer(PolicyTrainerBase):
 
     def calc_logprobs(self, model, query_responses, context_length):
         responses = query_responses[:, context_length:]
-        output_logits = self.forward(generation_model, query_responses).logits
+        output_logits = self.forward(model, query_responses).logits
         response_logits = gen_output_logits[:, context_length - 1 : -1]
         response_logits /= max(self.args.temperature, 1e-7)
         response_logprobs = logprobs_from_logits(response_logits, responses, gather=True)

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -184,7 +184,7 @@ class RLOOTrainer(PolicyTrainerBase):
             entropy_avg = (
                 torch.logsumexp(active_logits, dim=-1)
                 - torch.sum(prob_dist * active_logits, dim=-1)
-            )
+            ).mean()
 
             self.store_metrics({
                 "objective/kl": kl.sum(1).mean(),

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -178,7 +178,7 @@ class RLOOTrainer(PolicyTrainerBase):
                 "policy/approxkl_avg": 0.5 * (logprobs_diff**2).mean(),
                 "loss/policy_avg": self.accelerator.gather(pg_loss).mean().item(),
                 "val/ratio": new_ratio.mean(),
-                "val/ratio_var": new_ratio.mean().var(),
+                #"val/ratio_var": new_ratio.mean().var(),
                 "val/num_eos_tokens": (responses == self.tokenizer.eos_token_id).sum().item(),
                 "policy/clipfrac_avg": self.accelerator.gather(pg_clipfrac).mean().item(),
                 "policy/entropy_avg": entropy_avg

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -76,7 +76,8 @@ class RLOOTrainer(PolicyTrainerBase):
 
             # be very careful with `padding_mask`;
             # see https://excalidraw.com/#json=LWnzG4w2k5DjF_EOL_xPt,e2w3a-hFJ_gX5vOfeyXGTw
-            response_idxs = torch.arange(responses.shape[1], device=responses.device).repeat(responses.shape[0], 1)
+            response_idxs = torch.arange(responses.shape[1], device=responses.device).repeat(
+                responses.shape[0], 1)
             padding_mask = response_idxs > sequence_lengths.unsqueeze(1)
             gen_logprobs = torch.masked_fill(gen_logprobs, padding_mask, INVALID_LOGPROB)
             ref_logprobs = torch.masked_fill(ref_logprobs, padding_mask, INVALID_LOGPROB)

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -46,6 +46,7 @@ class RLOOTrainer(PolicyTrainerBase):
         with torch.no_grad():
 
             with self.ref_model_mgr as ref_model:
+                print("ref_model.active_adapters", ref_model.active_adapters)
                 _, ref_logprobs = self.calc_logprobs(
                     ref_model, query_responses, context_length
                 )
@@ -98,6 +99,7 @@ class RLOOTrainer(PolicyTrainerBase):
             advantages = rlhf_reward - mean_other
 
         # calculate gradients and loss
+        print("self.model.active_adapters", self.model.active_adapters)
         active_logits, active_logprobs = self.calc_logprobs(
             self.model, query_responses, context_length
         )

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -70,7 +70,10 @@ class RLOOTrainer(PolicyTrainerBase):
             # Response Processing 3. filter response. Ensure that the sample contains truncate_token_id
             # responses not passing that filter will receive a low (fixed) score
             if self.args.non_eos_penalty:
-                contain_eos_token = torch.any(postprocessed_responses == self.tokenizer.eos_token_id, dim=-1)
+                contain_eos_token = torch.any(
+                    postprocessed_responses == self.tokenizer.eos_token_id,
+                    dim=-1
+                )
                 non_eos_penalty_rewards = torch.full_like(scores, self.args.penalty_reward_value)
                 scores = torch.where(contain_eos_token, scores, non_eos_penalty_rewards)
 
@@ -96,7 +99,7 @@ class RLOOTrainer(PolicyTrainerBase):
 
         # calculate gradients and loss
         active_logits, active_logprobs = self.calc_logprobs(
-            model, query_responses, context_length
+            self.model, query_responses, context_length
         )
         active_logprobs = torch.masked_fill(
             active_logprobs, padding_mask, INVALID_LOGPROB

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -85,7 +85,7 @@ class RLOOTrainer(PolicyTrainerBase):
             # PR TODO: refactor into a function shared by ppov2 which calculates sequences and logprobs
             #          see DPOTrainer.concatenated_forward
 
-            with self.cast_model_ctx(), with self.ref_model_mgr as ref_model:
+            with self.cast_model_ctx(), self.ref_model_mgr as ref_model:
                 _, ref_logprobs = self.calc_logprobs(
                     ref_model, query_responses, context_length
                 )

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -144,12 +144,10 @@ class RLOOTrainer(PolicyTrainerBase):
             advantages = rlhf_reward - mean_other
 
         # calculate gradients and loss
-        with self.time_metric_ctx("calc_loss"):
-
-            with self.cast_model_ctx():
-                active_logits, active_logprobs = self.calc_logprobs(
-                    model, query_responses, context_length
-                )
+        with self.time_metric_ctx("calc_loss"), self.cast_model_ctx():
+            active_logits, active_logprobs = self.calc_logprobs(
+                model, query_responses, context_length
+            )
             active_logprobs = torch.masked_fill(
                 active_logprobs, padding_mask, INVALID_LOGPROB
             )

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -143,22 +143,6 @@ class RLOOTrainer(PolicyTrainerBase):
             mean_other = (rlhf_sum - rlhf_reward) / (n - 1)
             advantages = rlhf_reward - mean_other
 
-            _advantages = torch.zeros_like(rlhf_reward)
-            for i in range(0, len(advantages)):
-                other_response_rlhf_rewards = []
-                for j in range(0, len(advantages)):
-                    if i != j:
-                        other_response_rlhf_rewards.append(rlhf_reward[j])
-                advantages[i] = rlhf_reward[i] - torch.stack(other_response_rlhf_rewards).mean(0)
-            torch.cuda.empty_cache()
-
-        print("kl[0]", kl[0])
-        print("rlhf_reward[]", rlhf_reward[0])
-        print("non_score_reward[0]", non_score_reward[0])
-        print("advantages[0]", advantages[0])
-        print("_advantages[0]", _advantages[0])
-
-
         # calculate gradients and loss
         with self.time_metric_ctx("calc_loss"):
 
@@ -201,7 +185,6 @@ class RLOOTrainer(PolicyTrainerBase):
             })
 
         loss = pg_loss.to(self.args.device)
-        print("loss", loss)
 
         # PR TODO: decorator which calls gc.collect(); torch.cuda.empty_cache()
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -46,7 +46,6 @@ class RLOOTrainer(PolicyTrainerBase):
         with torch.no_grad():
 
             with self.ref_model_mgr() as ref_model:
-                print("ref_model.active_adapters", ref_model.active_adapters)
                 _, ref_logprobs = self.calc_logprobs(
                     ref_model, query_responses, context_length
                 )
@@ -99,7 +98,6 @@ class RLOOTrainer(PolicyTrainerBase):
             advantages = rlhf_reward - mean_other
 
         # calculate gradients and loss
-        print("self.model.active_adapters", self.model.active_adapters)
         active_logits, active_logprobs = self.calc_logprobs(
             self.model, query_responses, context_length
         )

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -164,9 +164,9 @@ class RLOOTrainer(PolicyTrainerBase):
             # we generated `self.args.rloo_k` many responses per prompt
             # now we can implement the RLOO loss by subtracting the reward of
             # a response by the average rewards of other `rloo_k - 1` responses
-            rlhf_mean = rlhf_reward.mean()
+            rlhf_sum = rlhf_reward.sum(dim=0, keepdim=True)
             n = rlhf_reward.size(0)
-            mean_other = (rlhf_mean * n - rlhf_reward) / (n - 1)
+            mean_other = (total_sum - rlhf_reward) / (n - 1)
             advantages = rlhf_reward - mean_other
 
             _advantages = torch.zeros_like(rlhf_reward)
@@ -181,8 +181,8 @@ class RLOOTrainer(PolicyTrainerBase):
         print("kl", kl.mean())
         print("rlhf_reward", rlhf_reward.mean())
         print("non_score_reward", non_score_reward.mean())
-        print("advantages", advantages.mean())
-        print("_advantages", _advantages.mean())
+        print("advantages[0]", advantages[0])
+        print("_advantages[0]", _advantages[0])
 
 
         with self.time_metric_ctx("calc_loss"):

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -167,9 +167,9 @@ class RLOOTrainer(PolicyTrainerBase):
             rlhf_mean = rlhf_reward.mean()
             n = rlhf_reward.size(0)
             mean_other = (rlhf_mean * n - rlhf_reward) / (n - 1)
-            _advantages = rlhf_reward - mean_other
+            advantages = rlhf_reward - mean_other
 
-            advantages = torch.zeros_like(rlhf_reward)
+            _advantages = torch.zeros_like(rlhf_reward)
             for i in range(0, len(advantages)):
                 other_response_rlhf_rewards = []
                 for j in range(0, len(advantages)):
@@ -178,11 +178,11 @@ class RLOOTrainer(PolicyTrainerBase):
                 advantages[i] = rlhf_reward[i] - torch.stack(other_response_rlhf_rewards).mean(0)
             torch.cuda.empty_cache()
 
-        print("kl", kl)
-        print("rlhf_reward", rlhf_reward)
-        print("non_score_reward", non_score_reward)
-        print("advantages", advantages)
-        print("_advantages", _advantages)
+        print("kl", kl.mean())
+        print("rlhf_reward", rlhf_reward.mean())
+        print("non_score_reward", non_score_reward.mean())
+        print("advantages", advantages.mean())
+        print("_advantages", _advantages.mean())
 
 
         with self.time_metric_ctx("calc_loss"):

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -45,7 +45,7 @@ class RLOOTrainer(PolicyTrainerBase):
 
         with torch.no_grad():
 
-            with self.ref_model_mgr as ref_model:
+            with self.ref_model_mgr() as ref_model:
                 print("ref_model.active_adapters", ref_model.active_adapters)
                 _, ref_logprobs = self.calc_logprobs(
                     ref_model, query_responses, context_length

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -110,7 +110,7 @@ class RLOOTrainer(PolicyTrainerBase):
                         generation_model, query_responses, context_length
                     )
 
-                self.model_manager("ref") as ref_model:
+                with self.model_manager("ref") as ref_model:
                     _, ref_logprobs = self.calc_logprobs(
                         ref_model, query_responses, context_length
                     )

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -658,22 +658,18 @@ def neftune_post_forward_hook(module, input, output):
     return output
 
 
-def peft_module_casting(model, dtype):
+def peft_module_casting_to_bf16(model):
     from peft.tuners.tuners_utils import BaseTunerLayer
 
     for name, module in model.named_modules():
         if isinstance(module, BaseTunerLayer):
-            module = module.to(dtype)
+            module = module.to(torch.bfloat16)
         elif isinstance(module, torch.nn.LayerNorm) or "norm" in name:
             module = module.to(torch.float32)
         elif any(x in name for x in ["lm_head", "embed_tokens", "wte", "wpe"]):
             if hasattr(module, "weight"):
                 if module.weight.dtype == torch.float32:
-                    module = module.to(dtype)
-
-
-peft_module_casting_to_bf16 = lambda model: peft_module_casting(model, dtype=torch.bfloat16)
-peft_module_casting_to_fp16 = lambda model: peft_module_casting(model, dtype=torch.float16)
+                    module = module.to(torch.bfloat16)
 
 
 def trl_sanitze_kwargs_for_tagging(model, tag_names, kwargs=None):


### PR DESCRIPTION
WIP: Unify Policy Trainers


# Overview / Problem

Many trainers within trl follow the same paradigm:
- 1) Create a base model and a frozen reference model
- 2) Given a batch,
  - 2a) Generate using one or both models
  - 2b) Get logits
  - 2c) Use trainer-specific method to calculate loss
  - 2d) backpropagate, and log metrics

Trainers following this workflow include `PPOTrainer`, `DPOTrainer`, `KTOTrainer`, and the new `RLOOTrainer` [(in PR)](https://github.com/huggingface/trl/pull/1540).
- https://github.com/search?q=repo%3Ahuggingface%2Ftrl+%22You+passed+a+model_id%22&type=code

Despite sharing these features, each trainer has repetitive and sometimes inconsistent implementations of core components including reference model management, generation of policy output, and even model saving.

This has resulted in a number of bugs, confusion, and unnecessary redundant work when implementing new policy trainers.


# `PolicyTrainerBase`

The goal for this PR is to introduce an abstract `PolicyTrainerBase` with the `RLOOTrainer` adapted from https://github.com/huggingface/trl/pull/1540

The adapted `RLOOTrainer` only implements `training_step()` which is provided a batch of inputs, calculates loss, applies backprop, and logs metrics.

`PolicyTrainerBase` takes care of everything else, primarily preparation and management of the reference model, along with preparation of the generation config, and a utility function for generation of output sequences and logits.

I'll have to consider the generation function carefully, as that is one of the most complex components of the different policy trainers (see `PPOTrainer`s implementation https://github.com/huggingface/trl/blob/b32656f7266c02500ea346eda75a0db7a9a1bb75/trl/trainer/ppo_trainer.py#L431-L565)


# Remaining Work:

- [ ] Reproduce REINFORCE RLOO results from https://github.com/huggingface/trl/pull/1540
- [ ] Ensure accelerate with multiple GPUs works
- [ ] Ensure deepspeed works
- [ ] add eval step