### PR TITLE
(AsyncLLMEngine) Change VLLM Server from Sync to Async

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -237,7 +237,11 @@ class GRPOConfig(TrainingArguments):
     )
     vllm_server_port: int = field(
         default=8000,
-        metadata={"help": "Port of the vLLM server to connect to."},
+        metadata={"help": "Http port of the vLLM server to connect to."},
+    )
+    vllm_server_nccl_port: int = field(
+        default=51216,
+        metadata={"help": "Nccl port of the vLLM server to connect to. This port is used to update weights."},
     )
     vllm_server_timeout: float = field(
         default=120.0,


### PR DESCRIPTION
1. Change VLLM Server from Sync to Async
    - if is_async=True:
        client first call `generate` (non-blocking), then after a while call `get_future` (with identical arguments) to get result
    - if is_async=False:
        client automatically call `get_future` inside `generate`, blocking further execution before the generation is complete

<div align="center">
<img src="https://github.com/user-attachments/assets/0b69ab74-56d5-4ec5-8f2c-0b879d6927c0" width="400" >
</div>


2. Speed up grpo_trainer 1.5x faster by submitting N=`gradient_accumulation_steps` batches, so that training and vllm generation can run in parallel! 
However, I have to admit that this piece of code is not elegant enough, remove them if they disqualifies.

<div align="center">
<img src="https://github.com/user-attachments/assets/b4c97113-b5af-4dec-b19d-19378de38ff0" width="400" >
</div>


3. I leave some room by adding a `RolloutEngine` in `trl.scripts.vllm_serve`, for more sophisticated vllm inference functionality, trying to support `lm_generate > MCP tool_call > lm_generate > another MCP tool_call > ...`, but not complete yet.

<div align="center">
<img src="https://github.com/user-attachments/assets/eb8f0d79-3925-4130-94e9-e62c9d710419" width="400" >
</div>

4. add vllm_server_nccl_port in config (previously cannot change default)

<div align="center">
<img src="https://github.com/user-attachments/assets/912b49bb-fa6d-4268-98f0-868c3f646ce8" width="400" >
</div>

