### PR TITLE
Bugfix: Preserve token fields when converting TrainingArguments to SFTConfig

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -223,6 +223,7 @@ class SFTTrainerTester(unittest.TestCase):
                 eval_steps=2,
                 save_steps=2,
                 per_device_train_batch_size=2,
+                hub_token="not_a_real_token",
             )
 
             trainer = SFTTrainer(
@@ -231,6 +232,8 @@ class SFTTrainerTester(unittest.TestCase):
                 train_dataset=self.train_dataset,
                 eval_dataset=self.eval_dataset,
             )
+
+            assert trainer.args.hub_token == training_args.hub_token
 
             trainer.train()
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -148,9 +148,7 @@ class SFTTrainer(Trainer):
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
             args_as_dict = args.to_dict()
             # Manually copy token values as TrainingArguments.to_dict() redacts them
-            for k in args_as_dict.keys():
-                if k.endswith("_token"):
-                    args_as_dict[k] = getattr(args, k)
+            args_as_dict.update({k: getattr(args, k) for k in args_as_dict.keys() if k.endswith("_token")})
             args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -146,7 +146,11 @@ class SFTTrainer(Trainer):
             warnings.warn(f"No `SFTConfig` passed, using `output_dir={output_dir}`.")
             args = SFTConfig(output_dir=output_dir)
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
-            args = SFTConfig(**args.to_dict())
+            args_as_dict = args.to_dict()
+            # Manually copy token values as TrainingArguments.to_dict() redacts them
+            args_as_dict['hub_token'] = args.hub_token
+            args_as_dict['push_to_hub_token'] = args.push_to_hub_token
+            args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:
             warnings.warn(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -148,7 +148,9 @@ class SFTTrainer(Trainer):
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
             args_as_dict = args.to_dict()
             # Manually copy token values as TrainingArguments.to_dict() redacts them
-            args_as_dict |= {k: getattr(args, k) for k in args_as_dict.keys() if k.endswith("_token")}
+            for k in args_as_dict.keys():
+                if k.endswith("_token"):
+                    args_as_dict[k] = getattr(args, k)
             args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -148,8 +148,8 @@ class SFTTrainer(Trainer):
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
             args_as_dict = args.to_dict()
             # Manually copy token values as TrainingArguments.to_dict() redacts them
-            args_as_dict['hub_token'] = args.hub_token
-            args_as_dict['push_to_hub_token'] = args.push_to_hub_token
+            args_as_dict["hub_token"] = args.hub_token
+            args_as_dict["push_to_hub_token"] = args.push_to_hub_token
             args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -146,8 +146,9 @@ class SFTTrainer(Trainer):
             warnings.warn(f"No `SFTConfig` passed, using `output_dir={output_dir}`.")
             args = SFTConfig(output_dir=output_dir)
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
+            args_as_dict = args.to_dict()
             # Manually copy token values as TrainingArguments.to_dict() redacts them
-            args_as_dict = args.to_dict() | {"hub_token": args.hub_token, "push_to_hub_token": args.push_to_hub_token}
+            args_as_dict |= {k: getattr(args, k) for k in args_as_dict.keys() if k.endswith("_token")}
             args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -146,10 +146,8 @@ class SFTTrainer(Trainer):
             warnings.warn(f"No `SFTConfig` passed, using `output_dir={output_dir}`.")
             args = SFTConfig(output_dir=output_dir)
         elif args is not None and args.__class__.__name__ == "TrainingArguments":
-            args_as_dict = args.to_dict()
             # Manually copy token values as TrainingArguments.to_dict() redacts them
-            args_as_dict["hub_token"] = args.hub_token
-            args_as_dict["push_to_hub_token"] = args.push_to_hub_token
+            args_as_dict = args.to_dict() | {"hub_token": args.hub_token, "push_to_hub_token": args.push_to_hub_token}
             args = SFTConfig(**args_as_dict)
 
         if model_init_kwargs is not None:


### PR DESCRIPTION
## What does this PR do?

This fixes a bug introduced in #1707, where if you create a `transformers.TrainingArguments` and pass it into `SFTTrainer`, you end up with `SFTTrainer.args.hub_token = "<PUSH_TO_HUB_TOKEN>"`, breaking the push-to-Hub functionality.

## Explanation

`TrainingArguments.to_dict()` redacts token fields ([transformers/src/transformers/training_args.py:2417](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L2417)), so we have to individually copy them over when converting to SFTConfig to avoid breaking push_to_hub functionality.

To be clear, users can work around this bug by directly creating an `SFTConfig` rather than creating a `TrainingArguments` object, but strangely some tutorials mix and match them, so maintaining compatibility seems prudent.

## Other notes

This PR also adds a test. I was able to run the test and verify this satisfies the test line I added, however, I couldn't figure out how to run the full tests without having a `wandb` account configured.

This is my first contribution to this repo, so apologies in advance if I missed something. Happy to revise or make any changes.