### PR TITLE
📉 Optimize GRPO memory usage by redefining `per_device_batch_size` as generations per device

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -24,8 +24,6 @@ This example demonstrates how to train a model using the GRPO method. We train a
 ></iframe>
 
 Below is the script to train the model.
-Note that the input tensor for the forward pass has a size of `num_generations * per_device_train_batch_size` because GRPO generates `num_generations` completions for each prompt in the batch. Adjusting these values appropriately can help prevent OOM errors.
-Consequently, the effective train batch size is `num_generations * per_device_train_batch_size * gradient_accumulation_steps`.
 
 ```python
 # train_grpo.py

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestCLI(unittest.TestCase):
         from trl.cli import main
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # Create a temporary directory
-            command = f"trl grpo --output_dir {tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --reward_model_name_or_path trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_prompt_only --num_generations 3 --max_completion_length 32 --report_to none"
+            command = f"trl grpo --output_dir {tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --reward_model_name_or_path trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_prompt_only --num_generations 4 --max_completion_length 32 --report_to none"
             with patch("sys.argv", command.split(" ")):
                 main()
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -49,7 +49,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -78,8 +78,8 @@ class GRPOTrainerTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
-                per_device_eval_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+                per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 eval_strategy="steps",
@@ -106,7 +106,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -149,7 +149,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -185,7 +185,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -221,7 +221,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -295,7 +295,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -334,7 +334,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -367,7 +367,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",
@@ -400,7 +400,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 torch_compile=True,
@@ -431,7 +431,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 sync_ref_model=True,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -260,7 +260,7 @@ class GRPOTrainerTester(unittest.TestCase):
             training_args = GRPOConfig(
                 output_dir=tmp_dir,
                 learning_rate=0.1,  # increase the learning rate to speed up the test
-                per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=32,  # reduce the completion length to reduce memory usage
                 report_to="none",

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -137,6 +137,8 @@ def setup_chat_format(
 
 def remove_hooks(model: "DeepSpeedEngine") -> None:
     """Removes the optimizer hooks from a DeepSpeed ZeRO-3 model."""
+    if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
+        return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
         optimizer_offload = model.optimizer.parameter_offload
     elif model.optimizer is not None:
@@ -164,6 +166,8 @@ def iter_params(module, recurse=False):
 
 def add_hooks(model: "DeepSpeedEngine") -> None:
     """Adds the optimizer hooks from a DeepSpeed ZeRO-3 model."""
+    if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
+        return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
         optimizer_offload = model.optimizer.parameter_offload
     elif model.optimizer is not None:

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -50,6 +50,11 @@ class GRPOConfig(TrainingArguments):
             Temperature for sampling. The higher the temperature, the more random the completions.
         max_completion_length (`int` or `None`, *optional*, defaults to `256`):
             Maximum length of the generated completion.
+        ds3_gather_for_generation (`bool`, *optional*, defaults to `True`):
+            This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for generation,
+            improving generation speed. However, disabling this option allows training models that exceed the VRAM
+            capacity of a single GPU, albeit at the cost of slower generation. Disabling this option is not compatible
+            with vLLM generation.
 
         > Parameters that control generation acceleration powered by vLLM
 
@@ -132,6 +137,15 @@ class GRPOConfig(TrainingArguments):
     max_completion_length: Optional[int] = field(
         default=256,
         metadata={"help": "Maximum length of the generated completion."},
+    )
+    ds3_gather_for_generation: bool = field(
+        default=True,
+        metadata={
+            "help": "This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for "
+            "generation, improving generation speed. However, disabling this option allows training models that "
+            "exceed the VRAM capacity of a single GPU, albeit at the cost of slower generation. Disabling this option "
+            "is not compatible with vLLM generation."
+        },
     )
 
     # Parameters that control generation acceleration powered by vLLM

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -99,11 +99,6 @@ class GRPOConfig(TrainingArguments):
             τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
-
-        > Parameters taht control the logging
-
-        log_completions (`bool`, *optional*, defaults to `False`):
-            Whether to log the completions during training.
     """
 
     # Parameters that control the model and reference model
@@ -231,10 +226,4 @@ class GRPOConfig(TrainingArguments):
             "help": "τ parameter from the TR-DPO paper, which determines how frequently the current policy is "
             "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
         },
-    )
-
-    # Parameters that control the logging
-    log_completions: bool = field(
-        default=False,
-        metadata={"help": "Whether to log the completions during training."},
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -45,8 +45,8 @@ class GRPOConfig(TrainingArguments):
         max_prompt_length (`int` or `None`, *optional*, defaults to `512`):
             Maximum length of the prompt. If the prompt is longer than this value, it will be truncated left.
         num_generations (`int` or `None`, *optional*, defaults to `8`):
-            Number of generations per prompt to sample. It must be evenly divisible by the effective batch size
-            (`num_processes` * `per_device_train_batch_size`).
+            Number of generations per prompt to sample. The global batch size (num_processes * per_device_batch_size)
+            must be divisible by this value.
         temperature (`float`, *optional*, defaults to `0.9`):
             Temperature for sampling. The higher the temperature, the more random the completions.
         max_completion_length (`int` or `None`, *optional*, defaults to `256`):
@@ -125,8 +125,8 @@ class GRPOConfig(TrainingArguments):
     num_generations: Optional[int] = field(
         default=8,
         metadata={
-            "help": "Number of generations to sample. It must be evenly divisible by the effective batch size "
-            "(num_processes * per_device_train_batch_size)."
+            "help": "Number of generations to sample. The global batch size (num_processes * per_device_batch_size) "
+            "must be divisible by this value."
         },
     )
     temperature: Optional[float] = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -99,6 +99,11 @@ class GRPOConfig(TrainingArguments):
             τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
+
+        > Parameters taht control the logging
+
+        log_completions (`bool`, *optional*, defaults to `False`):
+            Whether to log the completions during training.
     """
 
     # Parameters that control the model and reference model
@@ -226,4 +231,10 @@ class GRPOConfig(TrainingArguments):
             "help": "τ parameter from the TR-DPO paper, which determines how frequently the current policy is "
             "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
         },
+    )
+
+    # Parameters that control the logging
+    log_completions: bool = field(
+        default=False,
+        metadata={"help": "Whether to log the completions during training."},
     )

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -407,7 +407,9 @@ class GRPOTrainer(Trainer):
         if self.args.use_vllm:
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
-                with unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model:
+                with unwrap_model_for_generation(
+                    self.model, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
+                ) as unwrapped_model:
                     if is_compiled_module(unwrapped_model):
                         state_dict = unwrapped_model._orig_mod.state_dict()
                     else:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -552,7 +552,8 @@ class GRPOTrainer(Trainer):
                 output_reward_func = reward_func(prompts=prompts, completions=completions, **reward_kwargs)
                 rewards_per_func[:, i] = torch.tensor(output_reward_func, dtype=torch.float32, device=device)
 
-        # Gather the reward per function: this part is crucial, because the rewards are normalized per group
+        # Gather the reward per function: this part is crucial, because the rewards are normalized per group and the
+        # completions may be distributed across processes
         rewards_per_func = gather(rewards_per_func)
 
         # Sum the rewards from all reward functions

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import random
 import textwrap
 import warnings
 from collections import defaultdict
@@ -22,11 +23,13 @@ from unittest.mock import patch
 import torch
 import torch.utils.data
 import transformers
-from accelerate.utils import broadcast_object_list, gather_object
+from accelerate import Accelerator
+from accelerate.utils import broadcast, broadcast_object_list, gather_object
 from accelerate.utils.other import is_compiled_module
 from datasets import Dataset, IterableDataset
 from packaging import version
-from torch import nn
+from torch import Tensor, nn
+from torch.utils.data import Sampler
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForSequenceClassification,
@@ -61,6 +64,64 @@ if is_wandb_available():
 # What we call a reward function is a callable that takes a list of prompts and completions and returns a list of
 # rewards. When it's a string, it's a model ID, so it's loaded as a pretrained model.
 RewardFunc = Union[str, PreTrainedModel, Callable[[list, list], list[float]]]
+
+
+class RepeatRandomSampler(Sampler):
+    """
+    Sampler that repeats the indices of a dataset N times.
+    """
+
+    def __init__(self, data_source, repeat_count):
+        self.data_source = data_source
+        self.repeat_count = repeat_count
+        self.num_samples = len(data_source)
+
+    def __iter__(self):
+        while True:
+            index = random.randint(0, self.num_samples - 1)  # Pick a random index
+            for _ in range(self.repeat_count):
+                yield index  # Yield the same index N times
+
+    def __len__(self):
+        return self.num_samples * self.repeat_count  # Theoretically infinite, but define a max length if needed
+
+
+def broadcast_and_slice_dict(accelerator: Accelerator, tensor_dict: dict[str, Tensor], from_process: int = 0):
+    """
+    Broadcasts a dictionary of tensors from one process to all processes and slices the tensors based on the process
+    index.
+    """
+
+    is_from = accelerator.local_process_index == from_process
+
+    # Only rank 0 has the tensor_dict, others start with None
+    metadata = {k: (v.shape, v.dtype) for k, v in tensor_dict.items()} if is_from else None
+
+    # Broadcast metadata to all processes
+    metadata = [metadata]  # Wrap in a list to make it mutable
+    metadata = broadcast_object_list(metadata, from_process=from_process)
+    metadata = metadata[0]  # Unwrap
+
+    # Non-main processes initialize empty tensor_dict
+    if not is_from:
+        tensor_dict = {
+            k: torch.empty(shape, dtype=dtype, device=accelerator.device) for k, (shape, dtype) in metadata.items()
+        }
+
+    # Broadcast tensors
+    for k in tensor_dict.keys():
+        tensor_dict[k] = broadcast(tensor_dict[k], from_process=from_process)
+
+    # Compute slice indices
+    B = next(iter(tensor_dict.values())).shape[0]  # Get first dimension size
+    assert B % accelerator.num_processes == 0, "Batch size must be divisible by world size"
+    chunk_size = B // accelerator.num_processes
+
+    # Slice the tensors
+    start, end = accelerator.local_process_index * chunk_size, (accelerator.local_process_index + 1) * chunk_size
+    sliced_dict = {k: v[start:end] for k, v in tensor_dict.items()}
+
+    return sliced_dict
 
 
 class GRPOTrainer(Trainer):
@@ -280,6 +341,21 @@ class GRPOTrainer(Trainer):
             optimizers=optimizers,
         )
 
+        # Maybe move this elsewhere in the future:
+        # Check if the per_device_train_batch_size * num processes can be divided by the number of generations
+
+        if args.per_device_train_batch_size * self.accelerator.num_processes % self.num_generations != 0:
+            possible_values = [
+                i
+                for i in range(2, self.accelerator.num_processes * args.per_device_train_batch_size + 1)
+                if (self.accelerator.num_processes * args.per_device_train_batch_size) % i == 0
+            ]
+            raise ValueError(
+                f"The number of generations per prompt ({self.num_generations}) must be evenly divisible by the "
+                f"effective batch size ({self.accelerator.num_processes} x {args.per_device_train_batch_size}). "
+                f"Given this batch size, the valid values for the number of generations are: {possible_values}."
+            )
+
         if self.use_vllm:
             if not is_vllm_available():
                 raise ImportError(
@@ -324,7 +400,6 @@ class GRPOTrainer(Trainer):
                         enable_prefix_caching=True,
                     )
                 self.sampling_params = SamplingParams(
-                    n=self.num_generations,
                     temperature=args.temperature,
                     max_tokens=self.max_completion_length,
                 )
@@ -340,7 +415,6 @@ class GRPOTrainer(Trainer):
                 max_new_tokens=self.max_completion_length,
                 do_sample=True,
                 temperature=args.temperature,
-                num_return_sequences=self.num_generations,
                 pad_token_id=processing_class.pad_token_id,
             )
 
@@ -373,6 +447,9 @@ class GRPOTrainer(Trainer):
         if self._signature_columns is None:
             self._signature_columns = ["prompt"]
 
+    def _get_train_sampler(self) -> Sampler:
+        return RepeatRandomSampler(self.train_dataset, self.num_generations)
+
     # Get the per-token log probabilities for the completions for the model and the reference model
     def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep):
         # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
@@ -390,6 +467,28 @@ class GRPOTrainer(Trainer):
         return torch.stack(per_token_logps)
 
     def _prepare_inputs(self, inputs: dict[str, Union[torch.Tensor, Any]]) -> dict[str, Union[torch.Tensor, Any]]:
+        # When using vLLM, ne need to first update the model weights
+        if self.args.use_vllm and self.state.global_step != self._last_loaded_step:
+            with unwrap_model_for_generation(
+                self.model, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
+            ) as unwrapped_model:
+                if is_compiled_module(unwrapped_model):
+                    state_dict = unwrapped_model._orig_mod.state_dict()
+                else:
+                    state_dict = unwrapped_model.state_dict()
+            if self.accelerator.is_main_process:
+                llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                llm_model.load_weights(state_dict.items())
+            self._last_loaded_step = self.state.global_step
+
+        # Gather inputs and process them in the main process. This is important because the rewards are normalized
+        # per group.
+        inputs = gather_object(inputs)
+        prepared = self._prepare_main(inputs) if self.accelerator.is_main_process else None
+        prepared = broadcast_and_slice_dict(self.accelerator, prepared)
+        return prepared
+
+    def _prepare_main(self, inputs: dict[str, Union[torch.Tensor, Any]]) -> dict[str, Union[torch.Tensor, Any]]:
         device = self.accelerator.device
         prompts = [x["prompt"] for x in inputs]
         prompts_text = [maybe_apply_chat_template(example, self.processing_class)["prompt"] for example in inputs]
@@ -405,36 +504,9 @@ class GRPOTrainer(Trainer):
 
         # Generate completions using either vLLM or regular generation
         if self.args.use_vllm:
-            # First, have main process load weights if needed
-            if self.state.global_step != self._last_loaded_step:
-                with unwrap_model_for_generation(
-                    self.model, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
-                ) as unwrapped_model:
-                    if is_compiled_module(unwrapped_model):
-                        state_dict = unwrapped_model._orig_mod.state_dict()
-                    else:
-                        state_dict = unwrapped_model.state_dict()
-                if self.accelerator.is_main_process:
-                    llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
-                    llm_model.load_weights(state_dict.items())
-                self._last_loaded_step = self.state.global_step
-
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process
-            all_prompts_text = gather_object(prompts_text)
-            if self.accelerator.is_main_process:
-                outputs = self.llm.generate(all_prompts_text, sampling_params=self.sampling_params, use_tqdm=False)
-                completion_ids = [out.token_ids for completions in outputs for out in completions.outputs]
-            else:
-                completion_ids = [None] * len(all_prompts_text) * self.num_generations
-
-            # Broadcast the completions from the main process to all processes, ensuring each process receives its
-            # corresponding slice.
-            completion_ids = broadcast_object_list(completion_ids, from_process=0)
-            process_slice = slice(
-                self.accelerator.process_index * len(prompts) * self.num_generations,
-                (self.accelerator.process_index + 1) * len(prompts) * self.num_generations,
-            )
-            completion_ids = completion_ids[process_slice]
+            outputs = self.llm.generate(prompts_text, sampling_params=self.sampling_params, use_tqdm=False)
+            completion_ids = [out.token_ids for completions in outputs for out in completions.outputs]
 
             # Pad the completions, and concatenate them with the prompts
             completion_ids = [torch.tensor(ids, device=device) for ids in completion_ids]
@@ -453,7 +525,6 @@ class GRPOTrainer(Trainer):
             prompt_length = prompt_ids.size(1)
             prompt_ids = prompt_completion_ids[:, :prompt_length]
             completion_ids = prompt_completion_ids[:, prompt_length:]
-            prompt_mask = prompt_mask.repeat_interleave(self.num_generations, dim=0)
 
         # Mask everything after the first EOS token
         is_eos = completion_ids == self.processing_class.eos_token_id
@@ -484,8 +555,6 @@ class GRPOTrainer(Trainer):
             completions = [[{"role": "assistant", "content": completion}] for completion in completions]
 
         # Compute the rewards
-        prompts = [prompt for prompt in prompts for _ in range(self.num_generations)]  # repeat prompts
-
         rewards_per_func = torch.zeros(len(prompts), len(self.reward_funcs), device=device)
         for i, (reward_func, reward_processing_class) in enumerate(
             zip(self.reward_funcs, self.reward_processing_classes)
@@ -504,11 +573,8 @@ class GRPOTrainer(Trainer):
                     rewards_per_func[:, i] = reward_func(**reward_inputs).logits[:, 0]  # Shape (B*G,)
             else:
                 # Repeat all input columns (but "prompt" and "completion") to match the number of generations
-                reward_kwargs = {key: [] for key in inputs[0].keys() if key not in ["prompt", "completion"]}
-                for key in reward_kwargs:
-                    for example in inputs:
-                        # Repeat each value in the column for `num_generations` times
-                        reward_kwargs[key].extend([example[key]] * self.num_generations)
+                keys = [key for key in inputs[0] if key not in ["prompt", "completion"]]
+                reward_kwargs = {key: [example[key] for example in inputs] for key in keys}
                 output_reward_func = reward_func(prompts=prompts, completions=completions, **reward_kwargs)
                 rewards_per_func[:, i] = torch.tensor(output_reward_func, dtype=torch.float32, device=device)
 
@@ -525,7 +591,7 @@ class GRPOTrainer(Trainer):
         advantages = (rewards - mean_grouped_rewards) / (std_grouped_rewards + 1e-4)
 
         # Log the metrics
-        reward_per_func = self.accelerator.gather_for_metrics(rewards_per_func).mean(0)
+        reward_per_func = rewards_per_func.mean(0)
         for i, reward_func in enumerate(self.reward_funcs):
             if isinstance(reward_func, nn.Module):  # Module instead of PretrainedModel for compat with compiled models
                 reward_func_name = reward_func.config._name_or_path.split("/")[-1]
@@ -533,16 +599,16 @@ class GRPOTrainer(Trainer):
                 reward_func_name = reward_func.__name__
             self._metrics[f"rewards/{reward_func_name}"].append(reward_per_func[i].item())
 
-        self._metrics["reward"].append(self.accelerator.gather_for_metrics(rewards).mean().item())
-        self._metrics["reward_std"].append(self.accelerator.gather_for_metrics(std_grouped_rewards).mean().item())
+        self._metrics["reward"].append(rewards.mean().item())
+        self._metrics["reward_std"].append(std_grouped_rewards.mean().item())
 
         return {
-            "prompt_ids": prompt_ids,
-            "prompt_mask": prompt_mask,
-            "completion_ids": completion_ids,
-            "completion_mask": completion_mask,
-            "ref_per_token_logps": ref_per_token_logps,
-            "advantages": advantages,
+            "prompt_ids": prompt_ids.contiguous(),
+            "prompt_mask": prompt_mask.contiguous(),
+            "completion_ids": completion_ids.contiguous(),
+            "completion_mask": completion_mask.contiguous(),
+            "ref_per_token_logps": ref_per_token_logps.contiguous(),
+            "advantages": advantages.contiguous(),
         }
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -100,6 +100,15 @@ def broadcast_and_slice_dict(accelerator: Accelerator, tensor_dict: dict[str, Te
     """
     Broadcasts a dictionary of tensors from one process to all processes and slices the tensors based on the process
     index.
+
+    ```
+       Process 0            Process 0        Process 1
+    [[ 1,  2,  3],   ->    [[1, 2, 3],     [[ 7,  8,  9],
+     [ 4,  5,  6],          [4, 5, 6]]      [10, 11, 12]]
+     [ 7,  8,  9],
+     [10, 11, 12]]
+    }
+    ```
     """
 
     is_from = accelerator.local_process_index == from_process

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -483,8 +483,8 @@ class GRPOTrainer(Trainer):
             # corresponding slice.
             completion_ids = broadcast_object_list(completion_ids, from_process=0)
             process_slice = slice(
-                self.accelerator.process_index * len(prompts) * self.num_generations,
-                (self.accelerator.process_index + 1) * len(prompts) * self.num_generations,
+                self.accelerator.process_index * len(prompts),
+                (self.accelerator.process_index + 1) * len(prompts),
             )
             completion_ids = completion_ids[process_slice]
 
@@ -575,8 +575,8 @@ class GRPOTrainer(Trainer):
 
         # Slice to keep only the local part of the data
         process_slice = slice(
-            self.accelerator.process_index * len(prompts) * self.num_generations,
-            (self.accelerator.process_index + 1) * len(prompts) * self.num_generations,
+            self.accelerator.process_index * len(prompts),
+            (self.accelerator.process_index + 1) * len(prompts),
         )
         advantages = advantages[process_slice]
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -455,6 +455,7 @@ class GRPOTrainer(Trainer):
         if self._signature_columns is None:
             self._signature_columns = ["prompt"]
 
+    # We need a custom sampler that samples the same prompt multiple times
     def _get_train_sampler(self) -> Sampler:
         return RepeatRandomSampler(self.train_dataset, self.num_generations)
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -96,7 +96,9 @@ class RepeatRandomSampler(Sampler):
         return self.num_samples * self.repeat_count
 
 
-def broadcast_and_slice_dict(accelerator: Accelerator, tensor_dict: dict[str, Tensor], from_process: int = 0):
+def broadcast_and_slice_dict(
+    accelerator: Accelerator, tensor_dict: Union[dict[str, Tensor], None], from_process: int = 0
+) -> dict[str, Tensor]:
     """
     Broadcasts a dictionary of tensors from one process to all processes and slices the tensors based on the process
     index.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -467,6 +467,9 @@ class GRPOTrainer(Trainer):
     def _get_train_sampler(self) -> Sampler:
         return RepeatRandomSampler(self.train_dataset, self.num_generations)
 
+    def _get_eval_sampler(self, eval_dataset) -> Sampler:
+        return RepeatRandomSampler(eval_dataset, self.num_generations)
+
     # Get the per-token log probabilities for the completions for the model and the reference model
     def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep):
         # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -300,7 +300,6 @@ class GRPOTrainer(Trainer):
 
         # Initialize the metrics
         self._metrics = defaultdict(list)
-        self.log_completions = args.log_completions
 
         super().__init__(
             model=model,
@@ -596,15 +595,6 @@ class GRPOTrainer(Trainer):
 
         self._metrics["reward"].append(rewards.mean().item())
         self._metrics["reward_std"].append(std_grouped_rewards.mean().item())
-
-        if (
-            self.accelerator.is_main_process
-            and self.log_completions
-            and self.state.global_step % self.args.logging_steps == 0
-        ):
-            for prompt, completion, reward in zip(prompts, completions, rewards):
-                text = f"---\n\033[31m{prompt}\033[34m{completion}\033[0m\n--- \033[32mReward: {reward}\033[0m ---"
-                self.accelerator.print(text)
 
         return {
             "prompt_ids": prompt_ids,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -341,9 +341,7 @@ class GRPOTrainer(Trainer):
             optimizers=optimizers,
         )
 
-        # Maybe move this elsewhere in the future:
         # Check if the per_device_train_batch_size * num processes can be divided by the number of generations
-
         if args.per_device_train_batch_size * self.accelerator.num_processes % self.num_generations != 0:
             possible_values = [
                 i
@@ -351,8 +349,8 @@ class GRPOTrainer(Trainer):
                 if (self.accelerator.num_processes * args.per_device_train_batch_size) % i == 0
             ]
             raise ValueError(
-                f"The number of generations per prompt ({self.num_generations}) must be evenly divisible by the "
-                f"effective batch size ({self.accelerator.num_processes} x {args.per_device_train_batch_size}). "
+                f"The global batch size ({self.accelerator.num_processes} x {args.per_device_train_batch_size}) "
+                f"must be evenly divisible by the number of generations per prompt ({self.num_generations})."
                 f"Given this batch size, the valid values for the number of generations are: {possible_values}."
             )
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -364,11 +364,8 @@ class GRPOTrainer(Trainer):
 
         # Check if the per_device_train_batch_size * num processes can be divided by the number of generations
         if args.per_device_train_batch_size * self.accelerator.num_processes % self.num_generations != 0:
-            possible_values = [
-                i
-                for i in range(2, self.accelerator.num_processes * args.per_device_train_batch_size + 1)
-                if (self.accelerator.num_processes * args.per_device_train_batch_size) % i == 0
-            ]
+            global_batch_size = args.per_device_train_batch_size * self.accelerator.num_processes
+            possible_values = [i for i in range(2, global_batch_size + 1) if (global_batch_size) % i == 0]
             raise ValueError(
                 f"The global batch size ({self.accelerator.num_processes} x {args.per_device_train_batch_size}) "
                 f"must be evenly divisible by the number of generations per prompt ({self.num_generations})."


### PR DESCRIPTION
### Background
In the current implementation of GRPO, each device samples `N` prompts. For these `N` prompts, `G` generations are produced, and the loss is computed over them. However, this approach is highly memory-intensive, especially when using `G ≥ 8`, often leading to OOM errors, even with a batch size of just 1 prompt per device.

### Proposed change 
This PR introduces a more flexible approach:  
- Instead of defining `per_device_batch_size` as the number of prompts per device, it now represents the **number of generations per device**.  
- This allows for much greater flexibility in choosing the number of generations (`G`) and the batch size per device.  
- The only constraint is that the global batch size (`num_processes * per_device_batch_size`) must be divisible by `G`.

Note that these settings should be equivalent:
```python
num_generations = ...  # eg, 8
num_prompts_per_device = ...  # eg, 1
# main
GRPOConfig(num_generations=num_generations, per_device_batch_size=num_prompts_per_device, ...)
# this PR
GRPOConfig(num_generations=num_generations, per_device_batch_size=num_generations*num_prompts_per_device, ...)
```

` (new setting) and ``per_device_batch_size==1` (old setting)

### Benefits
- Reduces memory, making it feasible to use higher `G` or completion length without hitting OOM
- Provides more control over batch size and generation count per device
- Ensures scalability while maintaining the integrity of GRPO's training logic

Before: 

![image](https://github.com/user-attachments/assets/fcfa4b71-929f-4626-8444-13c9d72004c4)


Now:

![image](https://github.com/user-attachments/assets/d1cc5100-17ec-4379-9050-af1fe0081fd0)
