### PR TITLE
fix: Fix typo in filename in ultrafeedback-prompt.py

### DIFF
--- a/examples/datasets/ultrafeedback-prompt.py
+++ b/examples/datasets/ultrafeedback-prompt.py
@@ -81,7 +81,7 @@ Column:
 
 ## Generation script
 
-The script used to generate this dataset can be found [here](https://github.com/huggingface/trl/blob/main/examples/datasets/ultafeedback-prompt.py).
+The script used to generate this dataset can be found [here](https://github.com/huggingface/trl/blob/main/examples/datasets/ultrafeedback-prompt.py).
 """)
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

A typo in the filename where "ultra" was misspelled as "ulta" (missing the letter "**r**").
Fixed ultafeedback-prompt.py → **ultrafeedback-prompt.py**


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone