### PR TITLE
📌  vLLM >= 0.7.1 for device fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ EXTRAS = {
     "quantization": ["bitsandbytes"],
     "scikit": ["scikit-learn"],
     "test": ["parameterized", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "pytest"],
-    "vllm": ["vllm; sys_platform != 'win32'"],  # vllm is not available on Windows
+    "vllm": ["vllm>=0.7.1; sys_platform != 'win32'"],  # vllm is not available on Windows
     "vlm": ["Pillow"],
 }
 EXTRAS["dev"] = []


### PR DESCRIPTION
# What does this PR do?

Fixes #2745 by ensuring minimum vllm version.