### PR TITLE
[Docs] Add Liger-Kernel usage to SFTTrainer page

### DIFF
--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -596,7 +596,7 @@ The saved model is fully compatible with Hugging Face's transformers library. Le
 
 ### Increase 20% throughput and reduces 60% memory using Liger-Kernel
 
-[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. The kernel works out of the box with Flash Attention, PyTorch FSDP, and Microsoft DeepSpeed. We welcome contributions from the community to gather the best kernels for LLM training.
+[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. The kernel works out of the box with Flash Attention, PyTorch FSDP, and Microsoft DeepSpeed.
 
 | Speed Up                 | Memory Reduction        |
 |--------------------------|-------------------------|

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -609,16 +609,14 @@ With great memory reduction, you can potentially turn off cpu_offloading or grad
 
 ```bash
 pip install liger-kernel
+```
 
-```diff
-+ from liger_kernel.transformers import AutoLigerKernelForCausalLM
+2. Once installed, set `use_liger` in [SFTConfig](https://github.com/huggingface/trl/blob/850ddcf598984013007d384c6b3e311def2a616e/trl/trainer/sft_config.py#L69). No other changes are needed!
 
-...
-
-# This AutoModel wrapper class automatically monkey-patches the
-# model with the optimized Liger kernels if the model is supported.
-+ model = AutoLigerKernelForCausalLM.from_pretrained("path/to/some/model")
-- model = AutoModelForCausalLM.from_pretrained("path/to/some/model")
+```python
+config = SFTConfig(
+  use_liger=True
+)
 ```
 
 To learn more about Liger-Kernel, visit their [official repository](https://github.com/linkedin/Liger-Kernel/).

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -604,7 +604,11 @@ With great memory reduction, you can potentially turn off cpu_offloading or grad
 |--------------------------|-------------------------|
 | ![Speed up](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-tps.png) | ![Memory](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-memory.png) |
 
-To use Liger-Kernel in `SFTTrainer`, you can first install Liger-Kernel according to [the official website](https://github.com/linkedin/Liger-Kernel). Once installed, we can use it out-of-the-box with two simple line changes:
+
+1. To use Liger-Kernel in `SFTTrainer`, first install by 
+
+```bash
+pip install liger-kernel
 
 ```diff
 + from liger_kernel.transformers import AutoLigerKernelForCausalLM

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -598,17 +598,21 @@ The saved model is fully compatible with Hugging Face's transformers library. Le
 
 [Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. The kernel works out of the box with Flash Attention, PyTorch FSDP, and Microsoft DeepSpeed. We welcome contributions from the community to gather the best kernels for LLM training.
 
-To use Liger-Kernel in `SFTTrainer`, we should first install Liger-Kernel according to [the official website](https://github.com/linkedin/Liger-Kernel). Once installed, we can use it out-of-the-box with one simple line change:
+| Speed Up                 | Memory Reduction        |
+|--------------------------|-------------------------|
+| ![Speed up](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-tps.png) | ![Memory](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-memory.png) |
+
+To use Liger-Kernel in `SFTTrainer`, you can first install Liger-Kernel according to [the official website](https://github.com/linkedin/Liger-Kernel). Once installed, we can use it out-of-the-box with two simple line changes:
 
 ```diff
 + from liger_kernel.transformers import AutoLigerKernelForCausalLM
 
 ...
 
-- model = AutoModelForCausalLM.from_pretrained("path/to/some/model")
 # This AutoModel wrapper class automatically monkey-patches the
 # model with the optimized Liger kernels if the model is supported.
-model = AutoLigerKernelForCausalLM.from_pretrained("path/to/some/model")
++ model = AutoLigerKernelForCausalLM.from_pretrained("path/to/some/model")
+- model = AutoModelForCausalLM.from_pretrained("path/to/some/model")
 ```
 
 ## Best practices

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -594,7 +594,7 @@ trainer.train()
 
 The saved model is fully compatible with Hugging Face's transformers library. Learn more about unsloth in their [official repository](https://github.com/unslothai/unsloth).
 
-### Increase 20% throughput and reduces 60% memory using Liger-Kernel
+## Liger-Kernel: Increase 20% throughput and reduces 60% memory for multi-GPU training
 
 [Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. That way, we can **4x** our context length, as described in the benchmark below. They have implemented Hugging Face Compatible `RMSNorm`, `RoPE`, `SwiGLU`, `CrossEntropy`, `FusedLinearCrossEntropy`, and more to come. The kernel works out of the box with [Flash Attention](https://github.com/Dao-AILab/flash-attention), [PyTorch FSDP](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html), and [Microsoft DeepSpeed](https://github.com/microsoft/DeepSpeed).
 

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -596,7 +596,9 @@ The saved model is fully compatible with Hugging Face's transformers library. Le
 
 ### Increase 20% throughput and reduces 60% memory using Liger-Kernel
 
-[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. That way, we can **4x** our context length, as described in the benchmark below. They have implemented Hugging Face Compatible `RMSNorm`, `RoPE`, `SwiGLU`, `CrossEntropy`, `FusedLinearCrossEntropy`, and more to come.
+[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. That way, we can **4x** our context length, as described in the benchmark below. They have implemented Hugging Face Compatible `RMSNorm`, `RoPE`, `SwiGLU`, `CrossEntropy`, `FusedLinearCrossEntropy`, and more to come. The kernel works out of the box with [Flash Attention](https://github.com/Dao-AILab/flash-attention), [PyTorch FSDP](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html), and [Microsoft DeepSpeed](https://github.com/microsoft/DeepSpeed).
+
+With great memory reduction, you can potentially turn off cpu_offloading or gradient checkpointing to further boost the performance. 
 
 | Speed Up                 | Memory Reduction        |
 |--------------------------|-------------------------|

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -596,7 +596,7 @@ The saved model is fully compatible with Hugging Face's transformers library. Le
 
 ### Increase 20% throughput and reduces 60% memory using Liger-Kernel
 
-[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. The kernel works out of the box with Flash Attention, PyTorch FSDP, and Microsoft DeepSpeed.
+[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. They have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come.
 
 | Speed Up                 | Memory Reduction        |
 |--------------------------|-------------------------|
@@ -614,6 +614,8 @@ To use Liger-Kernel in `SFTTrainer`, you can first install Liger-Kernel accordin
 + model = AutoLigerKernelForCausalLM.from_pretrained("path/to/some/model")
 - model = AutoModelForCausalLM.from_pretrained("path/to/some/model")
 ```
+
+To learn more about Liger-Kernel, visit their [official repository](https://github.com/linkedin/Liger-Kernel/).
 
 ## Best practices
 

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -594,6 +594,23 @@ trainer.train()
 
 The saved model is fully compatible with Hugging Face's transformers library. Learn more about unsloth in their [official repository](https://github.com/unslothai/unsloth).
 
+### Increase 20% throughput and reduces 60% memory using Liger-Kernel
+
+[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. The kernel works out of the box with Flash Attention, PyTorch FSDP, and Microsoft DeepSpeed. We welcome contributions from the community to gather the best kernels for LLM training.
+
+To use Liger-Kernel in `SFTTrainer`, we should first install Liger-Kernel according to [the official website](https://github.com/linkedin/Liger-Kernel). Once installed, we can use it out-of-the-box with one simple line change:
+
+```diff
++ from liger_kernel.transformers import AutoLigerKernelForCausalLM
+
+...
+
+- model = AutoModelForCausalLM.from_pretrained("path/to/some/model")
+# This AutoModel wrapper class automatically monkey-patches the
+# model with the optimized Liger kernels if the model is supported.
+model = AutoLigerKernelForCausalLM.from_pretrained("path/to/some/model")
+```
+
 ## Best practices
 
 Pay attention to the following best practices when training a model with that trainer:

--- a/docs/source/sft_trainer.mdx
+++ b/docs/source/sft_trainer.mdx
@@ -596,7 +596,7 @@ The saved model is fully compatible with Hugging Face's transformers library. Le
 
 ### Increase 20% throughput and reduces 60% memory using Liger-Kernel
 
-[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. They have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come.
+[Liger Kernel](https://github.com/linkedin/Liger-Kernel) is a collection of Triton kernels designed specifically for LLM training. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. That way, we can **4x** our context length, as described in the benchmark below. They have implemented Hugging Face Compatible `RMSNorm`, `RoPE`, `SwiGLU`, `CrossEntropy`, `FusedLinearCrossEntropy`, and more to come.
 
 | Speed Up                 | Memory Reduction        |
 |--------------------------|-------------------------|


### PR DESCRIPTION
# What does this PR do?

Document a famous package `Liger-Kernel` usage in SFT trainer page that can can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%.

Reference: [Liger-Kernel](https://github.com/linkedin/Liger-Kernel/tree/main)

followup of: https://github.com/huggingface/transformers/pull/32860

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.