### PR TITLE
[GRPO] Disable prefix cache for models with sliding window

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -400,7 +400,8 @@ class GRPOTrainer(Trainer):
                 profiling_patch = patch(
                     "vllm.worker.worker.Worker._assert_memory_footprint_increased_during_profiling", return_value=None
                 )
-                # for now, vLLM does not support `enable_prefix_caching` with a model that has sliding window
+                # vLLM does not support `enable_prefix_caching` with a model that has sliding window,
+                # see https://github.com/vllm-project/vllm/issues/3355
                 has_sliding_window = hasattr(self.model.config, "sliding_window")
                 with world_size_patch, profiling_patch:
                     self.llm = LLM(


### PR DESCRIPTION
# What does this PR do?

The PR disables prefix cache in vLLM for models with sliding window.
Currently, vLLM does not support sliding window & prefix cache.


<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.