### PR TITLE
add vllm support for token ids as input

### DIFF
--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -15,7 +15,7 @@
 import atexit
 import logging
 import time
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from torch import nn
@@ -131,7 +131,7 @@ class VLLMClient:
 
     def generate(
         self,
-        prompts: list[str],
+        prompts: Union[list[str], list[list[int]]],
         n: int = 1,
         repetition_penalty: float = 1.0,
         temperature: float = 1.0,


### PR DESCRIPTION
# What does this PR do?

This PR adds support for vLLM server & client to accept token ids as input. 

The vLLM engine does support token ids as input as opposed to text under the hood, this PR makes the feature available to end users. The rationale behind is that in certain training user cases user wants precise control of what exact input tokens are used for vLLM, therefore adding this capability to let user have full control of input tokens before sending to vLLM. 

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 