### PR TITLE
CLI SFT Quantization Fix

### DIFF
--- a/examples/scripts/sft.py
+++ b/examples/scripts/sft.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         device_map="auto",
         quantization_config=quantization_config,
     )
-    training_args.model_init_kwargs = model_kwargs
+
     tokenizer = AutoTokenizer.from_pretrained(
         model_config.model_name_or_path, trust_remote_code=model_config.trust_remote_code, use_fast=True
     )

--- a/examples/scripts/sft.py
+++ b/examples/scripts/sft.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     # Training
     ################
     trainer = SFTTrainer(
-        model=model_config.model_name_or_path,
+        model=model,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split],


### PR DESCRIPTION
# What does this PR do?
Fixes #2150
This PR addresses the quantization issue by switching to `AutoModelForCausalLM` and using `prepare_model_for_kbit_training` to improve memory efficiency when training a quantized model. 

### IMPORTANT:
While this fix works well on single GPU instances, I encountered an issue on multi-GPU setups. When using `accelerate launch`, it automatically set `--num_processes` to 2 (since there are 2 GPUs), but instead of performing distributed training, the script ran twice on each GPU and crashed. This was resolved by manually launching the script with:
```bash
python sft.py
```
or
```bash
accelerate launch --num_process 1 sft.py
```

I’d appreciate it if you could test these changes on a multi-GPU instance to confirm whether this fix only works with `--num_process` set to 1. If that's the case, we may need to modify `cli.py` or find another solution to handle multi-GPU setups properly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.