### PR TITLE
Add length-normalized DPO

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -67,6 +67,7 @@ class DPOConfig(TrainingArguments):
                 - `"discopop"`: DiscoPOP (a.k.a Log-Ratio Modulated Loss, LRML) loss from the [DiscoPOP](https://huggingface.co/papers/2406.08414) paper.
                 - `"apo_zero"`: APO-zero loss from the [APO](https://huggingface.co/papers/2408.06266) paper.
                 - `"apo_down"`: APO-down loss from the [APO](https://huggingface.co/papers/2408.06266) paper.
+                - `"dpo_norm"`: length-normalized DPO from [Tulu 3](https://huggingface.co/papers/2411.15124) papers, but first introduced in [SimPO](https://huggingface.co/papers/2405.14734) paper.
         use_weighting (`bool`, *optional*, defaults to `False`):
             Whether or not to weight the loss as done in the [WPO](https://huggingface.co/papers/2406.11827) paper.
         label_pad_token_id (`int`, *optional*, defaults to `-100`):
@@ -165,6 +166,7 @@ class DPOConfig(TrainingArguments):
         "discopop",
         "apo_zero",
         "apo_down",
+        "dpo_norm",
     ] = "sigmoid"
     use_weighting: bool = False
     label_pad_token_id: int = -100


### PR DESCRIPTION
# What does this PR do?

This PR adds the length-normalized DPO used in Tulu-3 and introduced in the SimPO paper under `dpo_norm` loss type. This implementation and naming were inspired by the Open-Instruct implementation [[1]](https://github.com/allenai/open-instruct/blob/26b7325903813dd05ed7f4f04fa49f2794ef3b97/open_instruct/dpo_tune.py#L956) [[2]](https://github.com/allenai/open-instruct/blob/26b7325903813dd05ed7f4f04fa49f2794ef3b97/open_instruct/dpo_utils.py#L167-L168).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.