### PR TITLE
Co-Locating vLLM Instances with Training Processes Via External Launcher

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -102,6 +102,10 @@ class GRPOConfig(TrainingArguments):
             support this feature.
         vllm_guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
             Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled.
+        vllm_external_launcher (`bool`, *optional*, defaults to `False`):
+            Whether to use an external launcher for distributed vLLM execution. If set to `True`, vLLM will be 
+            initialized in **all processes**, each assigned to its respective device. This allows multi-GPU 
+            or multi-node execution with vLLM's external launcher, enabling improved large-scale inference.
 
         > Parameters that control the training
 
@@ -275,6 +279,14 @@ class GRPOConfig(TrainingArguments):
     vllm_guided_decoding_regex: Optional[str] = field(
         default=None,
         metadata={"help": "Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled."},
+    )
+    vllm_external_launcher: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "Whether to use an external launcher for distributed vLLM execution. If set to `True`, vLLM will be "
+                    "initialized in all processes, each assigned to its respective device. This enables optimized "
+                    "multi-GPU or multi-node inference."
+        },
     )
 
     # Parameters that control the training

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -506,6 +506,9 @@ class GRPOTrainer(Trainer):
                         device=vllm_device,
                         gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
                         dtype=self.args.vllm_dtype,
+                        # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
+                        # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
+                        # This is particularly useful here because we generate completions from the same prompts.
                         enable_prefix_caching=self.args.vllm_enable_prefix_caching,
                         max_model_len=self.args.vllm_max_model_len,
                         distributed_executor_backend="external_launcher" if self.args.vllm_external_launcher else None,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,10 +59,10 @@ from .utils import (
     selective_log_softmax,
 )
 
-import debugpy
-debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
-print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
-debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
+# import debugpy
+# debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
+# print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
+# debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
 
 if is_peft_available():
     from peft import PeftConfig, get_peft_model
@@ -848,11 +848,15 @@ class GRPOTrainer(Trainer):
                     # Since 'prompts' contains 'num_generations' duplicates, we first take unique prompts, and generate
                     # num_generations outputs for each one. This is faster than generating outputs for each duplicate
                     # prompt individually.
+                    print("In the main process, let's check all prompts size")
+                    print("all_prompts_text", len(all_prompts_text))
+                    print("ordered size: ", len(ordered_set_of_prompts))
                     ordered_set_of_prompts = all_prompts_text[:: self.num_generations]
                     with profiling_context(self, "vLLM.generate"):
                         all_outputs = self.llm.generate(
                             ordered_set_of_prompts, sampling_params=self.sampling_params, use_tqdm=False
                         )
+                    print("all_outputs size: ", len(all_outputs))
                     completion_ids = []
                     for outputs in all_outputs:
                         for output in outputs.outputs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -481,9 +481,8 @@ class GRPOTrainer(Trainer):
                             "`vllm_gpu_memory_utilization` accordingly."
                         )
 
-                # Prepare a list of context managers
+                # Prepare a list of context managers according to device type and vllm w/o external launcher
                 cmanagers = []
-
                 if not self.args.vllm_external_launcher:
                     cmanagers.extend([
                         functools.partial(patch, "torch.distributed.get_world_size", return_value=1),
@@ -501,7 +500,7 @@ class GRPOTrainer(Trainer):
                     for cm in cmanagers:
                         stack.enter_context(cm())
 
-                    # Initialize the LLM
+                    # Initialize the LLM (set distributed_executor_backend = external_launcher if requested)
                     self.llm = LLM(
                         model=model.name_or_path,
                         device=vllm_device,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,6 +59,10 @@ from .utils import (
     selective_log_softmax,
 )
 
+import debugpy
+debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
+print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
+debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
 
 if is_peft_available():
     from peft import PeftConfig, get_peft_model

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -822,7 +822,8 @@ class GRPOTrainer(Trainer):
                 completion_ids = [None] * len(all_prompts_text)
 
             if not self.args.vllm_external_launcher:
-                # Broadcast completions to all processes
+                # Broadcast the completions from the main process to all processes, ensuring each process receives its
+                # corresponding slice.
                 completion_ids = broadcast_object_list(completion_ids, from_process=0)
                 process_slice = slice(
                     self.accelerator.process_index * len(prompts),

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -850,8 +850,9 @@ class GRPOTrainer(Trainer):
                     # prompt individually.
                     print("In the main process, let's check all prompts size")
                     print("all_prompts_text", len(all_prompts_text))
-                    print("ordered size: ", len(ordered_set_of_prompts))
+                    
                     ordered_set_of_prompts = all_prompts_text[:: self.num_generations]
+                    print("ordered size: ", len(ordered_set_of_prompts))
                     with profiling_context(self, "vLLM.generate"):
                         all_outputs = self.llm.generate(
                             ordered_set_of_prompts, sampling_params=self.sampling_params, use_tqdm=False

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -458,7 +458,9 @@ class GRPOTrainer(Trainer):
                 if self.args.vllm_external_launcher:
                     # External launcher mode: Assign vLLM to the current process's device
                     vllm_device = f"{device_type}:{self.accelerator.process_index}"  
+                    print("---- Using external launcher - multi vllm")
                 else:
+                    print("---- Using single vllm")
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
                         # if self.args.vllm_external_launcher --> current device
@@ -736,8 +738,10 @@ class GRPOTrainer(Trainer):
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:
                 if self.args.vllm_external_launcher:
+                    print("-- External launcher - work your own batch")
                     prompts_to_use = prompts_text  # Each GPU handles its own batch
                 else:
+                    print("-- No External launcher - work all batches")
                     prompts_to_use = all_prompts_text[::self.num_generations]  # Unique prompts for generation
 
                 # Generate completions

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,11 +59,6 @@ from .utils import (
     selective_log_softmax,
 )
 
-# import debugpy
-# debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
-# print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
-# debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
-
 if is_peft_available():
     from peft import PeftConfig, get_peft_model
 
@@ -458,9 +453,7 @@ class GRPOTrainer(Trainer):
                 if self.args.vllm_external_launcher:
                     # External launcher mode: Assign vLLM to the current process's device
                     vllm_device = f"{device_type}:{self.accelerator.process_index}"  
-                    print("---- Using external launcher - multi vllm")
                 else:
-                    print("---- Using single vllm")
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
                         # if self.args.vllm_external_launcher --> current device
@@ -738,10 +731,8 @@ class GRPOTrainer(Trainer):
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:
                 if self.args.vllm_external_launcher:
-                    print("-- External launcher - work your own batch")
                     prompts_to_use = prompts_text  # Each GPU handles its own batch
                 else:
-                    print("-- No External launcher - work all batches")
                     prompts_to_use = all_prompts_text[::self.num_generations]  # Unique prompts for generation
 
                 # Generate completions

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -456,7 +456,6 @@ class GRPOTrainer(Trainer):
                 else:
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
-                        # if self.args.vllm_external_launcher --> current device
                         if device_module.device_count() == 1:
                             vllm_device = f"{device_type}:0"  # particular case when training with onyl 1 device: share it
                         else:
@@ -519,7 +518,7 @@ class GRPOTrainer(Trainer):
                     repetition_penalty=args.repetition_penalty,
                 )
 
-            self._last_loaded_step = 0  # Tag to avoid unnecessary loading during gradient accumulation
+            self._last_loaded_step = 0  # tag to avoid useless loading during grad accumulation
             if not self.args.vllm_external_launcher:
                 # When using vLLM, the main process is responsible for loading the model weights. This can cause process
                 # desynchronization and seems to lead to DeepSpeed hanging during initialization. To prevent this, we
@@ -726,7 +725,7 @@ class GRPOTrainer(Trainer):
                 self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
-            # Gather prompts only once if needed
+            # Generate completions using vLLM: gather all prompts and use them in a single call in the main process unless external launcher enabled
             all_prompts_text = gather_object(prompts_text) if not self.args.vllm_external_launcher else None
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -469,25 +469,25 @@ class GRPOTrainer(Trainer):
                         else:
                             vllm_device = f"{device_type}:{self.accelerator.num_processes}"  # take the next GPU idx
                 
-                # Check that the requested device is available
-                if (
-                    vllm_device.split(":")[0] == f"{device_type}"
-                    and int(vllm_device.split(":")[1]) >= device_module.device_count()
-                ):
-                    raise ValueError(
-                        f"The requested device for vllm ({vllm_device}) is not available. You are likely using vLLM "
-                        "without restricting the number of GPUs for training. Set the `--num_processes` argument to a "
-                        "value lower than the number of GPUs available on your machine—typically, reducing it by one "
-                        f"is sufficient. In your case: `--num_processes {device_module.device_count() - 1}`."
+                    # Check that the requested device is available
+                    if (
+                        vllm_device.split(":")[0] == f"{device_type}"
+                        and int(vllm_device.split(":")[1]) >= device_module.device_count()
+                    ):
+                        raise ValueError(
+                            f"The requested device for vllm ({vllm_device}) is not available. You are likely using vLLM "
+                            "without restricting the number of GPUs for training. Set the `--num_processes` argument to a "
+                            "value lower than the number of GPUs available on your machine—typically, reducing it by one "
+                            f"is sufficient. In your case: `--num_processes {device_module.device_count() - 1}`."
                     )
-                # Check that the requested device is not also used for training
-                if vllm_device in {f"{device_type}:{idx}" for idx in range(self.accelerator.num_processes)}:
-                    warnings.warn(
-                        f"The requested device {vllm_device} is also being used for training. For higher throughput "
-                        "and to avoid out-of-memory errors, it is recommended to use a dedicated device for vLLM. "
-                        "If this is intentional, you may ignore this warning but should adjust "
-                        "`vllm_gpu_memory_utilization` accordingly."
-                    )
+                    # Check that the requested device is not also used for training
+                    if vllm_device in {f"{device_type}:{idx}" for idx in range(self.accelerator.num_processes)}:
+                        warnings.warn(
+                            f"The requested device {vllm_device} is also being used for training. For higher throughput "
+                            "and to avoid out-of-memory errors, it is recommended to use a dedicated device for vLLM. "
+                            "If this is intentional, you may ignore this warning but should adjust "
+                            "`vllm_gpu_memory_utilization` accordingly."
+                        )
 
                 # Initialize LLM under ExitStack (only apply patches if not using external launcher)
                 with contextlib.ExitStack() as stack:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -789,6 +789,8 @@ class GRPOTrainer(Trainer):
         prompt_inputs = super()._prepare_inputs(prompt_inputs)
         prompt_ids, prompt_mask = prompt_inputs["input_ids"], prompt_inputs["attention_mask"]
 
+        print("prompts:" , len(prompts), " prompts_text", len(prompts_text), " prompts_input ", len(prompt_inputs), "prompt_ids ", len(prompt_ids), "prompt mask ", len(prompt_mask))
+
         if self.max_prompt_length is not None:
             prompt_ids = prompt_ids[:, -self.max_prompt_length :]
             prompt_mask = prompt_mask[:, -self.max_prompt_length :]


### PR DESCRIPTION
# What does this PR do?

Fixes #3064 

Addresses:
#3114 
#2971 
#2922
#2887 


# Motivation
vLLM has introduced support for an [external launcher](https://github.com/vllm-project/vllm/pull/12071), enabling vLLM processes to be co-located with other workloads, such as training.

Benefits of delivering External Launcher to the GRPO:
- Improved Inference Speed – It reduces the time required for GRPO training.
- Optimized GPU Utilization – Instead of dedicating an entire GPU solely to vLLM, multiple vLLM instances can now be colocated with training processes.

To leverage this feature, I added an option in TRL to spawn vLLM processes per GPU using the external launcher.

## Modifications in This PR:
This PR updates the GRPO trainer to:
- Introduce an option (self.args.vllm_external_launcher) to enable vLLM initialization via the external launcher.
- Initialize vLLM processes on each GPU using distributed_executor_backend="external_launcher".
- Remove the need to gather prompts across devices and set num_generation = 1, as each vLLM instance processes its own batch independently.
- This approach enables multi-vLLM execution in GRPO without relying on RAY, achieving efficiency gains with minimal modifications.

## Results:
- Running GRPO training with this configuration
<details>
  <summary>Click to view YAML</summary>

  ```yaml
  # Model arguments
  model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
  model_revision: main
  torch_dtype: bfloat16
  attn_implementation: flash_attention_2
  
  # Data training arguments
  chat_template: "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}"
  dataset_name: open-r1/OpenR1-Math-220k # limo datasset is smaller - open-R1 fork of Fabian (problem key error will occur)
  system_prompt: "You are a helpful AI Assistant that provides well-reasoned and detailed responses. You first think about the reasoning process as an internal monologue and then provide the user with the answer. Respond in the following format: <think>\n...\n</think>\n<answer>\n...\n</answer>"
  
  # GRPO trainer config
  bf16: true
  use_vllm: true
  vllm_gpu_memory_utilization: 0.2
  vllm_enable_prefix_caching: false
  vllm_external_launcher: true # if this is set to false, set vllm_device: auto
  do_eval: false
  gradient_accumulation_steps: 4
  gradient_checkpointing: true
  gradient_checkpointing_kwargs:
    use_reentrant: false
  learning_rate: 1.0e-06
  log_completions: false
  log_level: info
  logging_first_step: true
  logging_steps: 1
  logging_strategy: steps
  lr_scheduler_type: cosine_with_min_lr
  lr_scheduler_kwargs:
    min_lr_rate: 0.1
  max_prompt_length: 512
  max_completion_length: 2048
  max_steps: 20
  num_generations: 16
  num_train_epochs: 1
  overwrite_output_dir: true
  per_device_train_batch_size: 16
  reward_funcs:
  - length
  save_total_limit: 1
  seed: 42
  temperature: 0.7
  warmup_ratio: 0.1
  ```
</details>

- resulted in 2× faster GRPO training (see attached figure)
![Screenshot 2025-03-17 at 7 32 35 PM](https://github.com/user-attachments/assets/76a2f956-01a4-4bfa-8817-7eb225b3dc9c)

To run an experiment w/ the config above, define ACCELERATE_CONFIG = recipes/accelerate_configs/zero2.yaml (from open-R1 repo) and define GRPO_CONFIG as provided above, then run
-  `ACCELERATE_LOG_LEVEL=info accelerate launch --config_file $ACCELERATE_CONFIG --num_processes=8 src/open_r1/grpo.py --config $GRPO_CONFIG`  for multi vllm scenario
- `ACCELERATE_LOG_LEVEL=info accelerate launch --config_file $ACCELERATE_CONFIG --num_processes=7 src/open_r1/grpo.py --config $GRPO_CONFIG`  for single vllm scenario (remember to set `vllm_external_launcher: false` and `vllm_device: auto`).


## Discussions:

### Why 2× speedup instead of 7–8×?
Previously, 7 GPUs were allocated for training and 1 GPU for generation. With this change, all GPUs are now utilized for both training and generation. Given that vLLMs are parallelized across all 8 GPUs, one might expect a 7–8× speedup. However, testing against a standalone vLLM instance also showed similar performance behavior as follows.

- Setup 1 (Single vLLM - original behavior of TRL): for per_device_train_batch = 16, num_gen = 16, device_count = 7..
Each of the 7 devices processes 16 prompts, leading to a global total of 112 prompts. The main vLLM process selects every 16th prompt, meaning a single vLLM gets 7 prompts and generates 112 generations. 

- Setup 2 (Multi-vLLM - w/ external launcher): Each vLLM processes a local batch of 16 and generates one output per input. This results in 16 generations per vLLM instance.

Setup1 showed 79 sec latency vs. setup2 showed 36sec latency for the deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B model.  The observed speedup was around 2×, aligning with our findings in GRPO training above.

Setup script is below.

<details>
  <summary>Click to view script</summary>

  ```python
  import random
  import lorem
  import os
  import argparse
  import time
  from vllm import LLM, SamplingParams
  
  def parse_arguments():
      parser = argparse.ArgumentParser(description="vLLM test to validate GPRO training savings.")
      parser.add_argument("--model_name", type=str, required=True, help="Name of the model to use")
      parser.add_argument("--no_of_prompts", type=int, default=112, help="Number of random prompts / batch size")
      parser.add_argument("--num_gen", type=int, default=1, help="Number of generations per prompt (n in SamplingParams)")
      return parser.parse_args()
  
  # Function to generate a random prompt with a given character length
  def generate_prompt():
      length = random.randint(100, 500)  
      prompt = lorem.paragraph()  
      while len(prompt) < length:
          prompt += " " + lorem.sentence()  
      return prompt[:length]  # Trim to exact length
  
  def initialize_llm(model_name):
      os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # Ensure only GPU 0 is used
  
      llm = LLM(
          model=model_name,
          device="cuda",
          dtype="bfloat16",
          gpu_memory_utilization=0.3,
          enable_prefix_caching=False,
          max_model_len=None,  # Adjust as needed
      )
      return llm
  
  def run_inference(llm, prompts, num_gen):
      sampling_params = SamplingParams(
          max_tokens=2048,
          guided_decoding=None,
          n=num_gen,  # Number of generations per prompt
          temperature=0.7,
          top_p=1.0,
          top_k=50,
          min_p=0.0,
          repetition_penalty=1.0,
      )
  
      output = llm.generate(prompts, sampling_params)
 
      return output
  
  if __name__ == "__main__":
      args = parse_arguments()
  
      print(f"Initializing model: {args.model_name}")
      llm = initialize_llm(args.model_name)
  
      print(f"Generating {args.no_of_prompts} random prompts...")
      random_prompts = [generate_prompt() for _ in range(args.no_of_prompts)]
  
      print("Running inference...")
      start_time = time.time()
      results = run_inference(llm, random_prompts, args.num_gen)
      end_time = time.time()
  
      print(f"Inference completed in {end_time - start_time:.4f} seconds.")
  ```
</details>

We tried two different models (Qwen/Qwen2.5-Math-7B and deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B) and compared setup1 (no_of_prompts = 7, num_gen = 16) vs. setup2 (no_of_prompts = 16, num_gen = 1).  
`python script.py --model_name "Qwen/Qwen2.5-Math-7B" --no_of_prompts 16 --num_gen 1` vs. `python script.py --model_name "Qwen/Qwen2.5-Math-7B" --no_of_prompts 7 --num_gen 16`


CC @fabianlim 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.