### PR TITLE
fixed: OverflowError: out of range integral type conversion attempted

### DIFF
--- a/examples/scripts/chat.py
+++ b/examples/scripts/chat.py
@@ -32,6 +32,10 @@ from trl import TrlParser, init_zero_verbose
 from trl.commands.cli_utils import ChatArguments
 from trl.trainer.utils import get_quantization_config
 
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+device=accelerator.device
 
 init_zero_verbose()
 
@@ -222,7 +226,7 @@ def load_model_and_tokenizer(args):
         revision=args.model_revision,
         attn_implementation=args.attn_implementation,
         torch_dtype=torch_dtype,
-        device_map="auto",
+        device_map=device,
         quantization_config=quantization_config,
     )
     model = AutoModelForCausalLM.from_pretrained(
@@ -230,7 +234,7 @@ def load_model_and_tokenizer(args):
     )
 
     if getattr(model, "hf_device_map", None) is None:
-        model = model.to(args.device)
+        model = model.to(device)
 
     return model, tokenizer
 


### PR DESCRIPTION
 And this is fixed using accelerator library

# What does this PR do?

This PR fixed two issues by implementing the accelerate library, and those issue mainly comes when we have 2 or more GPUs in our system, and it was not handled properly, So I used `Accelerate` from hugging-face here to make it perfect.
during executing the commands given below
```
python examples/scripts/chat.py --model_name_or_path /home/trl/models/minimal/ppo/checkpoint-157
```
 and
```
trl chat  --model_name_or_path /home/trl/models/minimal/ppo/checkpoint-157
```

Fixes [issue #2205](https://github.com/huggingface/trl/issues/2205)
There are two issues which it fixes:
```
OverflowError: out of range integral type conversion attempted
```
and 
```
RuntimeError: probability tensor contains either inf, nan or element < 0
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Yes
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.