### PR TITLE
fix ppov2_trainer tensorboard logging bug

### DIFF
--- a/trl/trainer/ppov2_trainer.py
+++ b/trl/trainer/ppov2_trainer.py
@@ -498,6 +498,7 @@ class PPOv2Trainer(Trainer):
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = global_step
                 self.state.epoch = global_step / self.train_dataset_len  # used by self.log
+                self.state.global_step += 1
                 self.log(metrics)
             del kl, mean_kl, mean_entropy, mean_non_score_reward, scores, metrics, non_score_reward
             torch.cuda.empty_cache()


### PR DESCRIPTION
Tensorboard log fails because current code doesn't update global step.
- before:
![image](https://github.com/user-attachments/assets/0933b647-6690-41d0-9ab3-5197119b0197)
- after this PR:
![image](https://github.com/user-attachments/assets/e0bfaf2a-1358-4b15-b51a-c0eab50e4413)

- test command
```
python examples/scripts/ppo/ppo.py \
    --learning_rate 3e-6 \
    --output_dir ./output \
    --per_device_train_batch_size 1 \
    --gradient_accumulation_steps 1 \
    --total_episodes 100 \
    --model_name_or_path Qwen2/Qwen2-0.5B-Instruct \
    --non_eos_penalty \
    --sft_model_path Qwen2/Qwen2-0.5B-Instruct \
    --reward_model_path Qwen2/Qwen2-0.5B-Instruct \
    --report_to tensorboard \
    --local_rollout_forward_batch_size 1 \
    --logging_strategy steps \
    --logging_steps 1 
```