### PR TITLE
Fixed `SFTTrainer.compute_loss` hang from #3048's PR comments

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -464,7 +464,9 @@ class SFTTrainer(Trainer):
             model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
         )
         if mode == "train":
-            self._total_train_tokens += self.accelerator.gather_for_metrics(inputs["attention_mask"]).sum().item()
+            self._total_train_tokens += (
+                self.accelerator.gather_for_metrics(inputs["attention_mask"].sum()).sum().item()
+            )
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
         # Compute token accuracy if we have labels and if the model is not using Liger (no logits)


### PR DESCRIPTION
The PR suggestion in https://github.com/huggingface/trl/pull/3048 leads to the `gather_for_metrics` hanging.