### PR TITLE
🐯 `is_liger_kernel_available` with min version

### DIFF
--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -28,7 +28,7 @@ LIGER_KERNEL_MIN_VERSION = "0.5.6"
 _deepspeed_available = _is_package_available("deepspeed")
 _diffusers_available = _is_package_available("diffusers")
 _fastapi_available = _is_package_available("fastapi")
-_is_liger_kernel_available, _liger_kernel_version = _is_package_available("liger-kernel", return_version=True)
+_is_liger_kernel_available, _liger_kernel_version = _is_package_available("liger_kernel", return_version=True)
 _llm_blender_available = _is_package_available("llm_blender")
 _mergekit_available = _is_package_available("mergekit")
 _pydantic_available = _is_package_available("pydantic")

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -18,13 +18,17 @@ from itertools import chain
 from types import ModuleType
 from typing import Any
 
+from packaging import version
 from transformers.utils.import_utils import _is_package_available
 
+
+LIGER_KERNEL_MIN_VERSION = "0.5.6"
 
 # Use same as transformers.utils.import_utils
 _deepspeed_available = _is_package_available("deepspeed")
 _diffusers_available = _is_package_available("diffusers")
 _fastapi_available = _is_package_available("fastapi")
+_is_liger_kernel_available, _liger_kernel_version = _is_package_available("liger-kernel", return_version=True)
 _llm_blender_available = _is_package_available("llm_blender")
 _mergekit_available = _is_package_available("mergekit")
 _pydantic_available = _is_package_available("pydantic")
@@ -46,6 +50,10 @@ def is_diffusers_available() -> bool:
 
 def is_fastapi_available() -> bool:
     return _fastapi_available
+
+
+def is_liger_kernel_available(min_version: str = LIGER_KERNEL_MIN_VERSION) -> bool:
+    return _is_liger_kernel_available and version.parse(_liger_kernel_version) >= version.parse(min_version)
 
 
 def is_llm_blender_available() -> bool:

--- a/trl/scripts/env.py
+++ b/trl/scripts/env.py
@@ -19,10 +19,16 @@ from importlib.metadata import version
 import torch
 from accelerate.commands.config import default_config_file, load_config_from_file
 from transformers import is_bitsandbytes_available
-from transformers.utils import is_liger_kernel_available, is_openai_available, is_peft_available
+from transformers.utils import is_openai_available, is_peft_available
 
 from .. import __version__
-from ..import_utils import is_deepspeed_available, is_diffusers_available, is_llm_blender_available, is_vllm_available
+from ..import_utils import (
+    is_deepspeed_available,
+    is_diffusers_available,
+    is_liger_kernel_available,
+    is_llm_blender_available,
+    is_vllm_available,
+)
 from .utils import get_git_commit_hash
 
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -40,12 +40,12 @@ from transformers import (
     is_wandb_available,
 )
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
-from transformers.utils import is_liger_kernel_available, is_peft_available
+from transformers.utils import is_peft_available
 
 from ..data_utils import apply_chat_template, is_conversational, maybe_apply_chat_template
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..extras.vllm_client import VLLMClient
-from ..import_utils import is_deepspeed_available, is_rich_available, is_vllm_available
+from ..import_utils import is_deepspeed_available, is_liger_kernel_available, is_rich_available, is_vllm_available
 from ..models import create_reference_model, prepare_deepspeed, unwrap_model_for_generation
 from .callbacks import SyncRefModelCallback
 from .grpo_config import GRPOConfig

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -50,9 +50,10 @@ from transformers import (
     is_wandb_available,
 )
 from transformers.trainer_utils import EvalLoopOutput, has_length
-from transformers.utils import is_liger_kernel_available, is_peft_available
+from transformers.utils import is_peft_available
 
 from ..data_utils import maybe_apply_chat_template, maybe_extract_prompt, maybe_unpair_preference_dataset
+from ..import_utils import is_liger_kernel_available
 from ..models import PreTrainedModelWrapper, create_reference_model
 from .kto_config import KTOConfig
 from .utils import (


### PR DESCRIPTION
From @lewtun 

> FYI I just install `trl@main` and got this from trying to run GRPO:
> 
> ```
> Traceback (most recent call last):
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/bin/trl", line 4, in <module>
>     from trl.cli import main
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/trl/cli.py", line 24, in <module>
>     from .scripts.grpo import make_parser as make_grpo_parser
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/trl/scripts/grpo.py", line 22, in <module>
>     from trl import GRPOConfig, GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
>   File "<frozen importlib._bootstrap>", line 1229, in _handle_fromlist
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/trl/import_utils.py", line 127, in __getattr__
>     value = getattr(module, name)
>             ^^^^^^^^^^^^^^^^^^^^^
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/trl/import_utils.py", line 126, in __getattr__
>     module = self._get_module(self._class_to_module[name])
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/trl/import_utils.py", line 138, in _get_module
>     raise RuntimeError(
> RuntimeError: Failed to import trl.trainer.grpo_trainer because of the following error (look up to see its traceback):
> cannot import name 'LigerFusedLinearGRPOLoss' from 'liger_kernel.chunked_loss' (/fsx/lewis/git/hf/dev/open-r1/openr1/lib/python3.11/site-packages/liger_kernel/chunked_loss/__init__.py)
> ```
> 
> The solution is to bump liger-kernel like [here](https://github.com/huggingface/trl/blob/1d7b8c4f706a0df9fd4d3e8d0d576e8dd5dedb28/setup.py#L84C16-L84C35) but it's odd that doing a new install of trl didn't catch this (I had an older version of liger installed)



From me:

> I think it's because you did `pip install trl` and not `pip install trl[liger]`. Maybe the solution to avoid this is to also check the version in `is_liger_available` (returns `True` only if the min version is installed) , and more generally in all `is_xxx_availalbe`.


---

I suggest the following solution. Now when you run `is_liger_kernel_available` without the min version, it returns `False`.

1. It's a shame that you have to specify the min version in two places (`setup.py` and `import_utils.py`), but I can't think of any other easy and readable way to do it.

2. This implementation actually matches that of transformers, which, as everyone knows, is the source of all truth 🙇: https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py

3. We could do this with all our optional dependencies. But it's a bit time-consuming, so I'll leave it to follow-up PRs.