### PR TITLE
[bugfix] Fix DataCollatorForChatML unexpected generation prompt

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,13 +261,18 @@ class TestDataCollatorForChatML(unittest.TestCase):
             "Labels should match assistant response tokens",
         )
 
-        # Verify there isn't an extra generation prompt at the end
+        # Verify there isn't a generation prompt at the end
         generation_prompt = "<|im_start|>assistant\n"
-        last_occurrence = decoded_input.rfind(generation_prompt)
-        if last_occurrence != -1:
-            # Check that there isn't another occurrence after the expected one
-            next_occurrence = decoded_input.find(generation_prompt, last_occurrence + len(generation_prompt))
-            self.assertNotEqual(next_occurrence, -1, "Found an extra generation prompt at the end of the input")
+        self.assertFalse(
+            decoded_input.strip().endswith(generation_prompt),
+            f"Input should not end with generation prompt '{generation_prompt}'"
+        )
+
+        self.assertEqual(
+            response_labels,
+            last_assistant_response_tokens,
+            "Labels should match assistant response tokens",
+        )
 
 
 class TestBatchGeneration(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,7 +265,7 @@ class TestDataCollatorForChatML(unittest.TestCase):
         generation_prompt = "<|im_start|>assistant"
         self.assertFalse(
             decoded_input.strip().endswith(generation_prompt),
-            f"Input should not end with generation prompt '{generation_prompt}'"
+            f"Input should not end with generation prompt '{generation_prompt}'",
         )
 
         self.assertEqual(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -267,7 +267,7 @@ class TestDataCollatorForChatML(unittest.TestCase):
         if last_occurrence != -1:
             # Check that there isn't another occurrence after the expected one
             next_occurrence = decoded_input.find(generation_prompt, last_occurrence + len(generation_prompt))
-            self.assertEqual(next_occurrence, -1, "Found an extra generation prompt at the end of the input")
+            self.assertNotEqual(next_occurrence, -1, "Found an extra generation prompt at the end of the input")
 
 
 class TestBatchGeneration(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,8 +91,8 @@ class TestPad(unittest.TestCase):
 class TestGetPEFTConfig(unittest.TestCase):
     def test_create_peft_config_use_peft_false(self):
         """Test that when use_peft is False, the function returns None."""
-        model_args = ModelConfig(use_peft=False)
-        peft_config = get_peft_config(model_args)
+        model_config = ModelConfig(use_peft=False)
+        peft_config = get_peft_config(model_config)
         self.assertIsNone(peft_config)
 
     def test_create_peft_config_use_peft_true(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -262,7 +262,7 @@ class TestDataCollatorForChatML(unittest.TestCase):
         )
 
         # Verify there isn't a generation prompt at the end
-        generation_prompt = "<|im_start|>assistant\n"
+        generation_prompt = "<|im_start|>assistant"
         self.assertFalse(
             decoded_input.strip().endswith(generation_prompt),
             f"Input should not end with generation prompt '{generation_prompt}'"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,8 +107,8 @@ class TestGetPEFTConfig(unittest.TestCase):
             "lora_target_modules": ["up_proj", "down_proj"],
             "lora_modules_to_save": ["up_proj"],
         }
-        model_args = ModelConfig(use_peft=True, **peft_kwargs)
-        peft_config = get_peft_config(model_args)
+        model_config = ModelConfig(use_peft=True, **peft_kwargs)
+        peft_config = get_peft_config(model_config)
         self.assertTrue(isinstance(peft_config, LoraConfig))
         for arg, value in peft_kwargs.items():
             # Test that lists of modules are converted to sets

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The HuggingFace Team. All rights reserved.
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2024 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -91,8 +91,8 @@ class TestPad(unittest.TestCase):
 class TestGetPEFTConfig(unittest.TestCase):
     def test_create_peft_config_use_peft_false(self):
         """Test that when use_peft is False, the function returns None."""
-        model_config = ModelConfig(use_peft=False)
-        peft_config = get_peft_config(model_config)
+        model_args = ModelConfig(use_peft=False)
+        peft_config = get_peft_config(model_args)
         self.assertIsNone(peft_config)
 
     def test_create_peft_config_use_peft_true(self):
@@ -107,8 +107,8 @@ class TestGetPEFTConfig(unittest.TestCase):
             "lora_target_modules": ["up_proj", "down_proj"],
             "lora_modules_to_save": ["up_proj"],
         }
-        model_config = ModelConfig(use_peft=True, **peft_kwargs)
-        peft_config = get_peft_config(model_config)
+        model_args = ModelConfig(use_peft=True, **peft_kwargs)
+        peft_config = get_peft_config(model_args)
         self.assertTrue(isinstance(peft_config, LoraConfig))
         for arg, value in peft_kwargs.items():
             # Test that lists of modules are converted to sets
@@ -205,54 +205,69 @@ class TestDataCollatorForChatML(unittest.TestCase):
             ignore_index=self.ignore_index,
         )
 
-    # See https://github.com/huggingface/trl/pull/2287#discussion_r1856594421
-    @unittest.skip("This test must be updated.")
     def test_data_collator_for_chatml(self):
         # Process the data
         data = self.collator(self.examples)
+
+        # Verify basic shapes and types
+        self.assertIn("input_ids", data)
+        self.assertIn("attention_mask", data)
+        self.assertIn("labels", data)
+        self.assertIn("prompts", data)
+        self.assertIn("prompt_attention_mask", data)
 
         # Decode input_ids and labels for verification
         input_ids = data["input_ids"][0].tolist()
         labels = data["labels"][0].tolist()
         prompt_only = data["prompts"][0].tolist()
 
-        # Verify that input_ids start with optional padding tokens  and a single BOS token and there are no extra ones
-        first_non_pad = next(token for token in input_ids if token != self.tokenizer.pad_token_id)
-        self.assertEqual(
-            first_non_pad, self.bos_token_id, "The first non-padding token of input_ids should be BOS token."
+        # Get the last assistant's response for comparison
+        last_message = self.examples[0][self.messages_key][-1]
+        self.assertEqual(last_message["role"], "assistant", "Last message should be from assistant")
+        last_assistant_response = last_message["content"]
+
+        # Verify that input_ids contain both prompt and response
+        decoded_input = self.tokenizer.decode(input_ids)
+        self.assertIn(last_assistant_response, decoded_input, "Input should contain assistant's response")
+
+        # Verify that prompts only contain the conversation up to the last response
+        decoded_prompt = self.tokenizer.decode(prompt_only)
+        self.assertNotIn(last_assistant_response, decoded_prompt, "Prompt should not contain assistant's response")
+
+        # Verify labels are -100 for non-assistant parts
+        prompt_length = len(prompt_only)
+        self.assertTrue(
+            all(label == self.ignore_index for label in labels[:prompt_length]),
+            "Labels should be ignore_index for prompt tokens",
         )
-        self.assertEqual(input_ids.count(self.bos_token_id), 1, "There should be exactly one BOS token in input_ids.")
 
-        # Verify that the assistant's response token is present in input_ids and not in the prompt_only
-        last_assistant_response = self.examples[0][self.messages_key][-1]["content"]
-        last_assistant_response_tokens = self.tokenizer.encode(last_assistant_response, add_special_tokens=False)
-        response_in_input_ids = all(token in input_ids for token in last_assistant_response_tokens)
-        self.assertTrue(response_in_input_ids, "The assistant's response should be present in input_ids.")
+        # Verify labels match assistant response after prompt
+        # Add a filter to remove any trailing tokens after the first <|im_end|>
+        last_assistant_response_with_end = last_assistant_response + self.tokenizer.eos_token
+        last_assistant_response_tokens = self.tokenizer.encode(
+            last_assistant_response_with_end, add_special_tokens=False
+        )
 
-        # Check if the last assistant's response tokens are not in prompt_only
-        response_in_prompt = all(token in prompt_only for token in last_assistant_response_tokens)
-        self.assertFalse(response_in_prompt, "The assistant's response should not be present in prompt_only.")
-
-        # Verify that EOS token is at the end of input_ids
-        self.assertEqual(input_ids[-1], self.eos_token_id, "The last token of input_ids should be EOS token.")
-
-        # Verify that the labels preserved the target string (last_assistant_response)
-        last_assistant_response = self.examples[0][self.messages_key][-1]["content"]
-        last_assistant_response_tokens = self.tokenizer.encode(last_assistant_response, add_special_tokens=False)
-
-        # Find the start and end of the last assistant's response in the labels
-        response_start = next(i for i, label in enumerate(labels) if label != self.ignore_index)
-        response_end = next(i for i in range(len(labels) - 1, -1, -1) if labels[i] != self.ignore_index)
-
-        actual_response = labels[response_start : response_end - 1]
+        response_labels = []
+        for label in labels[prompt_length:]:
+            if label == self.ignore_index:
+                continue
+            response_labels.append(label)
+            if label == self.tokenizer.convert_tokens_to_ids("<|im_end|>"):
+                break
         self.assertEqual(
-            actual_response,
+            response_labels,
             last_assistant_response_tokens,
-            "The labels should preserve the last assistant's response tokens.",
+            "Labels should match assistant response tokens",
         )
 
-        # Verify that EOS token is at the end of labels
-        self.assertEqual(labels[-1], self.eos_token_id, "The last token of labels should be EOS token.")
+        # Verify there isn't an extra generation prompt at the end
+        generation_prompt = "<|im_start|>assistant\n"
+        last_occurrence = decoded_input.rfind(generation_prompt)
+        if last_occurrence != -1:
+            # Check that there isn't another occurrence after the expected one
+            next_occurrence = decoded_input.find(generation_prompt, last_occurrence + len(generation_prompt))
+            self.assertEqual(next_occurrence, -1, "Found an extra generation prompt at the end of the input")
 
 
 class TestBatchGeneration(unittest.TestCase):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -51,7 +51,6 @@ from transformers.utils import (
 from ..import_utils import is_unsloth_available
 from ..trainer.model_config import ModelConfig
 
-
 if is_peft_available():
     from peft import LoraConfig, PeftConfig
 
@@ -274,7 +273,7 @@ class DataCollatorForChatML:
             if "input_ids" not in example:
                 message = example[self.messages_key]
                 formatted_message = self.tokenizer.apply_chat_template(
-                    message, tokenize=False, add_generation_prompt=True
+                    message, tokenize=False, add_generation_prompt=False
                 )
                 tokenized_message = self.tokenizer(
                     formatted_message,

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -51,6 +51,7 @@ from transformers.utils import (
 from ..import_utils import is_unsloth_available
 from ..trainer.model_config import ModelConfig
 
+
 if is_peft_available():
     from peft import LoraConfig, PeftConfig
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2449 

Fix DataCollatorForChatML unexpected generation prompt
DataCollatorForChatML will add generation prompt like `<|start_header_id|>assistant<|end_header_id|>` after model response, which is not suitable for instruction tuning, as is referred in #2449 

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.  https://github.com/huggingface/trl/issues/2449
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).  Will do it afterwards if necessary.
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.