### PR TITLE
♾️ [CI] Remove `test_raise_error_not_causallm`

### DIFF
--- a/tests/test_modeling_value_head.py
+++ b/tests/test_modeling_value_head.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, GenerationConfig
+from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, GenerationConfig
 
 from trl import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValueHead, create_reference_model
 
@@ -380,14 +380,6 @@ class Seq2SeqValueHeadModelTester(BaseTester.VHeadModelTester, unittest.TestCase
 
         # Just check if the generation works
         _ = model.generate(input_ids, decoder_input_ids=decoder_input_ids, generation_config=generation_config)
-
-    def test_raise_error_not_causallm(self):
-        # Test with a model without a LM head
-        model_id = "trl-internal-testing/tiny-T5ForConditionalGeneration"
-        # This should raise a ValueError
-        with self.assertRaises(ValueError):
-            pretrained_model = AutoModel.from_pretrained(model_id)
-            _ = self.trl_model_class.from_pretrained(pretrained_model)
 
     @unittest.skip("This test needs to be run manually due to HF token issue.")
     def test_push_to_hub(self):


### PR DESCRIPTION
This PR https://github.com/huggingface/transformers/pull/37173 removes `GenerationMixin` inheritance by default in `PreTrainedModel`. Consequently, `AutoModel` now returns object without method `prepare_inputs_for_generation`.

This line:

https://github.com/huggingface/trl/blob/1d7b8c4f706a0df9fd4d3e8d0d576e8dd5dedb28/trl/models/modeling_base.py#L91

causes a premature error in this test `test_modeling_value_head.py::Seq2SeqValueHeadModelTester::test_raise_error_not_causallm`

https://github.com/huggingface/trl/blob/1d7b8c4f706a0df9fd4d3e8d0d576e8dd5dedb28/tests/test_modeling_value_head.py#L384-L390

which is bound to fail anyway, because that's what we're testing.


I propose to remove this test, which in fact tests a part of the codebase that is very little used, with a model that is also very little used.