### PR TITLE
👎 [GRPO] Adds option to disable dropout

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -38,6 +38,9 @@ class GRPOConfig(TrainingArguments):
         model_init_kwargs (`str`, `dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`GRPOTrainer`] is provided as a string.
+        disable_dropout (`bool`, *optional*, defaults to `False`):
+            Whether to disable dropout in the model. This is useful for training with a reference model, as it
+            prevents the model from generating different logprobs for the same input.
 
         > Parameters that control the data preprocessing
 
@@ -102,9 +105,6 @@ class GRPOConfig(TrainingArguments):
             speed, but may be numerically unstable for long training runs.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
-        disable_dropout (`bool`, *optional*, defaults to `False`):
-            Whether to disable dropout in the model. This is useful for training with a reference model, as it
-            prevents the model from generating different logprobs for the same input. If `True`, dropout is disabled.
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
@@ -164,6 +164,13 @@ class GRPOConfig(TrainingArguments):
         metadata={
             "help": "Keyword arguments for `transformers.AutoModelForCausalLM.from_pretrained`, used when the `model` "
             "argument of the `GRPOTrainer` is provided as a string."
+        },
+    )
+    disable_dropout: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to disable dropout in the model. This is useful for training with a reference model, as "
+            "it prevents the model from generating different logprobs for the same input."
         },
     )
 
@@ -289,14 +296,6 @@ class GRPOConfig(TrainingArguments):
     num_iterations: int = field(
         default=1,
         metadata={"help": "Number of iterations per batch (denoted as μ in the algorithm)."},
-    )
-    disable_dropout: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to disable dropout in the model. This is useful for training with a reference model, as "
-            "it prevents the model from generating different logprobs for the same input. If `True`, dropout is "
-            "disabled."
-        },
     )
     epsilon: float = field(
         default=0.2,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -101,6 +101,9 @@ class GRPOConfig(TrainingArguments):
             speed, but may be numerically unstable for long training runs.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
+        disable_dropout (`bool`, *optional*, defaults to `False`):
+            Whether to disable dropout in the model. This is useful for training with a reference model, as it
+            prevents the model from generating different logprobs for the same input. If `True`, dropout is disabled.
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
@@ -274,6 +277,14 @@ class GRPOConfig(TrainingArguments):
     num_iterations: int = field(
         default=1,
         metadata={"help": "Number of iterations per batch (denoted as μ in the algorithm)."},
+    )
+    disable_dropout: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to disable dropout in the model. This is useful for training with a reference model, as "
+            "it prevents the model from generating different logprobs for the same input. If `True`, dropout is "
+            "disabled."
+        },
     )
     epsilon: float = field(
         default=0.2,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -349,10 +349,10 @@ class GRPOTrainer(Trainer):
             # If PEFT configuration is not provided, create a reference model based on the initial model.
             self.ref_model = create_reference_model(model)
 
+        # Disable dropout in the model
         if args.disable_dropout:
-            if isinstance(model, nn.Module):
-                disable_dropout_in_model(model)
-            if self.ref_model is not None and isinstance(self.ref_model, nn.Module):
+            disable_dropout_in_model(model)
+            if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
 
         # Processing class
@@ -367,10 +367,6 @@ class GRPOTrainer(Trainer):
                 reward_funcs[i] = AutoModelForSequenceClassification.from_pretrained(
                     reward_func, num_labels=1, **model_init_kwargs
                 )
-                if args.disable_dropout:
-                    if isinstance(reward_funcs[i], nn.Module):
-                        disable_dropout_in_model(reward_funcs[i])
-
         self.reward_funcs = reward_funcs
 
         # Reward weights

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -349,7 +349,7 @@ class GRPOTrainer(Trainer):
             # If PEFT configuration is not provided, create a reference model based on the initial model.
             self.ref_model = create_reference_model(model)
 
-        # Disable dropout in the model
+        # Disable dropout in the models
         if args.disable_dropout:
             disable_dropout_in_model(model)
             if self.ref_model is not None:


### PR DESCRIPTION
# What does this PR do?
Adds an option to disable dropout. 

The RLOOTrainer disables dropout in policy, ref_model and reward model. This PR adds the option to disable dropout to the GRPOTrainer, which may improve training stability. 

[The N+ Implementation Details of RLHF with PPO: A Case Study on TL;DR Summarization](https://arxiv.org/pdf/2403.17031)
Provides more insight about why this option may improve training stability:

> We disable the dropout layers during training, similar to the settings in Ziegler et al. (2019); Huang
et al. (2024). This is important for PPO training, especially because with dropout activated, the log
probabilities of tokens will not be reproducible, making calculating the KL penalty unreliable while
also causing the ratios of the PPO to be not 1s during the first epoch, causing PPO optimization
problems. For consistency, we also disable dropout for SFT and RM training.