### PR TITLE
Fix: Add dataset_text_field in examples/scripts/sft.py

### DIFF
--- a/examples/scripts/sft.py
+++ b/examples/scripts/sft.py
@@ -16,6 +16,7 @@
 # regular:
 python examples/scripts/sft.py \
     --model_name_or_path="facebook/opt-350m" \
+    --dataset_text_field="text" \
     --report_to="wandb" \
     --learning_rate=1.41e-5 \
     --per_device_train_batch_size=64 \
@@ -30,6 +31,7 @@ python examples/scripts/sft.py \
 # peft:
 python examples/scripts/sft.py \
     --model_name_or_path="facebook/opt-350m" \
+    --dataset_text_field="text" \
     --report_to="wandb" \
     --learning_rate=1.41e-5 \
     --per_device_train_batch_size=64 \


### PR DESCRIPTION
When executing the command located at the top of [examples/scripts/sft.py](https://github.com/huggingface/trl/blob/34d273f227b30507c6d94ff1f93b6939794f38a3/examples/scripts/sft.py#L16), an error is thrown due to the `dataset_text_field` not being specified. I have added `"text"` as the `dataset_text_field` to align with the default dataset format used in timdettmers/openassistant-guanaco.

```shell
Repo card metadata block was not found. Setting CardData to empty.
/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/huggingface_hub/utils/_deprecation.py:100: FutureWarning: Deprecated argument(s) used in '__init__': model_init_kwargs. Will not be supported from version '1.0.0'.

Deprecated positional argument(s) used in SFTTrainer, please use the SFTConfig to set these arguments instead.
  warnings.warn(message, FutureWarning)
/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py:152: UserWarning: You passed `model_init_kwargs` to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.
  warnings.warn(
/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py:174: UserWarning: You passed a model_id to the SFTTrainer. This will automatically create an `AutoModelForCausalLM` or a `PeftModel` (if you passed a `peft_config`) for you.
  warnings.warn(
/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py:278: UserWarning: You didn't pass a `max_seq_length` argument to the SFTTrainer, this will default to 1024
  warnings.warn(
Map:   0%|                                                                                                                                        | 0/9846 [00:00<?, ? examples/s]
Traceback (most recent call last):
  File "/data/juyoung/EasyLM/examples/trl/scripts/sft.py", line 137, in <module>
    trainer = SFTTrainer(
              ^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/huggingface_hub/utils/_deprecation.py", line 101, in inner_f
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 362, in __init__
    train_dataset = self._prepare_dataset(
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 508, in _prepare_dataset
    return self._prepare_non_packed_dataloader(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 576, in _prepare_non_packed_dataloader
    tokenized_dataset = dataset.map(
                        ^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 602, in wrapper
    out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 567, in wrapper
    out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 3161, in map
    for rank, done, content in Dataset._map_single(**dataset_kwargs):
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 3552, in _map_single
    batch = apply_function_on_filtered_inputs(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 3421, in apply_function_on_filtered_inputs
    processed_inputs = function(*fn_args, *additional_args, **fn_kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 547, in tokenize
    element[dataset_text_field] if not use_formatting_func else formatting_func(element),
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/data/juyoung/.cache/pypoetry/virtualenvs/easylm--LeJdRf2-py3.11/lib/python3.11/site-packages/datasets/formatting/formatting.py", line 271, in __getitem__
    value = self.data[key]
            ~~~~~~~~~^^^^^
KeyError: None
```