### PR TITLE
🫣 Ignore CLI test for Python 3.9

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import sys
 import tempfile
 import unittest
 from io import StringIO
@@ -21,6 +22,11 @@ from unittest.mock import patch
 from trl.cli import main
 
 
+@unittest.skipIf(
+    sys.version_info < (3, 10),
+    "Transformers' generation codebase uses a Python >3.10 syntax (`str | None`), which seems to cause the CLI tests "
+    "to fail on Python <3.10.",  # let's say it's a known issue, but not expected to be fixed, because too niche
+)
 class TestCLI(unittest.TestCase):
     def test_dpo(self):
         with tempfile.TemporaryDirectory() as tmp_dir:  # Create a temporary directory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,8 +19,6 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from trl.cli import main
-
 
 @unittest.skipIf(
     sys.version_info < (3, 10),
@@ -29,6 +27,8 @@ from trl.cli import main
 )
 class TestCLI(unittest.TestCase):
     def test_dpo(self):
+        from trl.cli import main
+
         with tempfile.TemporaryDirectory() as tmp_dir:  # Create a temporary directory
             command = f"trl dpo --output_dir {tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_preference --report_to none"
             with patch("sys.argv", command.split(" ")):
@@ -36,18 +36,24 @@ class TestCLI(unittest.TestCase):
 
     @patch("sys.stdout", new_callable=StringIO)
     def test_env(self, mock_stdout):
+        from trl.cli import main
+
         command = "trl env"
         with patch("sys.argv", command.split(" ")):
             main()
         self.assertIn("TRL version: ", mock_stdout.getvalue().strip())
 
     def test_kto(self):
+        from trl.cli import main
+
         with tempfile.TemporaryDirectory() as tmp_dir:  # Create a temporary directory
             command = f"trl kto --output_dir {tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_unpaired_preference --report_to none"
             with patch("sys.argv", command.split(" ")):
                 main()
 
     def test_sft(self):
+        from trl.cli import main
+
         with tempfile.TemporaryDirectory() as tmp_dir:  # Create a temporary directory
             command = f"trl sft --output_dir {tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_language_modeling --report_to none"
             with patch("sys.argv", command.split(" ")):


### PR DESCRIPTION
# What does this PR do?

CI has been recently failing with Python 3.9 due to

```
RuntimeError: Failed to import transformers.generation.streamers because of the following error (look up to see its traceback):
unsupported operand type(s) for |: 'type' and 'NoneType'
```

It's a python>3.10 syntax begin used in transformers. I'm not sure why it causes issue only with the CI but my feeling is that we can safely ignore it as it seems to be a pretty niche limitation (CLI under Python3.9)

If anyone has a fix, I would be happy to merge it though.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.