### PR TITLE
[GRPO] Improve completion length logging

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -115,7 +115,14 @@ When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifi
 ## Logged metrics
 
 - `num_tokens`: The total number of tokens processed so far, including both prompts and completions.
-- `completion_length`: The average length of generated completions.
+- `mean_completion_length`: The average length of generated completions.
+- `min_completion_length`: The maximum length of generated completions.
+- `max_completion_length`: The minimun length of generated completions.
+- `mean_terminated_completion_length`: The average length of generated completions that terminate with EOS.
+- `min_terminated_completion_length`: The maximum length of generated completions that terminate with EOS.
+- `max_terminated_completion_length`: The minimun length of generated completions that terminate with EOS.
+- `max_terminated_completion_length`: The minimun length of generated completions that terminate with EOS.
+- `clipped_completions_ratio` :  The ratio of trucated (clipped) completions.
 - `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
 - `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
 - `reward`: The overall average reward after applying reward weights.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -884,8 +884,8 @@ class GRPOTrainer(Trainer):
         min_completion_length_eos = arg_completion_mask.float().min().item()
         max_completion_length_eos = arg_completion_mask.float().max().item()
         self._metrics[mode]["mean_terminated_completion_length"].append(mean_completion_length_eos)
-        self._metrics[mode]["min_terminate_completion_length"].append(min_completion_length_eos)
-        self._metrics[mode]["max_terminate_completion_length"].append(max_completion_length_eos)
+        self._metrics[mode]["min_terminated_completion_length"].append(min_completion_length_eos)
+        self._metrics[mode]["max_terminated_completion_length"].append(max_completion_length_eos)
 
         # Get the names of the reward functions
         reward_func_names = []

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -868,9 +868,25 @@ class GRPOTrainer(Trainer):
             self._total_train_tokens += self.accelerator.gather_for_metrics(attention_mask.sum()).sum().item()
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
-        completion_length = self.accelerator.gather_for_metrics(completion_mask.sum(1)).float().mean().item()
-        self._metrics[mode]["completion_length"].append(completion_length)
-
+        # log completion lengths, mean, min, max
+        arg_completion_mask = self.accelerator.gather_for_metrics(completion_mask.sum(1))
+        mean_completion_length = arg_completion_mask.float().mean().item()
+        min_completion_length = arg_completion_mask.float().min().item()
+        max_completion_length = arg_completion_mask.float().max().item()
+        self._metrics[mode]["mean_completion_length"].append(mean_completion_length)
+        self._metrics[mode]["min_completion_length"].append(min_completion_length)
+        self._metrics[mode]["max_completion_length"].append(max_completion_length)
+        
+        # identify sequences that terminated with EOS and log their lengths
+        agg_terminated_with_eos = self.accelerator.gather_for_metrics(is_eos.any(dim=1))
+        arg_completion_mask = arg_completion_mask[agg_terminated_with_eos]
+        mean_completion_length_eos = arg_completion_mask.float().mean().item()
+        min_completion_length_eos = arg_completion_mask.float().min().item()
+        max_completion_length_eos = arg_completion_mask.float().max().item() 
+        self._metrics[mode]["mean_terminated_completion_length"].append(mean_completion_length_eos)
+        self._metrics[mode]["min_terminate_completion_length"].append(min_completion_length_eos)
+        self._metrics[mode]["max_terminate_completion_length"].append(max_completion_length_eos)
+        
         # Get the names of the reward functions
         reward_func_names = []
         for reward_func in self.reward_funcs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -880,6 +880,9 @@ class GRPOTrainer(Trainer):
         # identify sequences that terminated with EOS and log their lengths
         agg_terminated_with_eos = self.accelerator.gather_for_metrics(is_eos.any(dim=1))
         arg_completion_mask = arg_completion_mask[agg_terminated_with_eos]
+        if len(arg_completion_mask) == 0:
+            # edge case where no completed sequences are found
+            arg_completion_mask = torch.zeros(1, device=device)
         mean_completion_length_eos = arg_completion_mask.float().mean().item()
         min_completion_length_eos = arg_completion_mask.float().min().item()
         max_completion_length_eos = arg_completion_mask.float().max().item()

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -876,17 +876,17 @@ class GRPOTrainer(Trainer):
         self._metrics[mode]["mean_completion_length"].append(mean_completion_length)
         self._metrics[mode]["min_completion_length"].append(min_completion_length)
         self._metrics[mode]["max_completion_length"].append(max_completion_length)
-        
+
         # identify sequences that terminated with EOS and log their lengths
         agg_terminated_with_eos = self.accelerator.gather_for_metrics(is_eos.any(dim=1))
         arg_completion_mask = arg_completion_mask[agg_terminated_with_eos]
         mean_completion_length_eos = arg_completion_mask.float().mean().item()
         min_completion_length_eos = arg_completion_mask.float().min().item()
-        max_completion_length_eos = arg_completion_mask.float().max().item() 
+        max_completion_length_eos = arg_completion_mask.float().max().item()
         self._metrics[mode]["mean_terminated_completion_length"].append(mean_completion_length_eos)
         self._metrics[mode]["min_terminate_completion_length"].append(min_completion_length_eos)
         self._metrics[mode]["max_terminate_completion_length"].append(max_completion_length_eos)
-        
+
         # Get the names of the reward functions
         reward_func_names = []
         for reward_func in self.reward_funcs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -877,7 +877,7 @@ class GRPOTrainer(Trainer):
         # identify sequences that terminated with EOS and log their lengths
         agg_terminated_with_eos = self.accelerator.gather_for_metrics(is_eos.any(dim=1))
         term_completion_mask = agg_completion_mask[agg_terminated_with_eos]
-        clipped_completions_ratio = 1 - (len(term_completion_mask) / len(agg_completion_mask))
+        clipped_completions_ratio = 1 - len(term_completion_mask) / len(agg_completion_mask)
         self._metrics[mode]["clipped_completions_ratio"].append(clipped_completions_ratio)
         if len(term_completion_mask) == 0:
             # edge case where no completed sequences are found


### PR DESCRIPTION
# What does this PR do?

- Adds min, mean and max logging of completion lengths
- Also logs min, mean, max completion logs for sequences that terminate in EOS
- Adds clipped completion ratio from [SimpleRL-Zero](https://arxiv.org/pdf/2503.18892)
Example:
![image](https://github.com/user-attachments/assets/1d7cfbac-7624-47fc-9f0c-f72d25f50d1a)
