### PR TITLE
Expose EOS token in SFTConfig

### DIFF
--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -47,6 +47,8 @@ class SFTConfig(TrainingArguments):
             `skip_prepare_dataset`.
         dataset_num_proc (`int` or `None`, *optional*, defaults to `None`):
             Number of processes to use for processing the dataset.
+        eos_token (`str` or `None`, *optional*, defaults to `None`):
+            Token used to indicate the end of a turn or sequence. If `None`, it defaults to `processing_class.eos_token`.
         pad_token (`int` or `None`, *optional*, defaults to `None`):
             Token used for padding. If `None`, it defaults to `processing_class.pad_token`, or if that is also `None`,
             it falls back to `processing_class.eos_token`.
@@ -94,6 +96,12 @@ class SFTConfig(TrainingArguments):
     dataset_num_proc: Optional[int] = field(
         default=None,
         metadata={"help": "Number of processes to use for processing the dataset."},
+    )
+    eos_token: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Token used to indicate the end of a turn or sequence. If `None`, it defaults to `processing_class.eos_token`."
+        },
     )
     pad_token: Optional[str] = field(
         default=None,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -237,7 +237,6 @@ class SFTTrainer(Trainer):
                     f"`processing_class` ({processing_class.__class__.__name__}). Ensure that the `eos_token` exists "
                     "in the vocabulary before using it as an EOS token."
                 )
-            processing_class.eos_token = eos_token
             processing_class.eos_token_id = eos_token_id
 
         # Model

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -228,6 +228,18 @@ class SFTTrainer(Trainer):
         if processing_class is None:
             processing_class = AutoTokenizer.from_pretrained(model_id)
 
+        if args.eos_token is not None:
+            eos_token = args.eos_token
+            eos_token_id = processing_class.convert_tokens_to_ids(eos_token)
+            if eos_token_id is None:
+                raise ValueError(
+                    f"The specified `eos_token` ('{eos_token}') is not found in the vocabulary of the given "
+                    f"`processing_class` ({processing_class.__class__.__name__}). Ensure that the `eos_token` exists "
+                    "in the vocabulary before using it as an EOS token."
+                )
+            processing_class.eos_token = eos_token
+            processing_class.eos_token_id = eos_token_id
+
         # Model
         if args.model_init_kwargs is not None and not isinstance(model, str):
             warnings.warn(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

This PR exposes `eos_token` in the `SFTConfig` to give users fine-grained control on which token in a given chat template should be used to indicate the end of a turn or sequence. 

Here's an example using a Qwen base model:

```
ACCELERATE_LOG_LEVEL=info TRANSFORMERS_VERBOSITY=info trl/scripts/sft.py \
    --model_name_or_path Qwen/Qwen2.5-1.5B \
    --dataset_name trl-lib/Capybara \
    --learning_rate 2.0e-5 \
    --max_seq_length 2048 \
    --num_train_epochs 2 \
    --per_device_train_batch_size 16 \
    --gradient_accumulation_steps 1 \
    --gradient_checkpointing \
    --bf16 \
    --use_liger_kernel \
    --logging_steps 5 \
    --eval_strategy steps \
    --eval_steps 100 \
    --eos_token '<|im_end|>' \
    --output_dir data/Qwen2-1.5B-SFT-no-packing
```

Before this change, the `sft.py` script would:

* Inherit the [base model's EOS token](https://huggingface.co/Qwen/Qwen2.5-1.5B/blob/main/tokenizer_config.json#L200), which is `<|endoftext|>`
* Train with the ChatML template, which is [defined](https://huggingface.co/Qwen/Qwen2.5-1.5B/blob/main/tokenizer_config.json#L198) by default in Qwen models

Thus the fine-tuned model would have a mismatch between the chat template's EOS token and that defined in the tokenizer config. As a result, inference would produced unbounded generations and fail to terminate at the end of a turn.

Partly related to https://github.com/huggingface/trl/pull/3200 and enables https://github.com/huggingface/open-r1/pull/604


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.