### PR TITLE
[GRPO] Adds an option to scale the loss by a constant factor

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -101,6 +101,8 @@ class GRPOConfig(TrainingArguments):
             speed, but may be numerically unstable for long training runs.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
+        use_max_tokens_norm (`bool`, *optional*, defaults to `False`):
+            Whether to use the max tokens norm. If `True`, the loss is normalized by a consant, the maximum possible number of tokens
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
@@ -274,6 +276,13 @@ class GRPOConfig(TrainingArguments):
     num_iterations: int = field(
         default=1,
         metadata={"help": "Number of iterations per batch (denoted as μ in the algorithm)."},
+    )
+    use_max_tokens_norm: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to use the max tokens norm. If `True`, the loss is normalized by a constant, the maximum "
+            "possible number of tokens."
+        },
     )
     epsilon: float = field(
         default=0.2,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -409,7 +409,7 @@ class GRPOTrainer(Trainer):
         self.use_vllm = args.use_vllm
         self.use_liger_loss = args.use_liger_loss
 
-        self.use_max_tokens_norm = self.args.use_max_tokens_norm
+        self.use_max_tokens_norm = args.use_max_tokens_norm
         if self.use_max_tokens_norm:
             if self.use_liger_loss:
                 raise ValueError("`use_max_tokens_norm` is not supported with `liger_loss`.")


### PR DESCRIPTION
# What does this PR do?
 This PR adds an option to scale the loss by a constant factor, equal to the maximum possible tokens in a batch.

The reasoning behind this PR is that I believe that the current normalization scheme, implemented in #2881, is not invariant to the ordering of samples across devices / gradient accumulation steps. Which may cause instabilities in training.

### Toy Example

Consider a `DDP=2` setting with a `per_device_train_batch_size=4`. For this example, assume that the loss per token is 1.
With global normalization: 
![image](https://github.com/user-attachments/assets/4ab78c97-0e70-4774-8507-c5cd875f72aa)

Here each token has an equal contribution the loss, but only inside the current device. The loss is not comparable to a setting where all the batch is on a single device, for example consider a `DDP=1` setting with `per_device_train_batch_size=4`

![image](https://github.com/user-attachments/assets/95fc37fe-2222-4615-8f1f-cd4ffab586f0)

One potential solution would be to gather the number of unmasked tokens across all devices and use this for normalization. But the same issue would also occur across gradient accumulation steps.


### Proposed solution
Calculate a constant factor `max_tokens_norm = per_device_train_batch_size * (max_prompt_length +max_completion_length)` and always normalize the loss by this constant factor. 

![image](https://github.com/user-attachments/assets/ca998fb7-fe33-4ae9-afd4-8aeb5996c83d)


The learning rate will probably need to be increased to get comparable results with our other baselines.
