### PR TITLE
Enable number of printed completions to be set

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -412,3 +412,6 @@ class GRPOConfig(TrainingArguments):
                 "configuration.",
                 DeprecationWarning,
             )
+
+        if self.num_completions_to_log == 0:
+            raise ValueError("`num_completions_to_log` must be `None` or greater than 0")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -134,6 +134,8 @@ class GRPOConfig(TrainingArguments):
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is
             installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`.
+        num_completions_to_log (`int`, *optional*, defaults to `None`):
+            Number of completions to log. If `None`, all completions are logged.
     """
 
     # Parameters that control the model and reference model
@@ -325,6 +327,10 @@ class GRPOConfig(TrainingArguments):
             "help": "Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is "
             "installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`."
         },
+    )
+    num_completions_to_log: Optional[int] = field(
+        default=None,
+        metadata={"help": "Number of completions to log. If `None`, all completions are logged."},
     )
 
     # Deprecated parameters

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -134,8 +134,8 @@ class GRPOConfig(TrainingArguments):
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is
             installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`.
-        num_completions_to_log (`int`, *optional*, defaults to `None`):
-            Number of completions to log. If `None`, all completions are logged.
+        num_completions_to_print (`int`, *optional*, defaults to `None`):
+            Number of completions to print with `rich`. If `None`, all completions are logged.
     """
 
     # Parameters that control the model and reference model
@@ -328,9 +328,9 @@ class GRPOConfig(TrainingArguments):
             "installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`."
         },
     )
-    num_completions_to_log: Optional[int] = field(
+    num_completions_to_print: Optional[int] = field(
         default=None,
-        metadata={"help": "Number of completions to log. If `None`, all completions are logged."},
+        metadata={"help": "Number of completions to print with `rich`. If `None`, all completions are logged."},
     )
 
     # Deprecated parameters
@@ -413,5 +413,5 @@ class GRPOConfig(TrainingArguments):
                 DeprecationWarning,
             )
 
-        if self.num_completions_to_log == 0:
+        if self.num_completions_to_print == 0:
             raise ValueError("`num_completions_to_log` must be `None` or greater than 0")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -134,7 +134,7 @@ class GRPOConfig(TrainingArguments):
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is
             installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`.
-        num_completions_to_print (`int`, *optional*, defaults to `None`):
+        num_completions_to_print (`int` or `None`, *optional*, defaults to `None`):
             Number of completions to print with `rich`. If `None`, all completions are logged.
     """
 
@@ -412,6 +412,3 @@ class GRPOConfig(TrainingArguments):
                 "configuration.",
                 DeprecationWarning,
             )
-
-        if self.num_completions_to_print == 0:
-            raise ValueError("`num_completions_to_log` must be `None` or greater than 0")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -428,7 +428,7 @@ class GRPOTrainer(Trainer):
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
         self.log_completions = args.log_completions
-        self.num_completions_to_log = args.num_completions_to_log
+        self.num_completions_to_print = args.num_completions_to_print
 
         super().__init__(
             model=model,
@@ -894,7 +894,7 @@ class GRPOTrainer(Trainer):
                         completions_to_log,
                         rewards_to_log,
                         self.state.global_step,
-                        self.num_completions_to_log,
+                        self.num_completions_to_print,
                     )
                 if self.args.report_to and "wandb" in self.args.report_to and wandb.run is not None:
                     import pandas as pd
@@ -907,8 +907,6 @@ class GRPOTrainer(Trainer):
                         "reward": rewards.tolist(),
                     }
                     df = pd.DataFrame(table)
-                    if self.num_completions_to_log is not None:
-                        df = df.sample(min(self.num_completions_to_log, len(df)))
                     wandb.log({"completions": wandb.Table(dataframe=df)})
 
         return {

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -428,6 +428,7 @@ class GRPOTrainer(Trainer):
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
         self.log_completions = args.log_completions
+        self.num_completions_to_log = args.num_completions_to_log
 
         super().__init__(
             model=model,
@@ -893,6 +894,7 @@ class GRPOTrainer(Trainer):
                         completions_to_log,
                         rewards_to_log,
                         self.state.global_step,
+                        self.num_completions_to_log,
                     )
                 if self.args.report_to and "wandb" in self.args.report_to and wandb.run is not None:
                     import pandas as pd
@@ -905,6 +907,8 @@ class GRPOTrainer(Trainer):
                         "reward": rewards.tolist(),
                     }
                     df = pd.DataFrame(table)
+                    if self.num_completions_to_log is not None:
+                        df = df.sample(min(self.num_completions_to_log, len(df)))
                     wandb.log({"completions": wandb.Table(dataframe=df)})
 
         return {

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1741,8 +1741,15 @@ def print_prompt_completions_sample(
     table.add_column("Completion", style="bright_green")
     table.add_column("Reward", style="bold cyan", justify="right")
 
+    # Some basic input validation
+    if num_samples is not None:
+        if num_samples >= len(prompts):
+            num_samples = None
+        if num_samples <= 0:
+            return
+
     # Subsample data if num_samples is specified
-    if num_samples is not None and 0 < num_samples < len(prompts):
+    if num_samples is not None:
         indices = random.sample(range(len(prompts)), num_samples)
         prompts = [prompts[i] for i in indices]
         completions = [completions[i] for i in indices]

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1691,7 +1691,9 @@ def selective_log_softmax(logits, index):
     return per_token_logps
 
 
-def print_prompt_completions_sample(prompts: list[str], completions: list[str], rewards: list[int], step: int) -> None:
+def print_prompt_completions_sample(
+    prompts: list[str], completions: list[str], rewards: list[int], step: int, num_samples: int = None
+) -> None:
     """
     Print out a sample of model completions to the console.
 
@@ -1707,6 +1709,8 @@ def print_prompt_completions_sample(prompts: list[str], completions: list[str], 
             List of rewards corresponding to the completions.
         step (`int`):
             Current training step number, used in the output title.
+        num_samples (`int`, *optional*):
+            Number of random samples to display. If None, all items will be displayed.
 
     Example:
     ```python
@@ -1736,6 +1740,13 @@ def print_prompt_completions_sample(prompts: list[str], completions: list[str], 
     table.add_column("Prompt", style="bright_yellow")
     table.add_column("Completion", style="bright_green")
     table.add_column("Reward", style="bold cyan", justify="right")
+
+    # Subsample data if num_samples is specified
+    if num_samples is not None and num_samples < len(prompts):
+        indices = random.sample(range(len(prompts)), num_samples)
+        prompts = [prompts[i] for i in indices]
+        completions = [completions[i] for i in indices]
+        rewards = [rewards[i] for i in indices]
 
     for prompt, completion, reward in zip(prompts, completions, rewards):
         table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1745,7 +1745,7 @@ def print_prompt_completions_sample(
     if num_samples is not None:
         if num_samples >= len(prompts):
             num_samples = None
-        if num_samples <= 0:
+        elif num_samples <= 0:
             return
 
     # Subsample data if num_samples is specified

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1692,7 +1692,7 @@ def selective_log_softmax(logits, index):
 
 
 def print_prompt_completions_sample(
-    prompts: list[str], completions: list[str], rewards: list[int], step: int, num_samples: Optional[int] = None
+    prompts: list[str], completions: list[str], rewards: list[int], step: int, num_samples: int = None
 ) -> None:
     """
     Print out a sample of model completions to the console.
@@ -1733,25 +1733,24 @@ def print_prompt_completions_sample(
     if not is_rich_available():
         raise ImportError("This feature requires `rich` to be installed. Please install it first: `pip install rich`")
 
+    console = Console()
+    table = Table(show_header=True, header_style="bold white", expand=True)
+
+    # Add columns
+    table.add_column("Prompt", style="bright_yellow")
+    table.add_column("Completion", style="bright_green")
+    table.add_column("Reward", style="bold cyan", justify="right")
+
     # Subsample data if num_samples is specified
-    num_samples = min(len(prompts), num_samples) if num_samples is not None else None
-    if num_samples is not None and num_samples > 0:
-        console = Console()
-        table = Table(show_header=True, header_style="bold white", expand=True)
-
-        # Add columns
-        table.add_column("Prompt", style="bright_yellow")
-        table.add_column("Completion", style="bright_green")
-        table.add_column("Reward", style="bold cyan", justify="right")
-
+    if num_samples is not None and 0 < num_samples < len(prompts):
         indices = random.sample(range(len(prompts)), num_samples)
         prompts = [prompts[i] for i in indices]
         completions = [completions[i] for i in indices]
         rewards = [rewards[i] for i in indices]
 
-        for prompt, completion, reward in zip(prompts, completions, rewards):
-            table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places
-            table.add_section()  # Adds a separator between rows
+    for prompt, completion, reward in zip(prompts, completions, rewards):
+        table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places
+        table.add_section()  # Adds a separator between rows
 
-        panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
-        console.print(panel)
+    panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
+    console.print(panel)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1709,8 +1709,8 @@ def print_prompt_completions_sample(
             List of rewards corresponding to the completions.
         step (`int`):
             Current training step number, used in the output title.
-        num_samples (`int`, *optional*):
-            Number of random samples to display. If None, all items will be displayed.
+        num_samples (`int` or `None`, *optional*, defaults to `None`):
+            Number of random samples to display. If `None` (default), all items will be displayed.
 
     Example:
     ```python
@@ -1742,7 +1742,7 @@ def print_prompt_completions_sample(
     table.add_column("Reward", style="bold cyan", justify="right")
 
     # Subsample data if num_samples is specified
-    if num_samples is not None and num_samples < len(prompts):
+    if num_samples is not None and 0 < num_samples < len(prompts):
         indices = random.sample(range(len(prompts)), num_samples)
         prompts = [prompts[i] for i in indices]
         completions = [completions[i] for i in indices]

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1692,7 +1692,7 @@ def selective_log_softmax(logits, index):
 
 
 def print_prompt_completions_sample(
-    prompts: list[str], completions: list[str], rewards: list[int], step: int, num_samples: int = None
+    prompts: list[str], completions: list[str], rewards: list[int], step: int, num_samples: Optional[int] = None
 ) -> None:
     """
     Print out a sample of model completions to the console.
@@ -1733,24 +1733,25 @@ def print_prompt_completions_sample(
     if not is_rich_available():
         raise ImportError("This feature requires `rich` to be installed. Please install it first: `pip install rich`")
 
-    console = Console()
-    table = Table(show_header=True, header_style="bold white", expand=True)
-
-    # Add columns
-    table.add_column("Prompt", style="bright_yellow")
-    table.add_column("Completion", style="bright_green")
-    table.add_column("Reward", style="bold cyan", justify="right")
-
     # Subsample data if num_samples is specified
-    if num_samples is not None and 0 < num_samples < len(prompts):
+    num_samples = min(len(prompts), num_samples) if num_samples is not None else None
+    if num_samples is not None and num_samples > 0:
+        console = Console()
+        table = Table(show_header=True, header_style="bold white", expand=True)
+
+        # Add columns
+        table.add_column("Prompt", style="bright_yellow")
+        table.add_column("Completion", style="bright_green")
+        table.add_column("Reward", style="bold cyan", justify="right")
+
         indices = random.sample(range(len(prompts)), num_samples)
         prompts = [prompts[i] for i in indices]
         completions = [completions[i] for i in indices]
         rewards = [rewards[i] for i in indices]
 
-    for prompt, completion, reward in zip(prompts, completions, rewards):
-        table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places
-        table.add_section()  # Adds a separator between rows
+        for prompt, completion, reward in zip(prompts, completions, rewards):
+            table.add_row(Text(prompt), Text(completion), f"{reward:.2f}")  # Formatting reward to 2 decimal places
+            table.add_section()  # Adds a separator between rows
 
-    panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
-    console.print(panel)
+        panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
+        console.print(panel)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR exposes a `num_completions_to_print` arg in the `GRPOConfig` so that users can control how many completions are printed to the terminal. I found the default (log everything) made the logs very verbose / large.

After discussing with @edbeeching I decided not to expose this for WandB since there we don't have to worry about the logs becoming overloaded.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.