### PR TITLE
KtoTrainer: BCO improvements

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
+import json
 import random
 import warnings
 from collections import deque
@@ -590,17 +592,19 @@ class ConstantLengthDataset(IterableDataset):
                 }
 
 
+@dataclass
 class RunningMoments:
-    def __init__(self, accelerator):
-        """
-        Calculates the running mean and standard deviation of a data stream. Reference:
-        https://github.com/OpenLMLab/MOSS-RLHF/blob/40b91eb2f2b71b16919addede0341d2bef70825d/utils.py#L75
-        """
-        self.mean = 0
-        self.std = 1
-        self.var = 1
-        self.count = 1e-24
-        self.accelerator = accelerator
+
+    """
+    Calculates the running mean and standard deviation of a data stream. Reference:
+    https://github.com/OpenLMLab/MOSS-RLHF/blob/40b91eb2f2b71b16919addede0341d2bef70825d/utils.py#L75
+    """
+
+    accelerator: Accelerator
+    mean: float = 0
+    std: float = 1
+    var: float = 1
+    count: float = 1e-24
 
     @torch.no_grad()
     def update(self, xs: torch.Tensor) -> Tuple[float, float]:
@@ -622,12 +626,28 @@ class RunningMoments:
         old_sum = self.var * self.count + delta**2 * self.count * xs_count / tot_count
         tot_sum = old_sum + new_sum
 
-        self.mean += delta * xs_count / tot_count
-        self.var = tot_sum / tot_count
-        self.std = (self.var * tot_count / (tot_count - 1)).float().sqrt()
-        self.count = tot_count
+        self.mean += (delta * xs_count / tot_count).item()
+        self.var = (tot_sum / tot_count).item()
+        self.std = (self.var * tot_count / (tot_count - 1)).float().sqrt().item()
+        self.count = tot_count.item()
 
         return xs_mean.item(), (xs_var * xs_count / (xs_count - 1)).float().sqrt().item()
+
+    def save_to_json(self, json_path: str):
+        """Save the content of this instance in JSON format inside `json_path`."""
+        # save everything except accelerator
+        save_dict = dataclasses.asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if k != "accelerator"})
+        json_string = json.dumps(save_dict, indent=2, sort_keys=True) + "\n"
+        with open(json_path, "w", encoding="utf-8") as f:
+            f.write(json_string)
+
+    @classmethod
+    def load_from_json(cls, accelerator: Accelerator, json_path: str):
+        """Create an instance from the content of `json_path`."""
+        # load everything except accelerator
+        with open(json_path, encoding="utf-8") as f:
+            text = f.read()
+        return cls(accelerator=accelerator, **json.loads(text))
 
 
 @torch.no_grad()


### PR DESCRIPTION

I recently experimented quite a bit with the BCO loss type in the KTO Trainer.  
This PR includes some changes that helped me to successfully and effectively run BCO on multiple GPUs (on Azure in this case):
- **When using the BCO loss type there is no need for the KL dataset anymore**. By skipping the creation of the KL dataset we save time and memory.
- **Do not assert both desired and undesired data with a per-device mini batch**. With this it was impossible to train large models that only allow a per-device batch size of 1. Also KTO and BCO are supposed to work with unpaired preference data with different amounts of desired or undesired examples. In my experiments BCO proofed to work well  without this assumption.
- **When checkpointing, also save the `RunningMoments` object which is used in BCO to calculate the $\delta$ mean reward value**. If this is not saved, it will corrupt the whole training process when restarting from a checkpoint. 

Please have a look at these and let me know if you can approve the solutions implemented here or if you prefer other solutions to the issues described above

@kashif @lewtun 
