### PR TITLE
Supporting multi-vLLM inference for GRPO

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -781,6 +781,7 @@ class GRPOTrainerTester(unittest.TestCase):
                 use_vllm=True,
                 vllm_device="cuda:0",  # will raise a warning, but allows this test to work with only one GPU
                 vllm_guided_decoding_regex=r"<reasoning>\n.*\n</reasoning>\n<answer>\n.*\n</answer>",
+                vllm_gpu_memory_utilization=0.4,  # reduce the memory utilization rate to reduce memory usage
             )
             trainer = GRPOTrainer(
                 model="Qwen/Qwen2.5-0.5B-Instruct",  # tiny model is too small for vLLM

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -176,6 +176,14 @@ class GRPOConfig(TrainingArguments):
             "(`pip install vllm`)."
         },
     )
+    vllm_worker_num: Optional[int] = field(
+        default=1,
+        metadata={
+            "help": "The number of vllm works used for inference. Notably, this number should be less or equal to "
+            "the number of process used for distributed training (i.e., `--num_processes`). In addition, please "
+            "ensure that `vllm_worker_num + num_processes <= world_size`."
+        },
+    )
     vllm_device: Optional[str] = field(
         default="auto",
         metadata={

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -62,6 +62,10 @@ class GRPOConfig(TrainingArguments):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept unused for
             training, as vLLM will require one for generation. vLLM must be installed (`pip install vllm`).
+            ensure that `vllm_worker_num + num_processes <= world_size`.
+        vllm_worker_num (`int`, *optional*, defaults to `1`):
+            Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept
+            the number of process used for distributed training (i.e., `--num_processes`). In addition, please
         vllm_device (`str`, *optional*, defaults to `"auto"`):
             Device where vLLM generation will run, e.g. `"cuda:1"`. If set to `"auto"` (default), the system will
             automatically select the next available GPU after the last one used for training. This assumes that

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -662,7 +662,7 @@ class GRPOTrainer(Trainer):
                 unwrapped_model.unmerge_adapter()
 
     def _split_vllm_inputs(self, ordered_set_of_prompts, n_splits):
-        size = (len(ordered_set_of_prompts) + 1) // n_splits
+        size = (len(ordered_set_of_prompts) + n_splits - 1) // n_splits
         data = [ordered_set_of_prompts[size * i : size * (i + 1)] for i in range(n_splits)]
         return data
 


### PR DESCRIPTION

# What does this PR do?

The current GRPO only uses 1 GPU for inference and $N-1$ GPUs for training, where $N$ is the world size. This PR allows users to leverage $K$ GPUs for inference and $N-K$ GPUs for training.

Method:
1. Apply for the resources with $N$ GPUs
2. initializing the distributed training  with $N-K$ processes  on GPU 0, 1, ... $N-K-1$.
3. Initializing the $K$ vLLM objects on 0 to $K-1$ training processes. However, the model parameters of the $K$ vLLM  objects will be placed on GPU $N-K$, $N-K+1$, ..., $N-1$.
4. Using the a vLLM object  to do the real-time inference for a subset of the prompts in each process.
5. Gathering the decoded data from 0 to $K-1$ processes. 

Constraints:
1. The number of vLLM instances should be less or equal to the number of training processes, i.e., K <= N-K. For example, for an environment with 8 GPUs, we can have at most 4 GPUs for inference. Other configs are also allowed, e.g., 1 inference 7 training, 2 inference 6 training, etc.

I tested with 4 A100-80 GPU. The script is from [open-r1](https://github.com/huggingface/open-r1). I train the Qwen-math-1.5B model with `G=num_generation=32` and  `per_device_train_batch_size=32`. Under this setting, I find that the config (2 infer, 2 train) is ~12% faster than (1 infer, 2 train). Probably scalling up the batch size and `num_generation` would introduce higher gains.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      https://github.com/huggingface/trl/issues/2887
      https://github.com/huggingface/trl/pull/2901
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?



## Who can review?
@qgallouedec @edbeeching 