### PR TITLE
↔️  GRPO: Set max_model_len when initializing vLLM instance

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -131,29 +131,25 @@ class GRPOConfig(TrainingArguments):
             "(`pip install vllm`)."
         },
     )
+    vllm_init_kwargs: Optional[dict] = field(
+        default_factory=lambda: {
+            "device": "auto",
+            "gpu_memory_utilization": 0.9,
+        },
+        metadata={
+            "help": "Keyword arguments for `vllm.LLM.__init__` when `use_vllm` is true"
+        },
+    ) 
     vllm_device: Optional[str] = field(
         default="auto",
         metadata={
-            "help": "Device where vLLM generation will run, e.g. 'cuda:1'. If set to 'auto' (default), the system "
-            "will automatically select the next available GPU after the last one used for training. This assumes "
-            "that training has not already occupied all available GPUs."
+            "help": "Deprecated. Set `device` in `vllm_init_kwargs` instead."
         },
     )
     vllm_gpu_memory_utilization: float = field(
         default=0.9,
         metadata={
-            "help": "Ratio (between 0 and 1) of GPU memory to reserve for the model weights, activations, and KV "
-            "cache on the device dedicated to generation powered by vLLM. Higher values will increase the KV cache "
-            "size and thus improve the model's throughput. However, if the value is too high, it may cause "
-            "out-of-memory (OOM) errors during initialization."
-        },
-    )
-    vllm_max_model_len: Optional[int] = field(
-        default=None,
-        metadata={
-            "help": "If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced"
-            "`vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model"
-            "context size, which might be much larger than the KV cache, leading to inefficiencies."
+            "help": "Deprecated. Set `gpu_memory_utilization` in `vllm_init_kwargs` instead." 
         },
     )
 
@@ -186,3 +182,20 @@ class GRPOConfig(TrainingArguments):
         default=0.04,
         metadata={"help": "KL coefficient."},
     )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.vllm_device:
+            warnings.warn(
+                "`vllm_device` is deprecated. Set `device` in `vllm_init_kwargs` instead.",
+                DeprecationWarning,
+            )
+            self.vllm_init_kwargs["device"] = self.vllm_device
+
+        if self.vllm_gpu_memory_utilization:
+            warnings.warn(
+                "`vllm_gpu_memory_utilization` is deprecated. Set `gpu_memory_utilization` in `vllm_init_kwargs` instead.",
+                DeprecationWarning,
+            )
+            self.vllm_init_kwargs["gpu_memory_utilization"] = self.vllm_gpu_memory_utilization

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -183,13 +183,13 @@ class GRPOConfig(TrainingArguments):
         metadata={
             "help": "Data type to use for vLLM generation. If set to 'auto', the data type will be automatically "
             "determined based on the model configuration. Find the supported values in the vLLM documentation."
-        }
+        },
     )
     vllm_max_model_len: Optional[int] = field(
         default=None,
         metadata={
-            "help": "If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced"
-            "`vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model"
+            "help": "If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced "
+            "`vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model "
             "context size, which might be much larger than the KV cache, leading to inefficiencies."
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -56,19 +56,8 @@ class GRPOConfig(TrainingArguments):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept unused for
             training, as vLLM will require one for generation. vLLM must be installed (`pip install vllm`).
-        vllm_device (`str`, *optional*, defaults to `"auto"`):
-            Device where vLLM generation will run, e.g. `"cuda:1"`. If set to `"auto"` (default), the system will
-            automatically select the next available GPU after the last one used for training. This assumes that
-            training has not already occupied all available GPUs.
-        vllm_gpu_memory_utilization (`float`, *optional*, defaults to `0.9`):
-            Ratio (between 0 and 1) of GPU memory to reserve for the model weights, activations, and KV cache on the
-            device dedicated to generation powered by vLLM. Higher values will increase the KV cache size and thus
-            improve the model's throughput. However, if the value is too high, it may cause out-of-memory (OOM) errors
-            during initialization.
-        vllm_max_model_len (`int` or `None`, *optional*, defaults to `None`):
-            If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced
-            `vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model
-            context size, which might be much larger than the KV cache, leading to inefficiencies.
+        vllm_init_kwargs (`dict`, *optional*, defaults to {"device": "auto", "gpu_memory_utilization": 0.9})
+            "Keyword arguments for `vllm.LLM.__init__` when `use_vllm` is true"
 
         > Parameters that control the training
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -131,13 +131,13 @@ class GRPOConfig(TrainingArguments):
         },
     ) 
     vllm_device: Optional[str] = field(
-        default="auto",
+        default=None,
         metadata={
             "help": "Deprecated. Set `device` in `vllm_init_kwargs` instead."
         },
     )
-    vllm_gpu_memory_utilization: float = field(
-        default=0.9,
+    vllm_gpu_memory_utilization: Optional[float] = field(
+        default=None,
         metadata={
             "help": "Deprecated. Set `gpu_memory_utilization` in `vllm_init_kwargs` instead." 
         },

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -57,7 +57,8 @@ class GRPOConfig(TrainingArguments):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept unused for
             training, as vLLM will require one for generation. vLLM must be installed (`pip install vllm`).
-        vllm_init_kwargs (`dict`, *optional*, defaults to {"device": "auto", "gpu_memory_utilization": 0.9})
+        vllm_init_kwargs (`dict`, *optional*, defaults to
+            {"device": "auto", "gpu_memory_utilization": 0.9, "enable_prefix_caching": True})
             "Keyword arguments for `vllm.LLM.__init__` when `use_vllm` is true"
 
         > Parameters that control the training

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -57,13 +57,22 @@ class GRPOConfig(TrainingArguments):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept unused for
             training, as vLLM will require one for generation. vLLM must be installed (`pip install vllm`).
-        vllm_init_kwargs (`dict`, *optional*, defaults to {
-                "device": "auto",
-                "gpu_memory_utilization": 0.9,
-                "enable_prefix_caching": True,
-                "dtype": "auto"
-            })
-            "Keyword arguments for `vllm.LLM.__init__` when `use_vllm` is true"
+        vllm_device (`str`, *optional*, defaults to `"auto"`):
+            Device where vLLM generation will run, e.g. `"cuda:1"`. If set to `"auto"` (default), the system will
+            automatically select the next available GPU after the last one used for training. This assumes that
+            training has not already occupied all available GPUs.
+        vllm_gpu_memory_utilization (`float`, *optional*, defaults to `0.9`):
+            Ratio (between 0 and 1) of GPU memory to reserve for the model weights, activations, and KV cache on the
+            device dedicated to generation powered by vLLM. Higher values will increase the KV cache size and thus
+            improve the model's throughput. However, if the value is too high, it may cause out-of-memory (OOM) errors
+            during initialization.
+        vllm_dtype (`str`, *optional*, defaults to `"auto"`):
+            Data type to use for vLLM generation. If set to `"auto"`, the data type will be automatically determined
+            based on the model configuration. Find the supported values in the vLLM documentation.
+        vllm_max_model_len (`int` or `None`, *optional*, defaults to `None`):
+            If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced
+            `vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model
+            context size, which might be much larger than the KV cache, leading to inefficiencies.
 
         > Parameters that control the training
 
@@ -126,30 +135,36 @@ class GRPOConfig(TrainingArguments):
             "(`pip install vllm`)."
         },
     )
-    vllm_init_kwargs: Optional[dict] = field(
-        default_factory=lambda: {
-            "device": "auto",
-            "gpu_memory_utilization": 0.9,
-            # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
-            # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
-            # This is particularly useful here because we generate completions from the same prompts.
-            "enable_prefix_caching": True,
-            "dtype": "auto"
-        },
-        metadata={
-            "help": "Keyword arguments for `vllm.LLM.__init__` when `use_vllm` is true"
-        },
-    ) 
     vllm_device: Optional[str] = field(
-        default=None,
+        default="auto",
         metadata={
-            "help": "Deprecated. Set `device` in `vllm_init_kwargs` instead."
+            "help": "Device where vLLM generation will run, e.g. 'cuda:1'. If set to 'auto' (default), the system "
+            "will automatically select the next available GPU after the last one used for training. This assumes "
+            "that training has not already occupied all available GPUs."
         },
     )
-    vllm_gpu_memory_utilization: Optional[float] = field(
+    vllm_gpu_memory_utilization: float = field(
+        default=0.9,
+        metadata={
+            "help": "Ratio (between 0 and 1) of GPU memory to reserve for the model weights, activations, and KV "
+            "cache on the device dedicated to generation powered by vLLM. Higher values will increase the KV cache "
+            "size and thus improve the model's throughput. However, if the value is too high, it may cause "
+            "out-of-memory (OOM) errors during initialization."
+        },
+    )
+    vllm_dtype: Optional[str] = field(
+        default="auto",
+        metadata={
+            "help": "Data type to use for vLLM generation. If set to 'auto', the data type will be automatically "
+            "determined based on the model configuration. Find the supported values in the vLLM documentation."
+        }
+    )
+    vllm_max_model_len: Optional[int] = field(
         default=None,
         metadata={
-            "help": "Deprecated. Set `gpu_memory_utilization` in `vllm_init_kwargs` instead." 
+            "help": "If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced"
+            "`vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model"
+            "context size, which might be much larger than the KV cache, leading to inefficiencies."
         },
     )
 
@@ -182,20 +197,3 @@ class GRPOConfig(TrainingArguments):
         default=0.04,
         metadata={"help": "KL coefficient."},
     )
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        if self.vllm_device:
-            warnings.warn(
-                "`vllm_device` is deprecated. Set `device` in `vllm_init_kwargs` instead.",
-                DeprecationWarning,
-            )
-            self.vllm_init_kwargs["device"] = self.vllm_device
-
-        if self.vllm_gpu_memory_utilization:
-            warnings.warn(
-                "`vllm_gpu_memory_utilization` is deprecated. Set `gpu_memory_utilization` in `vllm_init_kwargs` instead.",
-                DeprecationWarning,
-            )
-            self.vllm_init_kwargs["gpu_memory_utilization"] = self.vllm_gpu_memory_utilization

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -65,6 +65,10 @@ class GRPOConfig(TrainingArguments):
             device dedicated to generation powered by vLLM. Higher values will increase the KV cache size and thus
             improve the model's throughput. However, if the value is too high, it may cause out-of-memory (OOM) errors
             during initialization.
+        vllm_max_model_len (`int` or `None`, *optional*, defaults to `None`):
+            If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced
+            `vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model
+            context size, which might be much larger than the KV cache, leading to inefficiencies.
 
         > Parameters that control the training
 
@@ -142,6 +146,14 @@ class GRPOConfig(TrainingArguments):
             "cache on the device dedicated to generation powered by vLLM. Higher values will increase the KV cache "
             "size and thus improve the model's throughput. However, if the value is too high, it may cause "
             "out-of-memory (OOM) errors during initialization."
+        },
+    )
+    vllm_max_model_len: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "If set, the `max_model_len` to use for vLLM. This could be useful when running with reduced"
+            "`vllm_gpu_memory_utilization`, leading to a reduced KV cache size. If not set, vLLM will use the model"
+            "context size, which might be much larger than the KV cache, leading to inefficiencies."
         },
     )
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -291,7 +291,6 @@ class GRPOTrainer(Trainer):
                 vllm_device = self.args.vllm_device
                 if vllm_device == "auto":
                     vllm_device = f"cuda:{self.accelerator.num_processes}"  # take the next GPU idx
-                    vllm_init_kwargs["device"] = vllm_device
                 # Check that the requested device is available
                 if vllm_device.split(":")[0] == "cuda" and int(vllm_device.split(":")[1]) >= torch.cuda.device_count():
                     raise ValueError(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -314,7 +314,7 @@ class GRPOTrainer(Trainer):
                         model=model.name_or_path,
                         device=vllm_device,
                         gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
-                        max_model_len=(self.max_prompt_length + self.max_completion_length),
+                        max_model_len=self.args.vllm_max_model_len,
                     )
                 self.sampling_params = SamplingParams(
                     n=self.num_generations,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -314,6 +314,7 @@ class GRPOTrainer(Trainer):
                         model=model.name_or_path,
                         device=vllm_device,
                         gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
+                        max_model_len=(self.max_prompt_length + self.max_completion_length),
                     )
                 self.sampling_params = SamplingParams(
                     n=self.num_generations,


### PR DESCRIPTION
# What does this PR do?

By default, the vLLM model will be set up to support the max context of the input model.

However, during training we know we will only observe at most max_prompt_length + max_completion_length tokens, so we can use that to have a reduced memory footprint.

This is especially relevant when running on limited hardware as the improvement in memory can be significant.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.