### PR TITLE
☝️ [GRPO] Generate once per effective batch

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -50,8 +50,8 @@ class GRPOConfig(TrainingArguments):
         max_prompt_length (`int` or `None`, *optional*, defaults to `512`):
             Maximum length of the prompt. If the prompt is longer than this value, it will be truncated left.
         num_generations (`int` or `None`, *optional*, defaults to `8`):
-            Number of generations per prompt to sample. The global batch size (num_processes * per_device_batch_size)
-            must be divisible by this value.
+            Number of generations per prompt to sample. The effective batch size (num_processes * 
+            per_device_batch_size * gradient_accumulation_steps) must be evenly divisible by this value.
         max_completion_length (`int` or `None`, *optional*, defaults to `256`):
             Maximum length of the generated completion.
         ds3_gather_for_generation (`bool`, *optional*, defaults to `True`):
@@ -205,8 +205,8 @@ class GRPOConfig(TrainingArguments):
     num_generations: Optional[int] = field(
         default=8,
         metadata={
-            "help": "Number of generations to sample. The global batch size (num_processes * per_device_batch_size) "
-            "must be divisible by this value."
+            "help": "Number of generations to sample. The effective batch size (num_processes * per_device_batch_size "
+            "* gradient_accumulation_steps) must be evenly divisible by this value."
         },
     )
     max_completion_length: Optional[int] = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -50,7 +50,7 @@ class GRPOConfig(TrainingArguments):
         max_prompt_length (`int` or `None`, *optional*, defaults to `512`):
             Maximum length of the prompt. If the prompt is longer than this value, it will be truncated left.
         num_generations (`int` or `None`, *optional*, defaults to `8`):
-            Number of generations per prompt to sample. The effective batch size (num_processes * 
+            Number of generations per prompt to sample. The effective batch size (num_processes *
             per_device_batch_size * gradient_accumulation_steps) must be evenly divisible by this value.
         max_completion_length (`int` or `None`, *optional*, defaults to `256`):
             Maximum length of the generated completion.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -185,7 +185,6 @@ def nanstd(tensor: torch.Tensor) -> torch.Tensor:
     return torch.sqrt(variance)
 
 
-
 def split_tensor_dict(
     tensor_dict: dict[str, Optional[torch.Tensor]], num_chunks: int
 ) -> list[dict[str, Optional[torch.Tensor]]]:
@@ -212,6 +211,7 @@ def split_tensor_dict(
         }
         for i in range(num_chunks)
     ]
+
 
 def nanmin(tensor: torch.Tensor) -> torch.Tensor:
     """
@@ -241,7 +241,6 @@ def nanmax(tensor: torch.Tensor) -> torch.Tensor:
     if torch.isnan(tensor).all():
         return torch.tensor(float("nan"), dtype=tensor.dtype, device=tensor.device)
     return torch.max(tensor[~torch.isnan(tensor)])
-
 
 
 class GRPOTrainer(Trainer):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -747,7 +747,7 @@ class GRPOTrainer(Trainer):
 
     # Get the per-token log probabilities for the completions for the model and the reference model
     @profiling_decorator
-    def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep, batch_size=None):
+    def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep, batch_size=None) -> torch.Tensor:
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
         all_logps = []
         for i in range(0, input_ids.size(0), batch_size):


### PR DESCRIPTION
# What does this PR do?

#### Summary

This PR optimizes the generation process in GRPO when using gradient accumulation by ensuring that generation happens only once per effective batch, rather than once per micro-batch. This significantly improves performance—particularly with large gradient accumulation values—by leveraging the efficiency of vLLM with large batch sizes.

#### Context

Currently, when using GRPO with gradient accumulation, generation is triggered at every micro-batch. For instance, with a gradient accumulation factor of 16, generation is launched 16 times before a single network update. This is inefficient, especially given that vLLM performs better with larger batches.

#### What this PR changes

This PR modifies the logic so that generation occurs only once per *effective batch* (i.e., after all gradient accumulation steps). To enable this:
- The dataloader is adjusted to repeat the same batch `GAS` times (where `GAS` is the number of gradient accumulation steps).
- Generation is performed only during the first micro-batch.
- The actual sampled batch is only a slice of the loaded data

<img width="1104" alt="Screenshot 2025-04-12 at 09 58 41" src="https://github.com/user-attachments/assets/ff93deb3-fef0-4d7e-b3bb-aca5bd311ec0" />


#### Why it matters

This leads to a speedup in training, particularly with higher accumulation values, by making better use of vLLM’s batched generation capabilities.

> Note: This is a preparatory change. The full performance gains will be realized once the TRL vLLM server supports distributed parallelism (DP).

#### Review Notes

This change involves more complex indexing logic, which may make the diff harder to review. However, the code has been heavily commented for clarity and maintainability.

## Benchmark

Training time for 9 configs:
Note that for GAS=1, no speedup is expected

![time_comparison](https://github.com/user-attachments/assets/cd8d4ad5-6c35-4d25-bb35-c4c1e9af7cc3)

### Code used:

```python
from datasets import load_dataset
from trl import GRPOTrainer, GRPOConfig
import argparse
import subprocess

def get_git_commit_hash():
    try:
        commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()[:7]
        return commit_hash
    except subprocess.CalledProcessError:
        return None

if __name__ == "__main__":
    parser = argparse.ArgumentParser(description="GRPO Trainer")
    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
    parser.add_argument("--per_device_train_batch_size", type=int, default=1)
    parser.add_argument("--num_iterations", type=int, default=1)
    args = parser.parse_args()

    dataset = load_dataset("trl-lib/tldr", split="train[:2048]")

    # Dummy reward function: count the number of unique characters in the completions
    def reward_num_unique_chars(completions, **kwargs):
        return [len(set(c)) for c in completions]

    git_commit = get_git_commit_hash()
    run_name = f"GRPO_7B_{git_commit}_GAS_{args.gradient_accumulation_steps}_BS_{args.per_device_train_batch_size}_MU_{args.num_iterations}"

    trainer = GRPOTrainer(
        model="Qwen/Qwen2.5-7B",
        reward_funcs=reward_num_unique_chars,
        train_dataset=dataset,
        args=GRPOConfig(
            run_name=run_name,
            logging_steps=10,
            bf16=True,
            max_completion_length=128,
            gradient_checkpointing=True,
            use_vllm=True,
            num_iterations=args.num_iterations,
            gradient_accumulation_steps=args.gradient_accumulation_steps,
            per_device_train_batch_size=args.per_device_train_batch_size,
            vllm_server_timeout=360,
        ),
    )
    trainer.train()
```

```sh
#!/bin/bash
#SBATCH --output=/fsx/qgallouedec/logs/%x-%j.out
#SBATCH --error=/fsx/qgallouedec/logs/%x-%j.err
#SBATCH --nodes=1
#SBATCH --ntasks-per-node=1
#SBATCH --gres=gpu:8
#SBATCH --time=10:00:00
#SBATCH --qos=normal


# Run vLLM server
trl vllm-serve --model Qwen/Qwen2.5-7B --tensor_parallel_size 4 &

# Run trainin
CUDA_VISIBLE_DEVICES=4,5,6,7 accelerate launch \
     --config_file examples/accelerate_configs/deepspeed_zero3.yaml \
     --num_processes 4 \
     sandbox/3283.py \
     --gradient_accumulation_steps 16 \
     --per_device_train_batch_size 8 \
     --num_iterations 4
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.