### PR TITLE
[Draft] Add autocast to prediction_step for SFTTrainer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 accelerate
 datasets
 rich
-transformers>=4.46.0
+git+https://github.com/pdufour/transformers.git@train_predict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 accelerate
 datasets
 rich
-git+https://github.com/pdufour/transformers.git@train_predict
+transformers>=4.46.0

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1295,22 +1295,6 @@ class SFTTrainerTester(unittest.TestCase):
 
             processor.chat_template = """{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions. {% for message in messages %}{% if message['role'] == 'user' %}USER: {% else %}ASSISTANT: {% endif %}{% for item in message['content'] %}{% if item['type'] == 'text' %}{{ item['text'] }}{% elif item['type'] == 'image' %}<image>{% endif %}{% endfor %}{% if message['role'] == 'user' %} {% else %}{{eos_token}}{% endif %}{% endfor %}{% if add_generation_prompt %}ASSISTANT: {% endif %}"""
 
-
-            # def collate_fn(examples):
-            #     # Get the texts and images, and apply the chat template
-            #     texts = [processor.apply_chat_template(example["messages"], tokenize=False) for example in examples]
-            #     images = [example["images"][0] for example in examples]
-
-            #     # Tokenize the texts and process the images
-            #     batch = processor(texts, images, return_tensors="pt", padding=True)
-
-            #     # The labels are the input_ids, and we mask the padding tokens in the loss computation
-            #     labels = batch["input_ids"].clone()
-            #     labels[labels == processor.tokenizer.pad_token_id] = -100
-            #     batch["labels"] = labels
-
-            #     return batch
-
             def collate_fn(examples, mode="train"):
                 # Get the texts and images, and apply the chat template
                 texts = [processor.apply_chat_template(example["messages"], tokenize=False) for example in examples]

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -653,7 +653,7 @@ class SFTTrainer(Trainer):
         def compute_loss(self, model, inputs, return_outputs=False):
             context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
     
-            with torch.no_grad(), context_manager:
+            with context_manager:
                 return super().compute_loss(model, inputs, return_outputs=True)
         
     def prediction_step(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -651,7 +651,7 @@ class SFTTrainer(Trainer):
         context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
 
         with context_manager:
-            loss = super().compute_loss(model, inputs, return_outputs)
+            loss, metrics = super().compute_loss(model, inputs, return_outputs)
         
         # Make sure to move the loss to the device the original accumulating loss is at back in the `Trainer` class:
         loss = loss.to(self.args.device)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -132,6 +132,7 @@ class SFTTrainer(Trainer):
         model: Optional[Union[PreTrainedModel, nn.Module, str]] = None,
         args: Optional[SFTConfig] = None,
         data_collator: Optional[DataCollator] = None,  # type: ignore
+        eval_data_collator: Optional[DataCollator] = None,  # type: ignore
         train_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
         processing_class: Optional[
@@ -225,11 +226,11 @@ class SFTTrainer(Trainer):
             raise ValueError(
                 "You passed a `DataCollatorForCompletionOnlyLM` to the SFTTrainer. This is not compatible with the `packing` argument."
             )
-            
+
         # Initialize this variable to False. This helps tracking the case when `peft_module_casting_to_bf16`
         # has been called in order to properly call autocast if needed.
         self._peft_has_been_casted_to_bf16 = False
-        
+
         if is_peft_available() and peft_config is not None:
             if not isinstance(peft_config, PeftConfig):
                 raise ValueError(
@@ -417,6 +418,7 @@ class SFTTrainer(Trainer):
             model=model,
             args=args,
             data_collator=data_collator,
+            eval_data_collator=eval_data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -646,23 +646,6 @@ class SFTTrainer(Trainer):
         )
 
         model_card.save(os.path.join(self.args.output_dir, "README.md"))
-        
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
-    
-        with context_manager:
-            if return_outputs:
-                # Directly unpack when expecting both loss and outputs
-                loss, outputs = super().compute_loss(model, inputs, return_outputs=True)
-            else:
-                # Only retrieve loss when outputs are not needed
-                loss = super().compute_loss(model, inputs, return_outputs=False)
-    
-        # Move loss to the correct device in a single place
-        # loss = loss.to(self.args.device)
-        
-        # Return the appropriate values based on `return_outputs`
-        return (loss, outputs) if return_outputs else loss
 
     def prediction_step(
         self,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -650,12 +650,12 @@ class SFTTrainer(Trainer):
 
         model_card.save(os.path.join(self.args.output_dir, "README.md"))
 
-        def compute_loss(self, model, inputs, return_outputs=False):
-            context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
+    def compute_loss(self, model, inputs, return_outputs=False):
+        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
+
+        with context_manager:
+            return super().compute_loss(model, inputs, return_outputs=True)
     
-            with context_manager:
-                return super().compute_loss(model, inputs, return_outputs=True)
-        
     def prediction_step(
         self,
         model: Union[PreTrainedModel, nn.Module],

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -663,7 +663,7 @@ class SFTTrainer(Trainer):
     ):
         context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
 
-        with torch.no_grad(), prediction_context_manager:
+        with torch.no_grad(), context_manager:
             return super().prediction_step(
                 model, inputs, prediction_loss_only, ignore_keys, **gen_kwargs
             )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -651,7 +651,7 @@ class SFTTrainer(Trainer):
         model_card.save(os.path.join(self.args.output_dir, "README.md"))
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
+        context_manager = amp.autocast("cuda", dtype=torch.bfloat16) if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
 
         with context_manager:
             return super().compute_loss(model, inputs, return_outputs, num_items_in_batch)
@@ -664,7 +664,7 @@ class SFTTrainer(Trainer):
         ignore_keys: Optional[List[str]] = None,
         **gen_kwargs,
     ):
-        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
+        context_manager = amp.autocast("cuda", dtype=torch.bfloat16) if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
 
         with torch.no_grad(), context_manager:
             return super().prediction_step(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -649,16 +649,20 @@ class SFTTrainer(Trainer):
         
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
-
+    
         with context_manager:
-            loss, metrics = super().compute_loss(model, inputs, return_outputs)
-        
-        # Make sure to move the loss to the device the original accumulating loss is at back in the `Trainer` class:
+            if return_outputs:
+                # Directly unpack when expecting both loss and outputs
+                loss, outputs = super().compute_loss(model, inputs, return_outputs=True)
+            else:
+                # Only retrieve loss when outputs are not needed
+                loss = super().compute_loss(model, inputs, return_outputs=False)
+    
+        # Move loss to the correct device in a single place
         loss = loss.to(self.args.device)
-
-        if return_outputs:
-            return (loss, metrics)
-        return loss
+        
+        # Return the appropriate values based on `return_outputs`
+        return (loss, outputs) if return_outputs else loss
 
     def prediction_step(
         self,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
+import contextlib
 import inspect
 import os
 import warnings
@@ -655,7 +656,7 @@ class SFTTrainer(Trainer):
         ignore_keys: Optional[List[str]] = None,
         **gen_kwargs,
     ):
-        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
+        context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
 
         with torch.no_grad(), context_manager:
             return super().prediction_step(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -650,6 +650,12 @@ class SFTTrainer(Trainer):
 
         model_card.save(os.path.join(self.args.output_dir, "README.md"))
 
+        def compute_loss(self, model, inputs, return_outputs=False):
+            context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
+    
+            with torch.no_grad(), context_manager:
+                return super().compute_loss(model, inputs, return_outputs=True)
+        
     def prediction_step(
         self,
         model: Union[PreTrainedModel, nn.Module],

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -659,7 +659,7 @@ class SFTTrainer(Trainer):
                 loss = super().compute_loss(model, inputs, return_outputs=False)
     
         # Move loss to the correct device in a single place
-        loss = loss.to(self.args.device)
+        # loss = loss.to(self.args.device)
         
         # Return the appropriate values based on `return_outputs`
         return (loss, outputs) if return_outputs else loss

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -651,8 +651,15 @@ class SFTTrainer(Trainer):
         context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else nullcontext()
 
         with context_manager:
-            return super().compute_loss(model, inputs, return_outputs)
+            loss = super().compute_loss(model, inputs, return_outputs)
         
+        # Make sure to move the loss to the device the original accumulating loss is at back in the `Trainer` class:
+        loss = loss.to(self.args.device)
+
+        if return_outputs:
+            return (loss, metrics)
+        return loss
+
     def prediction_step(
         self,
         model: Union[PreTrainedModel, nn.Module],

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -15,7 +15,7 @@ import dataclasses
 import inspect
 import os
 import warnings
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union, Any
 
 import datasets
 import torch
@@ -655,7 +655,7 @@ class SFTTrainer(Trainer):
         
     def prediction_step(
         self,
-        model: nn.Module,
+        model: Union[PreTrainedModel, nn.Module],
         inputs: Dict[str, Union[torch.Tensor, Any]],
         prediction_loss_only: bool,
         ignore_keys: Optional[List[str]] = None,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -63,7 +63,6 @@ if is_liger_kernel_available():
 if is_wandb_available():
     import wandb
 
-
 class SFTTrainer(Trainer):
     r"""
     Class definition of the Supervised Finetuning Trainer (SFT Trainer).

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -650,11 +650,11 @@ class SFTTrainer(Trainer):
 
         model_card.save(os.path.join(self.args.output_dir, "README.md"))
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         context_manager = amp.autocast("cuda") if self._peft_has_been_casted_to_bf16 else contextlib.nullcontext()
 
         with context_manager:
-            return super().compute_loss(model, inputs, return_outputs=True)
+            return super().compute_loss(model, inputs, return_outputs, num_items_in_batch)
     
     def prediction_step(
         self,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -63,6 +63,7 @@ if is_liger_kernel_available():
 if is_wandb_available():
     import wandb
 
+
 class SFTTrainer(Trainer):
     r"""
     Class definition of the Supervised Finetuning Trainer (SFT Trainer).


### PR DESCRIPTION
# What does this PR do?

**Note: not ready for review until https://github.com/huggingface/transformers/pull/32346 lands.**

There is a PR to add predict_with_generate to the base Trainer class https://github.com/huggingface/transformers/pull/32346/files. However without any changes to SFTrainer, it throws error if you use it and have mixed precision turned on.

You can see a simliar bug (and fix) happened here - https://github.com/huggingface/trl/pull/1203

This pull request aims to make SFTrainer compatible with the soon-to-land predict_with_generate changes.

*Reproducible Example:*
```
import torch
from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig
from trl import SFTConfig, SFTTrainer
from datasets import Dataset
from peft import LoraConfig
from PIL import Image
from io import BytesIO

model_id = "meta-llama/Llama-3.2-11B-Vision-Instruct"
bnb_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_use_double_quant=True, bnb_4bit_quant_type="nf4", bnb_4bit_compute_dtype=torch.bfloat16)
model = AutoModelForVision2Seq.from_pretrained(model_id, device_map="auto", torch_dtype=torch.bfloat16, quantization_config=bnb_config)

processor = AutoProcessor.from_pretrained(model_id)
tokenizer = processor.tokenizer

peft_config = LoraConfig(target_modules=["k_proj", "o_proj", "q_proj", "v_proj"], task_type="CAUSAL_LM")

args = SFTConfig(
    max_steps=2, output_dir="/tmp/test-model", gradient_checkpointing=True, bf16=True, bf16_full_eval=True,
    logging_steps=1, push_to_hub=False, report_to="wandb", eval_strategy="steps", eval_steps=2,
    generation_config={"num_beams": 1, "max_length": 1024}, predict_with_generate=True,
    gradient_checkpointing_kwargs={"use_reentrant": False}, dataset_kwargs={"skip_prepare_dataset": True},
    remove_unused_columns=False
)

# Example of structured data without URLs for images
data = [
    {
        "messages": [
            {
                "role": "user",
                "content": [
                    {"type": "text", "text": "Generate code for a web page that looks exactly like this."},
                    {"type": "image", "image": "placeholder"}
                ]
            },
            {
                "role": "assistant",
                "content": [
                    {"type": "text", "text": "<html><body>Sample HTML content for the web page...</body></html>"}
                ]
            }
        ]
    }
]

dataset = Dataset.from_list(data)

def generate_placeholder_image():
    placeholder_image = Image.new("RGB", (256, 256), color="gray")
    return placeholder_image

def collate_fn(examples, mode):
    texts = [processor.apply_chat_template(example["messages"], tokenize=False).strip() for example in examples]
    texts_eval = [processor.apply_chat_template([example["messages"][0]], add_generation_prompt=True).strip() for example in examples]

    images = [[generate_placeholder_image()] for _ in examples]
    
    processor.tokenizer.padding_side = "right"
    batch = processor(text=texts, images=images, return_tensors="pt", padding=True)
    
    if mode == 'test':
        processor.tokenizer.padding_side = "left"
        batch_eval = processor(text=texts_eval, images=images, return_tensors="pt", padding=True)
        batch["generation_input_ids"] = batch_eval["input_ids"]
        batch["generation_attention_mask"] = batch_eval["attention_mask"]

    labels = batch["input_ids"].clone()
    labels[labels == tokenizer.pad_token_id] = -100
    image_token_id = processor.tokenizer.convert_tokens_to_ids(processor.image_token)
    labels[labels == image_token_id] = -100
    batch["labels"] = labels
    
    return batch

trainer = SFTTrainer(
    model=model, args=args, train_dataset=dataset, data_collator=lambda x: collate_fn(x, mode='train'), eval_dataset=dataset, 
    dataset_text_field="messages", tokenizer=tokenizer, peft_config=peft_config,
    compute_metrics = lambda: dict(),
)

trainer.eval_data_collator = lambda examples: collate_fn(examples, 'test')

trainer.train()
print('Done')

```

# Test Plan

**Test fail case**
1) Install transformers branch with train_predict flag `pip install git+https://github.com/pdufour/transformers.git@train_predict`
2) Edit the above code and comment out the `generation config`, ` predict_with_generate=True,` arg, and `print(f"bf16 casting status: {trainer._peft_has_been_casted_to_bf16}")` line
2) Run the above code
3) See the error

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/126f739b-4a6f-44ba-a6d1-896cd7fc9330">


**Test success case**
1) Install trl branch with this fix (this pr)`pip install git+https://github.com/pdufour/trl.git@train_predict`
2) Run the code
3) See no error



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.