### PR TITLE
📦 `trl.templates` in excluded packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
     package_data={
         "trl": ["templates/*.md"],
     },
-    packages=find_packages(exclude={"tests", "tests.slow"}),
+    packages=find_packages(exclude={"tests", "tests.slow", "trl.templates"}),
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS,
     python_requires=">=3.9",


### PR DESCRIPTION
When building the package:

```bash
$ python -m build
...
/tmp/build-env-kw_0huok/lib/python3.11/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'trl.templates' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'trl.templates' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'trl.templates' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'trl.templates' to be distributed and are
        already explicitly excluding 'trl.templates' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
creating build/lib/trl/templates
copying trl/templates/lm_model_card.md -> build/lib/trl/templates
```
