### PR TITLE
GRPOTrainer adds support for OpenAI API-compatible servers to models that generate samples

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -249,3 +249,21 @@ class GRPOConfig(TrainingArguments):
         default=False,
         metadata={"help": "Whether to log the completions during training."},
     )
+
+    # reference model using api server
+    use_openai_compatible_server: bool = field(
+        default=False,
+        metadata={"help": "Whether to use openai compatible server."},
+    )
+    api_endpoint: str = field(
+        default=None,
+        metadata={"help": "Openai compatible server API endpoint."},
+    )
+    api_key: str = field(
+        default=None,
+        metadata={"help": "Openai compatible server API key."},
+    )
+    ref_model_name: str = field(
+        default=None,
+        metadata={"help": "Openai compatible server reference model name."},
+    )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -250,7 +250,7 @@ class GRPOConfig(TrainingArguments):
         metadata={"help": "Whether to log the completions during training."},
     )
 
-    # reference model using api server
+    # reference model using OpenAI compatible api server
     use_openai_compatible_server: bool = field(
         default=False,
         metadata={"help": "Whether to use openai compatible server."},

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -581,7 +581,7 @@ class GRPOTrainer(Trainer):
             # don't use any chattemplate, because the server have load it.
             for prompt in prompts:
                 # request server
-                response = self.ref_llm(messages=[{"role": "user", "content": prompt}])
+                response = self.ref_llm(messages=prompt)
                 completion_text = response.choices[0].message.content
                 completion_tokens = self.processing_class.encode(completion_text, add_special_tokens=False)
                 completions.append(completion_tokens)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -578,7 +578,8 @@ class GRPOTrainer(Trainer):
 
         elif self.args.use_openai_compatible_server:
             completions = []
-            for prompt in prompts_text:
+            # don't use any chattemplate, because the server have load it.
+            for prompt in prompts:
                 # request server
                 response = self.ref_llm(messages=[{"role": "user", "content": prompt}])
                 completion_text = response.choices[0].message.content


### PR DESCRIPTION
# What does this PR do?
The original generative model is loaded on a single GPU, which becomes very slow when the generation length reaches 4096 or more. Therefore, I suggest loading the generation model externally to leverage multi-GPU support.

## Motivation Behind This Feature:

The motivation for this feature stems from performance limitations when using the original vllm generative model, which currently loads on a single GPU. This becomes a bottleneck, especially when the generation length reaches 4096 tokens or more, significantly slowing down the process. By utilizing multiple GPUs, we can distribute the workload more efficiently and drastically improve performance, especially for long-generation tasks.

This feature is crucial for my project, as faster generation times are essential. I believe it could also benefit the broader community by enhancing the scalability and efficiency of model inference on multi-GPU setups.

## Requested Feature:

The feature I am requesting involves loading the generative model outside of the current single-GPU setup in order to leverage multi-GPU capabilities. This would improve performance for tasks involving large generation lengths, making the library more efficient and scalable for demanding use cases.

## Code Snippet:
GRPOTrainer  `__init__`
```python
elif self.args.use_openai_compatible_server:
    api_endpoint = args.api_endpoint
    api_key = args.api_key

    openai_serving_client = openai.OpenAI(base_url=api_endpoint, api_key=api_key, )
    # set the openai logger to ERROR level to avoid mess log information
    logging.getLogger("openai").setLevel(logging.ERROR)
    logging.getLogger("httpx").setLevel(logging.ERROR)
    self.ref_model_name = args.ref_model_name

    self.ref_llm = partial(openai_serving_client.chat.completions.create,
            model=args.ref_model_name,
            max_tokens=self.max_completion_length,
            temperature=args.temperature,
    )
```

GRPOTrainer `_prepare_inputs`
```python
elif self.args.use_openai_compatible_server:
    completions = []
    # don't use any chattemplate, because the server have load it.
    for prompt in prompts:
        # request server
        response = self.ref_llm(messages=prompt)
        completion_text = response.choices[0].message.content
        completion_tokens = self.processing_class.encode(completion_text, add_special_tokens=False)
        completions.append(completion_tokens)

    completion_ids = completions
    completion_ids = [torch.tensor(ids, device=device) for ids in completion_ids]
    completion_ids = pad(completion_ids, padding_value=self.processing_class.pad_token_id)
    prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)

```

## Fixes # (issue)
The issue mentioned in: https://github.com/huggingface/trl/issues/2887

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. **If additional documentation improvements are needed, I would be happy to contribute.**