### PR TITLE
Group completion metrics by common prefix

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -116,11 +116,11 @@ When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifi
 
 - `num_tokens`: The total number of tokens processed so far, including both prompts and completions.
 - `completions/mean_length`: The average length of generated completions.
-- `completions/min_length`: The maximum length of generated completions.
-- `completions/max_length`: The minimun length of generated completions.
+- `completions/min_length`: The minimun length of generated completions.
+- `completions/max_length`: The maximum length of generated completions.
 - `completions/mean_terminated_length`: The average length of generated completions that terminate with EOS.
 - `completions/min_terminated_length`: The minimun length of generated completions that terminate with EOS.
-- `completions/max_terminated_length`: The minimun length of generated completions that terminate with EOS.
+- `completions/max_terminated_length`: The maximum length of generated completions that terminate with EOS.
 - `completions/clipped_ratio` :  The ratio of trucated (clipped) completions.
 - `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
 - `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -115,14 +115,13 @@ When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifi
 ## Logged metrics
 
 - `num_tokens`: The total number of tokens processed so far, including both prompts and completions.
-- `mean_completion_length`: The average length of generated completions.
-- `min_completion_length`: The maximum length of generated completions.
-- `max_completion_length`: The minimun length of generated completions.
-- `mean_terminated_completion_length`: The average length of generated completions that terminate with EOS.
-- `min_terminated_completion_length`: The maximum length of generated completions that terminate with EOS.
-- `max_terminated_completion_length`: The minimun length of generated completions that terminate with EOS.
-- `max_terminated_completion_length`: The minimun length of generated completions that terminate with EOS.
-- `clipped_completions_ratio` :  The ratio of trucated (clipped) completions.
+- `completions/mean_length`: The average length of generated completions.
+- `completions/min_length`: The maximum length of generated completions.
+- `completions/max_length`: The minimun length of generated completions.
+- `completions/mean_terminated_length`: The average length of generated completions that terminate with EOS.
+- `completions/min_terminated_length`: The minimun length of generated completions that terminate with EOS.
+- `completions/max_terminated_length`: The minimun length of generated completions that terminate with EOS.
+- `completions/clipped_ratio` :  The ratio of trucated (clipped) completions.
 - `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
 - `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
 - `reward`: The overall average reward after applying reward weights.

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -121,7 +121,7 @@ When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifi
 - `completions/mean_terminated_length`: The average length of generated completions that terminate with EOS.
 - `completions/min_terminated_length`: The minimun length of generated completions that terminate with EOS.
 - `completions/max_terminated_length`: The maximum length of generated completions that terminate with EOS.
-- `completions/clipped_ratio` :  The ratio of trucated (clipped) completions.
+- `completions/clipped_ratio` :  The ratio of truncated (clipped) completions.
 - `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
 - `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
 - `reward`: The overall average reward after applying reward weights.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -870,21 +870,21 @@ class GRPOTrainer(Trainer):
 
         # log completion lengths, mean, min, max
         agg_completion_mask = self.accelerator.gather_for_metrics(completion_mask.sum(1))
-        self._metrics[mode]["mean_completion_length"].append(agg_completion_mask.float().mean().item())
-        self._metrics[mode]["min_completion_length"].append(agg_completion_mask.float().min().item())
-        self._metrics[mode]["max_completion_length"].append(agg_completion_mask.float().max().item())
+        self._metrics[mode]["completions/mean_length"].append(agg_completion_mask.float().mean().item())
+        self._metrics[mode]["completions/min_length"].append(agg_completion_mask.float().min().item())
+        self._metrics[mode]["completions/max_length"].append(agg_completion_mask.float().max().item())
 
         # identify sequences that terminated with EOS and log their lengths
         agg_terminated_with_eos = self.accelerator.gather_for_metrics(is_eos.any(dim=1))
         term_completion_mask = agg_completion_mask[agg_terminated_with_eos]
         clipped_completions_ratio = 1 - len(term_completion_mask) / len(agg_completion_mask)
-        self._metrics[mode]["clipped_completions_ratio"].append(clipped_completions_ratio)
+        self._metrics[mode]["completions/clipped_ratio"].append(clipped_completions_ratio)
         if len(term_completion_mask) == 0:
             # edge case where no completed sequences are found
             term_completion_mask = torch.zeros(1, device=device)
-        self._metrics[mode]["mean_terminated_completion_length"].append(term_completion_mask.float().mean().item())
-        self._metrics[mode]["min_terminated_completion_length"].append(term_completion_mask.float().min().item())
-        self._metrics[mode]["max_terminated_completion_length"].append(term_completion_mask.float().max().item())
+        self._metrics[mode]["completions/mean_terminated_length"].append(term_completion_mask.float().mean().item())
+        self._metrics[mode]["completions/min_terminated_length"].append(term_completion_mask.float().min().item())
+        self._metrics[mode]["completions/max_terminated_length"].append(term_completion_mask.float().max().item())
 
         # Get the names of the reward functions
         reward_func_names = []


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Aligns the completions metrics to be grouped with the same prefix (like we do for rewards). This makes it easier to get an overview in WandB because the metrics get grouped in different sections:

![Screenshot 2025-04-02 at 16 07 27](https://github.com/user-attachments/assets/6db552db-ae64-4233-8aaa-1dd57c7e151d)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.