### PR TITLE
[GRPO] Reduce steps where loss starts to remain at 0, accelerate training

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -639,6 +639,10 @@ class GRPOTrainer(Trainer):
         std_grouped_rewards = std_grouped_rewards.repeat_interleave(self.num_generations, dim=0)
         advantages = (rewards - mean_grouped_rewards) / (std_grouped_rewards + 1e-4)
 
+        epsilon = 1e-4
+        noise = torch.randn_like(advantages) * epsilon
+        advantages = advantages + noise
+
         # Slice to keep only the local part of the data
         process_slice = slice(
             self.accelerator.process_index * len(prompts),


### PR DESCRIPTION
#2703 

Due to the standardization of `advantages`, the `advantages` is summed in the loss calculation to make it 0, i.e. loss=β KL. But in the first step, since the actor model and ref model are the same, KL=0, which means the first loss must be 0.
And we believe that the main reason why GRPO can start training with an initial loss of 0, besides still having gradients, is due to the calculation error of the GPU.

So, our acceleration approach is to add small perturbations to the loss to accelerate the model changes caused by computational errors in the first few steps; After the formal training begins, the added disturbance is too small and can be ignored, or equivalently dropped out, to improve the model's generalization.
Specifically, we choose to add perturbations after the reward is standardized, because the key to the first step having a loss of 0 is that summing up the standardized rewards will result in it being exactly 0. 
﻿
After adding perturbations, the loss obtains a perturbation with a mean of 0 and a variance of 1e-4. Because we have observed that the initial KL is larger than 1e-4, which means that after the first few steps of acceleration, the disturbance of 1e-4 can be quickly ignored.
﻿
Verification result:
![image](https://github.com/user-attachments/assets/d7732efe-3a05-41af-9e43-97dae7466363)

After the above improvements, after about 15 steps of training, the loss starts training;
When there is no improvement, the loss needs to exceed 100 steps to reach the same level.