### PR TITLE
📉 Add `learning_rate` argument to `_maybe_log_save_evaluate`

### DIFF
--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -695,7 +695,9 @@ class OnlineDPOTrainer(Trainer):
 
     # Same as Trainer._maybe_log_save_evaluate but log our metrics
     # start_time defaults to None to allow compatibility with transformers<=4.46
-    def _maybe_log_save_evaluate(self, tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time=None):
+    def _maybe_log_save_evaluate(
+        self, tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time=None, learning_rate=None
+    ):
         if self.control.should_log and self.state.global_step > self._globalstep_last_logged:
             logs: dict[str, float] = {}
 
@@ -708,7 +710,10 @@ class OnlineDPOTrainer(Trainer):
             logs["loss"] = round(tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged), 4)
             if grad_norm is not None:
                 logs["grad_norm"] = grad_norm.detach().item() if isinstance(grad_norm, torch.Tensor) else grad_norm
-            logs["learning_rate"] = self._get_learning_rate()
+            if learning_rate is not None:
+                logs["learning_rate"] = learning_rate
+            else:
+                logs["learning_rate"] = self._get_learning_rate()
 
             # Add our metrics
             for key, val in self.stats.items():


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is on `release v0.16` branch!

This PR addresses a breaking change introduced in the `transformers` dev branch: https://github.com/huggingface/transformers/pull/36973. This was fixed in the `trl` main branch with #3176, but this fix is not part of TRL 0.16, which could cause issues once transformers new release goes live. To prevent this, we will release v0.16.1, which includes a fix.
By releasing this patch ahead of the upcoming `transformers` release, users will avoid potential bugs caused by the breaking change in `transformers` dev branch. This ensures that `trl` remains compatible with the new `transformers` version as soon as it's released.

This breaking case was reported thanks to this CI: https://github.com/huggingface/trl/actions/workflows/tests_latest.yml
