### PR TITLE
Do not upcast adapters when using FSDP+QLoRA

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -237,7 +237,14 @@ class SFTTrainer(Trainer):
 
                         model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
-                model = get_peft_model(model, peft_config)
+                if (
+                    "autocast_adapter_dtype" in list(inspect.signature(get_peft_model).parameters)
+                    and getattr(model, "is_loaded_in_4bit", False)
+                    and is_sharded_qlora
+                ):
+                    model = get_peft_model(model, peft_config, autocast_adapter_dtype=False)
+                else:
+                    model = get_peft_model(model, peft_config)
                 if (
                     args is not None
                     and args.bf16


### PR DESCRIPTION
### What does this PR do?
1. When using FSDP, all tensors need to be of the same type when it flattens them. As such, we need to avoid upcasting the adapter parameters.