### PR TITLE
RLHF trainers: add a low VRAM threshold

### DIFF
--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -58,6 +58,8 @@ class KTOConfig(TrainingArguments):
             Dict of Optional kwargs to pass when instantiating the ref model from a string.
         dataset_num_proc: (`Optional[int]`, *optional*, defaults to `None`):
             Number of processes to use for processing the datasets.
+        low_vram_threshold (`Optional[int]`, *optional*):
+            Threshold for low VRAM mode, in number of tokens for a given sample (should be in range from 0 to whatever the context size of the training session is). This will perform certain operations on the CPU instead of in VRAM which are prone to give VRAM usage spikes, if the context size of the sample exceeds the threshold. This can be enabled if the trainer runs out of VRAM during training, at a slight performance cost. Note: the trainer will give a hint about what to set this to when it crashes. Look above the Traceback line.
     """
 
     max_length: Optional[int] = None
@@ -82,3 +84,5 @@ class KTOConfig(TrainingArguments):
     model_init_kwargs: Optional[Dict] = None
     ref_model_init_kwargs: Optional[Dict] = None
     dataset_num_proc: Optional[int] = None
+
+    low_vram_threshold: Optional[int] = None

--- a/trl/trainer/orpo_config.py
+++ b/trl/trainer/orpo_config.py
@@ -51,6 +51,8 @@ class ORPOConfig(TrainingArguments):
             Dict of Optional kwargs to pass when instantiating the model from a string
         dataset_num_proc (`Optional[int]`, *optional*):
             The number of workers to use to tokenize the data. Defaults to None.
+        low_vram_threshold (`Optional[int]`, *optional*):
+            Threshold for low VRAM mode, in number of tokens for a given sample (should be in range from 0 to whatever the context size of the training session is). This will perform certain operations on the CPU instead of in VRAM which are prone to give VRAM usage spikes, if the context size of the sample exceeds the threshold. This can be enabled if the trainer runs out of VRAM during training, at a slight performance cost. Note: the trainer will give a hint about what to set this to when it crashes. Look above the Traceback line.
     """
 
     max_length: Optional[int] = None
@@ -69,3 +71,5 @@ class ORPOConfig(TrainingArguments):
     model_init_kwargs: Optional[Dict] = None
 
     dataset_num_proc: Optional[int] = None
+
+    low_vram_threshold: Optional[int] = None


### PR DESCRIPTION
The RLHF trainers (this PR addresses ORPO and KTO) use a `get_batch_logps()` method which will cause pretty huge spikes in VRAM for high token samples. This pull request lets the user pick a context length (hinted to in the crash when running out of VRAM) which transfers the tensors to CPU and performs the operation there instead, at a small performance cost.

For example, doing a DPO training run on Llama 3.1 8B with 2x24 GB VRAM, the trainer will hit an OOM error when it encounters a sample of length 2000. Using 2000 as `low_vram_threshold` lets the trainer complete successfully. Since the trainer will only do the operation on CPU if the length exceeds the threshold, this has a near negligible performance cost. In fact, I originally did it as a boolean (i.e. `low_vram_threshold=0`), and couldn't even tell there was a slow-down.

Update: I extended this to cover KTO trainer as well, as it is suffering from exactly the same bottleneck. Using FSDP, I was able to train on ~3500 token entries before it OOM'd, when training against Llama 3.1 8B with 2x24 GB VRAM. By introducing the low vram threshold, I am able to complete the training process.