### PR TITLE
Use any reward model for online methods

### DIFF
--- a/docs/source/online_dpo_trainer.md
+++ b/docs/source/online_dpo_trainer.md
@@ -79,19 +79,16 @@ Instead of a judge, you can chose to use a reward model -- see [Reward Bench](ht
 
 - judge = PairRMJudge()
 + reward_model = AutoModelForSequenceClassification.from_pretrained("trl-lib/Qwen2-0.5B-Reward", num_labels=1)
++ reward_tokenizer = AutoTokenizer.from_pretrained("trl-lib/Qwen2-0.5B-Reward")
 
   trainer = OnlineDPOTrainer(
       ...
 -     judge=judge,
 +     reward_model=reward_model,
++     reward_processing_class=reward_tokenizer,
+      ...
   )
 ```
-
-<Tip warning={true}>
-
-Make sure that the SFT model and reward model use the _same_ chat template and the same tokenizer. Otherwise, you may find the model completions are scored incorrectly during training.
-
-</Tip>
 
 ### Encourage EOS token generation
 

--- a/examples/scripts/dpo.py
+++ b/examples/scripts/dpo.py
@@ -126,9 +126,11 @@ if __name__ == "__main__":
     )
 
     trainer.train()
-    metrics = trainer.evaluate()
-    trainer.log_metrics("eval", metrics)
-    trainer.save_metrics("eval", metrics)
+
+    if training_args.eval_strategy != "no":
+        metrics = trainer.evaluate()
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
 
     # Save and push to hub
     trainer.save_model(training_args.output_dir)

--- a/examples/scripts/dpo_online.py
+++ b/examples/scripts/dpo_online.py
@@ -96,6 +96,8 @@ if __name__ == "__main__":
         reward_tokenizer = AutoTokenizer.from_pretrained(
             training_args.reward_model_path,
             trust_remote_code=model_config.trust_remote_code,
+            truncation=True,
+            truncation_side="left",  # since we judge the completion, truncating left is more appropriate
         )
     else:
         reward_model = None
@@ -131,11 +133,14 @@ if __name__ == "__main__":
         reward_processing_class=reward_tokenizer,
         peft_config=get_peft_config(model_config),
     )
-    generation_config = GenerationConfig(
-        max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
-    )
-    completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
-    trainer.add_callback(completions_callback)
+
+    if training_args.eval_strategy != "no":
+        generation_config = GenerationConfig(
+            max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
+        )
+        completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
+        trainer.add_callback(completions_callback)
+
     trainer.train()
 
     # Save and push to hub

--- a/examples/scripts/dpo_online.py
+++ b/examples/scripts/dpo_online.py
@@ -93,8 +93,13 @@ if __name__ == "__main__":
             trust_remote_code=model_config.trust_remote_code,
             **model_kwargs,
         )
+        reward_tokenizer = AutoTokenizer.from_pretrained(
+            training_args.reward_model_path,
+            trust_remote_code=model_config.trust_remote_code,
+        )
     else:
         reward_model = None
+        reward_tokenizer = None
 
     if training_args.judge is not None:
         judge_cls = JUDGES[training_args.judge]
@@ -123,6 +128,7 @@ if __name__ == "__main__":
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split],
         processing_class=tokenizer,
+        reward_processing_class=reward_tokenizer,
         peft_config=get_peft_config(model_config),
     )
     generation_config = GenerationConfig(

--- a/examples/scripts/gkd.py
+++ b/examples/scripts/gkd.py
@@ -46,7 +46,7 @@ python examples/scripts/gkd.py \
 
 from accelerate import PartialState
 from datasets import load_dataset
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, GenerationConfig
 
 from trl import (
     GKDConfig,
@@ -125,8 +125,14 @@ if __name__ == "__main__":
         processing_class=tokenizer,
         peft_config=get_peft_config(model_config),
     )
-    completions_callback = LogCompletionsCallback(trainer, trainer.generation_config, num_prompts=8)
-    trainer.add_callback(completions_callback)
+
+    if training_args.eval_strategy != "no":
+        generation_config = GenerationConfig(
+            max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
+        )
+        completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
+        trainer.add_callback(completions_callback)
+
     trainer.train()
 
     # Save and push to hub

--- a/examples/scripts/nash_md.py
+++ b/examples/scripts/nash_md.py
@@ -132,12 +132,14 @@ if __name__ == "__main__":
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
         processing_class=tokenizer,
     )
-    generation_config = GenerationConfig(
-        max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
-    )
-    completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
-    trainer.add_callback(completions_callback)
-    # train the model
+
+    if training_args.eval_strategy != "no":
+        generation_config = GenerationConfig(
+            max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
+        )
+        completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
+        trainer.add_callback(completions_callback)
+
     trainer.train()
 
     # Save and push to hub

--- a/examples/scripts/reward_modeling.py
+++ b/examples/scripts/reward_modeling.py
@@ -124,9 +124,11 @@ if __name__ == "__main__":
     # Save model and push to Hub
     ############################
     trainer.save_model(training_args.output_dir)
-    metrics = trainer.evaluate()
-    trainer.log_metrics("eval", metrics)
-    trainer.save_metrics("eval", metrics)
+
+    if training_args.eval_strategy != "no":
+        metrics = trainer.evaluate()
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
 
     # Save and push to hub
     trainer.save_model(training_args.output_dir)

--- a/examples/scripts/xpo.py
+++ b/examples/scripts/xpo.py
@@ -117,12 +117,14 @@ if __name__ == "__main__":
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
         processing_class=tokenizer,
     )
-    generation_config = GenerationConfig(
-        max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
-    )
-    completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
-    trainer.add_callback(completions_callback)
-    # train the model
+
+    if training_args.eval_strategy != "no":
+        generation_config = GenerationConfig(
+            max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
+        )
+        completions_callback = LogCompletionsCallback(trainer, generation_config, num_prompts=8)
+        trainer.add_callback(completions_callback)
+
     trainer.train()
 
     # Save and push to hub

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -18,6 +18,7 @@ from trl import HfPairwiseJudge, PairRMJudge, RandomPairwiseJudge, RandomRankJud
 
 
 class TestJudges(unittest.TestCase):
+    @classmethod
     def setUpClass(cls):
         # Initialize once to download the model. This ensures it’s downloaded before running tests, preventing issues
         # where concurrent tests attempt to load the model while it’s still downloading.

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -18,7 +18,7 @@ from trl import HfPairwiseJudge, PairRMJudge, RandomPairwiseJudge, RandomRankJud
 
 
 class TestJudges(unittest.TestCase):
-    def setUpClass(self):
+    def setUpClass(cls):
         # Initialize once to download the model. This ensures it’s downloaded before running tests, preventing issues
         # where concurrent tests attempt to load the model while it’s still downloading.
         PairRMJudge()

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -18,6 +18,11 @@ from trl import HfPairwiseJudge, PairRMJudge, RandomPairwiseJudge, RandomRankJud
 
 
 class TestJudges(unittest.TestCase):
+    def setUpClass(self):
+        # Initialize once to download the model. This ensures it’s downloaded before running tests, preventing issues
+        # where concurrent tests attempt to load the model while it’s still downloading.
+        PairRMJudge()
+
     def _get_prompts_and_completions(self):
         prompts = ["The capital of France is", "The biggest planet in the solar system is"]
         completions = [["Paris", "Marseille"], ["Saturn", "Jupiter"]]

--- a/tests/test_nash_md_trainer.py
+++ b/tests/test_nash_md_trainer.py
@@ -20,7 +20,7 @@ from transformers import AutoModelForCausalLM, AutoModelForSequenceClassificatio
 from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
-from trl import NashMDConfig, NashMDTrainer, RandomPairwiseJudge, is_llmblender_available
+from trl import NashMDConfig, NashMDTrainer, PairRMJudge, is_llmblender_available
 
 
 if is_peft_available():
@@ -171,7 +171,7 @@ class TestNashMDTrainer(unittest.TestCase):
                 report_to="none",
             )
             dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
-            judge = RandomPairwiseJudge()
+            judge = PairRMJudge()
 
             trainer = NashMDTrainer(
                 model=self.model,

--- a/tests/test_nash_md_trainer.py
+++ b/tests/test_nash_md_trainer.py
@@ -20,7 +20,7 @@ from transformers import AutoModelForCausalLM, AutoModelForSequenceClassificatio
 from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
-from trl import NashMDConfig, NashMDTrainer, PairRMJudge, is_llmblender_available
+from trl import NashMDConfig, NashMDTrainer, RandomPairwiseJudge, is_llmblender_available
 
 
 if is_peft_available():
@@ -171,7 +171,7 @@ class TestNashMDTrainer(unittest.TestCase):
                 report_to="none",
             )
             dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
-            judge = PairRMJudge()
+            judge = RandomPairwiseJudge()
 
             trainer = NashMDTrainer(
                 model=self.model,

--- a/tests/test_online_dpo_trainer.py
+++ b/tests/test_online_dpo_trainer.py
@@ -21,6 +21,7 @@ from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
 from trl import OnlineDPOConfig, OnlineDPOTrainer, PairRMJudge, is_llmblender_available
+from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
 
 
 if is_peft_available():
@@ -33,6 +34,9 @@ class TestOnlineDPOTrainer(unittest.TestCase):
         self.model = AutoModelForCausalLM.from_pretrained(self.model_id)
         self.ref_model = AutoModelForCausalLM.from_pretrained(self.model_id)
         self.reward_model = AutoModelForSequenceClassification.from_pretrained("EleutherAI/pythia-14m", num_labels=1)
+        self.reward_tokenizer = AutoTokenizer.from_pretrained("EleutherAI/pythia-14m")
+        self.reward_tokenizer.chat_template = SIMPLE_CHAT_TEMPLATE
+        self.reward_tokenizer.pad_token = self.reward_tokenizer.eos_token
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
@@ -53,9 +57,10 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 model=self.model,
                 reward_model=self.reward_model,
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
+                reward_processing_class=self.reward_tokenizer,
             )
             trainer.train()
 
@@ -79,9 +84,10 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 ref_model=self.ref_model,
                 reward_model=self.reward_model,
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
+                reward_processing_class=self.reward_tokenizer,
             )
             trainer.train()
 
@@ -103,9 +109,11 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 OnlineDPOTrainer(
                     model=self.model,
                     ref_model=self.model,  # ref_model can't be the same as model
+                    reward_model=self.reward_model,
                     args=training_args,
-                    processing_class=self.tokenizer,
                     train_dataset=dummy_dataset["train"],
+                    processing_class=self.tokenizer,
+                    reward_processing_class=self.reward_tokenizer,
                 )
 
     @require_peft
@@ -126,9 +134,10 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 model=self.model,
                 reward_model=self.reward_model,
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
+                reward_processing_class=self.reward_tokenizer,
                 peft_config=lora_config,
             )
 
@@ -156,9 +165,10 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 ref_model=self.ref_model,
                 reward_model=self.reward_model,
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
+                reward_processing_class=self.reward_tokenizer,
                 peft_config=lora_config,
             )
 
@@ -188,9 +198,10 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 model=model,
                 reward_model=self.reward_model,
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
+                reward_processing_class=self.reward_tokenizer,
                 peft_config=lora_train_config,
             )
 
@@ -200,7 +211,8 @@ class TestOnlineDPOTrainer(unittest.TestCase):
             self.assertIn("train_loss", trainer.state.log_history[-1])
 
     @unittest.skipIf(not is_llmblender_available(), "llm-blender is not available")
-    def test_training_with_judge(self):
+    @parameterized.expand([("standard_prompt_only",), ("conversational_prompt_only",)])
+    def test_training_with_judge(self, config_name):
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = OnlineDPOConfig(
                 output_dir=tmp_dir,
@@ -210,15 +222,15 @@ class TestOnlineDPOTrainer(unittest.TestCase):
                 eval_strategy="steps",
                 report_to="none",
             )
-            dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+            dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
 
             trainer = OnlineDPOTrainer(
                 model=self.model,
                 judge=PairRMJudge(),
                 args=training_args,
-                processing_class=self.tokenizer,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],
+                processing_class=self.tokenizer,
             )
             trainer.train()
 

--- a/tests/test_online_dpo_trainer.py
+++ b/tests/test_online_dpo_trainer.py
@@ -20,7 +20,7 @@ from transformers import AutoModelForCausalLM, AutoModelForSequenceClassificatio
 from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
-from trl import OnlineDPOConfig, OnlineDPOTrainer, PairRMJudge, is_llmblender_available
+from trl import OnlineDPOConfig, OnlineDPOTrainer, RandomPairwiseJudge, is_llmblender_available
 from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
 
 
@@ -226,7 +226,7 @@ class TestOnlineDPOTrainer(unittest.TestCase):
 
             trainer = OnlineDPOTrainer(
                 model=self.model,
-                judge=PairRMJudge(),
+                judge=RandomPairwiseJudge(),
                 args=training_args,
                 train_dataset=dummy_dataset["train"],
                 eval_dataset=dummy_dataset["test"],

--- a/tests/test_trainers_args.py
+++ b/tests/test_trainers_args.py
@@ -272,12 +272,13 @@ class TrainerArgTester(unittest.TestCase):
             reward_model = AutoModelForSequenceClassification.from_pretrained("EleutherAI/pythia-14m", num_labels=1)
             tokenizer = AutoTokenizer.from_pretrained("EleutherAI/pythia-14m")
             trainer = OnlineDPOTrainer(
-                args=training_args,
-                processing_class=tokenizer,
                 model=model,
                 ref_model=ref_model,
                 reward_model=reward_model,
+                args=training_args,
                 train_dataset=dataset,
+                processing_class=tokenizer,
+                reward_processing_class=tokenizer,
             )
             self.assertEqual(trainer.args.max_new_tokens, 42)
             self.assertEqual(trainer.args.temperature, 0.5)

--- a/tests/test_xpo_trainer.py
+++ b/tests/test_xpo_trainer.py
@@ -20,7 +20,7 @@ from transformers import AutoModelForCausalLM, AutoModelForSequenceClassificatio
 from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
-from trl import PairRMJudge, XPOConfig, XPOTrainer, is_llmblender_available
+from trl import RandomPairwiseJudge, XPOConfig, XPOTrainer, is_llmblender_available
 
 
 if is_peft_available():
@@ -171,7 +171,7 @@ class TestXPOTrainer(unittest.TestCase):
                 report_to="none",
             )
             dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
-            judge = PairRMJudge()
+            judge = RandomPairwiseJudge()
 
             trainer = XPOTrainer(
                 model=self.model,

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -122,6 +122,7 @@ class NashMDTrainer(OnlineDPOTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
+            reward_processing_class=processing_class, # for now, NashMDTrainer can't use any reward model
             peft_config=peft_config,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -122,7 +122,7 @@ class NashMDTrainer(OnlineDPOTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
-            reward_processing_class=processing_class, # for now, NashMDTrainer can't use any reward model
+            reward_processing_class=processing_class,  # for now, NashMDTrainer can't use any reward model
             peft_config=peft_config,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -434,7 +434,6 @@ class OnlineDPOTrainer(Trainer):
         device = prompt_completion_ids.device
         completions_ids = prompt_completion_ids[:, context_length:]
         completions = self.processing_class.batch_decode(completions_ids, skip_special_tokens=True)
-        completions = [completion.strip() for completion in completions]  # remove the leading space # MAYBE MOVE
         if is_conversational({"prompt": prompts[0]}):
             completions = [[{"role": "assistant", "content": completion}] for completion in completions]
 

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -121,6 +121,7 @@ class XPOTrainer(OnlineDPOTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
+            reward_processing_class=processing_class, # for now, XPOTrainer can't use any reward model
             peft_config=peft_config,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -121,7 +121,7 @@ class XPOTrainer(OnlineDPOTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
-            reward_processing_class=processing_class, # for now, XPOTrainer can't use any reward model
+            reward_processing_class=processing_class,  # for now, XPOTrainer can't use any reward model
             peft_config=peft_config,
             compute_metrics=compute_metrics,
             callbacks=callbacks,


### PR DESCRIPTION
# What does this PR do?

This PR allows any reward model to be used with Online DPO, i.e. it removes the requirement to have the same chat template and tokenizer.

The user must now provide `reward_processing_class`.
```python
trainer = OnlineDPOTrainer(
    model=model,
    reward_model=reward_model,
    args=training_args,
    train_dataset=train_dataset,
    processing_class=tokenizer,
    reward_processing_class=reward_tokenizer,  # <-
)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.