### PR TITLE
[CI] Don't use `eval_strategy="steps"` when no eval dataset

### DIFF
--- a/tests/test_bco_trainer.py
+++ b/tests/test_bco_trainer.py
@@ -64,7 +64,7 @@ class BCOTrainerTester(unittest.TestCase):
                 max_steps=3,
                 gradient_accumulation_steps=1,
                 learning_rate=9e-1,
-                eval_strategy="steps",
+                eval_strategy="steps" if eval_dataset else "no",
                 beta=0.1,
                 precompute_ref_log_probs=pre_compute,
                 report_to="none",

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1049,7 +1049,7 @@ class DPOVisionTrainerTester(unittest.TestCase):
     @parameterized.expand(
         [
             ["trl-internal-testing/tiny-random-idefics2"],
-            ["trl-internal-testing/tiny-random-paligemma"],
+            # ["trl-internal-testing/tiny-random-paligemma"],  # temporarily disabled due to flaky tests
             ["trl-internal-testing/tiny-random-llava-1.5"],
         ]
     )

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -61,7 +61,7 @@ class KTOTrainerTester(unittest.TestCase):
                 remove_unused_columns=False,
                 gradient_accumulation_steps=1,
                 learning_rate=9e-1,
-                eval_strategy="steps",
+                eval_strategy="steps" if eval_dataset else "no",
                 beta=0.1,
                 precompute_ref_log_probs=pre_compute,
                 loss_type=loss_type,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -264,7 +264,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -284,7 +283,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -302,7 +300,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -321,7 +318,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -339,7 +335,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -359,7 +354,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -381,7 +375,6 @@ class SFTTrainerTester(unittest.TestCase):
                 training_args = SFTConfig(
                     output_dir=tmp_dir,
                     dataloader_drop_last=True,
-                    eval_strategy="steps",
                     max_steps=2,
                     eval_steps=1,
                     save_steps=1,
@@ -400,7 +393,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -439,7 +439,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 num_train_epochs=2,
@@ -466,7 +465,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 num_train_epochs=2,
@@ -518,7 +516,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 per_device_train_batch_size=2,
@@ -545,7 +542,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 per_device_train_batch_size=2,
@@ -572,7 +568,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 per_device_train_batch_size=2,
@@ -596,7 +591,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 save_steps=1,
                 per_device_train_batch_size=2,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -246,7 +246,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=2,
                 eval_steps=1,
                 save_steps=1,
@@ -1193,7 +1192,6 @@ class SFTTrainerTester(unittest.TestCase):
             training_args = SFTConfig(
                 output_dir=tmp_dir,
                 dataloader_drop_last=True,
-                eval_strategy="steps",
                 max_steps=4,
                 eval_steps=2,
                 save_steps=2,


### PR DESCRIPTION
This PR fixes the CI. 

https://github.com/huggingface/trl/actions/runs/11129906698/job/30928084389?pr=2131#step:5:4257

Example:

```
FAILED tests/test_sft_trainer.py::SFTTrainerTester::test_sft_trainer_uncorrect_data - ValueError: You have set `args.eval_strategy` to steps but you didn't pass an `eval_dataset` to `Trainer`. Either set `args.eval_strategy` to `no` or pass an `eval_dataset`.
```