### PR TITLE
Fix inheritance order in PPOv2Config

### DIFF
--- a/trl/trainer/ppov2_config.py
+++ b/trl/trainer/ppov2_config.py
@@ -12,7 +12,7 @@ from ..trainer.utils import (
 
 
 @dataclass
-class PPOv2Config(TrainingArguments, OnpolicyRuntimeConfig):
+class PPOv2Config(OnpolicyRuntimeConfig, TrainingArguments):
     # common config
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
     """the name of this experiment"""

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -13,7 +13,7 @@ INVALID_LOGPROB = 1.0
 
 
 @dataclass
-class RLOOConfig(TrainingArguments, OnpolicyRuntimeConfig):
+class RLOOConfig(OnpolicyRuntimeConfig, TrainingArguments):
     # common config
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
     """the name of this experiment"""


### PR DESCRIPTION
Hi, I get the following error when importing PPOv2Config
`TypeError: non-default argument 'output_dir' follows default argument`

Changing the order of inheritance in the class definition solves this problem.