### PR TITLE
CI / core: Pin `numpy` to `!=2.0.0` for CI and to users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ __version__ = "0.9.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 REQUIRED_PKGS = [
     "torch>=1.4.0",
     "transformers>=4.31.0",
-    "numpy>=1.18.2",
+    "numpy>=1.18.2,!=2.0.0",
     "accelerate",
     "datasets",
     "tyro>=0.5.11",
@@ -72,8 +72,8 @@ EXTRAS = {
     "test": ["parameterized", "pytest", "pytest-xdist", "accelerate", "pytest-cov", "pytest-xdist", "scikit-learn"],
     "peft": ["peft>=0.4.0"],
     "diffusers": ["diffusers>=0.18.0"],
-    "deepspeed": ["deepspeed>=0.9.5", "numpy>=1.18.2,!=2.0.0"],
-    "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed", "numpy>=1.18.2,!=2.0.0"],
+    "deepspeed": ["deepspeed>=0.9.5"],
+    "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed"],
     "quantization": ["bitsandbytes<=0.41.1"],
 }
 EXTRAS["dev"] = []

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ __version__ = "0.9.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 REQUIRED_PKGS = [
     "torch>=1.4.0",
     "transformers>=4.31.0",
-    "numpy>=1.18.2,!=2.0.0",
+    "numpy>=1.18.2",
     "accelerate",
     "datasets",
     "tyro>=0.5.11",

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,8 @@ EXTRAS = {
     "test": ["parameterized", "pytest", "pytest-xdist", "accelerate", "pytest-cov", "pytest-xdist", "scikit-learn"],
     "peft": ["peft>=0.4.0"],
     "diffusers": ["diffusers>=0.18.0"],
-    "deepspeed": ["deepspeed>=0.9.5"],
-    "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed"],
+    "deepspeed": ["deepspeed>=0.9.5", "numpy>=1.18.2,!=2.0.0"],
+    "benchmark": ["wandb", "ghapi", "openrlbenchmark==0.2.1a5", "requests", "deepspeed", "numpy>=1.18.2,!=2.0.0"],
     "quantization": ["bitsandbytes<=0.41.1"],
 }
 EXTRAS["dev"] = []

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ __version__ = "0.9.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 REQUIRED_PKGS = [
     "torch>=1.4.0",
     "transformers>=4.31.0",
-    "numpy>=1.18.2",
+    "numpy>=1.18.2,!=2.0.0",
     "accelerate",
     "datasets",
     "tyro>=0.5.11",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ __version__ = "0.9.5.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc1
 REQUIRED_PKGS = [
     "torch>=1.4.0",
     "transformers>=4.31.0",
-    "numpy>=1.18.2,!=2.0.0",
+    "numpy>=1.18.2,<2.0.0",
     "accelerate",
     "datasets",
     "tyro>=0.5.11",

--- a/tests/test_best_of_n_sampler.py
+++ b/tests/test_best_of_n_sampler.py
@@ -23,6 +23,7 @@ class BestOfNSamplerTester(unittest.TestCase):
     tokenizer = AutoTokenizer.from_pretrained(ref_model_name)
     tokenizer.pad_token = tokenizer.eos_token
     output_length_sampler = LengthSampler(2, 6)
+    dummy = None
 
     def test_different_input_types(self):
         r"""

--- a/tests/test_best_of_n_sampler.py
+++ b/tests/test_best_of_n_sampler.py
@@ -23,7 +23,6 @@ class BestOfNSamplerTester(unittest.TestCase):
     tokenizer = AutoTokenizer.from_pretrained(ref_model_name)
     tokenizer.pad_token = tokenizer.eos_token
     output_length_sampler = LengthSampler(2, 6)
-    dummy = None
 
     def test_different_input_types(self):
         r"""


### PR DESCRIPTION
TRL has an optional dependency with DeepSpeed which is right now not compatible with numpy >= 2.0.0

Related: https://github.com/microsoft/DeepSpeed/issues/5671

cc @vwxyzjn 