### PR TITLE
Issue #1751 Fix

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -159,13 +159,14 @@ class SFTTrainer(Trainer):
             raise ValueError("You passed model_init_kwargs to the SFTConfig, but your model is already instantiated.")
         else:
             model_init_kwargs = args.model_init_kwargs
+            print("Dtype :", model_init_kwargs["torch_dtype"], type(model_init_kwargs["torch_dtype"]))
             model_init_kwargs["torch_dtype"] = (
                 model_init_kwargs["torch_dtype"]
                 if model_init_kwargs["torch_dtype"] in ["auto", None]
                 else getattr(torch, model_init_kwargs["torch_dtype"])
             )
 
-        print("model_init_kwargs", model_init_kwargs)
+        
 
         if infinite is not None:
             warnings.warn(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -160,13 +160,13 @@ class SFTTrainer(Trainer):
         else:
             model_init_kwargs = args.model_init_kwargs
             print("Dtype :", model_init_kwargs["torch_dtype"], type(model_init_kwargs["torch_dtype"]))
+            print("The fix : ", type(f'{model_init_kwargs["torch_dtype"]}'))
+            
             model_init_kwargs["torch_dtype"] = (
                 model_init_kwargs["torch_dtype"]
                 if model_init_kwargs["torch_dtype"] in ["auto", None]
-                else getattr(torch, model_init_kwargs["torch_dtype"])
+                else getattr(torch, f'{model_init_kwargs["torch_dtype"]}')
             )
-
-        
 
         if infinite is not None:
             warnings.warn(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -159,13 +159,11 @@ class SFTTrainer(Trainer):
             raise ValueError("You passed model_init_kwargs to the SFTConfig, but your model is already instantiated.")
         else:
             model_init_kwargs = args.model_init_kwargs
-            print("Dtype :", model_init_kwargs["torch_dtype"], type(model_init_kwargs["torch_dtype"]))
-            print("The fix : ", type(f'{model_init_kwargs["torch_dtype"]}'))
 
             model_init_kwargs["torch_dtype"] = (
                 model_init_kwargs["torch_dtype"]
                 if model_init_kwargs["torch_dtype"] in ["auto", None]
-                else getattr(torch, f'{model_init_kwargs["torch_dtype"]}'.split('.')[-1])
+                else getattr(torch, f'{model_init_kwargs["torch_dtype"]}'.split('.')[-1]) # hacky fix, have to dive into Trainer to see.
             )
 
         if infinite is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -165,6 +165,8 @@ class SFTTrainer(Trainer):
                 else getattr(torch, model_init_kwargs["torch_dtype"])
             )
 
+        print("model_init_kwargs", model_init_kwargs)
+
         if infinite is not None:
             warnings.warn(
                 "The `infinite` argument is deprecated and will be removed in a future version of TRL. Use `TrainingArguments.max_steps` or `TrainingArguments.num_train_epochs` instead to control training length."

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -161,11 +161,11 @@ class SFTTrainer(Trainer):
             model_init_kwargs = args.model_init_kwargs
             print("Dtype :", model_init_kwargs["torch_dtype"], type(model_init_kwargs["torch_dtype"]))
             print("The fix : ", type(f'{model_init_kwargs["torch_dtype"]}'))
-            
+
             model_init_kwargs["torch_dtype"] = (
                 model_init_kwargs["torch_dtype"]
                 if model_init_kwargs["torch_dtype"] in ["auto", None]
-                else getattr(torch, f'{model_init_kwargs["torch_dtype"]}')
+                else getattr(torch, f'{model_init_kwargs["torch_dtype"]}'.split('.')[-1])
             )
 
         if infinite is not None:


### PR DESCRIPTION
#1751 mentioned that the TRL CLI is not completely capturing the torch_dtype. I thought the issue was urgent, so quickly patched a hacky fix, which at least initiates the SFT Trainer. 

Original Issue : 
On running the following command :
```
trl sft --model_name_or_path=facebook/opt-125m --dataset_name=imdb  --dataset_text_field=text --max_steps=1 --torch_dtype=bfloat16 --output_dir=./test
```
The error was that trl sft is does not identify it as a string when calling `getattr(torch, model_init_kwargs["torch_dtype"])`.

The fix was made which allows the to not break the pipeline at this stage. Although it is a hacky fix, I'm willing to work on it further :)

The error after that is from the transformers library that isn't able to serialize the dtype object(screenshot attached):

```
...
...
TypeError: Object of type dtype is not JSON serializable
Traceback (most recent call last):
```   

![Screenshot 2024-06-18 171826](https://github.com/huggingface/trl/assets/85068689/e9001b98-3ee6-4a20-abe4-d73415e06ddb)
