### PR TITLE
📢 Improve GRPO trainer error message for invalid num_generations

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -445,13 +445,11 @@ class GRPOTrainer(Trainer):
         num_processes = self.accelerator.num_processes
         global_batch_size = args.per_device_train_batch_size * num_processes
         possible_values = [n_gen for n_gen in range(2, global_batch_size + 1) if (global_batch_size) % n_gen == 0]
-        
         if self.num_generations < 2:
             raise ValueError(
                 f"GRPO requires at least 2 generations per prompt to calculate the advantages. "
                 f"You provided {self.num_generations}, which is less than the minimum required."
             )
-            
         if self.num_generations not in possible_values:
             raise ValueError(
                 f"The global train batch size ({num_processes} x {args.per_device_train_batch_size}) must be evenly "

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -445,6 +445,13 @@ class GRPOTrainer(Trainer):
         num_processes = self.accelerator.num_processes
         global_batch_size = args.per_device_train_batch_size * num_processes
         possible_values = [n_gen for n_gen in range(2, global_batch_size + 1) if (global_batch_size) % n_gen == 0]
+        
+        if self.num_generations < 2:
+            raise ValueError(
+                f"GRPO requires at least 2 generations per prompt to calculate the advantages. "
+                f"You provided {self.num_generations}, which is less than the minimum required."
+            )
+            
         if self.num_generations not in possible_values:
             raise ValueError(
                 f"The global train batch size ({num_processes} x {args.per_device_train_batch_size}) must be evenly "


### PR DESCRIPTION
This PR fixes a confusing error message when users try to use `num_generations=1` with the GRPO trainer.

**Current Message:**
`ValueError: The global train batch size (1 x 4) must be evenly divisible by the number of generations per prompt (1). Given the current train batch size, the valid values for the number of generations are: [2, 4].`
This is mathematically incorrect since 1 is a valid divisor of any number, and confused me in the beginning. The real issue is that GRPO requires at least 2 generations to function properly.

**Changes**
Just raise a ValueError if `num_generations<2` with a more informative message.

