### PR TITLE
[GRPO] Allow the use of the vllm logprobs, rather than recomputing them

### DIFF
--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -185,7 +185,7 @@ class VLLMClient:
         )
         if response.status_code == 200:
             response_json = response.json()
-            return response_json["completion_ids"], response_json["logprobs"]
+            return response_json["completion_ids"], response_json["log_probs"]
         else:
             raise Exception(f"Request failed: {response.status_code}, {response.text}")
 

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -184,7 +184,8 @@ class VLLMClient:
             },
         )
         if response.status_code == 200:
-            return response.json()["completion_ids"]
+            response_json = response.json()
+            return response_json["completion_ids"], response_json["logprobs"]
         else:
             raise Exception(f"Request failed: {response.status_code}, {response.text}")
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -347,10 +347,7 @@ def main(script_args: ScriptArguments):
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
         completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
         log_probs = [list(output.logprobs) for outputs in all_outputs for output in outputs.outputs]
-        return {
-                "completion_ids": completion_ids,
-                "log_probs": log_probs
-            }
+        return {"completion_ids": completion_ids, "log_probs": log_probs}
 
     class InitCommunicatorRequest(BaseModel):
         host: str

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -347,7 +347,6 @@ def main(script_args: ScriptArguments):
         )
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
         completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
-        print(all_outputs)
         log_probs = [[list(p.values())[0].logprob for p in output.logprobs] for outputs in all_outputs for output in outputs.outputs]
         return {"completion_ids": completion_ids, "log_probs": log_probs}
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -343,10 +343,12 @@ def main(script_args: ScriptArguments):
             min_p=request.min_p,
             max_tokens=request.max_tokens,
             guided_decoding=guided_decoding,
+            logprobs=1,
         )
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
         completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
-        log_probs = [list(output.logprobs) for outputs in all_outputs for output in outputs.outputs]
+        print(all_outputs)
+        log_probs = [[list(p.values())[0].logprob for p in output.logprobs] for outputs in all_outputs for output in outputs.outputs]
         return {"completion_ids": completion_ids, "log_probs": log_probs}
 
     class InitCommunicatorRequest(BaseModel):

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -299,6 +299,7 @@ def main(script_args: ScriptArguments):
 
     class GenerateResponse(BaseModel):
         completion_ids: list[list[int]]
+        log_probs: list[list[float]]
 
     @app.post("/generate/", response_model=GenerateResponse)
     async def generate(request: GenerateRequest):
@@ -312,6 +313,7 @@ def main(script_args: ScriptArguments):
         Returns:
             `GenerateResponse`:
                 - `completion_ids` (list of list of `int`): A list of lists of token IDs for each generated completion.
+                - `log_probs` (list of list of `float`): A list of lists of float representing the token logprobs.
 
         Example request:
         ```json
@@ -321,6 +323,7 @@ def main(script_args: ScriptArguments):
         Example response:
         ```json
         {"completion_ids": [[101, 102, 103], [201, 202, 203]]}
+        {"log_probs": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]]}
         ```
         """
 
@@ -343,7 +346,11 @@ def main(script_args: ScriptArguments):
         )
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
         completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
-        return {"completion_ids": completion_ids}
+        log_probs = [list(output.logprobs) for outputs in all_outputs for output in outputs.outputs]
+        return {
+                "completion_ids": completion_ids,
+                "log_probs": log_probs
+            }
 
     class InitCommunicatorRequest(BaseModel):
         host: str

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -81,6 +81,8 @@ class GRPOConfig(TrainingArguments):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, ensure that a GPU is kept unused for
             training, as vLLM will require one for generation. vLLM must be installed (`pip install vllm`).
+        use_vllm_logprobs (`bool`, *optional*, defaults to `False`):
+            Whether to use vLLM's logprobs for the `"old_logprobs"` in the GRPO loss. Requires `use_vllm=True`.
         vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
             Host of the vLLM server to connect to.
         vllm_server_port (`int`, *optional*, defaults to `8000`):
@@ -229,6 +231,12 @@ class GRPOConfig(TrainingArguments):
         metadata={
             "help": "Whether to use vLLM for generating completions. If set to `True`, ensure that a vLLM server is "
             "running. To run the server, install vLLM (`pip install vllm`) and run `trl vllm-serve`."
+        },
+    )
+    use_vllm_logprobs: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to use vLLM's logprobs for the 'old_logprobs' in the GRPO loss. Requires use_vllm=True."
         },
     )
     vllm_server_host: str = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -737,7 +737,7 @@ class GRPOTrainer(Trainer):
             completion_ids = [torch.tensor(ids, device=device) for ids in completion_ids]
             completion_ids = pad(completion_ids, padding_value=self.processing_class.pad_token_id)
             vllm_log_probs = [torch.tensor(logp, device=device) for logp in vllm_log_probs]
-            vllm_log_probs = pad(completion_ids, padding_value=self.processing_class.pad_token_id)
+            vllm_log_probs = pad(vllm_log_probs, padding_value=self.processing_class.pad_token_id)
             prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         else:
             # Regular generation path

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -769,8 +769,7 @@ class GRPOTrainer(Trainer):
             # When using num_iterations == 1, old_per_token_logps == per_token_logps, so we can skip it's
             # computation here, and use per_token_logps.detach() instead.
             if self.num_iterations > 1:
-                if self.args.used_vllm_logprobs:
-                    # Wrap with torch.tensor and pad?
+                if self.args.use_vllm_logprobs:
                     old_per_token_logps = vllm_log_probs
                 else:
                     old_per_token_logps = self._get_per_token_logps(


### PR DESCRIPTION
This PR exposes the logprobs of token IDs that were generated from the vllm client. 
The default will be false, as they are likely different to those produced by the policy. 

