### PR TITLE
Standardize pushing to Hub in examples

### DIFF
--- a/examples/scripts/alignprop.py
+++ b/examples/scripts/alignprop.py
@@ -127,4 +127,7 @@ if __name__ == "__main__":
 
     trainer.train()
 
-    trainer.push_to_hub(args.hf_hub_model_id)
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/bco.py
+++ b/examples/scripts/bco.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     )
 
     # Initialize the BCO trainer
-    bco_trainer = BCOTrainer(
+    trainer = BCOTrainer(
         model,
         ref_model,
         args=training_args,
@@ -159,5 +159,9 @@ if __name__ == "__main__":
     )
 
     # Train and push the model to the Hub
-    bco_trainer.train()
-    bco_trainer.save_model(training_args.output_dir)
+    trainer.train()
+
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/cpo.py
+++ b/examples/scripts/cpo.py
@@ -117,4 +117,8 @@ if __name__ == "__main__":
 
     # train and save the model
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/ddpo.py
+++ b/examples/scripts/ddpo.py
@@ -207,4 +207,7 @@ if __name__ == "__main__":
 
     trainer.train()
 
-    trainer.push_to_hub(args.hf_hub_model_id)
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/dpo.py
+++ b/examples/scripts/dpo.py
@@ -137,4 +137,8 @@ if __name__ == "__main__":
     metrics = trainer.evaluate()
     trainer.log_metrics("eval", metrics)
     trainer.save_metrics("eval", metrics)
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/dpo_online.py
+++ b/examples/scripts/dpo_online.py
@@ -116,3 +116,8 @@ if __name__ == "__main__":
     completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
     trainer.add_callback(completions_callback)
     trainer.train()
+
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/dpo_visual.py
+++ b/examples/scripts/dpo_visual.py
@@ -132,4 +132,8 @@ if __name__ == "__main__":
     )
 
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/gkd.py
+++ b/examples/scripts/gkd.py
@@ -132,4 +132,7 @@ if __name__ == "__main__":
     trainer.add_callback(completions_callback)
     trainer.train()
 
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/kto.py
+++ b/examples/scripts/kto.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         dataset = dataset.map(format_dataset, num_proc=training_args.dataset_num_proc)
 
     # Initialize the KTO trainer
-    kto_trainer = KTOTrainer(
+    trainer = KTOTrainer(
         model,
         ref_model,
         args=training_args,
@@ -127,6 +127,9 @@ if __name__ == "__main__":
     )
 
     # Train and push the model to the Hub
-    kto_trainer.train()
-    kto_trainer.save_model(training_args.output_dir)
-    kto_trainer.push_to_hub()
+    trainer.train()
+
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/nash_md.py
+++ b/examples/scripts/nash_md.py
@@ -121,5 +121,7 @@ if __name__ == "__main__":
     # train the model
     trainer.train()
 
-    # save the model
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/orpo.py
+++ b/examples/scripts/orpo.py
@@ -118,4 +118,8 @@ if __name__ == "__main__":
 
     # train and save the model
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/ppo/ppo.py
+++ b/examples/scripts/ppo/ppo.py
@@ -129,7 +129,10 @@ if __name__ == "__main__":
         eval_dataset=eval_dataset,
     )
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
+
     trainer.generate_completions()

--- a/examples/scripts/ppo/ppo_tldr.py
+++ b/examples/scripts/ppo/ppo_tldr.py
@@ -134,7 +134,10 @@ if __name__ == "__main__":
         eval_dataset=eval_dataset,
     )
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
+
     trainer.generate_completions()

--- a/examples/scripts/reward_modeling.py
+++ b/examples/scripts/reward_modeling.py
@@ -126,5 +126,8 @@ if __name__ == "__main__":
     metrics = trainer.evaluate()
     trainer.log_metrics("eval", metrics)
     trainer.save_metrics("eval", metrics)
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
-    trainer.push_to_hub()
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/rloo/rloo.py
+++ b/examples/scripts/rloo/rloo.py
@@ -129,7 +129,10 @@ if __name__ == "__main__":
         eval_dataset=eval_dataset,
     )
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
+
     trainer.generate_completions()

--- a/examples/scripts/rloo/rloo_tldr.py
+++ b/examples/scripts/rloo/rloo_tldr.py
@@ -133,7 +133,10 @@ if __name__ == "__main__":
         eval_dataset=eval_dataset,
     )
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
+
     trainer.generate_completions()

--- a/examples/scripts/sft.py
+++ b/examples/scripts/sft.py
@@ -105,4 +105,8 @@ if __name__ == "__main__":
     )
 
     trainer.train()
+
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -130,6 +130,10 @@ if __name__ == "__main__":
     trainer.train()
 
     trainer.save_model(training_args.output_dir)
-    trainer.push_to_hub()
-    if Accelerator().is_main_process:
-        processor.push_to_hub(training_args.hub_model_id)
+
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()
+        if Accelerator().is_main_process:
+            processor.push_to_hub(training_args.hub_model_id)

--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -135,5 +135,5 @@ if __name__ == "__main__":
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
-        if Accelerator().is_main_process:
+        if trainer.accelerator.is_main_process:
             processor.push_to_hub(training_args.hub_model_id)

--- a/examples/scripts/xpo.py
+++ b/examples/scripts/xpo.py
@@ -104,5 +104,7 @@ if __name__ == "__main__":
     # train the model
     trainer.train()
 
-    # save the model
+    # Save and push to hub
     trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub()

--- a/trl/trainer/alignprop_config.py
+++ b/trl/trainer/alignprop_config.py
@@ -94,6 +94,8 @@ class AlignPropConfig:
             Absolute timestep to which the gradients are backpropagated. Used only if `truncated_backprop_rand=False`.
         truncated_rand_backprop_minmax (`Tuple[int, int]`, *optional*, defaults to `(0, 50)`):
             Range of diffusion timesteps for randomized truncated backpropagation.
+        push_to_hub (`bool`, *optional*, defaults to `False`):
+            Whether to push the final model to the Hub.
     """
 
     exp_name: str = os.path.basename(sys.argv[0])[: -len(".py")]
@@ -128,6 +130,7 @@ class AlignPropConfig:
     truncated_backprop_rand: bool = True
     truncated_backprop_timestep: int = 49
     truncated_rand_backprop_minmax: Tuple[int, int] = (0, 50)
+    push_to_hub: bool = False
 
     def to_dict(self):
         output_dict = {}

--- a/trl/trainer/ddpo_config.py
+++ b/trl/trainer/ddpo_config.py
@@ -114,6 +114,8 @@ class DDPOConfig:
             Maximum number of workers to use for async reward computation.
         negative_prompts (`Optional[str]`, *optional*, defaults to `""`):
             Comma-separated list of prompts to use as negative examples.
+        push_to_hub (`bool`, *optional*, defaults to `False`):
+            Whether to push the final model checkpoint to the Hub.
     """
 
     exp_name: str = os.path.basename(sys.argv[0])[: -len(".py")]
@@ -156,6 +158,7 @@ class DDPOConfig:
     async_reward_computation: bool = False
     max_workers: int = 2
     negative_prompts: str = ""
+    push_to_hub: bool = False
 
     def to_dict(self):
         output_dict = {}

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1004,6 +1004,8 @@ class OnPolicyConfig(TrainingArguments):
             Mini batch size per GPU.
         mini_batch_size (`Optional[int]`, *optional*, defaults to `None`):
             Mini batch size across GPUs.
+        push_to_hub (`bool`, *optional*, defaults to `False`):
+            Whether to push the model to the Hub after training.
     """
 
     run_name: Optional[str] = None
@@ -1025,6 +1027,7 @@ class OnPolicyConfig(TrainingArguments):
     batch_size: Optional[int] = None
     local_mini_batch_size: Optional[int] = None
     mini_batch_size: Optional[int] = None
+    push_to_hub: bool = False
 
 
 def first_true_indices(bools: torch.Tensor, dtype=torch.long):


### PR DESCRIPTION
# What does this PR do?

Standardise pushing to hub in the examples. Will help #2123.

adds

```python
     # Save and push to hub
     trainer.save_model(training_args.output_dir)
     if training_args.push_to_hub:
         trainer.push_to_hub()
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.