### PR TITLE
🌡️ Fix temperature inconsistency in GRPO trainer

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -658,8 +658,11 @@ class GRPOTrainer(Trainer):
         input_ids = input_ids[:, -logits_to_keep:]
         # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
         # See https://github.com/huggingface/trl/issues/2770
-        logits = logits[:, -logits_to_keep:] / self.temperature
-        return selective_log_softmax(logits, input_ids)  #  compute logprobs for the input tokens
+        logits = logits[:, -logits_to_keep:]
+        # Divide logits by sampling temperature.
+        # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
+        logits = logits / self.temperature
+        return selective_log_softmax(logits, input_ids)  # compute logprobs for the input tokens
 
     @profiling_decorator
     def _move_model_to_vllm(self):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -379,8 +379,8 @@ class GRPOTrainer(Trainer):
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length  # = |o_i| in the GRPO paper
         self.num_generations = args.num_generations  # = G in the GRPO paper
+        self.temperature = args.temperature
         self.use_vllm = args.use_vllm
-        self.generation_temperature = args.temperature + 1e-7
 
         # Multi-step
         self.num_iterations = args.num_iterations  # = 𝜇 in the GRPO paper
@@ -523,7 +523,7 @@ class GRPOTrainer(Trainer):
                     max_tokens=self.max_completion_length,
                     guided_decoding=guided_decoding,
                     n=args.num_generations,
-                    temperature=self.generation_temperature,
+                    temperature=args.temperature,
                     top_p=args.top_p,
                     top_k=-1 if args.top_k is None else args.top_k,
                     min_p=0.0 if args.min_p is None else args.min_p,
@@ -541,7 +541,7 @@ class GRPOTrainer(Trainer):
                 max_new_tokens=self.max_completion_length,
                 do_sample=True,
                 pad_token_id=processing_class.pad_token_id,
-                temperature=self.generation_temperature,
+                temperature=args.temperature,
                 top_p=args.top_p,
                 top_k=args.top_k,
                 min_p=args.min_p,
@@ -658,7 +658,7 @@ class GRPOTrainer(Trainer):
         input_ids = input_ids[:, -logits_to_keep:]
         # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
         # See https://github.com/huggingface/trl/issues/2770
-        logits = logits[:, -logits_to_keep:] / self.generation_temperature
+        logits = logits[:, -logits_to_keep:] / self.temperature
         return selective_log_softmax(logits, input_ids)  #  compute logprobs for the input tokens
 
     @profiling_decorator


### PR DESCRIPTION
# What does this PR do?

It fixes the temperature scaling omission when computing the model's and reference model's log probabilities, potentially causing highly biased policy gradients.

This should be consistent with other TRL implementations as PPO and RLOO.  Omitting this term has been evidenced to potentially cause detrimental instabilities when fine-tuning LLMs with RL (e.g., [see here](https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo)). Consistently with these results, using my own custom implementation after this fix also seems to work better. I tried doing additional research, but I could not find references that mention purposefully biasing the optimization leads to benefits... am I missing something?

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.