### PR TITLE
setup_chat_format: throw error if there is already a template in base model

### DIFF
--- a/tests/test_dataset_formatting.py
+++ b/tests/test_dataset_formatting.py
@@ -119,6 +119,8 @@ class SetupChatFormatTestCase(unittest.TestCase):
     def setUp(self):
         self.tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
         self.model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
+        # remove built-in chat_template to simulate a model having no chat_template
+        self.tokenizer.chat_template = None
 
     def test_setup_chat_format(self):
         original_tokenizer_len = len(self.tokenizer)

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -84,6 +84,8 @@ def setup_chat_format(
     """
     Setup chat format by adding special tokens to the tokenizer, setting the correct format, and extending the embedding layer of the model based on the new special tokens.
 
+    If the model already has a chat template, this will throw an error. If you want to overwrite it, please set `tokenizer.chat_template` to `None`.
+
     Args:
         model (`~transformers.PreTrainedModel`): The model to be modified.
         tokenizer (`~transformers.PreTrainedTokenizer`): The tokenizer to be modified.

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -94,6 +94,10 @@ def setup_chat_format(
         model (`~transformers.PreTrainedModel`): The modified model.
         tokenizer (`~transformers.PreTrainedTokenizer`): The modified tokenizer.
     """
+    # check if model already had a chat template
+    if tokenizer.chat_template is not None:
+        raise ValueError("Chat template is already added to the tokenizer. If you want to overwrite it, please set it to None")
+
     # check if format available and retrieve
     if format not in FORMAT_MAPPING:
         raise ValueError(f"Format {format} not available. Please use one of {FORMAT_MAPPING.keys()}")

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -96,7 +96,9 @@ def setup_chat_format(
     """
     # check if model already had a chat template
     if tokenizer.chat_template is not None:
-        raise ValueError("Chat template is already added to the tokenizer. If you want to overwrite it, please set it to None")
+        raise ValueError(
+            "Chat template is already added to the tokenizer. If you want to overwrite it, please set it to None"
+        )
 
     # check if format available and retrieve
     if format not in FORMAT_MAPPING:


### PR DESCRIPTION
# What does this PR do?

Hi TRL team,

The context for this PR is from https://github.com/ggerganov/llama.cpp/pull/9778 . The user called `setup_chat_format` on base model `Llama-3.2-3B-Instruct`, which already has the llama-3.2 chat template. This will result in sub-optimal end result.

I believe it will be better to throw an error here, so that we don't overwrite chat template of the base model.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

(feel free to edit this part)