### PR TITLE
[ORPO] Correct label mask for pad tokens

### DIFF
--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -715,7 +715,7 @@ class ORPOTrainer(Trainer):
         else:
             labels = concatenated_batch["concatenated_input_ids"].clone()
             attention_mask = concatenated_batch["concatenated_attention_mask"]
-            labels = torch.where(attention_mask == 1, labels, -100)
+            labels = torch.where(attention_mask == 1, labels, self.label_pad_token_id)
 
         chosen_nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
 

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -714,6 +714,8 @@ class ORPOTrainer(Trainer):
             labels = concatenated_batch["concatenated_labels"].clone()
         else:
             labels = concatenated_batch["concatenated_input_ids"].clone()
+            attention_mask = concatenated_batch["concatenated_attention_mask"]
+            labels = torch.where(attention_mask == 1, labels, -100)
 
         chosen_nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
 


### PR DESCRIPTION
Recent [fix](https://github.com/huggingface/trl/commit/57aebe9c36021e679662181468b04ff42432daf3) for calculating NLL loss for a whole sequence introduced a bug. When input_ids are copied to labels, pad tokens are not masked.

This PR aims to patch this by masking labels based on the attention mask.

I've tested it with batch_size=1, and now the initial loss is correct.