### PR TITLE
Fix PPO/RLOO examples

### DIFF
--- a/examples/scripts/ppo/ppo.py
+++ b/examples/scripts/ppo/ppo.py
@@ -50,7 +50,6 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml
     --sft_model_path EleutherAI/pythia-1b-deduped \
     --reward_model_path EleutherAI/pythia-1b-deduped \
     --local_rollout_forward_batch_size 1 \
-    --deepspeed3 \
     --missing_eos_penalty 1.0
 """
 
@@ -88,7 +87,7 @@ if __name__ == "__main__":
     # Dataset
     ################
     dataset = load_dataset("trl-internal-testing/descriptiveness-sentiment-trl-style", split="descriptiveness")
-    eval_samples = 20
+    eval_samples = 100
     train_dataset = dataset.select(range(len(dataset) - eval_samples))
     eval_dataset = dataset.select(range(len(dataset) - eval_samples, len(dataset)))
     dataset_text_field = "prompt"

--- a/examples/scripts/rloo/rloo.py
+++ b/examples/scripts/rloo/rloo.py
@@ -54,7 +54,6 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml
     --sft_model_path EleutherAI/pythia-1b-deduped \
     --reward_model_path EleutherAI/pythia-1b-deduped \
     --local_rollout_forward_batch_size 1 \
-    --deepspeed3 \
     --missing_eos_penalty 1.0
 """
 
@@ -89,7 +88,7 @@ if __name__ == "__main__":
     # Dataset
     ################
     dataset = load_dataset("trl-internal-testing/descriptiveness-sentiment-trl-style", split="descriptiveness")
-    eval_samples = 20
+    eval_samples = 100
     train_dataset = dataset.select(range(len(dataset) - eval_samples))
     eval_dataset = dataset.select(range(len(dataset) - eval_samples, len(dataset)))
     dataset_text_field = "prompt"


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

While debugging https://github.com/huggingface/trl/issues/1891, I noticed the PPO/RLOO examples do not work with DDP/ZeRO-3 due to having too small an evaluation dataset:

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/fsx/lewis/git/hf/trl/examples/scripts/rloo/rloo.py", line 131, in <module>
[rank1]:     trainer.train()
[rank1]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 474, in train
[rank1]:     self.generate_completions(sampling=True)
[rank1]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 496, in generate_completions
[rank1]:     query = batch["input_ids"]
[rank1]: TypeError: 'NoneType' object is not subscriptable
[rank4]: Traceback (most recent call last):
[rank4]:   File "/fsx/lewis/git/hf/trl/examples/scripts/rloo/rloo.py", line 131, in <module>
[rank4]:     trainer.train()
[rank4]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 474, in train
[rank4]:     self.generate_completions(sampling=True)
[rank4]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 496, in generate_completions
[rank4]:     query = batch["input_ids"]
[rank4]: TypeError: 'NoneType' object is not subscriptable
[rank7]: Traceback (most recent call last):
[rank7]:   File "/fsx/lewis/git/hf/trl/examples/scripts/rloo/rloo.py", line 131, in <module>
[rank7]:     trainer.train()
[rank7]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 474, in train
[rank7]:     self.generate_completions(sampling=True)
[rank7]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 496, in generate_completions
[rank7]:     query = batch["input_ids"]
[rank7]: TypeError: 'NoneType' object is not subscriptable
[rank3]: Traceback (most recent call last):
[rank3]:   File "/fsx/lewis/git/hf/trl/examples/scripts/rloo/rloo.py", line 131, in <module>
[rank3]:     trainer.train()
[rank3]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 474, in train
[rank3]:     self.generate_completions(sampling=True)
[rank3]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 496, in generate_completions
[rank3]:     query = batch["input_ids"]
[rank3]: TypeError: 'NoneType' object is not subscriptable
[rank0]: Traceback (most recent call last):
[rank0]:   File "/fsx/lewis/git/hf/trl/examples/scripts/rloo/rloo.py", line 131, in <module>
[rank0]:     trainer.train()
[rank0]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 474, in train
[rank0]:     self.generate_completions(sampling=True)
[rank0]:   File "/fsx/lewis/git/hf/trl/trl/trainer/rloo_trainer.py", line 496, in generate_completions
[rank0]:     query = batch["input_ids"]
[rank0]: TypeError: 'NoneType' object is not subscriptable
```

This PR fixes the issue by increasing the eval dataset size.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.