### PR TITLE
Pin liger-kernel and vLLM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,13 +85,13 @@ EXTRAS = {
     "diffusers": ["diffusers>=0.18.0"],
     "judges": ["openai>=1.23.2", "llm-blender>=0.0.2"],
     # liger-kernel depends on triton, which is only available on Linux https://github.com/triton-lang/triton#compatibility
-    "liger": ["liger-kernel>=0.5.3; sys_platform != 'win32'"],
+    "liger": ["liger-kernel==0.5.3; sys_platform != 'win32'"], # can be set to >=0.5.3 when https://github.com/linkedin/Liger-Kernel/issues/586 is fixed
     "mergekit": ["mergekit>=0.0.5.1"],
     "peft": ["peft>=0.8.0"],
     "quantization": ["bitsandbytes"],
     "scikit": ["scikit-learn"],
     "test": ["parameterized", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "pytest"],
-    "vllm": ["vllm>=0.7.2; sys_platform != 'win32'"],  # vllm is not available on Windows
+    "vllm": ["vllm==0.7.2; sys_platform != 'win32'"],  # vllm is not available on Windows / 0.7.3 causes hanging. temporary pinning until the issue is resolved
     "vlm": ["Pillow"],
 }
 EXTRAS["dev"] = []


### PR DESCRIPTION
liger-kernel: v0.5.3 introduced a bug, see https://github.com/linkedin/Liger-Kernel/issues/586
vLLM, starting from 0.7.3, learning hangs while gathering. Reported in the vLLM slack:

---
Hi there!

I wanted to try how it would speed things up with GRPO but the a subsequent gather seems to hang with 0.7.3 (it's not the case with 0.7.2): any idea why?

```python
# demo_vllm.py
from unittest.mock import patch
from accelerate.utils import gather_object
from accelerate import Accelerator
from vllm import LLM


def main():
    accelerator = Accelerator()
    if accelerator.is_main_process:
        # vLLM is not compatible with accelerate. So we need to patch it to make sure we can (1) place the vLLM model
        # on the desired device (world_size_patch) and (2) avoid a test that is not designed for our setting (profiling_patch).
        world_size_patch = patch("torch.distributed.get_world_size", return_value=1)
        profiling_patch = patch("vllm.worker.worker.Worker._assert_memory_footprint_increased_during_profiling", return_value=None)
        with world_size_patch, profiling_patch:
            LLM(model="Qwen/Qwen2.5-1.5B", device="cuda:7")

    # When using vLLM, the main process is responsible for loading the model weights. This can cause process desynchronization and seems
    # to lead to DeepSpeed hanging during initialization. To prevent this, we  synchronize all processes after vLLM has been fully initialized.
    accelerator.wait_for_everyone()

    prompts_text = ["Some text"]
    gather_object(prompts_text)  # it hangs here
    print("after gather")


if __name__ == "__main__":
    trainer = main()
```

```
accelerate launch --num_processes 7 demo_vllm.py
```