### PR TITLE
[ODPO] Fix global step for consistent checkpointing with global updates

### DIFF
--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -338,7 +338,6 @@ class OnlineDPOTrainer(Trainer):
                 contain_eos_token = torch.any(postprocessed_responses == tokenizer.eos_token_id, dim=-1)
                 if args.non_eos_penalty:
                     scores = torch.where(contain_eos_token, scores, args.penalty_reward_value)
-                # accelerator.print(f"{scores=}, {(contain_eos_token.sum() / len(contain_eos_token))=}")
 
                 # be very careful with `padding_mask_p1`; see https://excalidraw.com/#json=LWnzG4w2k5DjF_EOL_xPt,e2w3a-hFJ_gX5vOfeyXGTw
                 response_idxs = torch.arange(responses.shape[1], device=responses.device).repeat(responses.shape[0], 1)
@@ -467,7 +466,6 @@ class OnlineDPOTrainer(Trainer):
                                 ] = rejected_logprobs_sum.mean()
                         gradient_accumulation_idx += 1
                     minibatch_idx += 1
-                    self.state.global_step += 1
                     # del everything and empty cache
                     # fmt: off
                     del (
@@ -505,11 +503,11 @@ class OnlineDPOTrainer(Trainer):
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = self.state.episode
                 self.state.epoch = self.state.episode / self.train_dataset_len  # used by self.log
-                self.state.global_step += 1
                 self.log(metrics)
             del (kl, mean_kl, mean_entropy, scores, scores_margin)
 
             self.lr_scheduler.step()
+            self.state.global_step += 1
             self.control = self.callback_handler.on_step_end(args, self.state, self.control)
             if self.control.should_save:
                 self._save_checkpoint(model, trial=None, metrics=metrics)


### PR DESCRIPTION
This PR aligns the `global_step` to increment in the same way as the outer update loop. This ensures that the intermediate checkpoints align with the value set in `save_steps`.

The main impact of this change is that it affects the LR scheduler since the global step in incremented differently. See e.g. these two WandB runs:

* Without fix: https://wandb.ai/huggingface/huggingface/runs/t1v4qfj1?nw=nwuserlewtun
* With fix: https://wandb.ai/huggingface/huggingface/runs/sfebrzr6/overview

This subsequently affects the training dynamics, but I am unsure if the original implementation was actually correct or not wrt the global step.

![Screenshot 2024-08-20 at 15 04 13](https://github.com/user-attachments/assets/eb18021f-592f-4cf2-be79-75fc9463335c)


Closes #1889 