### PR TITLE
Fix logits compuation in KTO trainer prediction step

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1324,8 +1324,7 @@ class KTOTrainer(Trainer):
             "eval_logits/chosen": metrics["logits/chosen"],
             "eval_logits/rejected": metrics["logits/rejected"],
         }
-        logits = tuple(v.unsqueeze(dim=0) for k, v in logits_dict.items() if k not in ignore_keys)
-        logits = torch.stack(logits).mean(axis=1).to(self.accelerator.device)
+        logits = torch.tensor([v for k, v in logits_dict.items() if k not in ignore_keys]).to(self.accelerator.device)
         labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
 
         return (loss.detach(), logits, labels)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1324,7 +1324,7 @@ class KTOTrainer(Trainer):
             "eval_logits/chosen": metrics["logits/chosen"],
             "eval_logits/rejected": metrics["logits/rejected"],
         }
-        logits = torch.tensor([v for k, v in logits_dict.items() if k not in ignore_keys]).to(self.accelerator.device)
+        logits = torch.tensor([v for k, v in logits_dict.items() if k not in ignore_keys], device=self.accelerator.device)
         labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
 
         return (loss.detach(), logits, labels)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1324,7 +1324,9 @@ class KTOTrainer(Trainer):
             "eval_logits/chosen": metrics["logits/chosen"],
             "eval_logits/rejected": metrics["logits/rejected"],
         }
-        logits = torch.tensor([v for k, v in logits_dict.items() if k not in ignore_keys], device=self.accelerator.device)
+        logits = torch.tensor(
+            [v for k, v in logits_dict.items() if k not in ignore_keys], device=self.accelerator.device
+        )
         labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
 
         return (loss.detach(), logits, labels)


### PR DESCRIPTION
# Description of the issue

There is a bug in the following [few lines](https://github.com/huggingface/trl/blob/a20e8227375f53435a3457b33079ab690ff51496/trl/trainer/kto_trainer.py#L1327C9-L1328C78) of code in `kto_trainer.py`

```
logits_dict = {
    "eval_logits/chosen": metrics["logits/chosen"],
    "eval_logits/rejected": metrics["logits/rejected"],
}
logits = tuple(v.unsqueeze(dim=0) for k, v in logits_dict.items() if k not in ignore_keys)
logits = torch.stack(logits).mean(axis=1).to(self.accelerator.device)
```

This assumes that the values in the `logits_dict` are tensors, but they are not. These values are computed in `get_batch_loss_metrics` where the the logits are averaged and `.item()` is called on the resulting tensor to get a `float`.

This causes the following error when running a KTO training:

```
AttributeError: 'float' object has no attribute 'unsqueeze'
```

# What does this PR do?
- Treat the values of `logits_dict` as floats
- Fixes `AttributeError: 'float' object has no attribute 'unsqueeze'` during the evaluation phase of a KTO training