### PR TITLE
New mismatch pair creation strategy

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -72,7 +72,7 @@ RUNNING_NAME = "running.pt"
 
 def _get_kl_dataset(batch: Dict[str, List[Any]]) -> Dict[str, List[Any]]:
     """Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of completions."""
-    batch["answer_input_ids"]  = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
+    batch["answer_input_ids"] = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
     batch["answer_attention_mask"] = [batch["answer_attention_mask"][-1]] + batch["answer_attention_mask"][:-1]
     return batch
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -71,9 +71,9 @@ RUNNING_NAME = "running.pt"
 
 
 def _get_kl_dataset(batch: Dict[str, List[Any]]) -> Dict[str, List[Any]]:
-    """Creates mismatched pairs of prompts and completions for the KL dataset by reversing the order of completions."""
-    batch["answer_input_ids"] = batch["answer_input_ids"][::-1]
-    batch["answer_attention_mask"] = batch["answer_attention_mask"][::-1]
+    """Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of completions."""
+    batch["answer_input_ids"]  = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
+    batch["answer_attention_mask"] = [batch["answer_attention_mask"][-1]] + batch["answer_attention_mask"][:-1]
     return batch
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #1911

With the current `_get_kl_dataset` in [`kto_trainer.py`](https://github.com/huggingface/trl/blob/main/trl/trainer/kto_trainer.py) you can have this situation when the batch size is odd:

```python
from typing import Any, Dict, List

def _get_kl_dataset(batch: Dict[str, List[Any]]) -> Dict[str, List[Any]]:
    """Creates mismatched pairs of prompts and completions for the KL dataset by reversing the order of completions."""
    batch["answer_input_ids"] = batch["answer_input_ids"][::-1]
    batch["answer_attention_mask"] = batch["answer_attention_mask"][::-1]
    return batch


input_ids = ["example_0", "example_1", "example_2"]
attention_mask = ["attention_mask_0", "attention_mask_1", "attention_mask_2"]

batch = {"answer_input_ids": input_ids, "answer_attention_mask": attention_mask}
kl_dataset = _get_kl_dataset(batch)["answer_input_ids"]

print(input_ids) # ['example_0', 'example_1', 'example_2']
print(kl_dataset) # ['example_2', 'example_1', 'example_0']
```

`example_1` matches, while it shouldn't.

To solve this, we add a +1 offset instead:

```python
from typing import Any, Dict, List

def _get_kl_dataset(batch: Dict[str, List[Any]]) -> Dict[str, List[Any]]:
    """Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of completions."""
    batch["answer_input_ids"]  = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
    batch["answer_attention_mask"] = [batch["answer_attention_mask"][-1]] + batch["answer_attention_mask"][:-1]
    return batch


input_ids = ["example_0", "example_1", "example_2"]
attention_mask = ["attention_mask_0", "attention_mask_1", "attention_mask_2"]

batch = {"answer_input_ids": input_ids, "answer_attention_mask": attention_mask}
kl_dataset = _get_kl_dataset(batch)["answer_input_ids"]

print(input_ids) # ['example_0', 'example_1', 'example_2']
print(kl_dataset) # ['example_2', 'example_0', 'example_1']
```

Now, all the examples mismatch.




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?: locally


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.