### PR TITLE
Promote `PairRMJudge` to top-Level import

### DIFF
--- a/docs/source/judges.mdx
+++ b/docs/source/judges.mdx
@@ -66,6 +66,10 @@ judge.judge(
 
 [[autodoc]] RandomPairwiseJudge
 
+## PairRMJudge
+
+[[autodoc]] PairRMJudge
+
 ## HfPairwiseJudge
 
 [[autodoc]] HfPairwiseJudge

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ EXTRAS = {
         "scikit-learn",
         "Pillow",
         "pytest-rerunfailures",
+        "llm-blender>=0.0.2",
     ],
     "peft": ["peft>=0.8.0"],
     "diffusers": ["diffusers>=0.18.0"],

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -1,6 +1,6 @@
 import unittest
 
-from trl import HfPairwiseJudge, RandomPairwiseJudge, RandomRankJudge
+from trl import HfPairwiseJudge, PairRMJudge, RandomPairwiseJudge, RandomRankJudge
 
 
 class TestJudges(unittest.TestCase):
@@ -27,6 +27,14 @@ class TestJudges(unittest.TestCase):
     @unittest.skip("This test needs to be run manually since it requires a valid Hugging Face API key.")
     def test_hugging_face_judge(self):
         judge = HfPairwiseJudge()
+        prompts, completions = self._get_prompts_and_completions()
+        ranks = judge.judge(prompts=prompts, completions=completions)
+        self.assertEqual(len(ranks), 2)
+        self.assertTrue(all(isinstance(rank, int) for rank in ranks))
+        self.assertEqual(ranks, [0, 1])
+
+    def test_pair_rm_judge(self):
+        judge = PairRMJudge()
         prompts, completions = self._get_prompts_and_completions()
         ranks = judge.judge(prompts=prompts, completions=completions)
         self.assertEqual(len(ranks), 2)

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -67,6 +67,7 @@ _import_structure = {
         "BasePairwiseJudge",
         "RandomRankJudge",
         "RandomPairwiseJudge",
+        "PairRMJudge",
         "HfPairwiseJudge",
         "OpenAIPairwiseJudge",
     ],
@@ -152,6 +153,7 @@ if TYPE_CHECKING:
         BasePairwiseJudge,
         RandomRankJudge,
         RandomPairwiseJudge,
+        PairRMJudge,
         HfPairwiseJudge,
         OpenAIPairwiseJudge,
     )

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -60,6 +60,7 @@ _import_structure = {
         "BasePairwiseJudge",
         "RandomRankJudge",
         "RandomPairwiseJudge",
+        "PairRMJudge",
         "HfPairwiseJudge",
         "OpenAIPairwiseJudge",
     ],
@@ -121,6 +122,7 @@ if TYPE_CHECKING:
         BasePairwiseJudge,
         RandomRankJudge,
         RandomPairwiseJudge,
+        PairRMJudge,
         HfPairwiseJudge,
         OpenAIPairwiseJudge,
     )


### PR DESCRIPTION
It seems to be an oversight.