### PR TITLE
remove unused optimizer config in prepare_deepspeed

### DIFF
--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -246,6 +246,9 @@ def prepare_deepspeed(model, accelerator):
                 }
             )
 
+    # remove optimizer related config, tell DeepSpeed do NOT create optimizer (prevent from potential OOM)
+    config_kwargs.pop("optimizer", None)
+
     # If ZeRO-3 is used, we shard both the active and reference model.
     # Otherwise, we assume the reference model fits in memory and is initialized on each device with ZeRO
     # disabled (stage 0)


### PR DESCRIPTION
# What does this PR do?

remove optimizer config in `prepare_deepspeed` in `model/utils.py`, to prevent potential OOM due to deepspeed creating  (never used) optimizer

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.