### PR TITLE
fixed adding bos and eos token unconditionally

### DIFF
--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -410,23 +410,23 @@ class CPOTrainer(Trainer):
                 )
 
             # add BOS token to head of prompt. Avoid adding if it's already there
-            if tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
-                prompt_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
-                chosen_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
-                rejected_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
             # add EOS token to end of answer. Avoid adding if it's already there
-            if tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
-                chosen_tokens["input_ids"].append(tokenizer.eos_token_id)
+            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
 
-            if tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
-                rejected_tokens["input_ids"].append(tokenizer.eos_token_id)
+            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -409,21 +409,25 @@ class CPOTrainer(Trainer):
                     "last token due to tokenizer merge ops."
                 )
 
-            # add BOS token to head of prompt
-            prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
-            chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
-            rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            # add BOS token to head of prompt. Avoid adding if it's already there
+            if tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+                prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
+            if tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+                chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
+            if tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+                rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
-            prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
+            # add EOS token to end of answer. Avoid adding if it's already there
+            if tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(tokenizer.eos_token_id)
+                chosen_tokens["attention_mask"].append(1)
 
-            # add EOS token to end of answer
-            chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            chosen_tokens["attention_mask"].append(1)
-
-            rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            rejected_tokens["attention_mask"].append(1)
+            if tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(tokenizer.eos_token_id)
+                rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))
 

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -410,23 +410,24 @@ class CPOTrainer(Trainer):
                 )
 
             # add BOS token to head of prompt. Avoid adding if it's already there
-            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
-                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+            bos_token_id = self.tokenizer.bos_token_id
+            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
-                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
-                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
             # add EOS token to end of answer. Avoid adding if it's already there
-            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
-                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            eos_token_id = self.tokenizer.eos_token_id
+            if eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-
-            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
-                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            if eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -411,22 +411,22 @@ class CPOTrainer(Trainer):
 
             # add BOS token to head of prompt. Avoid adding if it's already there
             bos_token_id = self.tokenizer.bos_token_id
-            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+            if prompt_len_input_ids == 0 or bos_token_id != prompt_tokens["prompt_input_ids"][0]:
                 prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+            if chosen_prompt_len_input_ids == 0 or bos_token_id != chosen_tokens["prompt_input_ids"][0]:
                 chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+            if rejected_prompt_len_input_ids == 0 or bos_token_id != rejected_tokens["prompt_input_ids"][0]:
                 rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
             # add EOS token to end of answer. Avoid adding if it's already there
             eos_token_id = self.tokenizer.eos_token_id
-            if eos_token_id != chosen_tokens["input_ids"][-1]:
+            if len(chosen_tokens["input_ids"]) == 0 or eos_token_id != chosen_tokens["input_ids"][-1]:
                 chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if eos_token_id != rejected_tokens["input_ids"][-1]:
+            if len(rejected_tokens["input_ids"]) == 0 or eos_token_id != rejected_tokens["input_ids"][-1]:
                 rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -772,23 +772,24 @@ class DPOTrainer(Trainer):
                 )
 
             # add BOS token to head of prompt. Avoid adding if it's already there
-            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
-                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+            bos_token_id = self.tokenizer.bos_token_id
+            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
-                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
-                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
-
             # add EOS token to end of answer. Avoid adding if it's already there
-            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
-                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            eos_token_id = self.tokenizer.eos_token_id
+            if eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
-                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            if eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -773,22 +773,22 @@ class DPOTrainer(Trainer):
 
             # add BOS token to head of prompt. Avoid adding if it's already there
             bos_token_id = self.tokenizer.bos_token_id
-            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+            if prompt_len_input_ids == 0 or bos_token_id != prompt_tokens["prompt_input_ids"][0]:
                 prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+            if chosen_prompt_len_input_ids == 0 or bos_token_id != chosen_tokens["prompt_input_ids"][0]:
                 chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+            if rejected_prompt_len_input_ids == 0 or bos_token_id != rejected_tokens["prompt_input_ids"][0]:
                 rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
             # add EOS token to end of answer. Avoid adding if it's already there
             eos_token_id = self.tokenizer.eos_token_id
-            if eos_token_id != chosen_tokens["input_ids"][-1]:
+            if len(chosen_tokens["input_ids"]) == 0 or eos_token_id != chosen_tokens["input_ids"][-1]:
                 chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if eos_token_id != rejected_tokens["input_ids"][-1]:
+            if len(rejected_tokens["input_ids"]) == 0 or eos_token_id != rejected_tokens["input_ids"][-1]:
                 rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -772,23 +772,23 @@ class DPOTrainer(Trainer):
                 )
 
             # add BOS token to head of prompt. Avoid adding if it's already there
-            if tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
-                prompt_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
-                chosen_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
-                rejected_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
 
             # add EOS token to end of answer. Avoid adding if it's already there
-            if tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
-                chosen_tokens["input_ids"].append(tokenizer.eos_token_id)
+            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
-                rejected_tokens["input_ids"].append(tokenizer.eos_token_id)
+            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -771,21 +771,25 @@ class DPOTrainer(Trainer):
                     "last token due to tokenizer merge ops."
                 )
 
-            # add BOS token to head of prompt
-            prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
-            chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
-            rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            # add BOS token to head of prompt. Avoid adding if it's already there
+            if tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+                prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
+            if tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+                chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
+            if tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+                rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
-            prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
-            # add EOS token to end of answer
-            chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            chosen_tokens["attention_mask"].append(1)
-
-            rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            rejected_tokens["attention_mask"].append(1)
+            # add EOS token to end of answer. Avoid adding if it's already there
+            if tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(tokenizer.eos_token_id)
+                chosen_tokens["attention_mask"].append(1)
+            if tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(tokenizer.eos_token_id)
+                rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -186,7 +186,15 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
             "answer_attention_mask": example["answer_attention_mask"],
         }
 
-        max_length = kwargs["max_length"] - 2
+        # calculate max length by checking if BOS/EOS is already there
+        max_length = kwargs["max_length"]
+        bos_token_id = kwargs["tokenizer"].bos_token_id
+        eos_token_id = kwargs["tokenizer"].eos_token_id
+        if bos_token_id != all_tokens["prompt_input_ids"][0]:
+            max_length -= 1
+        if eos_token_id != all_tokens["answer_input_ids"][-1]:
+            max_length -= 1
+
         # if combined sequence is too long (> max_length - 1 for BOS token - 1 for EOS), truncate the prompt
         if len(all_tokens["prompt_input_ids"]) + len(all_tokens["answer_input_ids"]) > max_length:
             for k in ["prompt_input_ids", "prompt_attention_mask"]:
@@ -202,20 +210,40 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
             for k in ["answer_input_ids", "answer_attention_mask"]:
                 all_tokens[k] = all_tokens[k][: max_length - kwargs["max_prompt_length"]]
 
-        # for legacy reasons, use the completion_* prefix to now refer to the joint sequence
-        batch[f"{kwargs['prefix']}prompt_input_ids"] = [kwargs["tokenizer"].bos_token_id] + all_tokens[
-            "prompt_input_ids"
-        ]
-        batch[f"{kwargs['prefix']}prompt_attention_mask"] = [1] + all_tokens["prompt_attention_mask"]
+        # all input_ids and attention mask as is. We then check if we need to add BOS/EOS tokens
+        batch[f"{kwargs['prefix']}prompt_input_ids"] = all_tokens["prompt_input_ids"]
+        batch[f"{kwargs['prefix']}prompt_attention_mask"] = all_tokens["prompt_attention_mask"]
         batch[f"{kwargs['prefix']}completion_input_ids"] = (
-            [kwargs["tokenizer"].bos_token_id]
-            + all_tokens["prompt_input_ids"]
+            all_tokens["prompt_input_ids"]
             + all_tokens["answer_input_ids"]
-            + [kwargs["tokenizer"].eos_token_id]
         )
         batch[f"{kwargs['prefix']}completion_attention_mask"] = (
-            [1] + all_tokens["prompt_attention_mask"] + all_tokens["answer_attention_mask"] + [1]
+            all_tokens["prompt_attention_mask"] + all_tokens["answer_attention_mask"]
         )
+
+        # add BOS, which affects both prompt and the full completion
+        if bos_token_id != all_tokens["prompt_input_ids"][0]:
+            batch[f"{kwargs['prefix']}prompt_input_ids"] = [bos_token_id] + batch[
+                f"{kwargs['prefix']}prompt_input_ids"
+            ]
+            batch[f"{kwargs['prefix']}prompt_attention_mask"] = [1] + batch[
+                f"{kwargs['prefix']}prompt_attention_mask"
+            ]
+            batch[f"{kwargs['prefix']}completion_input_ids"] = (
+                [bos_token_id]
+                + batch[f"{kwargs['prefix']}completion_input_ids"]
+            )
+            batch[f"{kwargs['prefix']}completion_attention_mask"] = (
+                [1] + batch[f"{kwargs['prefix']}completion_attention_mask"]
+            )
+        # add EOS, which affects only the full completion
+        if eos_token_id != all_tokens["answer_input_ids"][-1]:
+            batch[f"{kwargs['prefix']}completion_input_ids"] = batch[
+                f"{kwargs['prefix']}completion_input_ids"
+            ] + [eos_token_id]
+            batch[f"{kwargs['prefix']}completion_attention_mask"] = batch[
+                f"{kwargs['prefix']}completion_attention_mask"
+            ] + [1]
 
         batch[f"{kwargs['prefix']}completion_labels"] = batch[f"{kwargs['prefix']}completion_input_ids"][:]
         batch[f"{kwargs['prefix']}completion_labels"][: len(batch[f"{kwargs['prefix']}prompt_input_ids"])] = [

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -214,8 +214,7 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
         batch[f"{kwargs['prefix']}prompt_input_ids"] = all_tokens["prompt_input_ids"]
         batch[f"{kwargs['prefix']}prompt_attention_mask"] = all_tokens["prompt_attention_mask"]
         batch[f"{kwargs['prefix']}completion_input_ids"] = (
-            all_tokens["prompt_input_ids"]
-            + all_tokens["answer_input_ids"]
+            all_tokens["prompt_input_ids"] + all_tokens["answer_input_ids"]
         )
         batch[f"{kwargs['prefix']}completion_attention_mask"] = (
             all_tokens["prompt_attention_mask"] + all_tokens["answer_attention_mask"]
@@ -226,21 +225,18 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
             batch[f"{kwargs['prefix']}prompt_input_ids"] = [bos_token_id] + batch[
                 f"{kwargs['prefix']}prompt_input_ids"
             ]
-            batch[f"{kwargs['prefix']}prompt_attention_mask"] = [1] + batch[
-                f"{kwargs['prefix']}prompt_attention_mask"
+            batch[f"{kwargs['prefix']}prompt_attention_mask"] = [1] + batch[f"{kwargs['prefix']}prompt_attention_mask"]
+            batch[f"{kwargs['prefix']}completion_input_ids"] = [bos_token_id] + batch[
+                f"{kwargs['prefix']}completion_input_ids"
             ]
-            batch[f"{kwargs['prefix']}completion_input_ids"] = (
-                [bos_token_id]
-                + batch[f"{kwargs['prefix']}completion_input_ids"]
-            )
-            batch[f"{kwargs['prefix']}completion_attention_mask"] = (
-                [1] + batch[f"{kwargs['prefix']}completion_attention_mask"]
-            )
+            batch[f"{kwargs['prefix']}completion_attention_mask"] = [1] + batch[
+                f"{kwargs['prefix']}completion_attention_mask"
+            ]
         # add EOS, which affects only the full completion
         if eos_token_id != all_tokens["answer_input_ids"][-1]:
-            batch[f"{kwargs['prefix']}completion_input_ids"] = batch[
-                f"{kwargs['prefix']}completion_input_ids"
-            ] + [eos_token_id]
+            batch[f"{kwargs['prefix']}completion_input_ids"] = batch[f"{kwargs['prefix']}completion_input_ids"] + [
+                eos_token_id
+            ]
             batch[f"{kwargs['prefix']}completion_attention_mask"] = batch[
                 f"{kwargs['prefix']}completion_attention_mask"
             ] + [1]

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -221,7 +221,7 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
         )
 
         # add BOS, which affects both prompt and the full completion
-        if bos_token_id != all_tokens["prompt_input_ids"][0]:
+        if len(all_tokens["prompt_input_ids"]) == 0 or bos_token_id != all_tokens["prompt_input_ids"][0]:
             batch[f"{kwargs['prefix']}prompt_input_ids"] = [bos_token_id] + batch[
                 f"{kwargs['prefix']}prompt_input_ids"
             ]
@@ -233,7 +233,7 @@ def _process_tokens(example: Dict[str, Any], model: "PreTrainedModel" = None, **
                 f"{kwargs['prefix']}completion_attention_mask"
             ]
         # add EOS, which affects only the full completion
-        if eos_token_id != all_tokens["answer_input_ids"][-1]:
+        if len(all_tokens["answer_input_ids"]) == 0 or eos_token_id != all_tokens["answer_input_ids"][-1]:
             batch[f"{kwargs['prefix']}completion_input_ids"] = batch[f"{kwargs['prefix']}completion_input_ids"] + [
                 eos_token_id
             ]

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -439,21 +439,24 @@ class ORPOTrainer(Trainer):
                     "last token due to tokenizer merge ops."
                 )
 
-            # add BOS token to head of prompt
-            prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
-            chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
-            rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
-
-            prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
-
-            # add EOS token to end of answer
-            chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            chosen_tokens["attention_mask"].append(1)
-
-            rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
-            rejected_tokens["attention_mask"].append(1)
+            # add BOS token to head of prompt. Avoid adding if it's already there
+            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+                prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
+            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+                chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
+            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+                rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
+            
+            # add EOS token to end of answer. Avoid adding if it's already there
+            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+                chosen_tokens["attention_mask"].append(1)
+            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+                rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))
 

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -440,22 +440,24 @@ class ORPOTrainer(Trainer):
                 )
 
             # add BOS token to head of prompt. Avoid adding if it's already there
-            if self.tokenizer.bos_token_id != prompt_tokens["prompt_input_ids"][0]:
-                prompt_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + prompt_tokens["prompt_input_ids"]
+            bos_token_id = self.tokenizer.bos_token_id
+            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+                prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != chosen_tokens["prompt_input_ids"][0]:
-                chosen_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + chosen_tokens["prompt_input_ids"]
+            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+                chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if self.tokenizer.bos_token_id != rejected_tokens["prompt_input_ids"][0]:
-                rejected_tokens["prompt_input_ids"] = [self.tokenizer.bos_token_id] + rejected_tokens["prompt_input_ids"]
+            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+                rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
-            
+
             # add EOS token to end of answer. Avoid adding if it's already there
-            if self.tokenizer.eos_token_id != chosen_tokens["input_ids"][-1]:
-                chosen_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            eos_token_id = self.tokenizer.eos_token_id
+            if eos_token_id != chosen_tokens["input_ids"][-1]:
+                chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if self.tokenizer.eos_token_id != rejected_tokens["input_ids"][-1]:
-                rejected_tokens["input_ids"].append(self.tokenizer.eos_token_id)
+            if eos_token_id != rejected_tokens["input_ids"][-1]:
+                rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 
             longer_response_length = max(len(chosen_tokens["input_ids"]), len(rejected_tokens["input_ids"]))

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -441,22 +441,22 @@ class ORPOTrainer(Trainer):
 
             # add BOS token to head of prompt. Avoid adding if it's already there
             bos_token_id = self.tokenizer.bos_token_id
-            if bos_token_id != prompt_tokens["prompt_input_ids"][0]:
+            if prompt_len_input_ids == 0 or bos_token_id != prompt_tokens["prompt_input_ids"][0]:
                 prompt_tokens["prompt_input_ids"] = [bos_token_id] + prompt_tokens["prompt_input_ids"]
                 prompt_tokens["prompt_attention_mask"] = [1] + prompt_tokens["prompt_attention_mask"]
-            if bos_token_id != chosen_tokens["prompt_input_ids"][0]:
+            if chosen_prompt_len_input_ids == 0 or bos_token_id != chosen_tokens["prompt_input_ids"][0]:
                 chosen_tokens["prompt_input_ids"] = [bos_token_id] + chosen_tokens["prompt_input_ids"]
                 chosen_tokens["prompt_attention_mask"] = [1] + chosen_tokens["prompt_attention_mask"]
-            if bos_token_id != rejected_tokens["prompt_input_ids"][0]:
+            if rejected_prompt_len_input_ids == 0 or bos_token_id != rejected_tokens["prompt_input_ids"][0]:
                 rejected_tokens["prompt_input_ids"] = [bos_token_id] + rejected_tokens["prompt_input_ids"]
                 rejected_tokens["prompt_attention_mask"] = [1] + rejected_tokens["prompt_attention_mask"]
 
             # add EOS token to end of answer. Avoid adding if it's already there
             eos_token_id = self.tokenizer.eos_token_id
-            if eos_token_id != chosen_tokens["input_ids"][-1]:
+            if len(chosen_tokens["input_ids"]) == 0 or eos_token_id != chosen_tokens["input_ids"][-1]:
                 chosen_tokens["input_ids"].append(eos_token_id)
                 chosen_tokens["attention_mask"].append(1)
-            if eos_token_id != rejected_tokens["input_ids"][-1]:
+            if len(rejected_tokens["input_ids"]) == 0 or eos_token_id != rejected_tokens["input_ids"][-1]:
                 rejected_tokens["input_ids"].append(eos_token_id)
                 rejected_tokens["attention_mask"].append(1)
 


### PR DESCRIPTION
The original implementation in DPO/CPO will add BOS and EOS token to a tokenized sequence regardless if its already there. This is problematic when using tokenizers (e.g., gemma-2b) whose chat template _already_ adds BOS/EOS token.

The change is therefore to simply check if the start/last token is already BOS/EOS, before adding it.