### PR TITLE
Fix issue with precompute_ref_log_probs not working when rpo_alpha is None

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -163,7 +163,13 @@ class DPOTrainerTester(unittest.TestCase):
                 if param.sum() != 0:
                     assert not torch.allclose(param, new_param, rtol=1e-12, atol=1e-12)
 
-    def test_dpo_trainer_without_providing_ref_model(self):
+    @parameterized.expand(
+        [
+            [None, "Test when rpo_alpha is set to None"],
+            [0.5, "Test when rpo_alpha is set to 0.5"],
+        ]
+    )
+    def test_dpo_trainer_without_providing_ref_model(self, rpo_alpha, _):
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = DPOConfig(
                 output_dir=tmp_dir,
@@ -175,7 +181,7 @@ class DPOTrainerTester(unittest.TestCase):
                 eval_strategy="steps",
                 beta=0.1,
                 precompute_ref_log_probs=True,
-                rpo_alpha=0.5,
+                rpo_alpha=rpo_alpha,
                 report_to="none",
             )
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1375,7 +1375,7 @@ class DPOTrainer(Trainer):
         if (
             "reference_chosen_logps" in batch
             and "reference_rejected_logps" in batch
-            and self.args.rpo_alpha is not None
+            and (self.precompute_ref_log_probs or self.args.rpo_alpha is not None)
         ):
             reference_chosen_logps = batch["reference_chosen_logps"]
             reference_rejected_logps = batch["reference_rejected_logps"]


### PR DESCRIPTION
When using the `precompute_ref_log_probs=True` option, the training process is halted( the training loss sucks at 0.6932 which shows the model is not training). This issue arises due to the following code segment:

```
if (
            "reference_chosen_logps" in batch
            and "reference_rejected_logps" in batch
            and self.args.rpo_alpha is not None
        ):
            reference_chosen_logps = batch["reference_chosen_logps"]
            reference_rejected_logps = batch["reference_rejected_logps"]
```

The condition `self.args.rpo_alpha` is not None prevents the `reference_chosen_logps` and `reference_rejected_logps` from being used in the training process when `rpo_alpha` is set to None. This is problematic because when `precompute_ref_log_probs=True`, we still need to access these log probabilities from the batch regardless of the `rpo_alpha` value.


To resolve this issue, the condition should be adjusted to ensure that `reference_chosen_logps` and `reference_rejected_logps` are accessed when `precompute_ref_log_probs` is set to True, independent of the `rpo_alpha` value.