### PR TITLE
Fix (grpo_trainer) fix state_dict for zero3

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -330,7 +330,8 @@ class GRPOTrainer(Trainer):
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
                 if self.accelerator.is_main_process:
-                    self.vllm_client.load_weights(self.accelerator.unwrap_model(model).state_dict())
+                    state_dict = self.accelerator.get_state_dict(model)
+                    self.vllm_client.load_weights(state_dict)
                 self._last_loaded_step = self.state.global_step
                 self.accelerator.wait_for_everyone() # Wait for main process to finish loading weights
 


### PR DESCRIPTION
Since 

> https://github.com/huggingface/trl/blob/31f549b5af3ceef0b02c7411daba5c64ee9df3b3/trl/trainer/grpo_trainer.py#L333 we have the following line:

```python
self.accelerator.unwrap_model(model).state_dict()
```

> This approach doesn't work with DeepSpeed Zero3 and is very slow in that configuration. However, for projects like `open-r1` that require long chains of thought (CoT) with completion lengths exceeding 12K tokens, Zero3 is essential.

I just little changed unwarp_model to `self.accelerator.get_state_dict(model)`
