### PR TITLE
Fix apply_chat_template bugs for script/dpo

### DIFF
--- a/examples/scripts/dpo.py
+++ b/examples/scripts/dpo.py
@@ -155,14 +155,20 @@ if __name__ == "__main__":
             ds[key] = ds[key].select(range(50))
 
     def process(row):
+        # judge the third issue.
+        chat_right = True
         # judge chat template
         prompt = row["chosen"][:-1]
         chosen = [row["chosen"][-1]]
         test_prompt = tokenizer.apply_chat_template(prompt, tokenize=False)
-        test_chosen = tokenizer.apply_chat_template(chosen, tokenize=False)
+        try:
+            test_chosen = tokenizer.apply_chat_template(chosen, tokenize=False)
+        except Exception as e:
+            chat_right = False
         conversation = copy.deepcopy(prompt)
         conversation.append(row["chosen"][-1])
-        if tokenizer.apply_chat_template(conversation) == test_prompt + test_chosen:
+        # the chat_right is for the third issue, the subsequent checks is for the first and second issues.
+        if chat_right and tokenizer.apply_chat_template(conversation) == test_prompt + test_chosen:
             row["prompt"] = tokenizer.apply_chat_template(row["chosen"][:-1], tokenize=False)
             row["chosen"] = tokenizer.apply_chat_template([row["chosen"][-1]], tokenize=False)
             row["rejected"] = tokenizer.apply_chat_template([row["rejected"][-1]], tokenize=False)

--- a/trl/commands/cli_utils.py
+++ b/trl/commands/cli_utils.py
@@ -13,15 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import logging
 import os
 import sys
 from argparse import Namespace
 from dataclasses import dataclass, field
+from typing import List, Dict
 
 import yaml
 from transformers import HfArgumentParser
-
 
 logger = logging.getLogger(__name__)
 
@@ -101,8 +102,8 @@ class DPOScriptArguments:
         default=False,
         metadata={
             "help": "debug argument for distributed training;"
-            "fix for DDP issues with LM bias/mask buffers - invalid scalar type,`inplace operation. See"
-            "https://github.com/huggingface/transformers/issues/22482#issuecomment-1595790992"
+                    "fix for DDP issues with LM bias/mask buffers - invalid scalar type,`inplace operation. See"
+                    "https://github.com/huggingface/transformers/issues/22482#issuecomment-1595790992"
         },
     )
     config: str = field(default=None, metadata={"help": "Path to the optional config file"})
@@ -265,3 +266,56 @@ class TrlParser(HfArgumentParser):
             if action.dest in kwargs:
                 action.default = kwargs[action.dest]
                 action.required = False
+
+
+def is_right_apply_chat(tokenizer, prompt: List[Dict[str, str]], assistant_content: List[Dict[str, str]]) -> bool:
+    """
+    Checks if the assistant's content is correctly applied to the prompt in a chat template.
+
+    Args:
+        tokenizer: The tokenizer.
+        prompt: The initial prompt message.
+        assistant_content: The content provided by the assistant.
+
+    Returns:
+        bool: True if the assistant's content is correctly applied, False otherwise.
+    """
+    try:
+        test_assistant = tokenizer.apply_chat_template(assistant_content, tokenize=False)
+        test_prompt = tokenizer.apply_chat_template(prompt, tokenize=False)
+        conversation = copy.deepcopy(prompt)
+        conversation.append(assistant_content[0])
+        if tokenizer.apply_chat_template(conversation) == test_prompt + test_assistant:
+            return True
+        else:
+            return False
+    except Exception as e:
+        return False
+
+
+def fix_chat_template_if_needed(tokenizer, prompt: List[Dict[str, str]], chosen: List[Dict[str, str]], rejected: List[Dict[str, str]]):
+    """
+    Fixes the chat template if needed.
+
+    Args:
+        tokenizer: The tokenizer.
+        prompt: The initial prompt message.
+        chosen: The chosen response, a list containing a single dictionary representing the chosen message.
+        rejected: The rejected response, a list containing a single dictionary representing the rejected message.
+
+        Returns:
+        - tuple: A tuple containing the fixed prompt, fixed chosen response, and fixed rejected response.
+    """
+    conversation_chosen = copy.deepcopy(prompt)
+    conversation_rejected = copy.deepcopy(prompt)
+    conversation_chosen.append(chosen[0])
+    conversation_rejected.append(rejected[0])
+    conversation_chosen = tokenizer.apply_chat_template(conversation_chosen, tokenize=False)
+    conversation_rejected = tokenizer.apply_chat_template(conversation_rejected, tokenize=False)
+    # find position
+    start_position = conversation_chosen.find(chosen[0]['content'][0])
+    # The following is right
+    fixed_prompt = conversation_chosen[:start_position]
+    fixed_chosen = conversation_chosen[start_position:]
+    fixed_rejected = conversation_rejected[start_position:]
+    return fixed_prompt, fixed_chosen, fixed_rejected


### PR DESCRIPTION
The tokenizer.apply_chat_template is used in this example(axamples/scripts/dpo.py). 

The tokenizer.apply_chat_template is used separately for prompt, chosen, and rejected. This is correct in most cases, but errors will occur if the model used has a default system.

For example, in the qwen model, using tokenizer.apply_chat_template for prompt and chosen respectively, we get the following：
```
prompt：

<|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
Do you know the singer Adele?<|im_end|>

chosen：
<|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>assistant
Sure! Here are some ways to eat bananas and dragonfruits together<|im_end|>
```

If use tokenizer.apply_chat_template in a complete conversation, you will get the following result：
```
<|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
Do you know the singer Adele?<|im_end|>
<|im_start|>assistant
Sure! Here are some ways to eat bananas and dragonfruits together<|im_end|>
```

This means that the incoming prompt and chosen are not correctly concatenated in DpoTrainer.

So in this case, we need to judge the position of prompt and chosen more accurately, which is the function added by my PR.

