### PR TITLE
Fix max_completion_length for encoder_decoder models in KTO Trainer

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -526,6 +526,7 @@ class KTOTrainer(Trainer):
                 "truncation_mode": self.truncation_mode,
                 "label_pad_token_id": self.label_pad_token_id,
                 "max_prompt_length": self.max_prompt_length,
+                "max_completion_length": self.max_completion_length,
             }
             train_dataset = train_dataset.map(
                 _process_tokens,
@@ -566,6 +567,7 @@ class KTOTrainer(Trainer):
                     "truncation_mode": self.truncation_mode,
                     "label_pad_token_id": self.label_pad_token_id,
                     "max_prompt_length": self.max_prompt_length,
+                    "max_completion_length": self.max_completion_length,
                 }
                 eval_dataset = eval_dataset.map(
                     _process_tokens,


### PR DESCRIPTION
For encoder_decoder models the argument, `max_completion_length` is missing in the kto_trainer, leading to an error in [line 205](https://github.com/huggingface/trl/blob/1d0a7ea17b8055a6850970ab59a34709d8ca494d/trl/trainer/kto_trainer.py#L205).