### PR TITLE
🪆 Fix for Incorrect ValueError Handling in reward_weights in grpo_trainer.py

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -275,7 +275,7 @@ class GRPOTrainer(Trainer):
         if args.reward_weights is not None:
             if len(args.reward_weights) != len(reward_funcs):
                 raise ValueError(
-                    f"Number of reward weights ({len(len(args.reward_weights))}) must match number of reward "
+                    f"Number of reward weights ({len(args.reward_weights)}) must match number of reward "
                     f"functions ({len(reward_funcs)})"
                 )
             self.reward_weights = torch.tensor(args.reward_weights, dtype=torch.float32)


### PR DESCRIPTION
#### **Summary**
This pull request fixes a bug in the code where an extra `len` call in the `ValueError` message caused a `TypeError` to be thrown instead of the expected `ValueError`. The issue arises when checking the length of `args.reward_weights` against `reward_funcs`.

---

#### **Problem Description**
The original code contains an unnecessary nested `len` call:
```python
len(len(args.reward_weights))
```
This results in a `TypeError: object of type 'int' has no len()`, because `len(args.reward_weights)` returns an integer, and integers cannot be passed to `len()`.

[Here (grpo_trainer.py#L278)](https://github.com/huggingface/trl/blob/7347c292c3d18ff9209ad745ede6fce7e3b94155/trl/trainer/grpo_trainer.py#L278) is the problematic code:
```python
if args.reward_weights is not None:
    if len(args.reward_weights) != len(reward_funcs):
        raise ValueError(
            f"Number of reward weights ({len(len(args.reward_weights))}) must match number of reward "
            f"functions ({len(reward_funcs)})"
        )
    self.reward_weights = torch.tensor(args.reward_weights, dtype=torch.float32)
else:
    self.reward_weights = torch.ones(len(reward_funcs), dtype=torch.float32)
```

Instead of the expected `ValueError`, a `TypeError` is raised, making it difficult to identify the actual problem in the code.

---

#### **Proposed Fix**
The fix is to remove the unnecessary `len` call in the error message. Specifically, replace:
```python
len(len(args.reward_weights))
```
With:
```python
len(args.reward_weights)
```

The corrected code is as follows:
```python
if args.reward_weights is not None:
    if len(args.reward_weights) != len(reward_funcs):
        raise ValueError(
            f"Number of reward weights ({len(args.reward_weights)}) must match number of reward "
            f"functions ({len(reward_funcs)})"
        )
    self.reward_weights = torch.tensor(args.reward_weights, dtype=torch.float32)
else:
    self.reward_weights = torch.ones(len(reward_funcs), dtype=torch.float32)
```

---

#### **Why This Fix Is Necessary**
- Prevents the unintended `TypeError` that occurs due to the extra `len` call.
- Ensures proper error handling via the correct `ValueError`, which provides clarity on the mismatch between reward weights and reward functions.

---

#### **Validation Steps**
To ensure the fix resolves the issue, follow these steps:
1. **Setup**: Use an `args.reward_weights` that is not `None` and ensure its length does not match the `reward_funcs` length.
2. **Expected Behavior Before Fix**: A `TypeError` is raised at runtime.
3. **Expected Behavior After Fix**: The code correctly raises a `ValueError` with the following message:
   ```
   ValueError: Number of reward weights (X) must match number of reward functions (Y)
   ```
   Where `X` is the number of weights and `Y` is the number of functions.

---
