### PR TITLE
💡  GRPO vram-efficiency improvement; only compute relevant logprobs

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -389,7 +389,7 @@ class GRPOTrainer(Trainer):
         # Compute the log probabilities for the input tokens.
         token_logits = logits.gather(dim=-1, index=input_ids.unsqueeze(-1)).squeeze(-1)
         # use a loop to reduce memory peak
-        logsumexp_values = torch.stack([torch.logsumexp(l, dim=-1) for l in logits])
+        logsumexp_values = torch.stack([torch.logsumexp(lg, dim=-1) for lg in logits])
         token_log_probs = token_logits - logsumexp_values  # log_softmax = logits - log(sum(exp(logits)))
         return token_log_probs
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -379,15 +379,17 @@ class GRPOTrainer(Trainer):
         logits = model(
             input_ids=input_ids, attention_mask=attention_mask, logits_to_keep=logits_to_keep + 1
         ).logits  # (B, L, V)
-        logits = logits[  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
-            :, -(logits_to_keep + 1) : -1, :
-        ]
-        shifted_input_ids = input_ids[:, -logits_to_keep:]
-        # log_softmax for only the relevant token_ids; requires O(B*L-1) additional memory instead of O(B*L-1*V)
-        token_logits = logits.gather(dim=-1, index=shifted_input_ids.unsqueeze(-1)).squeeze(-1)
-        lse = torch.logsumexp(logits, dim=-1)  # (B, L-1), compute log_softmax denominator
-        per_token_logps = token_logits - lse  # (B, L-1)
-        return per_token_logps
+
+        logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
+
+        # Compute the log probabilities for the input tokens. Use a loop to reduce memory peak.
+        per_token_logps = []
+        for logits_row, input_ids_row in zip(logits[:, -logits_to_keep:], input_ids[:, -logits_to_keep:]):
+            token_logits = logits_row.gather(dim=-1, index=input_ids_row.unsqueeze(-1)).squeeze(-1)
+            lse = torch.logsumexp(logits_row, dim=-1)  # compute log_softmax denominator
+            token_log_prob = token_logits - lse  # log_softmax = logits - log(sum(exp(logits)))
+            per_token_logps.append(token_log_prob)
+        return torch.stack(per_token_logps)
 
     def _prepare_inputs(self, inputs: dict[str, Union[torch.Tensor, Any]]) -> dict[str, Union[torch.Tensor, Any]]:
         device = self.accelerator.device

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -384,7 +384,7 @@ class GRPOTrainer(Trainer):
         # Compute the log probabilities for the input tokens.
         # Use a loop to reduce memory peak; only compute logprobs for the input tokens to reduce memory peak
         per_token_logps = []
-        for logits_row, input_ids_row in zip(logits, input_ids[:, -logits_to_keep:]):
+        for logits_row, input_ids_row in zip(logits[:, -logits_to_keep:], input_ids[:, -logits_to_keep:]):
             token_logits = logits_row.gather(dim=-1, index=input_ids_row.unsqueeze(-1)).squeeze(-1)
             # log_softmax = logits - log(sum(exp(logits)))
             token_log_prob = token_logits - torch.logsumexp(logits_row, dim=-1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -379,7 +379,9 @@ class GRPOTrainer(Trainer):
         logits = model(
             input_ids=input_ids, attention_mask=attention_mask, logits_to_keep=logits_to_keep + 1
         ).logits  # (B, L, V)
-        logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
+        logits = logits[  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
+            :, -(logits_to_keep + 1) : -1, :
+        ]
         shifted_input_ids = input_ids[:, -logits_to_keep:]
         # log_softmax for only the relevant token_ids; requires O(B*L-1) additional memory instead of O(B*L-1*V)
         token_logits = logits.gather(dim=-1, index=shifted_input_ids.unsqueeze(-1)).squeeze(-1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -382,9 +382,9 @@ class GRPOTrainer(Trainer):
         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 
         input_ids = input_ids[:, -logits_to_keep:]
-        logits = logits[  # ensure logits are correct size across transformers versions; https://github.com/huggingface/trl/issues/2770
-            :, -logits_to_keep:
-        ]
+        # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves. 
+        # See https://github.com/huggingface/trl/issues/2770
+        logits = logits[:, -logits_to_keep:]
 
         # Compute the log probabilities for the input tokens.
         token_logits = logits.gather(dim=-1, index=input_ids.unsqueeze(-1)).squeeze(-1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -383,7 +383,7 @@ class GRPOTrainer(Trainer):
         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 
         input_ids = input_ids[:, -logits_to_keep:]
-        # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves. 
+        # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
         # See https://github.com/huggingface/trl/issues/2770
         logits = logits[:, -logits_to_keep:]
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -382,7 +382,7 @@ class GRPOTrainer(Trainer):
         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
 
         # Compute the log probabilities for the input tokens.
-        # Use a loop to reduce memory peak; only compute logprobs for the input tokens to reduce memory peak;
+        # Use a loop to reduce memory peak; only compute logprobs for the input tokens to reduce memory peak
         per_token_logps = []
         for logits_row, input_ids_row in zip(logits, input_ids[:, -logits_to_keep:]):
             token_logits = logits_row.gather(dim=-1, index=input_ids_row.unsqueeze(-1)).squeeze(-1)


### PR DESCRIPTION
# What does this PR do?
`GRPOTrainer` uses a method `_get_per_token_logps` to compute the per-token logprobs for every token in the input sequence. However, it uses `seq_len * vocab_size` additional memory in order to compute log_softmax, generating full log-probabilities for every possible token in the vocabulary at every index in the sequence. The next step then selects only the the actual input tokens to get the per-token logprobs for the input sequence.

This can be made more efficient by performing the selection first to get per-token logits, computing the softmax denominator (a reduction over the full set of logits), and then directly computing the logits only for the relevant tokens. This requires only `seq_len` additional memory.

Fixes # (issue)
NA but I'm happy to file an issue if needed

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.