### PR TITLE
[DataCollator] Add warning for out-of-vocabulary token IDs

### DIFF
--- a/trl/commands/scripts
+++ b/trl/commands/scripts
@@ -1,1 +1,0 @@
-/Users/swayam/trl/examples/scripts/

--- a/trl/commands/scripts
+++ b/trl/commands/scripts
@@ -1,0 +1,1 @@
+/Users/swayam/trl/examples/scripts/


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR adds a patch for #2293 adding a validation check in `DataCollatorForCompletionOnlyLM` to warn users when token IDs exceed the tokenizer's vocabulary size. This is a common issue that can occur when:
1. Using incorrect pad tokens (especially with LLaMA models)
2. Modifying tokenizer vocabulary without updating the model
3. Adding custom tokens without proper model resizing

The warning provides possible fixes, making debugging easier for users.



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?
@qgallouedec 