### PR TITLE
Use main process for dataset.map

### DIFF
--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -589,7 +589,7 @@ class BCOTrainer(Trainer):
         # issued.
         model.warnings_issued["estimate_tokens"] = True
 
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Apply the chat template if needed
             train_dataset = train_dataset.map(
                 maybe_apply_chat_template, fn_kwargs={"tokenizer": processing_class}, num_proc=args.dataset_num_proc

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -325,7 +325,7 @@ class CPOTrainer(Trainer):
 
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Extract the prompt if needed, and apply the chat template if needed
             train_dataset = train_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
             train_dataset = train_dataset.map(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -539,7 +539,7 @@ class DPOTrainer(Trainer):
         if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
             map_kwargs["num_proc"] = args.dataset_num_proc
 
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Extract prompt if needed
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Extracting prompt in {dataset_name} dataset"

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -584,7 +584,7 @@ class KTOTrainer(Trainer):
 
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Extract the prompt if needed
             train_dataset = train_dataset.map(
                 maybe_extract_prompt, num_proc=args.dataset_num_proc, desc="Extracting prompt from train dataset"

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -319,7 +319,7 @@ class ORPOTrainer(Trainer):
 
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Extract the prompt if needed, and apply the chat template if needed
             train_dataset = train_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
             train_dataset = train_dataset.map(

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -145,7 +145,7 @@ class PRMTrainer(Trainer):
             data_collator = DataCollatorForTokenClassification(processing_class, max_length=args.max_length)
 
         if "input_ids" not in train_dataset.column_names:
-            with PartialState().local_main_process_first():
+            with PartialState().main_process_first():
                 fn_kwargs = {
                     "tokenizer": processing_class,
                     "step_separator": args.step_separator,

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -204,7 +204,7 @@ class RewardTrainer(Trainer):
         model.warnings_issued["estimate_tokens"] = True
 
         if "input_ids_chosen" not in train_dataset.column_names:
-            with PartialState().local_main_process_first():
+            with PartialState().main_process_first():
                 fn_kwargs = {"tokenizer": processing_class}
                 train_dataset = train_dataset.map(maybe_apply_chat_template, fn_kwargs={"tokenizer": processing_class})
                 train_dataset = train_dataset.map(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -390,7 +390,7 @@ class SFTTrainer(Trainer):
         if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
             map_kwargs["num_proc"] = args.dataset_num_proc
 
-        with PartialState().local_main_process_first():
+        with PartialState().main_process_first():
             # Apply the formatting function if any
             if formatting_func is not None and is_processed:
                 warnings.warn(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR fixes a race condition that arises in our trainers when they are run on >16 nodes, for example:

```
[ip-26-0-160-242:0]:Converting train dataset to ChatML:  98%|█████████▊| 40000/40665 [00:15<00:00, 2123.26 examples/s][ip-26-0-160-242:0]:
[ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   1%|          | 335/40665 [00:00<00:12, 3297.59 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   2%|▏         | 825/40665 [00:00<00:09, 4231.38 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   4%|▎         | 1466/40665 [00:00<00:13, 2930.79 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   5%|▍         | 1953/40665 [00:00<00:11, 3447.54 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   6%|▌         | 2427/40665 [00:00<00:14, 2686.47 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   7%|▋         | 2894/40665 [00:00<00:12, 3117.34 examples/s][ip-26-0-161-142:0]:
[ip-26-0-161-142:0]:Applying chat template to train dataset:   8%|▊         | 3450/40665 [00:01<00:14, 2562.10 examples/s][ip-26-0-161-142:0]:
[ip-26-0-167-217:0]:Converting train dataset to ChatML:  99%|█████████▉| 40417/40665 [00:14<00:00, 2390.92 examples/s][ip-26-0-167-217:0]:
[ip-26-0-167-217:0]:Converting train dataset to ChatML: 100%|██████████| 40665/40665 [00:17<00:00, 2297.69 examples/s]
[ip-26-0-167-217:0]:[rank64]: Traceback (most recent call last):
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/src/open_r1/sft.py", line 205, in <module>
[ip-26-0-167-217:0]:[rank64]:     main(script_args, training_args, model_args)
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/src/open_r1/sft.py", line 138, in main
[ip-26-0-167-217:0]:[rank64]:     trainer = SFTTrainer(
[ip-26-0-167-217:0]:[rank64]:               ^^^^^^^^^^^
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/openr1/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 190, in __init__
[ip-26-0-167-217:0]:[rank64]:     train_dataset = self._prepare_dataset(
[ip-26-0-167-217:0]:[rank64]:                     ^^^^^^^^^^^^^^^^^^^^^^
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/openr1/lib/python3.11/site-packages/trl/trainer/sft_trainer.py", line 408, in _prepare_dataset
[ip-26-0-167-217:0]:[rank64]:     dataset = dataset.map(
[ip-26-0-167-217:0]:[rank64]:               ^^^^^^^^^^^^
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/openr1/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 562, in wrapper
[ip-26-0-167-217:0]:[rank64]:     out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
[ip-26-0-167-217:0]:[rank64]:                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/openr1/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 3079, in map
[ip-26-0-167-217:0]:[rank64]:     for rank, done, content in Dataset._map_single(**dataset_kwargs):
[ip-26-0-167-217:0]:[rank64]:   File "/fsx/lewis/git/hf/open-r1/openr1/lib/python3.11/site-packages/datasets/arrow_dataset.py", line 3567, in _map_single
[ip-26-0-167-217:0]:[rank64]:     os.chmod(cache_file_name, 0o666 & ~umask)
[ip-26-0-167-217:0]:[rank64]: FileNotFoundError: [Errno 2] No such file or directory: '/fsx/h4/.cache/datasets/open-r1___codeforces-cots_decontaminated/solutions/0.0.0/4c7d514813be31edee7b58b66b46bce62b000eb2/cache-8726fdbc2b6bb197.arrow'
```

The root cause stems from the use of `local_main_process_first()` which can cause N concurrent processes (one per node) to attempt to read the same file in the cache.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.