### PR TITLE
Update ppo_trainer.md documentation

### DIFF
--- a/docs/source/ppo_trainer.md
+++ b/docs/source/ppo_trainer.md
@@ -26,6 +26,8 @@ python examples/scripts/ppo/ppo.py \
     --gradient_accumulation_steps 1 \
     --total_episodes 10000 \
     --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --sft_model_path EleutherAI/pythia-1b-deduped \
+    --reward_model_path EleutherAI/pythia-1b-deduped \
     --missing_eos_penalty 1.0
 ```
 


### PR DESCRIPTION
# What does this PR do?
An error in the documentation for running PPO has been fixed. Many beginners could change the model in the original command and get an error because sft-model and reward-model were EleutherAI/pythia-1b-deduped by default.

<!-- Remove if not applicable -->

Fixes # (issue)
#2641

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.