### PR TITLE
Add a raw generate API to the vLLM server

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -323,6 +323,23 @@ def main(script_args: ScriptArguments):
         {"completion_ids": [[101, 102, 103], [201, 202, 203]]}
         ```
         """
+        all_outputs = await generate_raw(request)
+        completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
+        return {"completion_ids": completion_ids}
+
+    @app.post("/generate_raw/")
+    async def generate_raw(request: GenerateRequest):
+        """
+        Generates completions for the provided prompts and returns the raw list of RequestOutput objects.
+
+        Args:
+            request (`GenerateRequest`):
+                - `prompts` (list of `str`): A list of prompts (text strings) for the model to generate completions.
+
+        Returns:
+            `list[RequestOutput]`:
+                - `completion_ids` (list of list of `int`): A list of lists of token IDs for each generated completion.
+        """
 
         # Guided decoding, if enabled
         if request.guided_decoding_regex is not None:
@@ -342,8 +359,7 @@ def main(script_args: ScriptArguments):
             guided_decoding=guided_decoding,
         )
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
-        completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]
-        return {"completion_ids": completion_ids}
+        return all_outputs
 
     class InitCommunicatorRequest(BaseModel):
         host: str


### PR DESCRIPTION
# What does this PR do?
This PR adds a `generate_raw` endpoint to the vLLM server. While this is not strictly necessary (yet) for any trainer provided in TRL, this does allow for easier experimentation. For example, it is now straightforward to send curl requests and inspect the results. Additionally, this endpoint allows other processes to communicate with the same vLLM server as used by TRL which may be useful for some applications.

Speaking from personal experience, I actually need my TRL trainer and another process to utilise the same vLLM server and this was the easiest way to get that working. I imagine others might find it useful as well.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.