### PR TITLE
[ci] pin numpy to < 2 on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ __version__ = "0.11.0.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc
 REQUIRED_PKGS = [
     "torch>=1.4.0",
     "transformers>=4.31.0",
-    "numpy>=1.18.2",
+    "numpy>=1.18.2;platform_system!='Windows'",
+    "numpy<2;platform_system=='Windows'",
     "accelerate",
     "datasets",
     "tyro>=0.5.11",


### PR DESCRIPTION
# What does this PR do?
Fix windows CI failures by pinning numpy version < 2