### PR TITLE
Allow for saving the PPOTrainer value model (critic model)

### DIFF
--- a/examples/scripts/sft_video_llm.py
+++ b/examples/scripts/sft_video_llm.py
@@ -50,12 +50,12 @@ from typing import Any
 
 import requests
 import torch
-import wandb
 from datasets import load_dataset
 from peft import LoraConfig
 from qwen_vl_utils import process_vision_info
 from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig, Qwen2VLProcessor
 
+import wandb
 from trl import ModelConfig, ScriptArguments, SFTConfig, SFTTrainer, TrlParser, get_kbit_device_map
 
 

--- a/examples/scripts/sft_video_llm.py
+++ b/examples/scripts/sft_video_llm.py
@@ -50,12 +50,12 @@ from typing import Any
 
 import requests
 import torch
+import wandb
 from datasets import load_dataset
 from peft import LoraConfig
 from qwen_vl_utils import process_vision_info
 from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig, Qwen2VLProcessor
 
-import wandb
 from trl import ModelConfig, ScriptArguments, SFTConfig, SFTTrainer, TrlParser, get_kbit_device_map
 
 

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -59,7 +59,7 @@ class PPOConfig(OnPolicyConfig):
         lam (`float`, *optional*, defaults to `0.95`):
             Lambda value for GAE.
         save_value_model (`bool`, *optional*, defaults to `False`):
-            Whether the value model (also known as the critic model) should be saved when the policy model is saved.
+            Whether the value model (also known as the critic model) should be saved when the policy model is saved. If `False`, the folder will contain the files for the policy only. If `True`, the folder will contain sub-folders for the policy and value model. You can import them by specifying the subfolder using a keyword argument: `from_pretrained(repo_id, subfolder=subfolder)`
         ds3_gather_for_generation (`bool`, *optional*, defaults to `True`):
             This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for generation,
             improving generation speed. However, disabling this option allows training models that exceed the VRAM
@@ -125,7 +125,7 @@ class PPOConfig(OnPolicyConfig):
     )
     save_value_model: bool = field(
         default=False,
-        metadata={"help": "Whether the value model (also known as the critic model) should be saved when the policy model is saved."}
+        metadata={"help": "Whether the value model (also known as the critic model) should be saved when the policy model is saved. If `False`, the folder will contain the files for the policy only. If `True`, the folder will contain sub-folders for the policy and value model. You can import them by specifying the subfolder using a keyword argument: `from_pretrained(repo_id, subfolder=subfolder)`"}
     )
     ds3_gather_for_generation: bool = field(
         default=True,

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -125,7 +125,9 @@ class PPOConfig(OnPolicyConfig):
     )
     save_value_model: bool = field(
         default=False,
-        metadata={"help": "Whether the value model (also known as the critic model) should be saved when the policy model is saved. If `False`, the folder will contain the files for the policy only. If `True`, the folder will contain sub-folders for the policy and value model. You can import them by specifying the subfolder using a keyword argument: `from_pretrained(repo_id, subfolder=subfolder)`"}
+        metadata={
+            "help": "Whether the value model (also known as the critic model) should be saved when the policy model is saved. If `False`, the folder will contain the files for the policy only. If `True`, the folder will contain sub-folders for the policy and value model. You can import them by specifying the subfolder using a keyword argument: `from_pretrained(repo_id, subfolder=subfolder)`"
+        },
     )
     ds3_gather_for_generation: bool = field(
         default=True,

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -58,6 +58,8 @@ class PPOConfig(OnPolicyConfig):
             Discount factor.
         lam (`float`, *optional*, defaults to `0.95`):
             Lambda value for GAE.
+        save_value_model (`bool`, *optional*, defaults to `False`):
+            Whether the value model (also known as the critic model) should be saved when the policy model is saved.
         ds3_gather_for_generation (`bool`, *optional*, defaults to `True`):
             This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for generation,
             improving generation speed. However, disabling this option allows training models that exceed the VRAM
@@ -120,6 +122,10 @@ class PPOConfig(OnPolicyConfig):
     lam: float = field(
         default=0.95,
         metadata={"help": "Lambda value for GAE."},
+    )
+    save_value_model: bool = field(
+        default=False,
+        metadata={"help": "Whether the value model (also known as the critic model) should be saved when the policy model is saved."}
     )
     ds3_gather_for_generation: bool = field(
         default=True,

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -107,7 +107,7 @@ class PPOTrainer(Trainer):
         ref_model: Optional[nn.Module],
         reward_model: nn.Module,
         train_dataset: Dataset,
-        value_model: Optional[nn.Module] = None,
+        value_model: nn.Module,
         data_collator: Optional[DataCollatorWithPadding] = None,
         eval_dataset: Optional[Union[Dataset, dict[str, Dataset]]] = None,
         # less commonly used

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -328,6 +328,7 @@ class PPOTrainer(Trainer):
                 self.model.policy.set_adapter(self.model_adapter_name or "default")
 
     def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
+        import pdb;pdb.set_trace()
         # Handle the None case here so that we can have subfolders for policy and value
         if output_dir is None:
             output_dir = self.args.output_dir
@@ -340,7 +341,7 @@ class PPOTrainer(Trainer):
         if self.is_deepspeed_enabled:
             backup_deepspeed = self.deepspeed
             self.deepspeed = self.model
-        policy_output_dir = output_dir if not self.args.save_value_model else output_dir + "/policy_model"
+        policy_output_dir = output_dir if not self.args.save_value_model else os.path.join(output_dir, "policy_model")
         super().save_model(policy_output_dir, _internal_call)
 
         self.model = backup_model
@@ -355,7 +356,7 @@ class PPOTrainer(Trainer):
             if self.is_deepspeed_enabled:
                 backup_deepspeed = self.deepspeed
                 self.deepspeed = self.model
-            value_output_dir = output_dir if not self.args.save_value_model else output_dir + "/value_model"
+            value_output_dir = output_dir if not self.args.save_value_model else os.path.join(output_dir, "value_model")
             super().save_model(value_output_dir, _internal_call)
 
             self.model = backup_model

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -334,7 +334,14 @@ class PPOTrainer(Trainer):
         #     output_dir = self.args.output_dir
         #     if output_dir is None:
         #         raise ValueError("No output directory specified for saving the model")
-            
+        times_called = getattr(self, "_save_model_count", 0)    
+        times_called += 1
+        setattr(self, '_save_model_count', times_called)
+        print(f"save_model has been called {times_called} time")
+        print(f"{output_dir=}")
+        print(f"{type(self.model)=}")
+        if not hasattr(self.model, 'policy'):
+            return
         backup_model = self.model
         self.model = self.model.policy  # save only the policy
         print("Accessed policy, continuing")
@@ -364,7 +371,7 @@ class PPOTrainer(Trainer):
             self.model = backup_model
 
             if self.is_deepspeed_enabled:
-                self.deepspeed = backup_deepspeed 
+                self.deepspeed = backup_deepspeed
 
     def train(self):
         args = self.args

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -337,7 +337,7 @@ class PPOTrainer(Trainer):
             
         backup_model = self.model
         self.model = self.model.policy  # save only the policy
-
+        print("Accessed policy, continuing")
         if self.is_deepspeed_enabled:
             backup_deepspeed = self.deepspeed
             self.deepspeed = self.model
@@ -350,6 +350,7 @@ class PPOTrainer(Trainer):
             self.deepspeed = backup_deepspeed
         
         if self.args.save_value_model:
+            print("SAVING VALUE MODEL", end="")
             backup_model = self.model
             self.model = self.model.value_model
 
@@ -357,8 +358,9 @@ class PPOTrainer(Trainer):
                 backup_deepspeed = self.deepspeed
                 self.deepspeed = self.model
             value_output_dir = output_dir if not self.args.save_value_model else os.path.join(output_dir, "value_model")
+            print(" to " + value_output_dir)
             super().save_model(value_output_dir, _internal_call)
-
+            print("reseting model to the combined")
             self.model = backup_model
 
             if self.is_deepspeed_enabled:

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -334,7 +334,7 @@ class PPOTrainer(Trainer):
             if output_dir is None:
                 raise ValueError("No output directory specified for saving the model")
         # I am unsure whether this early return is legal. Line 4814 in Trainer.py says that save_model has to be executed on all processes for TPU training. Previously, save_model would be called in parallel while one process had already set self.model to self.model.policy, resulting in errors. Including this line gets rid of those errors and the model still gets uploaded.
-        if not hasattr(self.model, 'policy'):
+        if not hasattr(self.model, "policy"):
             return
         backup_model = self.model
         self.model = self.model.policy  # save only the policy
@@ -350,7 +350,7 @@ class PPOTrainer(Trainer):
 
         if self.is_deepspeed_enabled:
             self.deepspeed = backup_deepspeed
-        
+
         if self.args.save_value_model:
             backup_model = self.model
             self.model = self.model.value_model

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -350,7 +350,6 @@ class PPOTrainer(Trainer):
             self.deepspeed = backup_deepspeed
         
         if self.args.save_value_model:
-            print("SAVING VALUE MODEL", end="")
             backup_model = self.model
             self.model = self.model.value_model
 
@@ -358,7 +357,6 @@ class PPOTrainer(Trainer):
                 backup_deepspeed = self.deepspeed
                 self.deepspeed = self.model
             value_output_dir = output_dir if not self.args.save_value_model else os.path.join(output_dir, "value_model")
-            print(" to " + value_output_dir)
             super().save_model(value_output_dir, _internal_call)
             self.model = backup_model
 

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -328,12 +328,12 @@ class PPOTrainer(Trainer):
                 self.model.policy.set_adapter(self.model_adapter_name or "default")
 
     def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
-        import pdb;pdb.set_trace()
+        # import pdb;pdb.set_trace()
         # Handle the None case here so that we can have subfolders for policy and value
-        if output_dir is None:
-            output_dir = self.args.output_dir
-            if output_dir is None:
-                raise ValueError("No output directory specified for saving the model")
+        # if output_dir is None:
+        #     output_dir = self.args.output_dir
+        #     if output_dir is None:
+        #         raise ValueError("No output directory specified for saving the model")
             
         backup_model = self.model
         self.model = self.model.policy  # save only the policy


### PR DESCRIPTION
This PR adds functionality for `save_value_model: bool=False` which determines whether to save the value model that is trained by PPOTrainer. 

During training, PPO puts quite a lot of effort training the value model to be good at predicting the reward the policy will receive. That sounds like a valuable tool, and it is a shame that previously we had simply been discarding it. This PR adds functionality for keeping the value model.

I requested this feature [here](http://github.com/issues/created?issue=huggingface%7Ctrl%7C3293), and this PR resolves that.
It also resolves the error described in this issue: [no attribute 'policy' when pushing PPOTrainer to hub using example ppo.py script #3301](https://github.com/huggingface/trl/issues/3301)
**I'm unsure whether the way I fixed it, the early return on line 338 in PPOTrainer, is legal. Please check!**

I would love your feedback, @qgallouedec!