### PR TITLE
⚠️ Fix Attention Masking in GRPO

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -428,8 +428,12 @@ class GRPOTrainer(Trainer):
 
         # Get the per-token log probabilities for the completions for the model and the reference model
         def get_per_token_logps(model, input_ids, num_logits_to_keep):
-            # We add 1 to `num_logits_to_keep` because the last logits of the sequence is later excluded
-            logits = model(input_ids, num_logits_to_keep=num_logits_to_keep + 1).logits  # (B, L, V)
+            attention_mask = input_ids != self.processing_class.pad_token_id
+            logits = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                num_logits_to_keep=num_logits_to_keep + 1
+            ).logits  # (B, L, V)
             logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 
             # Compute the log probabilities for the input tokens. Use a loop to reduce memory peak.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -428,11 +428,10 @@ class GRPOTrainer(Trainer):
 
         # Get the per-token log probabilities for the completions for the model and the reference model
         def get_per_token_logps(model, input_ids, num_logits_to_keep):
-            attention_mask = input_ids != self.processing_class.pad_token_id
+            # We add 1 to `num_logits_to_keep` because the last logits of the sequence is later excluded
+            attention_mask = (input_ids != self.processing_class.pad_token_id).long()
             logits = model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                num_logits_to_keep=num_logits_to_keep + 1
+                input_ids=input_ids, attention_mask=attention_mask, num_logits_to_keep=num_logits_to_keep + 1
             ).logits  # (B, L, V)
             logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -438,7 +438,7 @@ class GRPOTrainer(Trainer):
         completion_sequence_indices = torch.arange(completion_is_eos.size(1), device=device).expand(
             completion_is_eos.size(0), -1
         )
-        completion_mask = (completion_sequence_indices <= completion_is_eos.unsqueeze(1)).long()  # (B*G, C)
+        completion_mask = (completion_sequence_indices <= completion_eos_idx.unsqueeze(1)).long()  # (B*G, C)
 
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_mask_repeated = prompt_inputs["attention_mask"].repeat_interleave(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -441,10 +441,10 @@ class GRPOTrainer(Trainer):
         completion_mask = (completion_sequence_indices <= completion_is_eos.unsqueeze(1)).long()  # (B*G, C)
 
         # Concatenate prompt_mask with completion_mask for logit computation
-        prompt_mask_extended = prompt_inputs["attention_mask"].repeat_interleave(
+        prompt_mask_repeated = prompt_inputs["attention_mask"].repeat_interleave(
             self.num_generations, dim=0
         )  # (B, P) -> (B*G, P)
-        attention_mask = torch.cat([prompt_mask_extended, completion_mask], dim=1)  # (B*G, P+C)
+        attention_mask = torch.cat([prompt_mask_repeated, completion_mask], dim=1)  # (B*G, P+C)
 
         # Get the per-token log probabilities for the completions for the model and the reference model
         def get_per_token_logps(model, input_ids, num_logits_to_keep):


### PR DESCRIPTION
# What does this PR do?

Fix a small yet dangerous issue -- not adding `attention_mask` when computing logits.

Will add more notes.

## Details
```python
from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig

model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-Coder-0.5B", device_map="auto")
tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-Coder-0.5B")

prompts = [
    "hello, 1 + 1 = ?",
    "hello, 12781297598217521580 + 120481209481290482 = ?",
]

prompt_inputs = tokenizer(
    prompts, return_tensors="pt", padding=True, padding_side="left", add_special_tokens=False
).to(model.device)

generation_config = GenerationConfig(
    max_new_tokens=100,
    do_sample=True,
    temperature=0.2,
    num_return_sequences=4,
    pad_token_id=tokenizer.pad_token_id,
)

prompt_completion_ids = model.generate(
    **prompt_inputs, generation_config=generation_config
)

prompt_length = prompt_inputs["input_ids"].size(1) #45
completion_ids = prompt_completion_ids[:, prompt_length:]
num_logits_to_keep = completion_ids.size(1) #100
```

```python
> input_ids

{'input_ids': tensor([[151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643,
         151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643,
         151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643,
         151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643,
          14990,     11,    220,     16,    488,    220,     16,    284,    937],
        [ 14990,     11,    220,     16,     17,     22,     23,     16,     17,
             24,     22,     20,     24,     23,     17,     16,     22,     20,
             17,     16,     20,     23,     15,    488,    220,     16,     17,
             15,     19,     23,     16,     17,     15,     24,     19,     23,
             16,     17,     24,     15,     19,     23,     17,    284,    937]],
       device='mps:0'), 'attention_mask': tensor([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]],
       device='mps:0')}
```

Note how there are a lot of padding tokens in the first element.

Now if we run
```python
input_ids = prompt_completion_ids

# Old Implementation's last prompt logit (for predicting first completion)
old_logps = model(prompt_completion_ids, num_logits_to_keep=num_logits_to_keep+1).logits[:, 0, :].log_softmax(dim=-1)

# This PR
attention_mask = (input_ids != tokenizer.pad_token_id).long()
new_logps = model(input_ids=input_ids, attention_mask=attention_mask, num_logits_to_keep=num_logits_to_keep+1).logits[:, 0, :].log_softmax(dim=-1)

# Ground Truth
correct_logps = model(**prompt_inputs).logits[:, -1, :].repeat_interleave(4, dim=0).log_softmax(dim=-1)
```

And we compare with
```python
# Check that the logits are the same
print(torch.allclose(old_logps, new_logps, atol=1e-5))
print(torch.allclose(old_logps, correct_logps, atol=1e-5))
print(torch.allclose(new_logps, correct_logps, atol=1e-5))
```

We'll get console output of
```
> False
> False
> True
```

Compute row-wise, we get
```python
for i in range(old_logps.size(0)):
    diff = torch.mean(torch.abs(old_logps[i] - correct_logps[i]))
    print(diff)

# tensor(1.5913, device='mps:0', grad_fn=<MeanBackward0>)
# tensor(1.5913, device='mps:0', grad_fn=<MeanBackward0>)
# tensor(1.5913, device='mps:0', grad_fn=<MeanBackward0>)
# tensor(1.5913, device='mps:0', grad_fn=<MeanBackward0>)
# tensor(0., device='mps:0', grad_fn=<MeanBackward0>)
# tensor(0., device='mps:0', grad_fn=<MeanBackward0>)
# tensor(0., device='mps:0', grad_fn=<MeanBackward0>)
# tensor(0., device='mps:0', grad_fn=<MeanBackward0>)
```