### PR TITLE
Change `non_eos_penalty` to be consistent across `OnPolicy` trainers

### DIFF
--- a/docs/source/ppov2_trainer.md
+++ b/docs/source/ppov2_trainer.md
@@ -55,7 +55,7 @@ The logged metrics are as follows. Here is an example [tracked run at Weights an
 * Debugging TIP: `val/ratio`: this number should float around 1.0, and it gets clipped by `--cliprange 0.2` with PPO's surrogate loss. So if this `ratio` is too high like 2.0 or 1000.0 or too small like 0.1, it means the updates between consecutive policies are too drastic. You should try undertand why this is happening and try to fix it.
 * Memory TIP: If you are running out of memory, you can try to reduce the `--per_device_train_batch_size` or increase the `--gradient_accumulation_steps` to reduce the memory footprint.
 * Memory TIP: If you have multiple GPUs, you can also run training with DeepSpeed stage 3 to reduce the memory footprint `accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml`.
-* Usage TIP: We recommend to use the "EOS trick" via `--non_eos_penalty --stop_token eos`, which replaces the score of completions that do not end with an EOS token with a static scalar penalty `--penalty_reward_value`. This can help the model learn to generate more coherent completions.
+* Usage TIP: We recommend to use the "EOS trick" via `--non_eos_penalty --stop_token eos`, which replaces the score of completions that do not end with an EOS token with a static scalar penalty `--missing_eos_penalty`. This can help the model learn to generate more coherent completions.
 
 
 ## What is my model doing exactly?

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -57,7 +57,7 @@ The logged metrics are as follows. Here is an example [tracked run at Weights an
 * Debugging TIP: `val/ratio`: this number should float around 1.0, and it gets clipped by `--cliprange 0.2` with PPO's surrogate loss. So if this `ratio` is too high like 2.0 or 1000.0 or too small like 0.1, it means the updates between consecutive policies are too drastic. You should try undertand why this is happening and try to fix it.
 * Memory TIP: If you are running out of memory, you can try to reduce the `--per_device_train_batch_size` or increase the `--gradient_accumulation_steps` to reduce the memory footprint.
 * Memory TIP: If you have multiple GPUs, you can also run training with DeepSpeed stage 3 to reduce the memory footprint `accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml`.
-* Usage TIP: We recommend to use the "EOS trick" via `--non_eos_penalty --stop_token eos`, which replaces the score of completions that do not end with an EOS token with a static scalar penalty `--penalty_reward_value`. This can help the model learn to generate more coherent completions.
+* Usage TIP: We recommend to use the "EOS trick" via `--non_eos_penalty --stop_token eos`, which replaces the score of completions that do not end with an EOS token with a static scalar penalty `--missing_eos_penalty`. This can help the model learn to generate more coherent completions.
 
 
 ## What is my model doing exactly?

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -336,7 +336,7 @@ class OnlineDPOTrainer(Trainer):
             )
 
         # Filter completion. Ensure that the sample contains stop_token_id
-        # Completions not passing that filter will receive a low (fixed) score
+        # Completions not passing that filter will receive a lower score.
         contain_eos_token = torch.any(completion_ids == self.tokenizer.eos_token_id, dim=-1)
         if self.args.missing_eos_penalty is not None:
             scores[~contain_eos_token] -= self.args.missing_eos_penalty

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -330,8 +330,8 @@ class RLOOTrainer(Trainer):
                 # responses not passing that filter will receive a low (fixed) score
                 # only query humans on responses that pass that filter
                 contain_eos_token = torch.any(postprocessed_responses == tokenizer.eos_token_id, dim=-1)
-                if args.non_eos_penalty:
-                    scores = torch.where(contain_eos_token, scores, args.penalty_reward_value)
+                if args.missing_eos_penalty:
+                    scores[~contain_eos_token] -= self.args.missing_eos_penalty
                 # accelerator.print(f"{scores=}, {(contain_eos_token.sum() / len(contain_eos_token))=}")
 
                 # be very careful with `padding_mask_p1`; see https://excalidraw.com/#json=LWnzG4w2k5DjF_EOL_xPt,e2w3a-hFJ_gX5vOfeyXGTw

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -922,7 +922,7 @@ class OnPolicyConfig(TrainingArguments):
             Sampling temperature.
         penalty_reward_value (`int`, *optional*, defaults to `-1`):
             Reward value for responses that do not contain `stop_token_id`.
-        non_eos_penalty (`bool`, *optional*, defaults to `False`):
+        missing_eos_penalty (`bool`, *optional*, defaults to `False`):
             Whether to penalize responses that do not contain `stop_token_id`.
         sft_model_path (`str`, *optional*, defaults to `"EleutherAI/pythia-160m"`):
             Path to the SFT model.
@@ -954,7 +954,7 @@ class OnPolicyConfig(TrainingArguments):
     stop_token_id: Optional[int] = None
     temperature: float = 0.7
     penalty_reward_value: int = -1
-    non_eos_penalty: bool = False
+    missing_eos_penalty: bool = False
     sft_model_path: str = "EleutherAI/pythia-160m"
     world_size: Optional[int] = None
     num_total_batches: Optional[int] = None

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -920,10 +920,8 @@ class OnPolicyConfig(TrainingArguments):
             Truncation token id.
         temperature (`float`, *optional*, defaults to `0.7`):
             Sampling temperature.
-        penalty_reward_value (`int`, *optional*, defaults to `-1`):
-            Reward value for responses that do not contain `stop_token_id`.
-        missing_eos_penalty (`bool`, *optional*, defaults to `False`):
-            Whether to penalize responses that do not contain `stop_token_id`.
+        missing_eos_penalty (`float`, *optional*, defaults to `None`):
+            How much to penalize (i.e. subtract) from responses that do not contain `stop_token_id`.
         sft_model_path (`str`, *optional*, defaults to `"EleutherAI/pythia-160m"`):
             Path to the SFT model.
         world_size (`Optional[int]`, *optional*, defaults to `None`):
@@ -953,7 +951,6 @@ class OnPolicyConfig(TrainingArguments):
     stop_token: Optional[Literal["eos"]] = None
     stop_token_id: Optional[int] = None
     temperature: float = 0.7
-    penalty_reward_value: int = -1
     missing_eos_penalty: bool = False
     sft_model_path: str = "EleutherAI/pythia-160m"
     world_size: Optional[int] = None


### PR DESCRIPTION
# What does this PR do?

This PR is designed to address this issue: https://github.com/huggingface/trl/issues/2012

To quickly recap, `PPOv2Trainer` and `RLOOTrainer` _replace_ non-EOS outputs' scores with a constant penalty, whereas `OnlineDPOTrainer` _subtracts_ non-EOS outputs' scores by a constant penalty.

## Before submitting
- [x ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?

No


## Who can review?

@qgallouedec 