### PR TITLE
Pin transformers version <4.47

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ REQUIRED_PKGS = [
     "accelerate>=0.34.0",
     "datasets>=2.21.0",
     "rich",  # rich shouldn't be a required package for trl, we should remove it from here
-    "transformers>=4.46.0",
+    "transformers<4.47.0",
 ]
 EXTRAS = {
     # Windows support is partially supported with DeepSpeed https://github.com/microsoft/DeepSpeed/tree/master#windows

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ import os
 from setuptools import find_packages, setup
 
 
-__version__ = "0.12.1"  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+__version__ = "0.12.2"  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
 
 REQUIRED_PKGS = [
     "accelerate>=0.34.0",

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
# What does this PR do?
pins the transformers version to <4.47

fixes [#2445](https://github.com/huggingface/trl/issues/2445)
