### PR TITLE
Add transformers library name for TRL repos

### DIFF
--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -32,6 +32,7 @@ logger = get_logger(__name__)
 
 MODEL_CARD_TEMPLATE = """---
 license: apache-2.0
+library_name: transformers
 tags:
 - trl
 - alignprop

--- a/trl/trainer/ddpo_trainer.py
+++ b/trl/trainer/ddpo_trainer.py
@@ -35,6 +35,7 @@ logger = get_logger(__name__)
 
 MODEL_CARD_TEMPLATE = """---
 license: apache-2.0
+library_name: transformers
 tags:
 - trl
 - ddpo

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -67,6 +67,7 @@ if is_deepspeed_available():
 
 MODEL_CARD_TEMPLATE = """---
 license: apache-2.0
+library_name: transformers
 tags:
 - trl
 - ppo


### PR DESCRIPTION
As of August 2, TRL model repos are no longer automatically tagged as `transformers` repos (previously this was inferred from the existence of a `config.json` file). 

This PR adds an explicit `library_name` tag to the TRL trainers that do not subclass `transformers.Trainer`. For all other trainers, the correct tag will be added via https://github.com/huggingface/transformers/pull/32623

cc @osanseviero 