### PR TITLE
🙅 PPO value_model can't be None, so it shouldn't be Optional

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -107,7 +107,7 @@ class PPOTrainer(Trainer):
         ref_model: Optional[nn.Module],
         reward_model: nn.Module,
         train_dataset: Dataset,
-        value_model: Optional[nn.Module] = None,
+        value_model: nn.Module,
         data_collator: Optional[DataCollatorWithPadding] = None,
         eval_dataset: Optional[Union[Dataset, dict[str, Dataset]]] = None,
         # less commonly used


### PR DESCRIPTION
Simple change to the typing and default value of value_model in PPOTrainer. Since it cannot be None, it should not default to None or be marked Optional. See [this issue](https://github.com/huggingface/trl/issues/3292).