### PR TITLE
🙋 Add Optional Eager Execution Mode for vLLM Serving

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -257,7 +257,7 @@ def main(script_args: ScriptArguments):
         revision=script_args.revision,
         tensor_parallel_size=script_args.tensor_parallel_size,
         gpu_memory_utilization=script_args.gpu_memory_utilization,
-        enforce_eager=script_args.enforce_eager_flag,
+        enforce_eager=script_args.enforce_eager,
         dtype=script_args.dtype,
         # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
         # directly reuse the KV cache if it shares the same prefix with one of the existing queries.

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -228,7 +228,7 @@ class ScriptArguments:
         default=None,
         metadata={
             "help": "Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute "
-            "the model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid.
+            "the model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid."
         },
     )
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -224,7 +224,7 @@ class ScriptArguments:
             "hardware support this feature."
         },
     )
-    enforce_eager_flag: Optional[bool] = field(
+    enforce_eager: Optional[bool] = field(
         default=None,
         metadata={
             "help": "Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute "

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -174,6 +174,9 @@ class ScriptArguments:
         enable_prefix_caching (`bool` or `None`, *optional*, defaults to `None`):
             Whether to enable prefix caching in vLLM. If set to `True`, ensure that the model and the hardware support
             this feature.
+        enforce_eager (`bool` or `None`, *optional*, defaults to `None`):
+            Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute the
+            model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid.
     """
 
     model: str = field(metadata={"help": "Model name or path to load the model from."})
@@ -227,8 +230,9 @@ class ScriptArguments:
     enforce_eager: Optional[bool] = field(
         default=None,
         metadata={
-            "help": "Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute "
-            "the model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid."
+            "help": "Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always "
+            "execute the model in eager mode. If `False` (default behavior), we will use CUDA graph and eager "
+            "execution in hybrid."
         },
     )
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -225,7 +225,7 @@ class ScriptArguments:
         },
     )
     enforce_eager_flag: Optional[bool] = field(
-        default=False,
+        default=None,
         metadata={
             "help": "Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute "
             "the model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid.


### PR DESCRIPTION
## Overview
This pull request introduces a new optional flag, `enforce_eager`, to the VLLM serving script. This enhancement gives users control over the execution mode of the model, allowing them to choose between eager execution or the default hybrid CUDA graph approach based on their specific needs. See https://docs.vllm.ai/en/stable/api/offline_inference/llm.html#vllm.LLM

## Changes Made
* Added a new boolean parameter `enforce_eager_flag` to the `ScriptArguments` class in `trl/scripts/vllm_serve.py`
* Updated the `main` function to pass this flag as `enforce_eager` to the model configuration
* Set the default value to `False` to maintain backward compatibility with existing behavior

## Benefits
* **Memory Optimization**: Enforcing eager execution can reduce memory usage in certain scenarios
* **Performance Flexibility**: Allows users to choose between memory efficiency and potential performance gains
* **Better Control**: Provides explicit control over execution strategy without modifying source code

## Technical Details
The changes primarily affect:
* `trl/scripts/vllm_serve.py` - Added new flag to the argument parser and passed it to the model configuration

## Testing
Verified the flag works correctly in both states:
* When `enforce_eager_flag=True`: Model uses pure eager execution
* When `enforce_eager_flag=False` (default): Model uses hybrid CUDA graph execution

## Related Issues
<!-- Replace with actual issue number if applicable -->
Fixes #XXXX

## Checklist Before Submitting
- [x] Read the [[contributor guidelines](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)
- [x] Updated documentation to reflect the new parameter
- [x] Tested the feature with different flag values
- [x] Maintained backward compatibility

## Who Can Review?
Anyone in the community is welcome to review once tests have passed. Team members with expertise in model serving or CUDA optimization would be particularly valuable reviewers.