### PR TITLE
Fix: authentication token kwarg not passed when loading PEFT adapters

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -215,7 +215,7 @@ class PreTrainedModelWrapper(nn.Module):
 
                 # Wrap the pretrained model with the trained peft adapter
                 pretrained_model = PeftModel.from_pretrained(
-                    pretrained_model, pretrained_model_name_or_path, is_trainable=is_trainable
+                    pretrained_model, pretrained_model_name_or_path, is_trainable=is_trainable, token=token
                 )
                 logging.info("Trained peft adapter loaded")
             else:


### PR DESCRIPTION
# Issue
The issue occurs when the following conditions are met
- we want to create any subclass of `PreTrainedModelWrapper` through the `from_pretrained` method
- the referenced model repository contains a Peft adapter
- the referenced model repository is private

The following things happen:
- the `adapter_config.json` gets downloaded using the token as authentication

since an adapter is present we
- instantiate and attempt to download the base model passing the token in the kwargs
- instantiate and attempt to download the PEFT adapter without passing the token
-> since the adapter repository is private, we're not able to load the adapter without passing the token. The `from_pretrained` method throws an error

# Fix
We pass the token as a keyword argument when instantiating the PeftModel.