### PR TITLE
Fix wrong argument bug in PPOv2Trainer

### DIFF
--- a/trl/trainer/ppov2_config.py
+++ b/trl/trainer/ppov2_config.py
@@ -12,7 +12,7 @@ from ..trainer.utils import (
 
 
 @dataclass
-class PPOv2Config(TrainingArguments, OnpolicyRuntimeConfig):
+class PPOv2Config(OnpolicyRuntimeConfig, TrainingArguments):
     # common config
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
     """the name of this experiment"""

--- a/trl/trainer/ppov2_trainer.py
+++ b/trl/trainer/ppov2_trainer.py
@@ -285,7 +285,7 @@ class PPOv2Trainer(Trainer):
                         query_response, logits = generate(
                             unwrapped_model.policy,
                             query,
-                            tokenizer,
+                            tokenizer.pad_token_id,
                             generation_config,
                         )
                         response = query_response[:, context_length:]
@@ -407,7 +407,7 @@ class PPOv2Trainer(Trainer):
                             mb_query_responses = query_responses[micro_batch_inds]
                             mb_logprobs = logprobs[micro_batch_inds]
 
-                            output, vpred_temp = forward(model, mb_query_responses, tokenizer)
+                            output, vpred_temp = forward(model, mb_query_responses, tokenizer.pad_token_id)
                             logits = output.logits[:, context_length - 1 : -1]
                             logits /= args.temperature + 1e-7
                             new_all_logprobs = F.log_softmax(logits, dim=-1)

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -13,7 +13,7 @@ INVALID_LOGPROB = 1.0
 
 
 @dataclass
-class RLOOConfig(TrainingArguments, OnpolicyRuntimeConfig):
+class RLOOConfig(OnpolicyRuntimeConfig, TrainingArguments):
     # common config
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
     """the name of this experiment"""


### PR DESCRIPTION
Hi @vwxyzjn , I noticed that in the PPOv2Trainer at two occurrences a function expects the tokenizer's pad_id as an argument instead of the tokenizer itself.