### PR TITLE
Use wrapped model for reference completions in `WinRateCallback` and set default `freq` to `eval_steps` in LogCompletionsCallback`

### DIFF
--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -255,12 +255,12 @@ class WinRateCallback(TrainerCallback):
         accelerator = self.trainer.accelerator
         # Use the reference model if available, otherwise use the initial model
         model = getattr(self.trainer, "ref_model", None)
-        # At this point, there are two cases where `ref_model` is None: 
-        # 1. The method doesn't require a reference model. 
-        # 2. The method uses a reference model, but `ref_model` is set to None. 
-        #    This occurs when using PEFT, where the reference model can be obtained by simply disabling the model's adapter. 
-        #    In theory, we should disable the adapter here, but since it's zero-initialized at the start of training, 
-        #    the model behaves identically with or without the adapter. 
+        # At this point, there are two cases where `ref_model` is None:
+        # 1. The method doesn't require a reference model.
+        # 2. The method uses a reference model, but `ref_model` is set to None.
+        #    This occurs when using PEFT, where the reference model can be obtained by simply disabling the model's adapter.
+        #    In theory, we should disable the adapter here, but since it's zero-initialized at the start of training,
+        #    the model behaves identically with or without the adapter.
         #    Therefore, there's no need to explicitly disable it at this point.
         if model is None:
             model = self.trainer.model_wrapped

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -253,7 +253,8 @@ class WinRateCallback(TrainerCallback):
         tokenizer = kwargs["tokenizer"]
         tokenizer.padding_side = "left"
         accelerator = self.trainer.accelerator
-        model = getattr(self.trainer, "ref_model", kwargs["model"])  # get the ref model if any, else use the model
+        # Use the reference model if available, otherwise use the initial model
+        model = getattr(self.trainer, "ref_model", self.trainer.model_wrapped)
         with accelerator.split_between_processes(self.eval_dataset["prompt"]) as prompts:
             self.ref_completions = _generate_completions(
                 prompts,
@@ -312,7 +313,7 @@ class LogCompletionsCallback(WandbCallback):
         num_prompts (`int`, *optional*):
             The number of prompts to generate completions for. If not provided, defaults to the number of examples in the evaluation dataset.
         freq (`int`, *optional*):
-            The frequency at which to log completions. If not provided, defaults to the trainer's `logging_steps`.
+            The frequency at which to log completions. If not provided, defaults to the trainer's `eval_steps`.
     """
 
     def __init__(
@@ -342,8 +343,8 @@ class LogCompletionsCallback(WandbCallback):
         if state.global_step == self._last_logged_step:
             return
 
-        # Only log every `freq` steps (if no `freq` is provided, log every `logging_steps` steps)
-        freq = self.freq or state.logging_steps
+        # Only log every `freq` steps (if no `freq` is provided, log every `eval_steps` steps)
+        freq = self.freq or state.eval_steps
         if state.global_step % freq != 0:
             return
 

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -254,7 +254,9 @@ class WinRateCallback(TrainerCallback):
         tokenizer.padding_side = "left"
         accelerator = self.trainer.accelerator
         # Use the reference model if available, otherwise use the initial model
-        model = getattr(self.trainer, "ref_model", self.trainer.model_wrapped)
+        model = getattr(self.trainer, "ref_model", None)
+        if model is None:
+            model = self.trainer.model_wrapped
         with accelerator.split_between_processes(self.eval_dataset["prompt"]) as prompts:
             self.ref_completions = _generate_completions(
                 prompts,

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -255,6 +255,13 @@ class WinRateCallback(TrainerCallback):
         accelerator = self.trainer.accelerator
         # Use the reference model if available, otherwise use the initial model
         model = getattr(self.trainer, "ref_model", None)
+        # At this point, there are two cases where `ref_model` is None: 
+        # 1. The method doesn't require a reference model. 
+        # 2. The method uses a reference model, but `ref_model` is set to None. 
+        #    This occurs when using PEFT, where the reference model can be obtained by simply disabling the model's adapter. 
+        #    In theory, we should disable the adapter here, but since it's zero-initialized at the start of training, 
+        #    the model behaves identically with or without the adapter. 
+        #    Therefore, there's no need to explicitly disable it at this point.
         if model is None:
             model = self.trainer.model_wrapped
         with accelerator.split_between_processes(self.eval_dataset["prompt"]) as prompts:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

While training some models with `GKDTrainer` I ran into an issue with ZeRO-3 and `WinRateCallback` where the initial model provided by the callback is _unwrapped_ and this incompatible with `unwrap_model_for_generation()`. I also realised that using `eval_steps` is far more intuitive for both `WinRateCallback` and `LogCompletionsCallback` because we usually reserve logging for fast computations like the loss, and `LogCompletionsCallback` produces a major bottleneck in the logging if we generate every `logging_steps`.

This PR fixes both issues


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.