### PR TITLE
don't cast the trainable lora layers to half precision

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -668,9 +668,7 @@ def peft_module_casting_to_bf16(model):
     from peft.tuners.tuners_utils import BaseTunerLayer
 
     for name, module in model.named_modules():
-        if isinstance(module, BaseTunerLayer):
-            module = module.to(torch.bfloat16)
-        elif isinstance(module, torch.nn.LayerNorm) or "norm" in name:
+        if isinstance(module, torch.nn.LayerNorm) or "norm" in name:
             module = module.to(torch.float32)
         elif any(x in name for x in ["lm_head", "embed_tokens", "wte", "wpe"]):
             if hasattr(module, "weight"):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -665,8 +665,6 @@ def neftune_post_forward_hook(module, input, output):
 
 
 def peft_module_casting_to_bf16(model):
-    from peft.tuners.tuners_utils import BaseTunerLayer
-
     for name, module in model.named_modules():
         if isinstance(module, torch.nn.LayerNorm) or "norm" in name:
             module = module.to(torch.float32)


### PR DESCRIPTION
### What does this PR do?
1. While the QLoRA repo https://github.com/artidoro/qlora/blob/7f4e95a68dc076bea9b3a413d2b512eca6d004e5/qlora.py#L395-L405 casts the trainable parameters to `bfloat16`(half-precision), this is incorrect and can lead to unstable training when using automatic mixed precision. Hence, this PR avoid casting the trainable params to half precision. This is inline with the changes we are making to fix this issue at https://github.com/artidoro/qlora/blob/7f4e95a68dc076bea9b3a413d2b512eca6d004e5/qlora.py#L395-L405
2. The impact of this PR would be increase in the GPU memory consumption as the trainable params are now in full precision.