### PR TITLE
🚧 Temporarily restrict diffusers to <0.33.0 due to ftfy optional dep issue breaking doc builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ REQUIRED_PKGS = [
 ]
 EXTRAS = {
     "deepspeed": ["deepspeed>=0.14.4"],
-    "diffusers": ["diffusers>=0.18.0"],
+    "diffusers": ["diffusers>=0.18.0,<0.33.0"],  # Temp set <0.33.0 due to ftfy optional dep issue breaking doc builds
     "judges": ["openai>=1.23.2", "llm-blender>=0.0.2"],
     "liger": ["liger-kernel>=0.5.6"],
     "mergekit": ["mergekit>=0.0.5.1"],


### PR DESCRIPTION
# What does this PR do?

See https://github.com/huggingface/trl/actions/runs/14362283321/job/40266585968#step:19:140


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.