### PR TITLE
Fix `TRL_USE_RICH` environment variable handling

### DIFF
--- a/examples/scripts/dpo.py
+++ b/examples/scripts/dpo.py
@@ -55,9 +55,10 @@ import multiprocessing
 import os
 from contextlib import nullcontext
 
-TRL_USE_RICH = os.environ.get("TRL_USE_RICH", False)
-
 from trl.commands.cli_utils import DPOScriptArguments, init_zero_verbose, TrlParser
+from trl.env_utils import strtobool
+
+TRL_USE_RICH = strtobool(os.getenv("TRL_USE_RICH", "0"))
 
 if TRL_USE_RICH:
     init_zero_verbose()

--- a/examples/scripts/sft.py
+++ b/examples/scripts/sft.py
@@ -49,9 +49,10 @@ import logging
 import os
 from contextlib import nullcontext
 
-TRL_USE_RICH = os.environ.get("TRL_USE_RICH", False)
-
 from trl.commands.cli_utils import init_zero_verbose, SFTScriptArguments, TrlParser
+from trl.env_utils import strtobool
+
+TRL_USE_RICH = strtobool(os.getenv("TRL_USE_RICH", "0"))
 
 if TRL_USE_RICH:
     init_zero_verbose()

--- a/examples/scripts/vsft_llava.py
+++ b/examples/scripts/vsft_llava.py
@@ -68,9 +68,10 @@ import logging
 import os
 from contextlib import nullcontext
 
-TRL_USE_RICH = os.environ.get("TRL_USE_RICH", False)
-
 from trl.commands.cli_utils import init_zero_verbose, SFTScriptArguments, TrlParser
+from trl.env_utils import strtobool
+
+TRL_USE_RICH = strtobool(os.getenv("TRL_USE_RICH", "0"))
 
 if TRL_USE_RICH:
     init_zero_verbose()

--- a/trl/commands/cli.py
+++ b/trl/commands/cli.py
@@ -41,8 +41,9 @@ def main():
 
         trl_examples_dir = os.path.dirname(__file__)
 
-    # Force-use rich
-    os.environ["TRL_USE_RICH"] = "1"
+    # Force-use rich if the `TRL_USE_RICH` env var is not set
+    if "TRL_USE_RICH" not in os.environ:
+        os.environ["TRL_USE_RICH"] = "1"
 
     if command_name == "chat":
         command = f"""

--- a/trl/env_utils.py
+++ b/trl/env_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Function `strtobool` copied and adapted from `distutils` (as deprected
+# in Python 3.10).
+# Reference: https://github.com/python/cpython/blob/48f9d3e3faec5faaa4f7c9849fecd27eae4da213/Lib/distutils/util.py#L308-L321
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to True or False booleans.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.
+
+    Raises:
+        ValueError: if 'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(
+        f"Invalid truth value, it should be a string but {val} was provided instead."
+    )

--- a/trl/env_utils.py
+++ b/trl/env_utils.py
@@ -31,6 +31,4 @@ def strtobool(val: str) -> bool:
         return True
     if val in ("n", "no", "f", "false", "off", "0"):
         return False
-    raise ValueError(
-        f"Invalid truth value, it should be a string but {val} was provided instead."
-    )
+    raise ValueError(f"Invalid truth value, it should be a string but {val} was provided instead.")


### PR DESCRIPTION
## Description

This PR fixes how the `TRL_USE_RICH` environment variable value is handled, since at the moment it cannot be disabled.

> [!WARNING]
> I'm not really happy with the current implementation since the `TRL_USE_RICH` environment variable is not used in the core, but it's used in the `examples/scripts` triggered via the CLI, which means that the same function needs to be used more than once and defining that once per file feels weird too. So would love your input here @vwxyzjn on what would be the best approach to ensure that the value is properly handled, but at the same time without adding noise to the codebase 😩 

Closes #1800