### PR TITLE
Remove extra print in reward_trainer.py

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -310,7 +310,6 @@ class RewardTrainer(Trainer):
             if num_print_samples >= 0 and len(table["chosen_text"]) >= num_print_samples:
                 break
         df = pd.DataFrame(table)
-        print_rich_table(pd.DataFrame(table))
         if self.accelerator.process_index == 0:
             print_rich_table(df[:num_print_samples])
             if "wandb" in self.args.report_to:


### PR DESCRIPTION
`print_rich_table` is called twice and the first call doesn't restrict to `num_print_samples`. Remove the first, extra call