### PR TITLE
📋 Add vLLM version to environment printout

### DIFF
--- a/trl/scripts/env.py
+++ b/trl/scripts/env.py
@@ -22,7 +22,7 @@ from transformers import is_bitsandbytes_available
 from transformers.utils import is_liger_kernel_available, is_openai_available, is_peft_available
 
 from .. import __version__
-from ..import_utils import is_deepspeed_available, is_diffusers_available, is_llm_blender_available
+from ..import_utils import is_deepspeed_available, is_diffusers_available, is_llm_blender_available, is_vllm_available
 from .utils import get_git_commit_hash
 
 
@@ -47,6 +47,7 @@ def print_env():
     info = {
         "Platform": platform.platform(),
         "Python version": platform.python_version(),
+        "TRL version": f"{__version__}+{commit_hash[:7]}" if commit_hash else __version__,
         "PyTorch version": version("torch"),
         "CUDA device(s)": ", ".join(devices) if torch.cuda.is_available() else "not available",
         "Transformers version": version("transformers"),
@@ -54,7 +55,6 @@ def print_env():
         "Accelerate config": accelerate_config_str,
         "Datasets version": version("datasets"),
         "HF Hub version": version("huggingface_hub"),
-        "TRL version": f"{__version__}+{commit_hash[:7]}" if commit_hash else __version__,
         "bitsandbytes version": version("bitsandbytes") if is_bitsandbytes_available() else "not installed",
         "DeepSpeed version": version("deepspeed") if is_deepspeed_available() else "not installed",
         "Diffusers version": version("diffusers") if is_diffusers_available() else "not installed",
@@ -62,6 +62,7 @@ def print_env():
         "LLM-Blender version": version("llm_blender") if is_llm_blender_available() else "not installed",
         "OpenAI version": version("openai") if is_openai_available() else "not installed",
         "PEFT version": version("peft") if is_peft_available() else "not installed",
+        "vLLM version": version("vllm") if is_vllm_available() else "not installed",
     }
 
     info_str = "\n".join([f"- {prop}: {val}" for prop, val in info.items()])


### PR DESCRIPTION
# What does this PR do?

```
$ trl env
[2025-02-24 10:22:41,365] [INFO] [real_accelerator.py:222:get_accelerator] Setting ds_accelerator to cuda (auto detect)

Copy-paste the following information when reporting an issue:

- Platform: Linux-5.15.0-1048-aws-x86_64-with-glibc2.31
- Python version: 3.12.2
- TRL version: 0.16.0.dev0+5975879
- PyTorch version: 2.2.2
- CUDA device(s): NVIDIA H100 80GB HBM3
- Transformers version: 4.47.0
- Accelerate version: 1.2.1
- Accelerate config: not found
- Datasets version: 3.2.0
- HF Hub version: 0.25.0
- bitsandbytes version: 0.45.0
- DeepSpeed version: 0.16.3
- Diffusers version: not installed
- Liger-Kernel version: not installed
- LLM-Blender version: not installed
- OpenAI version: not installed
- PEFT version: 0.13.2
- vLLM version: not installed
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.