### PR TITLE
📚 Accumulate completions for logging

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -136,6 +136,9 @@ class GRPOConfig(TrainingArguments):
             installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`.
         num_completions_to_print (`int` or `None`, *optional*, defaults to `None`):
             Number of completions to print with `rich`. If `None`, all completions are logged.
+        wandb_log_unique_prompts (`bool`, *optional*, defaults to `False`):
+            Whether to log unique prompts in wandb. If `True`, only unique prompts are logged. If `False`, all
+            prompts are logged.
     """
 
     # Parameters that control the model and reference model


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR fixes a bug where the `rich` and `wandb` tables were not logging the complete set of unique prompts for `gradient_accumulation_steps > 1`. Previously what happened is that the tables we logged for each gradient accumulation step, which is confusing when inspecting the logs for unique prompts.

Here's two runs with/without the fix for:

* `main`: https://wandb.ai/huggingface/huggingface/runs/j3vwwb5t/workspace?nw=nwuserlewtun
* `this_pr`: https://wandb.ai/huggingface/huggingface/runs/78q63hev/overview

These runs have:

* `gradient_accumulation_steps=4`
* `num_generations=16`
* `per_device_train_batch_size=4`
* `num_gpus = 8`

so we expect `num_unique_prompts=8`:

```
num_unique_prompts = num_gpus * per_device_train_batch_size * gradient_accumulation_steps / num_generations = 8
```

We see that without the fix, `wandb` only displays 2 unique prompts in the table (i.e. once per gradient accumulation step). With the fix, the prompts are grouped together per step, which incidentally makes the table scrolling faster in the UI as we have fewer steps to query.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.