### PR TITLE
Update callbacks.py for fix small python type error

### DIFF
--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -364,9 +364,9 @@ class LogCompletionsCallback(WandbCallback):
             column containing the prompts for generating completions.
         generation_config (`GenerationConfig`, *optional*):
             The generation config to use for generating completions.
-        num_prompts (`int`, *optional*):
+        num_prompts (`int` or `None`, *optional*):
             The number of prompts to generate completions for. If not provided, defaults to the number of examples in the evaluation dataset.
-        freq (`int`, *optional*):
+        freq (`int` or `None`, *optional*):
             The frequency at which to log completions. If not provided, defaults to the trainer's `eval_steps`.
     """
 

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -374,8 +374,8 @@ class LogCompletionsCallback(WandbCallback):
         self,
         trainer: Trainer,
         generation_config: Optional[GenerationConfig] = None,
-        num_prompts: int = None,
-        freq: int = None,
+        num_prompts: Optional[int] = None,
+        freq: Optional[int] = None,
     ):
         super().__init__()
         self.trainer = trainer


### PR DESCRIPTION
(write with AI claude)

# What does this PR do?

This PR improves type hints in the trainer callbacks by changing the parameter types of `num_prompts` and `freq` from `int` to `Optional[int]` to better reflect that these parameters can accept None values. This is a type annotation improvement with no functional changes.

## Before submitting (human checked)
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
    Yes  (human response)
- [x] Was this discussed/approved via a GitHub issue?
    No, this is a minor type annotation improvement.
- [x] Did you make sure to update the documentation with your changes?
    No documentation updates needed as this only affects type hints.
- [x] Did you write any new necessary tests?
    No new tests needed as this is only changing type hints.

## Who can review?

Anyone familiar with Python type hints can review this PR. This is a straightforward type annotation improvement in the trainer callbacks.