### PR TITLE
Fix: Compatibility for `formatting_func` returning a list

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -410,7 +410,7 @@ class SFTTrainer(Trainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Applying formatting function to {dataset_name} dataset"
 
-                batched = isinstance(formatting_func(next(iter(dataset))), list)
+                batched = isinstance(formatting_func(dataset), list)
 
                 def _func(example):
                     return {"text": formatting_func(example)}


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

When I defined `formatting_func` to return a list of processed strings following the documentation of SFTTrainer, an `IndexError` was raised.

```python
File ~/.conda/envs/rrag/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:413, in SFTTrainer._prepare_dataset(self, dataset, processing_class, args, packing, formatting_func, dataset_name)
    410 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
    411     map_kwargs["desc"] = f"Applying formatting function to {dataset_name} dataset"
--> 413 batched = isinstance(formatting_func(next(iter(dataset))), list)
    415 def _func(example):
    416     return {"text": formatting_func(example)}

Cell In[17], line 4, in formatting_prompts_func(example)
      2 output_texts = []
      3 for i in range(len(example['instruction'])):
----> 4     text = f"### Question: {example['instruction'][i]}\n ### Answer: {example['output'][i]}"
      5     output_texts.append(text)
      6 return output_texts

IndexError: string index out of range
```
I initially thought it was a documentation error and submitted a PR (https://github.com/huggingface/trl/pull/3141).

However, after reviewing the code, I found that it was a bug in the batched judgement. The issue was located in the following line:
https://github.com/huggingface/trl/blob/dee37342a8505beb5ad7e0dd01071c8b9ac584ba/trl/trainer/sft_trainer.py#L413 

After fixing the bug, the code is now compatible with `formatting_func` returning either a processed string or a list.

```python
def formatting_func(example):
    output_texts = []
    for i in range(len(example['instruction'])):
        text = f"### Question: {example['instruction'][i]}\n ### Answer: {example['output'][i]}"
        output_texts.append(text)
    return output_texts

batched = isinstance(formatting_func(dataset), list) # True

def formatting_func(example):
    text = f"### Question: {example['instruction']}\n ### Answer: {example['output']}"
    return text

batched = isinstance(formatting_func(dataset), list) # False
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

@qgallouedec 