### PR TITLE
📎 Fix is_clipped to compute the effective clip_ratio

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -967,11 +967,11 @@ class GRPOTrainer(Trainer):
             mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
             self._metrics[mode]["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
 
-        # Compute the effective clip_radio
+        # Compute the clip ratio
         is_clipped = (
             ((coef_1 < 1 - self.epsilon_low) & (advantages.unsqueeze(1) < 0)) |
             ((coef_1 > 1 + self.epsilon_high) & (advantages.unsqueeze(1) > 0))
-        ).float()
+        )
         clip_ratio = (is_clipped * completion_mask).sum() / completion_mask.sum()
         self._metrics[mode]["clip_ratio"].append(self.accelerator.gather_for_metrics(clip_ratio).mean().item())
         return loss

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -967,7 +967,11 @@ class GRPOTrainer(Trainer):
             mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
             self._metrics[mode]["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
 
-        is_clipped = (coef_1 < (1 - self.epsilon_low)) | (coef_1 > (1 + self.epsilon_high))
+        # Compute the effective clip_radio
+        is_clipped = (
+            ((coef_1 < 1 - self.epsilon_low) & (advantages.unsqueeze(1) < 0)) |
+            ((coef_1 > 1 + self.epsilon_high) & (advantages.unsqueeze(1) > 0))
+        ).float()
         clip_ratio = (is_clipped * completion_mask).sum() / completion_mask.sum()
         self._metrics[mode]["clip_ratio"].append(self.accelerator.gather_for_metrics(clip_ratio).mean().item())
         return loss

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -971,9 +971,8 @@ class GRPOTrainer(Trainer):
             self._metrics[mode]["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
 
         # Compute the clip ratio
-        is_clipped = (
-            ((coef_1 < 1 - self.epsilon_low) & (advantages.unsqueeze(1) < 0)) |
-            ((coef_1 > 1 + self.epsilon_high) & (advantages.unsqueeze(1) > 0))
+        is_clipped = ((coef_1 < 1 - self.epsilon_low) & (advantages.unsqueeze(1) < 0)) | (
+            (coef_1 > 1 + self.epsilon_high) & (advantages.unsqueeze(1) > 0)
         )
         clip_ratio = (is_clipped * completion_mask).sum() / completion_mask.sum()
         self._metrics[mode]["clip_ratio"].append(self.accelerator.gather_for_metrics(clip_ratio).mean().item())


### PR DESCRIPTION
# What does this PR do?



Below, let me briefly explain my motives and reasons, the code mainly uses the part marked in the figure.
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/23441357-144b-4dbc-b22f-296c209a259f" />

if (coef_1 < (1 - self.epsilon_low) and advantage > 0) or (coef_1 > (1 + self.epsilon_high) and advantage < 0)
then coef_1 * advantage < (1 - self.epsilon_low) * advantage
         coef_1 * advantage < (1 + self.epsilon_high) * advantage
min(per_token_loss1, per_token_loss2) = per_token_loss1

**From the perspective of loss, it is actually not clipped.**
`clip_ratio = (is_clipped * completion_mask).sum() / completion_mask.sum()`
**And this code also calculates an effective clip_ratio**       
**original code:** `is_clipped = (coef_1 < (1 - self.epsilon_low)) | (coef_1 > (1 + self.epsilon_high))`
**Therefore, we must combine the sign of the advantage with the original code to calculate is_clipped, thereby computing an effective clip_ratio**

**As follows**
`is_clipped = (coef_1 < (1 - self.epsilon_low) and advantage < 0) or (coef_1 > (1 + self.epsilon_high) and advantage > 0)`
if (coef_1 < (1 - self.epsilon_low) and advantage < 0) or (coef_1 > (1 + self.epsilon_high) and advantage > 0)
then coef_1 * advantage > (1 - self.epsilon_low) * advantage
         coef_1 * advantage > (1 + self.epsilon_high) * advantage
min(per_token_loss1, per_token_loss2) = per_token_loss2

**Therefore, by modifying is_clipped as described above, the effective clip_ratio can be correctly calculated**
