### PR TITLE
Raise UserWarning in RewardTraining if PEFT target_modules="all-linear"

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -202,8 +202,7 @@ class RewardTrainerTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dummy_dataset = load_dataset("trl-internal-testing/zen", "conversational_preference", split="train")
             training_args = RewardConfig(output_dir=tmp_dir, max_steps=3, report_to="none")
-
-            with self.assertWarns(UserWarning):
+            with self.assertWarns(UserWarning, msg="You passed target_modules="):
                 _ = RewardTrainer(
                     model=self.model,
                     args=training_args,

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -168,9 +168,9 @@ class RewardTrainer(Trainer):
                 )
                 if target_modules == INCLUDE_LINEAR_LAYERS_SHORTHAND:
                     warnings.warn(
-                        f"You passed target_modules='{INCLUDE_LINEAR_LAYERS_SHORTHAND}' in the peft_config."
-                        " This will result in all linear layers except the output layer being adapted. "
-                        " This will negatively impact the performance of the reward model as the newly initialized output layer will not be adapted or trained.",
+                        f"You passed target_modules='{INCLUDE_LINEAR_LAYERS_SHORTHAND}' in the peft_config. "
+                        "This will result in all linear layers except the output layer being adapted. "
+                        "This could negatively impact the performance of the reward model as the output layer (used for scoring of chosen and rejected completions) will not be adapted or trained.",
                         UserWarning,
                     )
                 model = get_peft_model(model, peft_config)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

I ran into a nasty edge case that I don't think is documented anywhere when using the `RewardTrainer` to train a reward model. If a `peft_config` is provided and `target_modules="all-linear"` ([a wild card that means: adapt all linear layers _except_ for the output](https://huggingface.co/docs/peft/main/en/package_reference/lora#peft.LoraConfig.target_modules)) then the output layer of the reward model, which is often newly initialized and is used to score the chosen/rejected completions, will go un-adapted (and therefore un-trained). Performance will be impacted as you might expect, e.g. here's two runs of mine with `target_modules="all-linear"` and `target_modules=None` (the default):

This PR simply raises a `UserWarning` in `RewardModel` in this case. You could almost argue that raising an error would be warranted, but I wonder if there is some scenario in which the output layer is already trained, and a user wants to just adapt some intermediate layers with LoRA.

## Before submitting


- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.