### PR TITLE
[GRPO] Fix loss normalization

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -707,7 +707,7 @@ class GRPOTrainer(Trainer):
         advantages = inputs["advantages"]
         per_token_loss = torch.exp(per_token_logps - per_token_logps.detach()) * advantages.unsqueeze(1)
         per_token_loss = -(per_token_loss - self.beta * per_token_kl)
-        loss = ((per_token_loss * completion_mask).sum(dim=1) / completion_mask.sum(dim=1)).mean()
+        loss = loss = (per_token_loss * completion_mask).sum(dim=1) / completion_mask.sum()
 
         # Log the metrics
         completion_length = self.accelerator.gather_for_metrics(completion_mask.sum(1)).float().mean().item()


### PR DESCRIPTION
# What does this PR do?


The current GRPO implementation uses `per-sequence normalization`, this PR corrects this to be `global normalization`


Details:
In Causal Language Modelling, we typically use `global normalization` to scale the loss, so that each unmasked token's loss provides the same contribution to the total loss. Example from transformers codebase: https://github.com/huggingface/transformers/blob/fae0f3dde83b7a54441f7a5bb0fc45d354fe81ce/src/transformers/loss/loss_utils.py#L24-L29

