### PR TITLE
Minor spelling fix in documentation (caracteres -> characters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ from trl import GRPOTrainer
 
 dataset = load_dataset("trl-lib/tldr", split="train")
 
-# Dummy reward function: count the number of unique caracteres in the completions
+# Dummy reward function: count the number of unique characters in the completions
 def reward_num_unique_chars(completions, **kwargs):
     return [len(set(c)) for c in completions]
 


### PR DESCRIPTION
# What does this PR do?

Documentation used Spanish word **caracteres** rather than English word **characters**.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

