### PR TITLE
Fixed the broken link to Text Environments doc in `docs\source\index.mdx`

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -21,7 +21,7 @@ Check the appropriate sections of the documentation depending on your needs:
 - [`PPOTrainer`](ppo_trainer): *Further fine-tune the supervised fine-tuned model using PPO algorithm*
 - [Best-of-N Sampling](best-of-n): *Use best of n sampling as an alternative way to sample predictions from your active model*
 - [`DPOTrainer`](dpo_trainer): *Direct Preference Optimization training using `DPOTrainer`.*
-- [`TextEnvironment`](text_environment): *Text environment to train your model using tools with RL.*
+- [`TextEnvironment`](text_environments): *Text environment to train your model using tools with RL.*
 
 ## Examples
 


### PR DESCRIPTION
Fixed a typo in `docs/source/index.mdx`. Should fix the broken link (https://huggingface.co/docs/trl/v0.9.4/en/text_environment) mentioned under [API documentation](https://huggingface.co/docs/trl/en/index#api-documentation).

It ain't much but it's honest work.