### PR TITLE
grpo_error

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -542,6 +542,7 @@ class GRPOTrainer(Trainer):
         else:
             # Regular generation path
             with unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model:
+                unwrapped_model.eval()
                 prompt_completion_ids = unwrapped_model.generate(
                     prompt_ids, attention_mask=prompt_mask, generation_config=self.generation_config
                 )


### PR DESCRIPTION
# What does this PR do?

Bug:
In GPRO-trainer, when generating text, change `unwrapped_model` to `unwrapped_model.eval()`.Ensure the correctness of the output results.

The core change is:
```
with unwrap_model_for_generation(model, self.accelerator) as unwrapped_model:
          unwrapped_model.eval()  #  +++
          prompt_completion_ids = unwrapped_model.generate(
              **prompt_inputs, generation_config=self.generation_config
          )
```
#  Before submitting
 - [ ] This PR fixes a typo or improves the docs (not applicable)
 - [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)
 - [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
 - [x] Did you make sure to update the documentation with your changes?
 - [x] Did you write any new necessary tests? (Added tests to verify correct loss calculation and gradient flow)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.