### PR TITLE
fix serialization of RunningMoments on multiple GPUs

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -611,7 +611,9 @@ class RunningMoments:
 
 
 @torch.no_grad()
-def get_global_statistics(accelerator, xs: torch.Tensor, mask=None, device="cpu") -> Tuple[float, float, int]:
+def get_global_statistics(
+    accelerator, xs: torch.Tensor, mask=None, device="cpu"
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """
     Computes element-wise mean and variance of the tensor across processes. Reference:
     https://github.com/OpenLMLab/MOSS-RLHF/blob/40b91eb2f2b71b16919addede0341d2bef70825d/utils.py#L57C1-L73C75
@@ -626,7 +628,7 @@ def get_global_statistics(accelerator, xs: torch.Tensor, mask=None, device="cpu"
     sum_var = accelerator.reduce(sum_var)
     global_var = sum_var / count
 
-    return global_mean.to(device), global_var.to(device), count.to(device)
+    return global_mean.to(device), global_var.to(device), count.item()
 
 
 def compute_accuracy(eval_pred) -> Dict[str, float]:


### PR DESCRIPTION

This issue is related to PR #1869  

When training in a distributed setup, the collected count of the RunningMoments class ended up being a tensor, not an integer. This led to errors in json serializtion.  

This fixes the type of xs_count in distributed trainings.  
Previous fix (see https://github.com/huggingface/trl/pull/1869/commits/c22035049d857775ce6ba82763e82b934959064b) caused tests to fail and was therefore reverted by @kashif. Also @seanexp 
