### PR TITLE
Bump the minimum transformers version to v4.46

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 datasets>=1.17.0
 torch>=1.4.0
 tqdm
-transformers>=4.40.0
+transformers>=4.46.0
 accelerate
 peft>=0.3.0
 tyro>=0.5.7

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ __version__ = "0.12.0.dev0"  # expected format is one of x.y.z.dev0, or x.y.z.rc
 
 REQUIRED_PKGS = [
     "torch>=1.4.0",
-    "transformers>=4.40.0",
+    "transformers>=4.46.0",
     "numpy>=1.18.2;platform_system!='Windows'",
     "numpy<2;platform_system=='Windows'",
     "accelerate",


### PR DESCRIPTION
# What does this PR do?

We use `processing_class` instead of `tokenizer`. Consequently we need to bump the transformers min version to v4.46.

This PR will be merged after transformers v4.46 release.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.