### PR TITLE
🐯 Fix LigerKernel for SFTTrainer

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -173,7 +173,6 @@ class SFTTrainer(Trainer):
             )
         if isinstance(model, str):
             model = self._create_model_from_path(model, args)
-        self.use_liger = is_liger_kernel_available() and isinstance(model, AutoLigerKernelForCausalLM)
 
         # PEFT configuration and model wrapping
         if peft_config is not None:
@@ -462,7 +461,7 @@ class SFTTrainer(Trainer):
         )
 
         # Compute token accuracy if we have labels and if the model is not using Liger (no logits)
-        if "labels" in inputs and not self.use_liger:
+        if "labels" in inputs and not self.args.use_liger:
             shift_logits = outputs.logits[..., :-1, :].contiguous()
             shift_labels = inputs["labels"][..., 1:].contiguous()
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes an issue where `use_liger=True` threw an error in the loss computation because the fix in #2874 was partially reverted in [this line](https://github.com/huggingface/trl/pull/2890/files#diff-67e157adfcd37d677fba66f610e3dfb56238cc550f221e8683fcfa0556e0f7caR180) of #2890. Without this change, one gets errors on the loss computation

```
[rank0]:     shift_logits = outputs.logits[..., :-1, :].contiguous()
[rank0]:                    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
[rank0]: TypeError: 'NoneType' object is not subscriptable
```

Command to test:

```shell
trl sft --model_name_or_path Qwen/Qwen2.5-0.5B     --dataset_name trl-lib/Capybara     --output_dir Qwen2.5-0.5B-SFT --use_liger true
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.