### PR TITLE
[GKD] Set custom EOS tokens in generation config

### DIFF
--- a/examples/scripts/gkd.py
+++ b/examples/scripts/gkd.py
@@ -46,7 +46,7 @@ python examples/scripts/gkd.py \
 
 from accelerate import PartialState
 from datasets import load_dataset
-from transformers import AutoTokenizer, GenerationConfig
+from transformers import AutoTokenizer
 
 from trl import (
     GKDConfig,
@@ -93,6 +93,7 @@ if __name__ == "__main__":
 
     tokenizer = AutoTokenizer.from_pretrained(
         model_config.model_name_or_path,
+        revision=model_config.model_revision,
         trust_remote_code=model_config.trust_remote_code,
         padding_side="left",
     )
@@ -124,10 +125,7 @@ if __name__ == "__main__":
         tokenizer=tokenizer,
         peft_config=get_peft_config(model_config),
     )
-    generation_config = GenerationConfig(
-        max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
-    )
-    completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
+    completions_callback = LogCompletionsCallback(trainer, trainer.generation_config, num_prompts=8)
     trainer.add_callback(completions_callback)
     trainer.train()
 

--- a/tests/test_gkd_trainer.py
+++ b/tests/test_gkd_trainer.py
@@ -239,3 +239,23 @@ class GKDTrainerTester(unittest.TestCase):
             self.assertIsNotNone(trainer.state.log_history[(-1)]["train_loss"])
             self.assertIsNotNone(trainer.state.log_history[0]["eval_loss"])
             self.assertIn("model.safetensors", os.listdir(tmp_dir + "/checkpoint-2"))
+
+    def test_generation_config_init(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = GKDConfig(output_dir=tmp_dir)
+            dummy_dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling")
+
+            trainer = GKDTrainer(
+                model=self.model_id,
+                teacher_model=self.model_id,
+                args=training_args,
+                train_dataset=dummy_dataset["train"],
+                eval_dataset=dummy_dataset["test"],
+                tokenizer=self.tokenizer,
+            )
+
+            self.assertEqual(trainer.generation_config.pad_token_id, self.tokenizer.eos_token_id)
+            self.assertEqual(trainer.generation_config.eos_token_id, self.model.generation_config.eos_token_id)
+            self.assertEqual(trainer.generation_config.max_new_tokens, training_args.max_new_tokens)
+            self.assertEqual(trainer.generation_config.temperature, training_args.temperature)
+            self.assertEqual(trainer.generation_config.top_k, 0)

--- a/trl/trainer/gkd_config.py
+++ b/trl/trainer/gkd_config.py
@@ -33,7 +33,7 @@ class GKDConfig(SFTConfig):
             beta is `0.0`, the loss is the KL divergence. When beta is `1.0`, the loss is the Inverse KL Divergence.
         max_new_tokens (`int`, *optional*, defaults to `128`):
             Maximum number of tokens to generate per completion.
-        eos_token_id (`Union[int, List[int]]`, *optional*):
+        eos_token_id (`Union[int, List[int]]`, *optional*, defaults to `None`):
             The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
         teacher_model_name_or_path (`Optional[str]`, *optional*, defaults to `None`):
             Model name or path of the teacher model. If `None`, the teacher model will be the same as the model

--- a/trl/trainer/gkd_config.py
+++ b/trl/trainer/gkd_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .sft_config import SFTConfig
 
@@ -33,8 +33,6 @@ class GKDConfig(SFTConfig):
             beta is `0.0`, the loss is the KL divergence. When beta is `1.0`, the loss is the Inverse KL Divergence.
         max_new_tokens (`int`, *optional*, defaults to `128`):
             Maximum number of tokens to generate per completion.
-        eos_token_id (`Union[int, List[int]]`, *optional*, defaults to `None`):
-            The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
         teacher_model_name_or_path (`Optional[str]`, *optional*, defaults to `None`):
             Model name or path of the teacher model. If `None`, the teacher model will be the same as the model
             being trained.
@@ -49,7 +47,6 @@ class GKDConfig(SFTConfig):
     lmbda: float = 0.5
     beta: float = 0.5
     max_new_tokens: int = 128
-    eos_token_id: List[int] = None
     teacher_model_name_or_path: Optional[str] = None
     teacher_model_init_kwargs: Optional[Dict[str, Any]] = None
     disable_dropout: bool = True

--- a/trl/trainer/gkd_config.py
+++ b/trl/trainer/gkd_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .sft_config import SFTConfig
 
@@ -33,6 +33,8 @@ class GKDConfig(SFTConfig):
             beta is `0.0`, the loss is the KL divergence. When beta is `1.0`, the loss is the Inverse KL Divergence.
         max_new_tokens (`int`, *optional*, defaults to `128`):
             Maximum number of tokens to generate per completion.
+        eos_token_id (`Union[int, List[int]]`, *optional*):
+            The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
         teacher_model_name_or_path (`Optional[str]`, *optional*, defaults to `None`):
             Model name or path of the teacher model. If `None`, the teacher model will be the same as the model
             being trained.
@@ -47,6 +49,7 @@ class GKDConfig(SFTConfig):
     lmbda: float = 0.5
     beta: float = 0.5
     max_new_tokens: int = 128
+    eos_token_id: List[int] = None
     teacher_model_name_or_path: Optional[str] = None
     teacher_model_init_kwargs: Optional[Dict[str, Any]] = None
     disable_dropout: bool = True

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -102,6 +102,15 @@ class GKDTrainer(SFTTrainer):
             use_cache=False if args.gradient_checkpointing else True,
             pad_token_id=self.tokenizer.pad_token_id,
         )
+        # Set custom EOS tokens if they are specified by the model's generation
+        # config. This is important for models with the Llama 3 chat template,
+        # which use special tokens <|eot_id|> and <|eom_id|> to mark the end of
+        # turns or messages.
+        if (
+            hasattr(self.model.generation_config, "eos_token_id")
+            and self.model.generation_config.eos_token_id is not None
+        ):
+            self.generation_config.eos_token_id = self.model.generation_config.eos_token_id
 
     @staticmethod
     def generalized_jsd_loss(
@@ -194,12 +203,6 @@ class GKDTrainer(SFTTrainer):
 
     @staticmethod
     def generate_on_policy_outputs(model, inputs, generation_config, pad_token_id=None):
-        # Set custom EOS tokens if they are specified by the model's generation
-        # config. This is important for models with the Llama 3 chat template,
-        # which use special tokens <|eot_id|> and <|eom_id|> to mark the end of
-        # turns or messages.
-        if hasattr(model.generation_config, "eos_token_id") and model.generation_config.eos_token_id is not None:
-            generation_config.eos_token_id = model.generation_config.eos_token_id
         # Generate output with respect to the prompt only
         generated_outputs = model.generate(
             input_ids=inputs["prompts"],

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -100,6 +100,7 @@ class GKDTrainer(SFTTrainer):
             do_sample=True,
             top_k=0,
             use_cache=False if args.gradient_checkpointing else True,
+            eos_token_id=args.eos_token_id,
         )
 
     @staticmethod

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -100,7 +100,6 @@ class GKDTrainer(SFTTrainer):
             do_sample=True,
             top_k=0,
             use_cache=False if args.gradient_checkpointing else True,
-            eos_token_id=args.eos_token_id,
         )
 
     @staticmethod

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1402,11 +1402,11 @@ def generate_model_card(
             Weights & Biases run URL.
         trainer_name (`str`):
             Trainer name.
-        trainer_citation (`str` or `None`):
+        trainer_citation (`str` or `None`, defaults to `None`):
             Trainer citation as a BibTeX entry.
-        paper_title (`str` or `None`):
+        paper_title (`str` or `None`, defaults to `None`):
             Paper title.
-        paper_id (`str` or `None`):
+        paper_id (`str` or `None`, defaults to `None`):
             ArXiv paper ID as `YYMM.NNNNN`.
 
     Returns:

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1380,9 +1380,9 @@ def generate_model_card(
     tags: Union[str, List[str], None],
     wandb_url: Optional[str],
     trainer_name: str,
-    trainer_citation: Optional[str],
-    paper_title: Optional[str],
-    paper_id: Optional[str],
+    trainer_citation: Optional[str] = None,
+    paper_title: Optional[str] = None,
+    paper_id: Optional[str] = None,
 ) -> ModelCard:
     """
     Generate a `ModelCard` from a template.


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR exposes aligns the `eos_token_id` attribute from `transformers.GenerationConfig` in GKD to support distillation of Llama 3 models which use special tokens `<|eot_id|>` and `<|eom_id|>` instead of the EOS token `<|endoftext|>` to indicate the end of a turn or message. We do this by checking the model's `generation_config` attribute and including the `eos_token_id` values in the GKD trainer's `GenerationConfig`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.