### PR TITLE
🛣️ `inference_mode` to `no_grad` when computing `old_per_token_logps`

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -776,7 +776,7 @@ class GRPOTrainer(Trainer):
 
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
 
-        with torch.inference_mode():
+        with torch.no_grad():
             # When using num_iterations == 1, old_per_token_logps == per_token_logps, so we can skip it's
             # computation here, and use per_token_logps.detach() instead.
             if self.num_iterations > 1:


### PR DESCRIPTION
Fixes #2953

I couldn't reproduce myself the bug, but numerous users reported that it solved the issue. AFAIK `no_grad` and `inference_mode` are mostly equivalent. The rule of thumb from the torch forum whose ref I no longer have is to prefer inference mode, and if it raises an error use no grad.