### PR TITLE
Add a variant of CPO, SimPO

### DIFF
--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -6,7 +6,7 @@ avoid generating adequate, but not perfect translations in Machine Translation (
 CPO aims to mitigate two fundamental shortcomings of SFT. First, SFT’s methodology of minimizing the discrepancy between predicted outputs and gold-standard references inherently caps model performance at the quality level of the training data. Secondly, SFT lacks a mechanism to prevent the model from rejecting mistakes in translations. The CPO objective is derived from the DPO objective.
 
 ## A Variant of CPO: SimPO
-There is also a variant of CPO, [SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734), which adds a reward margin and does not use BC regularization.
+There is also a variant of CPO, [SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734), which adds a reward margin and does not use BC regularization. Use the `loss_type="simpo"` in the `CPOConfig` to use this loss.
 
 ## Expected dataset format
 

--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -6,7 +6,7 @@ avoid generating adequate, but not perfect translations in Machine Translation (
 CPO aims to mitigate two fundamental shortcomings of SFT. First, SFT’s methodology of minimizing the discrepancy between predicted outputs and gold-standard references inherently caps model performance at the quality level of the training data. Secondly, SFT lacks a mechanism to prevent the model from rejecting mistakes in translations. The CPO objective is derived from the DPO objective.
 
 ## A Variant of CPO: SimPO
-[SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734) is a variant of CPO that adds a reward margin and does not use BC regularization.
+There is also a variant of CPO, [SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734), which adds a reward margin and does not use BC regularization.
 
 ## Expected dataset format
 

--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -5,6 +5,9 @@ avoid generating adequate, but not perfect translations in Machine Translation (
 
 CPO aims to mitigate two fundamental shortcomings of SFT. First, SFT’s methodology of minimizing the discrepancy between predicted outputs and gold-standard references inherently caps model performance at the quality level of the training data. Secondly, SFT lacks a mechanism to prevent the model from rejecting mistakes in translations. The CPO objective is derived from the DPO objective.
 
+## A Variant of CPO: SimPO
+[SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734) is a variant of CPO that adds a reward margin and does not use BC regularization.
+
 ## Expected dataset format
 
 The CPO trainer expects a format identical to the DPO trainer, which should include three entries. These entries should be named as follows:

--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -5,9 +5,6 @@ avoid generating adequate, but not perfect translations in Machine Translation (
 
 CPO aims to mitigate two fundamental shortcomings of SFT. First, SFT’s methodology of minimizing the discrepancy between predicted outputs and gold-standard references inherently caps model performance at the quality level of the training data. Secondly, SFT lacks a mechanism to prevent the model from rejecting mistakes in translations. The CPO objective is derived from the DPO objective.
 
-## A Variant of CPO: SimPO
-There is also a variant of CPO, [SimPO: Simple Preference Optimization with a Reference-Free Reward](https://arxiv.org/abs/2405.14734), which adds a reward margin and does not use BC regularization. Use the `loss_type="simpo"` in the `CPOConfig` to use this loss.
-
 ## Expected dataset format
 
 The CPO trainer expects a format identical to the DPO trainer, which should include three entries. These entries should be named as follows:
@@ -84,7 +81,7 @@ The [RSO](https://arxiv.org/abs/2309.06657) authors propose to use a hinge loss 
 
 The [IPO](https://arxiv.org/abs/2310.12036) authors provide a deeper theoretical understanding of the CPO algorithms and identify an issue with overfitting and propose an alternative loss which can be used via the `loss_type="ipo"` argument to the trainer. Note that the `beta`  parameter is the reciprocal of the gap between the log-likelihood ratios of the chosen vs the rejected completion pair and thus the smaller the `beta` the larger this gaps is. As per the paper the loss is averaged over log-likelihoods of the completion (unlike CPO which is summed only).
 
-
+The [SimPO](https://arxiv.org/abs/2405.14734) is an alternative loss that adds a reward margin, allows for length normalization, and does not use BC regularization. To use this loss, we can use SimPO easily by turning on`loss_type="simpo"` in the `CPOConfig`.
 ## Logging
 
 While training and evaluating we record the following reward metrics:

--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -82,6 +82,8 @@ The [RSO](https://arxiv.org/abs/2309.06657) authors propose to use a hinge loss 
 The [IPO](https://arxiv.org/abs/2310.12036) authors provide a deeper theoretical understanding of the CPO algorithms and identify an issue with overfitting and propose an alternative loss which can be used via the `loss_type="ipo"` argument to the trainer. Note that the `beta`  parameter is the reciprocal of the gap between the log-likelihood ratios of the chosen vs the rejected completion pair and thus the smaller the `beta` the larger this gaps is. As per the paper the loss is averaged over log-likelihoods of the completion (unlike CPO which is summed only).
 
 The [SimPO](https://arxiv.org/abs/2405.14734) is an alternative loss that adds a reward margin, allows for length normalization, and does not use BC regularization. To use this loss, we can use SimPO easily by turning on`loss_type="simpo"` in the `CPOConfig`.
+
+
 ## Logging
 
 While training and evaluating we record the following reward metrics:

--- a/tests/test_cpo_trainer.py
+++ b/tests/test_cpo_trainer.py
@@ -84,6 +84,8 @@ class CPOTrainerTester(unittest.TestCase):
             ["t5", "hinge"],
             ["gpt2", "ipo"],
             ["t5", "ipo"],
+            ["gpt2", "simpo"],
+            ["t5", "simpo"],
         ]
     )
     def test_cpo_trainer(self, name, loss_type):

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -41,6 +41,8 @@ class CPOConfig(TrainingArguments):
             The type of loss to use. This argument is required if you want to use the default data collator.
         label_pad_token_id (`int`, defaults to `-100`):
             The label pad token id. This argument is required if you want to use the default data collator.
+        simpo_gamma (`float`, defaults to `0.5`):
+            A target reward margin for the SimPO loss, used only when the "simpo" option is enabled.
         padding_value (`int`, defaults to `None`):
             The padding value if it is different to the tokenizer's pad_token_id.
         truncation_mode (`str`, defaults to `keep_end`):
@@ -67,9 +69,6 @@ class CPOConfig(TrainingArguments):
     loss_type: Literal["sigmoid", "hinge", "ipo", "kto_pair", "simpo"] = "sigmoid"
     disable_dropout: bool = True
     simpo_gamma: float = 0.5
-    """
-    simpo_gamma: A target reward margin for the SimPO loss, used only when the "simpo" option is enabled.
-    """
 
     label_pad_token_id: int = -100
     padding_value: int = None

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -64,8 +64,9 @@ class CPOConfig(TrainingArguments):
 
     beta: float = 0.1
     label_smoothing: float = 0
-    loss_type: Literal["sigmoid", "hinge", "ipo", "kto_pair"] = "sigmoid"
+    loss_type: Literal["sigmoid", "hinge", "ipo", "kto_pair", "simpo"] = "sigmoid"
     disable_dropout: bool = True
+    simpo_gamma: float = 0.5
 
     label_pad_token_id: int = -100
     padding_value: int = None

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -67,6 +67,9 @@ class CPOConfig(TrainingArguments):
     loss_type: Literal["sigmoid", "hinge", "ipo", "kto_pair", "simpo"] = "sigmoid"
     disable_dropout: bool = True
     simpo_gamma: float = 0.5
+    """
+    simpo_gamma: A target reward margin for the SimPO loss, used only when the "simpo" option is enabled.
+    """
 
     label_pad_token_id: int = -100
     padding_value: int = None

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -712,7 +712,7 @@ class CPOTrainer(Trainer):
         all_logps = self.get_batch_logps(
             all_logits,
             concatenated_batch["concatenated_labels"],
-            average_log_prob=self.loss_type == "ipo" or self.loss_type == "simpo",
+            average_log_prob=self.loss_type in ["ipo", "simpo"],
             is_encoder_decoder=self.is_encoder_decoder,
             label_pad_token_id=self.label_pad_token_id,
         )

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -584,7 +584,7 @@ class CPOTrainer(Trainer):
             The chosen_rewards and rejected_rewards tensors contain the rewards for the chosen and rejected responses, respectively.
         """
         logits = (policy_chosen_logps - policy_rejected_logps).to(self.accelerator.device)
-        
+
         # The beta is a temperature parameter for the CPO loss, typically something in the range of 0.1 to 0.5.
         # We ignore the reference model as beta -> 0. The label_smoothing parameter encodes our uncertainty about the labels and
         # calculates a conservative CPO loss.

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -707,7 +707,7 @@ class CPOTrainer(Trainer):
         if self.loss_type != "simpo":
             nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
         else:
-            nll_loss = 0
+            nll_loss = torch.tensor(0.0).to(self.accelerator.device)
 
         all_logps = self.get_batch_logps(
             all_logits,


### PR DESCRIPTION
This PR adds a variant of CPO reference-free method, called SimPO (https://arxiv.org/abs/2405.14734). The only difference is SimPO adds a reward margin and does not use BC regularization. 

Thanks for your help and notice!

cc @kashif @lewtun