### PR TITLE
Fix overriding optimize_device_cache with optimize_cuda_cache in PPOConfig

### DIFF
--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -143,9 +143,11 @@ class PPOConfig:
         warnings.warn(
             "The `optimize_cuda_cache` argument will be deprecated soon, please use `optimize_device_cache` instead."
         )
+
+        if optimize_device_cache is True:
+            raise ValueError(f"Both `optimize_device_cache` and `optimize_cuda_cache` were provided")
+
         optimize_device_cache = optimize_cuda_cache
-    else:
-        optimize_device_cache = False
 
     def __post_init__(self):
         if self.forward_batch_size is not None:

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -145,7 +145,7 @@ class PPOConfig:
         )
 
         if optimize_device_cache is True:
-            raise ValueError(f"Both `optimize_device_cache` and `optimize_cuda_cache` were provided")
+            raise ValueError("Both `optimize_device_cache` and `optimize_cuda_cache` were provided")
 
         optimize_device_cache = optimize_cuda_cache
 


### PR DESCRIPTION
Removed the unneeded else branch and added a check to prevent both options being set at the same time

Fixes: #1689 