### PR TITLE
Fix Documentation Overflow Issues for Long URLs in SFTConfig

### DIFF
--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -49,7 +49,8 @@ class SFTConfig(TrainingArguments):
             The number of sequences to use for the `ConstantLengthDataset`. Defaults to `1024`.
         chars_per_token (`Optional[float]`):
             The number of characters per token to use for the `ConstantLengthDataset`. Defaults to `3.6`. You can check how this is computed in the
-            stack-llama example: https://github.com/huggingface/trl/blob/08f550674c553c36c51d1027613c29f14f3676a5/examples/stack_llama/scripts/supervised_finetuning.py#L53.
+            stack-llama example:
+            https://github.com/huggingface/trl/blob/08f550674c553c36c51d1027613c29f14f3676a5/examples/stack_llama/scripts/supervised_finetuning.py#L53.
     """
 
     dataset_text_field: Optional[str] = None

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -50,7 +50,7 @@ class SFTConfig(TrainingArguments):
         chars_per_token (`Optional[float]`):
             The number of characters per token to use for the `ConstantLengthDataset`. Defaults to `3.6`. You can check how this is computed in the
             stack-llama example:
-            https://github.com/huggingface/trl/blob/08f550674c553c36c51d1027613c29f14f3676a5/examples/stack_llama/scripts/supervised_finetuning.py#L53.
+            [chars_token_ratio](https://github.com/huggingface/trl/blob/08f550674c553c36c51d1027613c29f14f3676a5/examples/stack_llama/scripts/supervised_finetuning.py#L53).
     """
 
     dataset_text_field: Optional[str] = None


### PR DESCRIPTION
This PR addresses the issue of long URL causing text overflow in the documentation string for the SFTConfig class. By adding line breaks to long URLs and adjusting the formatting, the documentation is now more readable and properly contained within the text box.

<img width="1055" alt="Screenshot 2024-06-20 at 2 38 12 PM" src="https://github.com/huggingface/trl/assets/48038715/aa1fc64b-60df-4498-9a23-fe4433195684">