### PR TITLE
Remove ds_config scheuduler params to prevent deepseed from creating scheduler for ref_model

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -911,23 +911,23 @@ class DPOTrainer(Trainer):
         deepspeed_plugin = self.accelerator.state.deepspeed_plugin
         config_kwargs = deepcopy(deepspeed_plugin.deepspeed_config)
 
-        if model is not None:
-            if hasattr(model, "config"):
-                hidden_size = (
-                    max(model.config.hidden_sizes)
-                    if getattr(model.config, "hidden_sizes", None)
-                    else getattr(model.config, "hidden_size", None)
+
+        if hasattr(model, "config"):
+            hidden_size = (
+                max(model.config.hidden_sizes)
+                if getattr(model.config, "hidden_sizes", None)
+                else getattr(model.config, "hidden_size", None)
+            )
+            if hidden_size is not None and config_kwargs["zero_optimization"]["stage"] == 3:
+                # Note that `stage3_prefetch_bucket_size` can produce DeepSpeed messages like: `Invalidate trace cache @ step 0: expected module 1, but got module 0`
+                # This is expected and is not an error, see: https://github.com/microsoft/DeepSpeed/discussions/4081
+                config_kwargs.update(
+                    {
+                        "zero_optimization.reduce_bucket_size": hidden_size * hidden_size,
+                        "zero_optimization.stage3_param_persistence_threshold": 10 * hidden_size,
+                        "zero_optimization.stage3_prefetch_bucket_size": 0.9 * hidden_size * hidden_size,
+                    }
                 )
-                if hidden_size is not None and config_kwargs["zero_optimization"]["stage"] == 3:
-                    # Note that `stage3_prefetch_bucket_size` can produce DeepSpeed messages like: `Invalidate trace cache @ step 0: expected module 1, but got module 0`
-                    # This is expected and is not an error, see: https://github.com/microsoft/DeepSpeed/discussions/4081
-                    config_kwargs.update(
-                        {
-                            "zero_optimization.reduce_bucket_size": hidden_size * hidden_size,
-                            "zero_optimization.stage3_param_persistence_threshold": 10 * hidden_size,
-                            "zero_optimization.stage3_prefetch_bucket_size": 0.9 * hidden_size * hidden_size,
-                        }
-                    )
 
         # If ZeRO-3 is used, we shard both the active and reference model.
         # Otherwise, we assume the reference model fits in memory and is initialized on each device with ZeRO disabled (stage 0)

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -907,7 +907,7 @@ class DPOTrainer(Trainer):
             self.running = RunningMoments(self.accelerator)
 
     def _prepare_deepspeed(self, model: PreTrainedModelWrapper):
-        # This method is only for wrapping a reference model using deepspeed and cannot be used for training.
+        # This method is only for wrapping a reference model using deepspeed and cannot be used for a model that is being trained.
         # Adapted from accelerate: https://github.com/huggingface/accelerate/blob/739b135f8367becb67ffaada12fe76e3aa60fefd/src/accelerate/accelerator.py#L1473
 
         deepspeed_plugin = self.accelerator.state.deepspeed_plugin

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -447,7 +447,7 @@ class DPOTrainer(Trainer):
         if not isinstance(model, str) and ref_model is model:
             raise ValueError(
                 "`model` and `ref_model` cannot be the same object. If you want `ref_model` to be the "
-                "same as `model`, you must mass a copy of it, or `None` if you use peft."
+                "same as `model`, you must pass a copy of it, or `None` if you use peft."
             )
 
         if model_init_kwargs is not None:


### PR DESCRIPTION
# What does this PR do?
Fixes #2154

My opinion is that popping the scheduler params off the deepcopied ds_config is the best way to solve this. This prevents deepspeed from attempting to build a scheduler for the engine (which is fine because any returned scheduler is ignored anyways). I explored some other avenues like using the Deepspeed inference engine instead but the different config would make it a nightmare.

Other:  
- Removed redundant None check, as ```ref_model``` is None checked before ```_prepare_deepspeed``` is called:
```
if self.ref_model is None:
    if not (self.is_peft_model or self.precompute_ref_log_probs):
        raise ValueError(
            "No reference model and model is not a Peft model. Try setting `precompute_ref_log_probs=True`"
        )
    if args.sync_ref_model:
        raise ValueError(
            "You currently cannot use `ref_model=None` with TR-DPO method. Please provide `ref_model`."
        )
else:
    if self.is_deepspeed_enabled:
        self.ref_model = self._prepare_deepspeed(self.ref_model)
    else:
        self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
```
also even if ```_prepare_deepspeed``` ends up getting used elsewhere passing ```model=None``` to deepspeed will hit an assert anyways.

- Added a comment to clarfify that ```_prepare_deepspeed``` can only be used on reference models that won't be trained
- Fixed typo

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?
