### PR TITLE
Fixed the GKD example and also moved the student generation inside se…

### DIFF
--- a/examples/scripts/gkd.py
+++ b/examples/scripts/gkd.py
@@ -18,6 +18,7 @@ python examples/scripts/gkd.py \
     --model_name_or_path Qwen/Qwen2-0.5B-Instruct \
     --teacher_model_name_or_path Qwen/Qwen2-1.5B-Instruct \
     --dataset_name trl-lib/chatbot_arena_completions \
+    --dataset_text_field prompt \
     --learning_rate 2e-5 \
     --per_device_train_batch_size 4 \
     --gradient_accumulation_steps 8 \
@@ -32,6 +33,7 @@ python examples/scripts/gkd.py \
     --model_name_or_path Qwen/Qwen2-0.5B-Instruct \
     --teacher_model_name_or_path Qwen/Qwen2-1.5B-Instruct \
     --dataset_name trl-lib/chatbot_arena_completions \
+    --dataset_text_field prompt \
     --learning_rate 2e-4 \
     --per_device_train_batch_size 4 \
     --gradient_accumulation_steps 8 \

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -287,21 +287,23 @@ class GKDTrainer(SFTTrainer):
         which are then used for training instead of the original inputs.
         """
         if self.seq_kd:
-            with unwrap_model_for_generation(self.teacher_model, self.accelerator) as unwrapped_model:
-                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
-                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
-                )
-            inputs["input_ids"] = new_input_ids
-            inputs["attention_mask"] = new_attention_mask
-            inputs["labels"] = new_labels
-        if random.random() <= self.lmbda:
-            with unwrap_model_for_generation(model, self.accelerator) as unwrapped_model:
-                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
-                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
-                )
-            inputs["input_ids"] = new_input_ids
-            inputs["attention_mask"] = new_attention_mask
-            inputs["labels"] = new_labels
+            if random.random() <= self.lmbda:
+                with unwrap_model_for_generation(model, self.accelerator) as unwrapped_model:
+                    new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
+                        unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
+                    )
+                inputs["input_ids"] = new_input_ids
+                inputs["attention_mask"] = new_attention_mask
+                inputs["labels"] = new_labels
+
+            else:
+                with unwrap_model_for_generation(self.teacher_model, self.accelerator) as unwrapped_model:
+                    new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
+                        unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
+                    )
+                inputs["input_ids"] = new_input_ids
+                inputs["attention_mask"] = new_attention_mask
+                inputs["labels"] = new_labels
 
         loss = super().training_step(model, inputs, num_items_in_batch)
         return loss


### PR DESCRIPTION
# What does this PR do?

This PR improves the Generative Knowledge Distillation (GKD) implementation in two ways:

1. Fixes the GKD example script by adding the required `dataset_text_field` parameter to properly handle the input data.
2. Refactors the GKD trainer to move student generation inside the sequential knowledge distillation (`seq_kd`) conditional block, making the implementation more closely aligned with the original paper's methodology

These changes improve the usability of the GKD example and ensure the training process better follows the theoretical foundation from the paper.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone familiar with the GKD implementation or knowledge distillation in general can review this PR. @huggingface/trl-team members may be particularly interested in reviewing the changes to ensure they align with the intended implementation.