### PR TITLE
🔖 Issues Auto-Labeller

### DIFF
--- a/.github/workflows/issue_auto_labeller.yml
+++ b/.github/workflows/issue_auto_labeller.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: August-murr/auto-labeler@main
         with:
-            hf-api-key: ${{ secrets.HF_API_KEY }}
+            hf-api-key: ${{ secrets.CI_HF_API_TOKEN }}

--- a/.github/workflows/issue_auto_labeller.yml
+++ b/.github/workflows/issue_auto_labeller.yml
@@ -1,0 +1,13 @@
+name: "OpenAI Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: August-murr/auto-labeler@main
+        with:
+            openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/issue_auto_labeller.yml
+++ b/.github/workflows/issue_auto_labeller.yml
@@ -1,7 +1,7 @@
-name: "OpenAI Issue Labeler"
+name: "Hugging Face Issue Labeler"
 on:
   issues:
-    types: [opened, edited]
+    types: opened
 
 jobs:
   triage:
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: August-murr/auto-labeler@main
         with:
-            openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+            hf-api-key: ${{ secrets.HF_API_KEY }}


### PR DESCRIPTION
I was playing around with OpenAI API and was thinking about useful things we could do with the repos and all the data like issues and feedbacks and trying to automate some tasks or just do something useful with them like analysis or reports and I thought of an auto labeller.

This auto labeller uses OpenAI API, so it needs an `OPENAI_API_KEY` secret. It will cost a few bucks per month, but there are also string-based and regex-based labellers that may be faster.

If you are interested then we could test and see how consistent it is.

couple of ideas for improvement :

we could one-shot or few-shot prompt it for more accuracy or use different kinds of models both of which can cost more.

 as for the speed, it takes about 30 seconds to label an issue.


any other ideas on anything useful we could do with OpenAI API or other stuff to either automate or analyze and get some value?