### PR TITLE
Added error check to RLOO, PPOv2, OnlineDPO that `ref_policy` and `policy` have different identities

### DIFF
--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -107,6 +107,10 @@ class OnlineDPOTrainer(Trainer):
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
     ) -> None:
+
+        if ref_policy is policy:
+            raise ValueError("`policy` and `ref_policy` are the same Python object but should not be. You probably want two copies of the same model.")
+
         self.ref_model = ref_model
 
         if reward_model is not None and judge is not None:

--- a/trl/trainer/ppov2_trainer.py
+++ b/trl/trainer/ppov2_trainer.py
@@ -83,6 +83,10 @@ class PPOv2Trainer(Trainer):
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         callbacks: Optional[List[TrainerCallback]] = None,
     ) -> None:
+
+        if ref_policy is policy:
+            raise ValueError("`policy` and `ref_policy` are the same Python object but should not be. You probably want two copies of the same model.")
+
         self.args = config
         args = config
         self.tokenizer = tokenizer

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -64,6 +64,10 @@ class RLOOTrainer(Trainer):
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         callbacks: Optional[List[TrainerCallback]] = None,
     ) -> None:
+
+        if ref_policy is policy:
+            raise ValueError("`policy` and `ref_policy` are the same Python object but should not be. You probably want two copies of the same model.")
+
         self.args = config
         args = config
         self.tokenizer = tokenizer


### PR DESCRIPTION
As discussed in [Issue 2046](https://github.com/huggingface/trl/issues/2046), we add an error check to make sure that the `ref_policy` and `policy` have different identities.

This is just a quick and dirty demonstration to show what I have in mind. Feedback is very welcome!