### PR TITLE
MoE Models: option to add load balancing loss

### DIFF
--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -88,11 +88,11 @@ The [IPO](https://arxiv.org/abs/2310.12036) authors provide a deeper theoretical
 
 ### For Mixture of Experts Models: Enabling the auxiliary loss
 
-MoEs are the most efficient if the load is about equally distributed between experts.  
-To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+MOEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that we train MOEs similarly during preference-tuning, it is beneficial to add the auxiliary loss from the load balancer to the final loss.  
 
 This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
-To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...` (default: 0.001).
 
 ## Logging
 

--- a/docs/source/cpo_trainer.mdx
+++ b/docs/source/cpo_trainer.mdx
@@ -86,6 +86,14 @@ The [RSO](https://arxiv.org/abs/2309.06657) authors propose to use a hinge loss 
 
 The [IPO](https://arxiv.org/abs/2310.12036) authors provide a deeper theoretical understanding of the CPO algorithms and identify an issue with overfitting and propose an alternative loss which can be used via the `loss_type="ipo"` argument to the trainer. Note that the `beta`  parameter is the reciprocal of the gap between the log-likelihood ratios of the chosen vs the rejected completion pair and thus the smaller the `beta` the larger this gaps is. As per the paper the loss is averaged over log-likelihoods of the completion (unlike CPO which is summed only).
 
+### For Mixture of Experts Models: Enabling the auxiliary loss
+
+MoEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+
+This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+
 ## Logging
 
 While training and evaluating we record the following reward metrics:

--- a/docs/source/dpo_trainer.mdx
+++ b/docs/source/dpo_trainer.mdx
@@ -121,6 +121,14 @@ The [RPO](https://arxiv.org/abs/2404.19733) paper implements an iterative prefer
 
 The [AOT](https://arxiv.org/abs/2406.05882) authors propose to use Distributional Preference Alignment Via Optimal Transport. Traditionally, the alignment algorithms use paired preferences at a sample level, which does not ensure alignment on the distributional level. AOT, on the other hand, can align LLMs on paired or unpaired preference data by making the reward distribution of the positive samples stochastically dominant in the first order on the distribution of negative samples. Specifically, `loss_type="aot"` is appropriate for  paired datasets, where each prompt has both chosen and rejected responses; `loss_type="aot_pair"` is for unpaired datasets. In a nutshell, `loss_type="aot"` ensures that the log-likelihood ratio of chosen to rejected of the aligned model has higher quantiles than that ratio for the reference model. `loss_type="aot_pair"` ensures that the chosen reward is higher on all quantiles than the rejected reward. Note that in both cases quantiles are obtained via sorting. To fully leverage the advantages of the AOT algorithm, it is important to maximize the per-GPU batch size.
 
+### For Mixture of Experts Models: Enabling the auxiliary loss
+
+MoEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+
+This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+
 ## Logging
 
 While training and evaluating we record the following reward metrics:

--- a/docs/source/dpo_trainer.mdx
+++ b/docs/source/dpo_trainer.mdx
@@ -123,11 +123,11 @@ The [AOT](https://arxiv.org/abs/2406.05882) authors propose to use Distributiona
 
 ### For Mixture of Experts Models: Enabling the auxiliary loss
 
-MoEs are the most efficient if the load is about equally distributed between experts.  
-To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+MOEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that we train MOEs similarly during preference-tuning, it is beneficial to add the auxiliary loss from the load balancer to the final loss.  
 
 This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
-To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...` (default: 0.001).
 
 ## Logging
 

--- a/docs/source/kto_trainer.mdx
+++ b/docs/source/kto_trainer.mdx
@@ -94,11 +94,11 @@ The `KTOTrainer` can be switched to this loss via the `loss_type="bco"` argument
 
 ### For Mixture of Experts Models: Enabling the auxiliary loss
 
-MoEs are the most efficient if the load is about equally distributed between experts.  
-To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+MOEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that we train MOEs similarly during preference-tuning, it is beneficial to add the auxiliary loss from the load balancer to the final loss.  
 
 This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
-To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...` (default: 0.001).
 
 ## KTOTrainer
 

--- a/docs/source/kto_trainer.mdx
+++ b/docs/source/kto_trainer.mdx
@@ -92,6 +92,14 @@ Given the binary signal data indicating whether a completion is desirable or und
 The [BCO](https://arxiv.org/abs/2404.04656) authors train a binary classifier whose logit serves as a reward so that the classifier maps {prompt, chosen completion} pairs to 1 and {prompt, rejected completion} pairs to 0.
 The `KTOTrainer` can be switched to this loss via the `loss_type="bco"` argument.
 
+### For Mixture of Experts Models: Enabling the auxiliary loss
+
+MoEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+
+This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+
 ## KTOTrainer
 
 [[autodoc]] KTOTrainer

--- a/docs/source/orpo_trainer.md
+++ b/docs/source/orpo_trainer.md
@@ -75,11 +75,11 @@ orpo_trainer.train()
 
 ### For Mixture of Experts Models: Enabling the auxiliary loss
 
-MoEs are the most efficient if the load is about equally distributed between experts.  
-To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+MOEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that we train MOEs similarly during preference-tuning, it is beneficial to add the auxiliary loss from the load balancer to the final loss.  
 
 This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
-To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...` (default: 0.001).
 
 ## Logging
 

--- a/docs/source/orpo_trainer.md
+++ b/docs/source/orpo_trainer.md
@@ -73,6 +73,14 @@ After this one can then call:
 orpo_trainer.train()
 ```
 
+### For Mixture of Experts Models: Enabling the auxiliary loss
+
+MoEs are the most efficient if the load is about equally distributed between experts.  
+To ensure that it stays this way during fine-tuning, it is beneficial to add the auxiliary loss from load balancing to the final loss.  
+
+This option is enabled by setting `output_router_logits=True` in the model config (e.g. MixtralConfig).  
+To scale how much the auxiliary loss contributes to the total loss, use the hyperparameter `router_aux_loss_coef=...`(default: 0.001).
+
 ## Logging
 
 While training and evaluating we record the following reward metrics:

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -270,6 +270,7 @@ class CPOTrainer(Trainer):
         self.label_smoothing = args.label_smoothing
         self.loss_type = args.loss_type
         self.cpo_alpha = args.cpo_alpha
+        self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
 
         if args.loss_type == "simpo":
             self.simpo_gamma = args.simpo_gamma
@@ -690,6 +691,9 @@ class CPOTrainer(Trainer):
             else {}
         )
 
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
+
         outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
@@ -733,6 +737,9 @@ class CPOTrainer(Trainer):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
+        if self.aux_loss_enabled:
+            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss, outputs.aux_loss)
+
         return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss)
 
     def get_batch_loss_metrics(
@@ -744,13 +751,16 @@ class CPOTrainer(Trainer):
         """Compute the CPO loss and other metrics for the given batch of inputs for train or test."""
         metrics = {}
 
+        forward_output = self.concatenated_forward(model, batch)
         (
             policy_chosen_logps,
             policy_rejected_logps,
             policy_chosen_logits,
             policy_rejected_logits,
             policy_nll_loss,
-        ) = self.concatenated_forward(model, batch)
+        ) = forward_output[:5]
+        if self.aux_loss_enabled:
+            aux_loss = forward_output[5]
 
         losses, chosen_rewards, rejected_rewards = self.cpo_loss(
             policy_chosen_logps,
@@ -770,6 +780,9 @@ class CPOTrainer(Trainer):
         metrics[f"{prefix}logits/rejected"] = policy_rejected_logits.detach().mean().cpu()
         metrics[f"{prefix}logits/chosen"] = policy_chosen_logits.detach().mean().cpu()
         metrics[f"{prefix}nll_loss"] = policy_nll_loss.detach().mean().cpu()
+
+        if self.aux_loss_enabled:
+            loss += getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss
 
         return loss, metrics
 

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -782,7 +782,7 @@ class CPOTrainer(Trainer):
         metrics[f"{prefix}nll_loss"] = policy_nll_loss.detach().mean().cpu()
 
         if self.aux_loss_enabled:
-            loss += getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss
+            loss += getattr(model.config, "router_aux_loss_coef", 0.0) * aux_loss
 
         return loss, metrics
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -479,6 +479,7 @@ class DPOTrainer(Trainer):
         self.beta = args.beta
         self.label_smoothing = args.label_smoothing
         self.loss_type = args.loss_type
+        self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
 
         self._stored_metrics = defaultdict(lambda: defaultdict(list))
 
@@ -1191,12 +1192,16 @@ class DPOTrainer(Trainer):
             if self.is_encoder_decoder
             else {}
         )
-        all_logits = model(
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
+
+        outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
             use_cache=False,
             **model_kwargs,
-        ).logits
+        )
+        all_logits = outputs.logits
 
         all_logps, size_completion = self.get_batch_logps(
             all_logits,
@@ -1232,6 +1237,9 @@ class DPOTrainer(Trainer):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
+        if self.aux_loss_enabled:
+            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss, outputs.aux_loss)
+
         return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss)
 
     def get_batch_loss_metrics(
@@ -1243,13 +1251,16 @@ class DPOTrainer(Trainer):
         """Compute the DPO loss and other metrics for the given batch of inputs for train or test."""
         metrics = {}
 
+        forward_output = self.concatenated_forward(model, batch)
         (
             policy_chosen_logps,
             policy_rejected_logps,
             policy_chosen_logits,
             policy_rejected_logits,
             policy_nll_loss,
-        ) = self.concatenated_forward(model, batch)
+        ) = forward_output[:5]
+        if self.aux_loss_enabled:
+            aux_loss = forward_output[5]
 
         # if reference_chosen_logps and reference_rejected_logps in batch use them, otherwise use the reference model
         if (
@@ -1301,6 +1312,9 @@ class DPOTrainer(Trainer):
         metrics[f"{prefix}logits/chosen"] = policy_chosen_logits.detach().mean().cpu()
         if self.args.rpo_alpha is not None:
             metrics[f"{prefix}nll_loss"] = policy_nll_loss.detach().mean().cpu()
+
+        if self.aux_loss_enabled:
+            return losses.mean() + getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss, metrics
 
         return losses.mean(), metrics
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1314,7 +1314,7 @@ class DPOTrainer(Trainer):
             metrics[f"{prefix}nll_loss"] = policy_nll_loss.detach().mean().cpu()
 
         if self.aux_loss_enabled:
-            return losses.mean() + getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss, metrics
+            return losses.mean() + getattr(model.config, "router_aux_loss_coef", 0.0) * aux_loss, metrics
 
         return losses.mean(), metrics
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1090,11 +1090,16 @@ class KTOTrainer(Trainer):
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
         KL_model_kwargs = (
             {
+                "input_ids": batch["KL_prompt_input_ids"],
+                "attention_mask": batch["KL_prompt_attention_mask"],
                 "labels": batch["KL_completion_labels"],
                 "decoder_input_ids": batch.get("KL_completion_decoder_input_ids"),
             }
             if self.is_encoder_decoder
-            else {}
+            else {
+                "input_ids": batch["KL_completion_input_ids"],
+                "attention_mask": batch["KL_completion_attention_mask"],
+            }
         )
         model_kwargs = (
             {
@@ -1109,8 +1114,6 @@ class KTOTrainer(Trainer):
 
         with torch.no_grad():
             KL_logits = model(
-                batch["KL_prompt_input_ids"],
-                attention_mask=batch["KL_prompt_attention_mask"],
                 **KL_model_kwargs,
             ).logits
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1088,7 +1088,6 @@ class KTOTrainer(Trainer):
     def forward(
         self, model: nn.Module, batch: Dict[str, Union[List, torch.LongTensor]]
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
-        
         KL_model_kwargs = (
             {
                 "labels": batch["KL_completion_labels"],
@@ -1106,7 +1105,7 @@ class KTOTrainer(Trainer):
             else {}
         )
         if self.aux_loss_enabled:
-            model_kwargs["output_router_logits"] = True 
+            model_kwargs["output_router_logits"] = True
 
         with torch.no_grad():
             KL_logits = model(
@@ -1359,7 +1358,7 @@ class KTOTrainer(Trainer):
 
         loss = losses.nanmean()
         if self.aux_loss_enabled:
-            loss += getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss
+            loss += getattr(model.config, "router_aux_loss_coef", 0.0) * aux_loss
 
         return loss, metrics
 

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -266,6 +266,7 @@ class ORPOTrainer(Trainer):
         self.tokenizer = tokenizer
 
         self.beta = args.beta
+        self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
 
         self._stored_metrics = defaultdict(lambda: defaultdict(list))
 
@@ -688,6 +689,9 @@ class ORPOTrainer(Trainer):
             else {}
         )
 
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
+
         outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
@@ -733,6 +737,9 @@ class ORPOTrainer(Trainer):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
+        if self.aux_loss_enabled:
+            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, chosen_nll_loss, outputs.aux_loss)
+
         return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, chosen_nll_loss)
 
     def get_batch_loss_metrics(
@@ -744,13 +751,16 @@ class ORPOTrainer(Trainer):
         """Compute the ORPO loss and other metrics for the given batch of inputs for train or test."""
         metrics = {}
 
+        forward_output = self.concatenated_forward(model, batch)
         (
             policy_chosen_logps,
             policy_rejected_logps,
             policy_chosen_logits,
             policy_rejected_logits,
             policy_nll_loss,
-        ) = self.concatenated_forward(model, batch)
+        ) = forward_output[:5]
+        if self.aux_loss_enabled:
+            aux_loss = forward_output[5]
 
         losses, chosen_rewards, rejected_rewards, log_odds_ratio, log_odds_chosen = self.odds_ratio_loss(
             policy_chosen_logps, policy_rejected_logps
@@ -772,6 +782,9 @@ class ORPOTrainer(Trainer):
         metrics[f"{prefix}nll_loss"] = policy_nll_loss.detach().mean().cpu()
         metrics[f"{prefix}log_odds_ratio"] = log_odds_ratio
         metrics[f"{prefix}log_odds_chosen"] = log_odds_chosen
+
+        if self.aux_loss_enabled:
+            loss += getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss
 
         return loss, metrics
 

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -784,7 +784,7 @@ class ORPOTrainer(Trainer):
         metrics[f"{prefix}log_odds_chosen"] = log_odds_chosen
 
         if self.aux_loss_enabled:
-            loss += getattr(model.config, "router_aux_loss_coef", 0.) * aux_loss
+            loss += getattr(model.config, "router_aux_loss_coef", 0.0) * aux_loss
 
         return loss, metrics
 


### PR DESCRIPTION
This fixes #1544  
It optionally enables adding the load balancing loss (also aux_loss) of Mixture of Experts models in DPO, KTO, CPO or ORPO.
We are using this for a while now and in our experiments, the models that were fine-tuned using this option perform best at the moment. Maybe that applies to other project as well, so I wanted to open-source the idea and leave it to the users to enable it or not.  

This option is simply enabled by setting `output_router_logits=True` in the MixtralConfig and optionally scale it with `router_aux_loss_coef =...`(default is 0.001)

@kashif @lewtun 