### PR TITLE
Update commands for code linting in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Follow these steps to start contributing:
    $ make test
    ```
 
-TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
+    TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
 
 We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,8 +179,8 @@ Follow these steps to start contributing:
    ```bash
    $ make test
    ```
-  
-<br> 
+<br>
+
 TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
 
 We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ Follow these steps to start contributing:
 
     TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
 
-We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.
+    We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.
 
 To apply these checks and corrections in one step, use:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,15 +186,15 @@ Follow these steps to start contributing:
 
     To apply these checks and corrections in one step, use:
 
-```bash
-$ make precommit
-```
+    ```bash
+    $ make precommit
+    ```
 
-This command runs the following:
-- Executes `pre-commit` hooks to automatically fix style issues with `ruff` and other tools.
-- Runs additional scripts such as adding copyright information.
+    This command runs the following:
+    - Executes `pre-commit` hooks to automatically fix style issues with `ruff` and other tools.
+    - Runs additional scripts such as adding copyright information.
 
-If you prefer to apply the style corrections separately or review them individually, the `pre-commit` hook will handle the formatting for the files in question.
+    If you prefer to apply the style corrections separately or review them individually, the `pre-commit` hook will handle the formatting for the files in question.
 
    Once you're happy with your changes, add changed files using `git add` and
    make a commit with `git commit` to record your changes locally:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,7 @@ repository here's how to run tests with `pytest` for the library:
 $ python -m pytest -sv ./tests
 ```
 
-That's how `make test` is implemented (sans the `pip install` line)!
+That's how `make test` is implemented (without the `pip install` line)!
 
 You can specify a smaller set of tests to test only the feature
 you're working on.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,6 @@ Follow these steps to start contributing:
    ```bash
    $ make test
    ```
-<br>
 
 TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Follow these steps to start contributing:
 
     We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.
 
-To apply these checks and corrections in one step, use:
+    To apply these checks and corrections in one step, use:
 
 ```bash
 $ make precommit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,13 +179,23 @@ Follow these steps to start contributing:
    ```bash
    $ make test
    ```
+  
+<br> 
+TRL relies on `ruff` for maintaining consistent code formatting across its source files. Before submitting any PR, you should apply automatic style corrections and run code verification checks.
 
-   TRL relies on `ruff` to format its source code
-   consistently. After you make changes, check for style corrections using ```ruff format``` and code verifications using ```ruff check```
+We provide a `precommit` target in the `Makefile` that simplifies this process by running all required checks and optimizations on only the files modified by your PR.
 
-   ```bash
-   $ make precommit
-   ```
+To apply these checks and corrections in one step, use:
+
+```bash
+$ make precommit
+```
+
+This command runs the following:
+- Executes `pre-commit` hooks to automatically fix style issues with `ruff` and other tools.
+- Runs additional scripts such as adding copyright information.
+
+If you prefer to apply the style corrections separately or review them individually, the `pre-commit` hook will handle the formatting for the files in question.
 
    Once you're happy with your changes, add changed files using `git add` and
    make a commit with `git commit` to record your changes locally:
@@ -198,7 +208,7 @@ Follow these steps to start contributing:
    Please write [good commit messages](https://chris.beams.io/posts/git-commit/).
 
    It is a good idea to sync your copy of the code with the original
-   Repository regularly. This way you can quickly account for changes:
+   repository regularly. This way you can quickly account for changes:
 
    ```bash
    $ git fetch upstream

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,13 +181,7 @@ Follow these steps to start contributing:
    ```
 
    TRL relies on `ruff` to format its source code
-   consistently. After you make changes, apply automatic style corrections and code verifications
-   that can't be automated in one go with:
-
-   This target is also optimized to only work with files modified by the PR you're working on.
-
-   If you prefer to run the checks one after the other, the following command apply the
-   style corrections:
+   consistently. After you make changes, check for style corrections using ```ruff format``` and code verifications using ```ruff check```
 
    ```bash
    $ make precommit


### PR DESCRIPTION
# What does this PR do?
As I was looking to for the code linting commands for a pr, I was confused by what I think is missing linting commands. It looks like a bad copy/paste?

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?