### PR TITLE
concatenate_inputs in dpo_trainer improved!

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -913,6 +913,95 @@ class DPOTrainer(Trainer):
         )
 
         return output
+    
+    @staticmethod
+    def concatenated_inputs(
+        batch: dict[str, Union[list, torch.LongTensor]], 
+        padding_value: int, 
+        is_encoder_decoder: bool = False, 
+        label_pad_token_id: int = -100, 
+        device: Optional[torch.device] = None
+    ) -> dict[str, torch.LongTensor]:
+        """
+        Concatenate the `chosen` and `rejected` inputs from the batch into a single tensor for both the prompt
+        and completion sequences.
+
+        Args:
+            batch (`dict[str, Union[list, torch.LongTensor]]`):
+                A batch of input data. The batch must contain the following keys:
+
+                - `"prompt_input_ids"`: Tensor of shape `(batch_size, prompt_length)` representing the prompt input IDs.
+                - `"chosen_input_ids"`: Tensor of shape `(batch_size, chosen_length)` representing the chosen completion input IDs.
+                - `"rejected_input_ids"`: Tensor of shape `(batch_size, rejected_length)` representing the rejected completion input IDs.
+                - `"prompt_pixel_values"` (optional): Tensor for pixel values, if available.
+                - `"prompt_pixel_attention_mask"` (optional): Tensor for pixel attention masks, if available.
+
+            padding_value (`int`):
+                The padding value to use for the concatenated completion sequences (`chosen_input_ids` and
+                `rejected_input_ids`).
+
+            is_encoder_decoder (`bool`, optional): Whether the model is an encoder-decoder model.
+            label_pad_token_id (`int`, optional): The label pad token id.
+            device (`Optional[torch.device]`, optional): The device for the concatenated inputs.
+
+        Returns:
+            `dict[str, torch.LongTensor]`: A dictionary containing:
+
+                - `"prompt_input_ids"`: Concatenated prompt input IDs of shape `(2 * batch_size, prompt_length)`.
+                - `"completion_input_ids"`: Concatenated chosen and rejected completion input IDs of shape `(2 * batch_size, max_completion_length)`.
+                - `"prompt_attention_mask"`: Concatenated prompt attention masks of shape `(2 * batch_size, prompt_length)`.
+                - `"completion_attention_mask"`: Concatenated chosen and rejected attention masks of shape `(2 * batch_size, max_completion_length)`.
+                - `"pixel_values"` (optional): Concatenated pixel values if `"prompt_pixel_values"` are present.
+                - `"pixel_attention_mask"` (optional): Concatenated pixel attention masks if `"prompt_pixel_attention_mask"` are present.
+        """
+        output = {}
+
+        # Handle prompt keys
+        for k in batch:
+            if k.startswith("prompt"):
+                concatenated_key = k.replace("prompt", "concatenated")
+                output[concatenated_key] = torch.cat([batch[k], batch[k]], dim=0)
+
+        max_length = max(batch["chosen_input_ids"].shape[1], batch["rejected_input_ids"].shape[1])
+
+        # Handle chosen and rejected keys
+        for k in batch:
+            if k.startswith("chosen") and isinstance(batch[k], torch.Tensor):
+                if "labels" in k or is_encoder_decoder:
+                    pad_value = label_pad_token_id
+                elif k.endswith("_input_ids"):
+                    pad_value = padding_value
+                elif k.endswith("_attention_mask"):
+                    pad_value = 0
+                concatenated_key = k.replace("chosen", "concatenated")
+                output[concatenated_key] = pad_to_length(batch[k], max_length, pad_value=pad_value)
+            elif k.startswith("rejected") and isinstance(batch[k], torch.Tensor):
+                if "labels" in k or is_encoder_decoder:
+                    pad_value = label_pad_token_id
+                elif k.endswith("_input_ids"):
+                    pad_value = padding_value
+                elif k.endswith("_attention_mask"):
+                    pad_value = 0
+                concatenated_key = k.replace("rejected", "concatenated")
+                output[concatenated_key] = torch.cat(
+                    (
+                        output[concatenated_key],
+                        pad_to_length(batch[k], max_length, pad_value=pad_value),
+                    ),
+                    dim=0,
+                ).to(device=device)
+
+        # Handle pixel keys
+        for k in batch:
+            if k.startswith("pixel"):
+                concatenated_key = k.replace("prompt", "concatenated")
+                output[concatenated_key] = torch.cat([batch[k], batch[k]], dim=0)
+
+        if is_encoder_decoder:
+            output["concatenated_input_ids"] = batch["prompt_input_ids"].repeat(2, 1).to(device=device)
+            output["concatenated_attention_mask"] = batch["prompt_attention_mask"].repeat(2, 1).to(device=device)
+
+        return output
 
     def dpo_loss(
         self,

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -845,7 +845,8 @@ class DPOTrainer(Trainer):
 
     @staticmethod
     def concatenated_inputs(
-        batch: dict[str, Union[list, torch.LongTensor]], padding_value: int
+        batch: dict[str, Union[list, torch.LongTensor]], padding_value: int,
+        is_encoder_decoder: bool = False, label_pad_token_id: int = -100,
     ) -> dict[str, torch.LongTensor]:
         """
         Concatenate the `chosen` and `rejected` inputs from the batch into a single tensor for both the prompt

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1128,7 +1128,12 @@ class DPOTrainer(Trainer):
         """
         num_examples = batch["prompt_input_ids"].shape[0]
 
-        concatenated_batch = self.concatenated_inputs(batch, padding_value=self.padding_value)
+        concatenated_batch = self.concatenated_inputs(
+            batch,
+            is_encoder_decoder=self.is_encoder_decoder,
+            label_pad_token_id=self.label_pad_token_id,
+            padding_value=self.padding_value,
+        )
 
         model_kwargs = {}
         if self.aux_loss_enabled:

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -887,9 +887,10 @@ class DPOTrainer(Trainer):
         """
         output = {}
 
-        #NOTES
+        #Notes Above
         max_length = max(batch["chosen_input_ids"].shape[1], batch["rejected_input_ids"].shape[1])
 
+        # Handle Chosen and Rejected responses
         for k in batch:
             #concat the chosen response; make sure to NOT overwrite the chosen
             if k.startswith("chosen") and isinstance(batch[k], torch.Tensor):
@@ -929,7 +930,7 @@ class DPOTrainer(Trainer):
 
         # To make sure prompt, the input_ids are the same for both the chosen and rejected responses
         if is_encoder_decoder:
-            output["concatenated_input_ids"] = batch["prompt_input_ids"].repeat(2, 1)
+            output["concatenated_input_ids"] = batch["prompt_input_ids"].repeat(2, 1) #repeat the prompt input_ids
             output["concatenated_attention_mask"] = batch["prompt_attention_mask"].repeat(2, 1)
 
         return output


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR is focused on improving the concatanate_inputs method in trl [dpo_trainer](https://github.com/huggingface/trl/blob/main/trl/trainer/dpo_trainer.py) in a sense that it provides more clarity and simplicity for the purpose of concatenating the prompt+completion (chosen/rejected) which further will be used in forwarding the model. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?
@qgallouedec
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.