### PR TITLE
🏁 Passing custom BOS/EOS token to `GPROTrainer.generation_config`

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -539,9 +539,9 @@ class GRPOTrainer(Trainer):
             self.generation_config = GenerationConfig(
                 max_new_tokens=self.max_completion_length,
                 do_sample=True,
+                pad_token_id=processing_class.pad_token_id,
                 bos_token_id=processing_class.bos_token_id,
                 eos_token_id=processing_class.eos_token_id,
-                pad_token_id=processing_class.pad_token_id,
                 temperature=args.temperature,
                 top_p=args.top_p,
                 top_k=args.top_k,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -539,6 +539,8 @@ class GRPOTrainer(Trainer):
             self.generation_config = GenerationConfig(
                 max_new_tokens=self.max_completion_length,
                 do_sample=True,
+                bos_token_id=processing_class.bos_token_id,
+                eos_token_id=processing_class.eos_token_id,
                 pad_token_id=processing_class.pad_token_id,
                 temperature=args.temperature,
                 top_p=args.top_p,


### PR DESCRIPTION
If you use a custom EOS token in the tokenizer input to `GPROTrainer`, it won't be used in generation.

The `GPROTrainer` code already passes the pad token ID, now it passes the BOS and EOS token IDs too.