### PR TITLE
⛏️ Add cli dict parsing for grpo_config

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -15,6 +15,8 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Optional, Union
 
+import transformers
+from packaging import version
 from transformers import TrainingArguments
 
 
@@ -141,7 +143,12 @@ class GRPOConfig(TrainingArguments):
             Whether to log unique prompts in wandb. If `True`, only unique prompts are logged. If `False`, all
             prompts are logged.
     """
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+
+    if version.parse(transformers.__version__) <= version.parse("4.50.3"):
+        from transformers.training_args import _VALID_DICT_FIELDS
+        _VALID_DICT_FIELDS.append("model_init_kwargs")
+    else:
+        _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters that control the model and reference model
     model_init_kwargs: Optional[Union[dict, str]] = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -35,7 +35,7 @@ class GRPOConfig(TrainingArguments):
     Parameters:
         > Parameters that control the model and reference model
 
-        model_init_kwargs (`str, dict[str, Any]` or `None`, *optional*, defaults to `None`):
+        model_init_kwargs (`str`, `dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`GRPOTrainer`] is provided as a string.
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -146,6 +146,7 @@ class GRPOConfig(TrainingArguments):
 
     if version.parse(transformers.__version__) <= version.parse("4.50.3"):
         from transformers.training_args import _VALID_DICT_FIELDS
+
         _VALID_DICT_FIELDS.append("model_init_kwargs")
     else:
         _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
 from transformers import TrainingArguments
 
@@ -34,7 +33,7 @@ class GRPOConfig(TrainingArguments):
     Parameters:
         > Parameters that control the model and reference model
 
-        model_init_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
+        model_init_kwargs (`str, dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`GRPOTrainer`] is provided as a string.
 
@@ -142,9 +141,10 @@ class GRPOConfig(TrainingArguments):
             Whether to log unique prompts in wandb. If `True`, only unique prompts are logged. If `False`, all
             prompts are logged.
     """
+    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters that control the model and reference model
-    model_init_kwargs: Optional[dict] = field(
+    model_init_kwargs: Optional[Union[dict, str]] = field(
         default=None,
         metadata={
             "help": "Keyword arguments for `transformers.AutoModelForCausalLM.from_pretrained`, used when the `model` "


### PR DESCRIPTION
# What does this PR do?

Adds dict parsing logic to `model_init_kwargs` in `grpo_config`, enabling dynamic configuration via CLI. Users can now pass dictionary-like strings (e.g., `--model_init_kwargs '{"torch_dtype":"bfloat16"`) through command-line arguments, which are automatically parsed into Python dicts for the target fields.

Logic is the same as [TrainingArguments](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L226).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.