### PR TITLE
🔮 Inference mode in `GeometricMixtureWrapper.forward`

### DIFF
--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -679,7 +679,6 @@ def create_reference_model(
 class GeometricMixtureWrapper(GenerationMixin):
     r"""
     Geometric Mixture generation wrapper that samples from the logits of two model's geometric mixture.
-    Note that the model is set to eval mode and so set it back to train mode if necessary.
 
     Args:
         model (`PreTrainedModel`): The model to be wrapped.
@@ -695,9 +694,9 @@ class GeometricMixtureWrapper(GenerationMixin):
     def __init__(self, model, ref_model, generation_config, mixture_coef=0.5, device=None):
         super().__init__()
 
-        self.model = model.eval()
+        self.model = model
         self.config = model.config
-        self.ref_model = ref_model.eval()
+        self.ref_model = ref_model
         self.generation_config = generation_config
         self.mixture_coef = mixture_coef
         self.device = device
@@ -705,7 +704,7 @@ class GeometricMixtureWrapper(GenerationMixin):
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(self, *args, **kwargs):
         model_outputs = self.model(*args, **kwargs)
         model_logits = model_outputs.logits

--- a/trl/models/modeling_base.py
+++ b/trl/models/modeling_base.py
@@ -679,6 +679,7 @@ def create_reference_model(
 class GeometricMixtureWrapper(GenerationMixin):
     r"""
     Geometric Mixture generation wrapper that samples from the logits of two model's geometric mixture.
+    Note that the model is set to eval mode and so set it back to train mode if necessary.
 
     Args:
         model (`PreTrainedModel`): The model to be wrapped.

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -184,6 +184,8 @@ class NashMDTrainer(OnlineDPOTrainer):
                     attention_mask=prompts["attention_mask"],
                     generation_config=self.generation_config,
                 )
+            # Set the model back to training mode after generation from geometric mixture
+            model.train()
 
         return model_output, mixture_output
 

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -184,8 +184,6 @@ class NashMDTrainer(OnlineDPOTrainer):
                     attention_mask=prompts["attention_mask"],
                     generation_config=self.generation_config,
                 )
-            # Set the model back to training mode after generation from geometric mixture
-            model.train()
 
         return model_output, mixture_output
 


### PR DESCRIPTION
# What does this PR do?

When calling the GeometricMixture generation mixer, the model is left in eval mode.