### PR TITLE
🦾 Test vLLM client-server

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -1,0 +1,155 @@
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+import subprocess
+import unittest
+
+import pytest
+from transformers import AutoModelForCausalLM
+from transformers.testing_utils import require_torch_multi_gpu
+
+from trl.extras.vllm_client import VLLMClient
+
+from .testing_utils import require_3_gpus
+
+
+@pytest.mark.slow
+@require_torch_multi_gpu
+class TestVLLMClientServer(unittest.TestCase):
+    model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
+
+    @classmethod
+    def setUpClass(cls):
+        # We want the server to run on GPU 1, so we set CUDA_VISIBLE_DEVICES to "1"
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = "1"  # Restrict to GPU 1
+
+        # Start the server process
+        cls.server_process = subprocess.Popen(
+            ["trl", "vllm-serve", "--model", cls.model_id], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+
+        # Initialize the client
+        cls.client = VLLMClient(connection_timeout=120)
+
+    def test_generate(self):
+        prompts = ["Hello, AI!", "Tell me a joke"]
+        outputs = self.client.generate(prompts)
+
+        # Check that the output is a list
+        self.assertIsInstance(outputs, list)
+
+        # Check that the number of generated sequences is equal to the number of prompts
+        self.assertEqual(len(outputs), len(prompts))
+
+        # Check that the generated sequences are lists of integers
+        for seq in outputs:
+            self.assertTrue(all(isinstance(tok, int) for tok in seq))
+
+    def test_generate_with_params(self):
+        prompts = ["Hello, AI!", "Tell me a joke"]
+        outputs = self.client.generate(prompts, n=2, repetition_penalty=0.9, temperature=0.8, max_tokens=32)
+
+        # Check that the output is a list
+        self.assertIsInstance(outputs, list)
+
+        # Check that the number of generated sequences is 2 times the number of prompts
+        self.assertEqual(len(outputs), 2 * len(prompts))
+
+        # Check that the generated sequences are lists of integers
+        for seq in outputs:
+            self.assertTrue(all(isinstance(tok, int) for tok in seq))
+
+        # Check that the length of the generated sequences is less than or equal to 32
+        for seq in outputs:
+            self.assertLessEqual(len(seq), 32)
+
+    def test_update_model_params(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, device_map="cuda")
+        self.client.update_model_params(model)
+
+    def test_reset_prefix_cache(self):
+        # Test resetting the prefix cache
+        self.client.reset_prefix_cache()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        # Check if the process is still running
+        if cls.server_process.poll() is None:
+            try:
+                os.kill(cls.server_process.pid, signal.SIGTERM)
+                cls.server_process.wait()
+            except ProcessLookupError:
+                pass  # Process already gone — safe to ignore
+
+
+@pytest.mark.slow
+@require_3_gpus
+class TestVLLMClientServerTP(unittest.TestCase):
+    model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
+
+    @classmethod
+    def setUpClass(cls):
+        # We want the server to run on GPU 1 and 2, so we set CUDA_VISIBLE_DEVICES to "1,2"
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = "1,2"  # Restrict to GPU 1 and 2
+
+        # Start the server process
+        cls.server_process = subprocess.Popen(
+            ["trl", "vllm-serve", "--model", cls.model_id, "--tensor_parallel_size", "2"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+
+        # Initialize the client
+        cls.client = VLLMClient(connection_timeout=120)
+
+    def test_generate(self):
+        prompts = ["Hello, AI!", "Tell me a joke"]
+        outputs = self.client.generate(prompts)
+
+        # Check that the output is a list
+        self.assertIsInstance(outputs, list)
+
+        # Check that the number of generated sequences is equal to the number of prompts
+        self.assertEqual(len(outputs), len(prompts))
+
+        # Check that the generated sequences are lists of integers
+        for seq in outputs:
+            self.assertTrue(all(isinstance(tok, int) for tok in seq))
+
+    def test_update_model_params(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, device_map="cuda")
+        self.client.update_model_params(model)
+
+    def test_reset_prefix_cache(self):
+        # Test resetting the prefix cache
+        self.client.reset_prefix_cache()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        # Check if the process is still running
+        if cls.server_process.poll() is None:
+            try:
+                os.kill(cls.server_process.pid, signal.SIGTERM)
+                cls.server_process.wait()
+            except ProcessLookupError:
+                pass  # Process already gone — safe to ignore

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -15,6 +15,7 @@
 import random
 import unittest
 
+import torch
 from transformers import is_bitsandbytes_available, is_comet_available, is_sklearn_available, is_wandb_available
 
 from trl import BaseBinaryJudge, BasePairwiseJudge
@@ -83,6 +84,13 @@ def require_no_wandb(test_case):
     Decorator marking a test that requires no wandb. Skips the test if wandb is available.
     """
     return unittest.skipUnless(not is_wandb_available(), "test requires no wandb")(test_case)
+
+
+def require_3_gpus(test_case):
+    """
+    Decorator marking a test that requires at least num_gpus GPUs. Skips the test if num_gpus is not available.
+    """
+    return unittest.skipUnless(torch.cuda.device_count() > 3, "test requires at least 3 GPUs")(test_case)
 
 
 class RandomBinaryJudge(BaseBinaryJudge):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -260,9 +260,15 @@ class VLLMClient:
         Closes the weight update group and cleans up the communication group.
         """
         url = f"http://{self.host}:{self.server_port}/close_communicator/"
-        response = self.session.post(url)
-        if response.status_code != 200:
-            raise Exception(f"Request failed: {response.status_code}, {response.text}")
+
+        try:
+            response = self.session.post(url)
+        except ConnectionError:
+            # The server might be already down, so we don't need to close the communicator
+            pass
+        else:
+            if response.status_code != 200:
+                raise Exception(f"Request failed: {response.status_code}, {response.text}")
 
 
 # Example usage


### PR DESCRIPTION
```
$ pytest tests/test_vllm_client_server.py -v
================================== test session starts ===================================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0 -- /fsx/qgallouedec/miniconda3/envs/trl/bin/python
cachedir: .pytest_cache
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: rerunfailures-15.0, cov-6.0.0, anyio-4.9.0, xdist-3.6.1
collected 7 items                                                                        

tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate PASSED       [ 14%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_params PASSED [ 28%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_reset_prefix_cache PASSED [ 42%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_update_model_params PASSED [ 57%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate PASSED     [ 71%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_reset_prefix_cache PASSED [ 85%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_update_model_params PASSED [100%]

==================================== warnings summary ====================================
../miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100
../miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100
../miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100
../miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100
  /fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    fields = self.model_fields

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 7 passed, 4 warnings in 155.43s (0:02:35) ========================
```