### PR TITLE
Support for Models With Pre-Finetuned LoRA Adapters in GRPO: Add use_peft_as_reference Flag

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -923,7 +923,9 @@ class GRPOTrainerTester(unittest.TestCase):
         training_args = GRPOConfig(
             output_dir=tempfile.mkdtemp(),
             learning_rate=0.1,
-            per_device_train_batch_size=1,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=32,
             use_peft_as_reference=True,
             report_to="none",
         )

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -919,9 +919,10 @@ class GRPOTrainerTester(unittest.TestCase):
     def test_peft_use_as_reference_flag_true(self):
         # Test that for a PEFT model with use_peft_as_reference=True, ref_model is set
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train").select(range(5))
-        training_args = GRPOConfig(
-            output_dir=tempfile.mkdtemp(),
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = GRPOConfig(
+                output_dir=tmp_dir,
             learning_rate=0.1,
             per_device_train_batch_size=3,
             num_generations=3,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -38,6 +38,9 @@ class GRPOConfig(TrainingArguments):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`GRPOTrainer`] is provided as a string.
 
+        use_peft_as_reference (`bool`, *optional*, defaults to `False`):
+            When True, for PEFT models (e.g., LoRA) that may already have fine-tuned weights, the reference model is created directly from the full model including the PEFT/LoRA (or quantized) weights. This stabilizes the KL divergence during GRPO tuning.
+
         > Parameters that control the data preprocessing
 
         remove_unused_columns (`bool`, *optional*, defaults to `False`):
@@ -144,6 +147,13 @@ class GRPOConfig(TrainingArguments):
         metadata={
             "help": "Keyword arguments for `transformers.AutoModelForCausalLM.from_pretrained`, used when the `model` "
             "argument of the `GRPOTrainer` is provided as a string."
+        },
+    )
+
+    use_peft_as_reference: bool = field(
+        default=False,
+        metadata={
+            "help": "When True, for PEFT models (e.g., LoRA) that may already have fine-tuned weights, the reference model is created directly from the full model including the PEFT/LoRA (or quantized) weights. This stabilizes the KL divergence during GRPO tuning."
         },
     )
 


### PR DESCRIPTION
# What does this PR do?

This PR introduces a new flag, use_peft_as_reference, to the GRPO configuration and trainer. When using the GRPO tuner with PEFT models (e.g. LoRA or quantized models), the trainer by default creates the reference model by disabling the adapter. This behavior, however, is undesirable when you are working with a model that has already been fine-tuned using LoRA weights—the reference model should mirror the full model (including the adapter) to avoid unwanted divergence.
With the new use_peft_as_reference flag, if set to True, the reference model is created directly using the full PEFT model (via create_reference_model), thereby retaining the fine-tuned adapter weights (or quantization) in the reference. This adjustment ensures a closer match between the policy and reference models, which translates into more stable KL divergence during training.
Additionally, the PR adds tests to verify that when the flag is enabled, the ref_model is properly set.


Fixes #3194


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.