### PR TITLE
fix DPOTrainer.tokenize_row is not hashable

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -538,7 +538,7 @@ class DPOTrainer(Trainer):
                 truncation_mode=self.truncation_mode,
                 label_pad_token_id=self.label_pad_token_id,
             )
-            tokenize_row_partial = partial(tokenize_row, tokenizer = tokenizer, processor=self.processor if self.is_vision_model else None, args=tokenize_row_config)
+            tokenize_row_partial = partial(tokenize_row, tokenizer = tokenizer, processor=self.processor if self.is_vision_model else None, tokenize_row_config=tokenize_row_config)
             train_dataset = train_dataset.map(tokenize_row_partial, num_proc=self.dataset_num_proc, writer_batch_size=10)
             if eval_dataset is not None:
                 eval_dataset = eval_dataset.map(


### PR DESCRIPTION
The current implementation of `tokenize_row` in the [TRL repository](https://github.com/huggingface/trl/blob/main/trl/trainer/dpo_trainer.py#L789) is a class function, which is not hashable. As a result, the `datasets` library assigns a "random" fingerprint to the transformed dataset, as mentioned in issue #1252. This leads to several issues:

1. Ideally, only the main process should tokenize the data. However, due to the different fingerprints being created, each process ends up tokenizing its own copy.
2. The `datasets.map` function also relies on the fingerprint, causing it to run in a single process regardless of the `dataset_num_proc` setting.
3. Since preprocessing time for large datasets can be very long with a single process, and the default timeout for the NCCL communicator is 30 minutes, it becomes impossible to run `dpo_trainer` with large datasets.

With this PR, these issues are resolved, ensuring proper functionality and efficiency.
Test command is:
```bash
 python examples/scripts/dpo.py \                                                                                              
    --dataset_name=trl-internal-testing/hh-rlhf-helpful-base-trl-style \
    --model_name_or_path=gpt2 \
    --per_device_train_batch_size 4 \
    --learning_rate 1e-3 \
    --gradient_accumulation_steps 1 \
    --logging_steps 10 \
    --eval_steps 500 \
    --output_dir="dpo_anthropic_hh" \
    --warmup_steps 150 \
    --report_to wandb \
    --bf16 \
    --logging_first_step \
    --no_remove_unused_columns \
    --dataset_num_proc 128
```

We run this command for twice, 
the first time, it tokenize the data with 128 processes
![Screenshot 2024-08-02 173029](https://github.com/user-attachments/assets/59663eb1-5bc5-4cde-9558-b90fe739fdb0)
and the second time it directly loads the tokenized data.

