### PR TITLE
improvement(utils.py): simplify repeating completion string

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -916,10 +916,10 @@ class GRPOTrainer(Trainer):
         if self.log_completions and self.state.global_step % self.args.logging_steps == 0:
             prompts_to_log = gather_object(prompts_text)
             completions_to_log = gather_object(completions_text)
-            rewards_to_log = rewards.tolist()
 
             if self.accelerator.is_main_process:
                 if is_rich_available():
+                    rewards_to_log = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).to('cpu')
                     print_prompt_completions_sample(
                         prompts_to_log,
                         completions_to_log,

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1691,6 +1691,30 @@ def selective_log_softmax(logits, index):
     return per_token_logps
 
 
+def simplify_repeated(completion: str, threshold: int = 100) -> str:
+    """
+    Detect repeated lines in a multi-line string and simplify it if repetitions exceed the threshold.
+
+    Parameters:
+        completion (str): The input multi-line string.
+        threshold (int): The maximum allowed repetition count for any line (default is 100).
+
+    Returns:
+        str: If any line repeats more than the threshold, returns a simplified string; otherwise, returns the original string.
+    """
+    # Split the string into lines and strip leading/trailing whitespace from each line
+    parts = [part.strip() for part in completion.split('\n')]
+    # Use Counter to count occurrences of each line
+    counter = Counter(parts)
+    # Check if any line repeats more than the threshold
+    for part, count in counter.items():
+        if count > threshold:
+            # If a line repeats more than the threshold, return the simplified string
+            return completion[:threshold] + f"[repetition exceeds {threshold} times]"
+    # If no line repeats more than the threshold, return the original string
+    return completion
+
+
 def print_prompt_completions_sample(prompts: list[str], completions: list[str], rewards: list[int], step: int) -> None:
     """
     Print out a sample of model completions to the console.
@@ -1738,7 +1762,7 @@ def print_prompt_completions_sample(prompts: list[str], completions: list[str], 
     table.add_column("Reward", style="bold cyan", justify="right")
 
     for prompt, completion, reward in zip(prompts, completions, rewards):
-        table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places
+        table.add_row(Text(prompt), Text(simplify_repeated(completion=completion)), f"{reward:.2f}")  # Formatting reward to 2 decimal places
         table.add_section()  # Adds a separator between rows
 
     panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")


### PR DESCRIPTION
# What does this PR do?

The old logs are too verbose:
- especially when the LLM is repeating itself
- the reward is also hard to debug because only the total score is printed, and it's not clear which function might have calculated incorrectly

Here is new logging:
![image](https://github.com/user-attachments/assets/f5e54a6d-f8ad-4cba-b92e-8796e27dd1ed)

save my screen and easy to debug reward funcs 2333~

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.