### PR TITLE
🧲 Use our own `require_bitsandbytes`

### DIFF
--- a/tests/slow/test_dpo_slow.py
+++ b/tests/slow/test_dpo_slow.py
@@ -21,11 +21,12 @@ from accelerate.utils.memory import release_memory
 from datasets import load_dataset
 from parameterized import parameterized
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
-from transformers.testing_utils import require_bitsandbytes, require_peft, require_torch_accelerator, torch_device
+from transformers.testing_utils import require_peft, require_torch_accelerator, torch_device
 from transformers.utils import is_peft_available
 
 from trl import DPOConfig, DPOTrainer
 
+from ..testing_utils import require_bitsandbytes
 from .testing_constants import DPO_LOSS_TYPES, DPO_PRECOMPUTE_LOGITS, GRADIENT_CHECKPOINTING_KWARGS, MODELS_TO_TEST
 
 

--- a/tests/slow/test_sft_slow.py
+++ b/tests/slow/test_sft_slow.py
@@ -22,7 +22,6 @@ from datasets import load_dataset
 from parameterized import parameterized
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import (
-    require_bitsandbytes,
     require_liger_kernel,
     require_peft,
     require_torch_accelerator,
@@ -33,6 +32,7 @@ from transformers.utils import is_peft_available
 from trl import SFTConfig, SFTTrainer
 from trl.models.utils import setup_chat_format
 
+from ..testing_utils import require_bitsandbytes
 from .testing_constants import DEVICE_MAP_OPTIONS, GRADIENT_CHECKPOINTING_KWARGS, MODELS_TO_TEST, PACKING_OPTIONS
 
 

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -29,16 +29,11 @@ from transformers import (
     PreTrainedTokenizerBase,
     is_vision_available,
 )
-from transformers.testing_utils import (
-    require_bitsandbytes,
-    require_peft,
-    require_torch_gpu_if_bnb_not_multi_backend_enabled,
-    require_vision,
-)
+from transformers.testing_utils import require_peft, require_torch_gpu_if_bnb_not_multi_backend_enabled, require_vision
 
 from trl import DPOConfig, DPOTrainer, FDivergenceType
 
-from .testing_utils import require_no_wandb
+from .testing_utils import require_bitsandbytes, require_no_wandb
 
 
 if is_vision_available():

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -14,9 +14,18 @@
 import random
 import unittest
 
-from transformers import is_sklearn_available, is_wandb_available
+from transformers import is_bitsandbytes_available, is_sklearn_available, is_wandb_available
 
 from trl import BaseBinaryJudge, BasePairwiseJudge, is_diffusers_available, is_llm_blender_available
+
+
+# transformers.testing_utils contain a require_bitsandbytes function, but relies on pytest markers that we don't use
+# in our test suite. So we need to implement our own version of this function.
+def require_bitsandbytes(test_case):
+    """
+    Decorator marking a test that requires bitsandbytes. Skips the test if bitsandbytes is not available.
+    """
+    return unittest.skipUnless(is_bitsandbytes_available(), "test requires bitsandbytes")(test_case)
 
 
 def require_diffusers(test_case):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -19,8 +19,8 @@ from transformers import is_bitsandbytes_available, is_sklearn_available, is_wan
 from trl import BaseBinaryJudge, BasePairwiseJudge, is_diffusers_available, is_llm_blender_available
 
 
-# transformers.testing_utils contain a require_bitsandbytes function, but relies on pytest markers that we don't use
-# in our test suite. So we need to implement our own version of this function.
+# transformers.testing_utils contains a require_bitsandbytes function, but relies on pytest markers which we don't use
+# in our test suite. We therefore need to implement our own version of this function.
 def require_bitsandbytes(test_case):
     """
     Decorator marking a test that requires bitsandbytes. Skips the test if bitsandbytes is not available.


### PR DESCRIPTION
# What does this PR do?

To avoid this warning in our tests:

```
../transformers/src/transformers/testing_utils.py:1163
  /fsx/qgallouedec/transformers/src/transformers/testing_utils.py:1163: PytestUnknownMarkWarning: Unknown pytest.mark.bitsandbytes - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    return pytest.mark.bitsandbytes(test_case)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.