### PR TITLE
Environments

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -27,6 +27,8 @@
     title: Distributing Training
   - local: use_model
     title: Using Trained Models
+  - local: training_agents
+    title: Training Agents
   title: How-to guides
 - sections:
   - local: deepspeed_integration

--- a/docs/source/training_agents.md
+++ b/docs/source/training_agents.md
@@ -1,0 +1,138 @@
+# Training Agents with Environments in TRL
+
+Environments in TRL provide a powerful way to customize the rollout process for reinforcement learning (RL) with language models, specifically when using vLLM as the backend. This enables advanced agent training workflows, such as allowing your model to interact with external tools or APIs during RL training.
+
+> **Note:**  
+> - Environments currently require vLLM as the backend.
+> - The only supported RL training method at this time is GRPO (Group Relative Policy Optimization).
+
+## Installation
+
+To use Environments and agent features, install TRL with the `[agents]` extra:
+
+```bash
+pip install trl[agents]
+```
+
+## What Are Environments?
+
+An **Environment** defines how rollouts (model generations) are performed during RL training. By customizing the rollout, you can enable your model to interact with external systems, execute code, or follow any custom logic during generation.
+
+TRL provides built-in environments, such as `CodeAgentEnvironment`, and you can also implement your own by subclassing `Environment`.
+
+---
+
+## Using the Built-in CodeAgentEnvironment
+
+The `CodeAgentEnvironment` allows your agent to write and execute code during training, using a code interpreter like the E2B Code Interpreter. This is useful for tasks where the model needs to solve problems by running code.
+
+You can also use the `run_agent` method to test and observe your agent's behavior outside of training.
+
+### Example: Running the CodeAgent Environment
+
+First, start a vLLM server with your model:
+
+```bash
+trl vllm-serve --model "Qwen/Qwen2.5-0.5B-Instruct"
+```
+
+Then, use the environment and client in Python:
+
+```python
+from trl import CodeAgentEnvironment, E2BExecutor, VLLMClientGenerationConfig, VLLMClient
+
+client = VLLMClient()
+gen_config = VLLMClientGenerationConfig(
+    n=8,
+    repetition_penalty=1.0,
+    temperature=0.8,
+    top_p=0.9,
+    top_k=10,
+    min_p=0.0,
+    max_tokens=256,
+)
+tokenizer = ...  # Load your tokenizer here
+code_executor = E2BExecutor(api_key="YOUR_E2B_TOKEN")
+my_env = CodeAgentEnvironment(
+    code_executor=code_executor,
+    tokenizer=tokenizer,
+    parsing_string="<code>",
+    stop_string="</code>",
+)
+prompts = [...]  # List of prompt strings
+responses = my_env.run_agent(
+    vllm_client=client,
+    generation_config=gen_config,
+    prompts=prompts
+)
+```
+
+---
+
+## Writing a Custom Environment
+
+To create your own environment, subclass `Environment` and implement a `generate` method. This method receives the vLLM client, a generation config, and a list of prompts, and must return a list of tokenized completions (as lists of token IDs).
+
+The `generate` method is called by the GRPO training loop to perform rollouts.
+
+**Example:**
+
+```python
+from trl import Environment, VLLMClientGenerationConfig
+
+class MyCustomEnv(Environment):
+    def __init__(self, ...):
+        # Your custom initialization
+        pass
+
+    def generate(self, vllm_client, generation_config: VLLMClientGenerationConfig, prompts: list[str]) -> list:
+        # Your custom rollout logic
+        completion_ids = vllm_client.generate(
+            prompts=prompts,
+            **vars(generation_config)
+        )
+        return completion_ids
+```
+
+You can add any additional methods or logic needed for your task.
+
+---
+
+## Training with a Custom Environment
+
+To use your environment for RL training, simply pass it to the `GRPOTrainer`:
+
+```python
+from trl import GRPOConfig, GRPOTrainer
+
+training_args = GRPOConfig(
+    output_dir="qwen_0.5B-agent",
+    use_vllm=True,
+    # ... other config options ...
+)
+
+trainer = GRPOTrainer(
+    model=...,                # Your model or model name
+    reward_funcs=...,         # Your reward function(s)
+    args=training_args,
+    environment=my_env,       # Your custom or built-in environment
+    # ... other trainer args ...
+)
+```
+
+Then, start training as usual:
+
+```python
+trainer.train()
+```
+
+---
+
+## Summary
+
+- **Environments** let you fully customize how rollouts are performed during RL training with TRL and vLLM.
+- Use built-in environments like `CodeAgentEnvironment` for code-executing agents, or implement your own by subclassing `Environment`.
+- The `generate` method is the key entry point for custom rollout logic.
+- Pass your environment to `GRPOTrainer` to use it during RL training.
+
+For more advanced examples, see the [notebooks](../notebooks/) or the TRL documentation.

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,16 @@ EXTRAS = {
     "bco": ["scikit-learn", "joblib"],
     "test": ["parameterized", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "pytest"],
     "vllm": ["vllm>=0.8.3", "fastapi", "pydantic", "requests", "uvicorn"],
-    "agents": [*EXTRAS["vllm"],"e2b-code-interpreter","python-dotenv","langchain_experimental",],
+    "agents": [
+        "vllm>=0.8.3",
+        "fastapi",
+        "pydantic",
+        "requests",
+        "uvicorn",
+        "e2b-code-interpreter",
+        "python-dotenv",
+        "langchain_experimental",
+    ],
     "vlm": ["Pillow"],
 }
 EXTRAS["dev"] = []

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ EXTRAS = {
     "bco": ["scikit-learn", "joblib"],
     "test": ["parameterized", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "pytest"],
     "vllm": ["vllm>=0.8.3", "fastapi", "pydantic", "requests", "uvicorn"],
+    "agents": [*EXTRAS["vllm"],"e2b-code-interpreter","python-dotenv","langchain_experimental",],
     "vlm": ["Pillow"],
 }
 EXTRAS["dev"] = []

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -23,9 +23,10 @@ from transformers import AutoModelForCausalLM, AutoModelForSequenceClassificatio
 from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
-from trl import GRPOConfig, GRPOTrainer, CodeAgentEnvironment, LocalExecutor
+from trl import CodeAgentEnvironment, GRPOConfig, GRPOTrainer, LocalExecutor
 from trl.trainer.grpo_trainer import RepeatSampler
-from .testing_utils import require_vllm, require_local_code_executer
+
+from .testing_utils import require_local_code_executer, require_vllm
 
 
 if is_peft_available():
@@ -708,7 +709,7 @@ class GRPOTrainerTester(unittest.TestCase):
     @require_vllm
     @require_local_code_executer
     @unittest.skip("We should add a mock for the vLLM server.")
-    def test_training_vllm(self):
+    def test_training_vllm_with_environment(self):
         """Test that training works with vLLM for generation."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         # initializing local code executer
@@ -720,8 +721,8 @@ class GRPOTrainerTester(unittest.TestCase):
         env = CodeAgentEnvironment(
             code_executor=code_executer,
             tokenizer=tokenizer,
-            )
-        
+        )
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = GRPOConfig(
                 output_dir=tmp_dir,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -25,6 +25,7 @@ from trl.import_utils import (
     is_llm_blender_available,
     is_mergekit_available,
     is_vllm_available,
+    is_langchain_experimental_available
 )
 
 
@@ -78,6 +79,11 @@ def require_vllm(test_case):
     """
     return unittest.skipUnless(is_vllm_available(), "test requires vllm")(test_case)
 
+def require_local_code_executer(test_case):
+    """
+    Decorator marking a test that requires local code executer using langchain_experimentals PythonREPL. Skips the test if local code executer is not available.
+    """
+    return unittest.skipUnless(is_langchain_experimental_available(), "test requires local code executer with langchain_experimentals")(test_case)
 
 def require_no_wandb(test_case):
     """

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -22,10 +22,10 @@ from trl import BaseBinaryJudge, BasePairwiseJudge
 from trl.import_utils import (
     is_diffusers_available,
     is_joblib_available,
+    is_langchain_experimental_available,
     is_llm_blender_available,
     is_mergekit_available,
     is_vllm_available,
-    is_langchain_experimental_available
 )
 
 
@@ -79,11 +79,15 @@ def require_vllm(test_case):
     """
     return unittest.skipUnless(is_vllm_available(), "test requires vllm")(test_case)
 
+
 def require_local_code_executer(test_case):
     """
     Decorator marking a test that requires local code executer using langchain_experimentals PythonREPL. Skips the test if local code executer is not available.
     """
-    return unittest.skipUnless(is_langchain_experimental_available(), "test requires local code executer with langchain_experimentals")(test_case)
+    return unittest.skipUnless(
+        is_langchain_experimental_available(), "test requires local code executer with langchain_experimentals"
+    )(test_case)
+
 
 def require_no_wandb(test_case):
     """

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -36,7 +36,7 @@ _import_structure = {
         "unpair_preference_dataset",
     ],
     "environment": ["TextEnvironment", "TextHistory"],
-    "extras": ["BestOfNSampler"],
+    "extras": ["BestOfNSampler","VLLMClient"],
     "models": [
         "SUPPORTED_ARCHITECTURES",
         "AutoModelForCausalLMWithValueHead",
@@ -130,7 +130,7 @@ if TYPE_CHECKING:
         unpair_preference_dataset,
     )
     from .environment import TextEnvironment, TextHistory
-    from .extras import BestOfNSampler
+    from .extras import BestOfNSampler, VLLMClient
     from .models import (
         SUPPORTED_ARCHITECTURES,
         AutoModelForCausalLMWithValueHead,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -21,7 +21,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 _import_structure = {
     "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment","VLLMClientGenerationConfig"],
-    "agents.utils": ["E2BExecutor"],
+    "agents.utils": ["E2BExecutor", "LocalExecutor", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -141,7 +141,7 @@ if TYPE_CHECKING:
         setup_chat_format,
     )
     from .agents.environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
-    from .agents.utils import E2BExecutor
+    from .agents.utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
     from .scripts import ScriptArguments, TrlParser, init_zero_verbose
     from .trainer import (
         AlignPropConfig,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -21,7 +21,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 _import_structure = {
     "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment", "VLLMClientGenerationConfig"],
-    "agents.utils": ["E2Bexecuter", "Localexecuter", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
+    "agents.utils": ["E2BExecuter", "Localexecuter", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -118,7 +118,7 @@ else:
 
 if TYPE_CHECKING:
     from .agents.environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
-    from .agents.utils import E2Bexecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
+    from .agents.utils import E2BExecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
     from .data_utils import (
         apply_chat_template,
         extract_prompt,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -20,6 +20,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 
 _import_structure = {
+    "agents.environments": ["Environment", "DefaultEnvironment", "VLLMClientGenerationConfig"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -138,6 +139,7 @@ if TYPE_CHECKING:
         create_reference_model,
         setup_chat_format,
     )
+    from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
     from .scripts import ScriptArguments, TrlParser, init_zero_verbose
     from .trainer import (
         AlignPropConfig,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -21,7 +21,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 _import_structure = {
     "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment", "VLLMClientGenerationConfig"],
-    "agents.utils": ["E2BExecutor", "LocalExecutor", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
+    "agents.utils": ["E2Bexecuter", "Localexecuter", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -118,7 +118,7 @@ else:
 
 if TYPE_CHECKING:
     from .agents.environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
-    from .agents.utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
+    from .agents.utils import E2Bexecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
     from .data_utils import (
         apply_chat_template,
         extract_prompt,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -21,6 +21,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 _import_structure = {
     "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment","VLLMClientGenerationConfig"],
+    "agents.utils": ["E2BExecutor"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -140,6 +141,7 @@ if TYPE_CHECKING:
         setup_chat_format,
     )
     from .agents.environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
+    from .agents.utils import E2BExecutor
     from .scripts import ScriptArguments, TrlParser, init_zero_verbose
     from .trainer import (
         AlignPropConfig,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -20,7 +20,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 
 _import_structure = {
-    "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment","VLLMClientGenerationConfig"],
+    "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment", "VLLMClientGenerationConfig"],
     "agents.utils": ["E2BExecutor", "LocalExecutor", "prepare_data_for_e2b_agent", "prepare_data_for_local_agent"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
@@ -37,7 +37,7 @@ _import_structure = {
         "unpair_preference_dataset",
     ],
     "environment": ["TextEnvironment", "TextHistory"],
-    "extras": ["BestOfNSampler","VLLMClient"],
+    "extras": ["BestOfNSampler", "VLLMClient"],
     "models": [
         "SUPPORTED_ARCHITECTURES",
         "AutoModelForCausalLMWithValueHead",
@@ -117,6 +117,8 @@ else:
     _import_structure["trainer"].extend(["DDPOConfig", "DDPOTrainer"])
 
 if TYPE_CHECKING:
+    from .agents.environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
+    from .agents.utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
     from .data_utils import (
         apply_chat_template,
         extract_prompt,
@@ -140,8 +142,6 @@ if TYPE_CHECKING:
         create_reference_model,
         setup_chat_format,
     )
-    from .agents.environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
-    from .agents.utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
     from .scripts import ScriptArguments, TrlParser, init_zero_verbose
     from .trainer import (
         AlignPropConfig,

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -20,7 +20,7 @@ from .import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffus
 
 
 _import_structure = {
-    "agents.environments": ["Environment", "DefaultEnvironment", "VLLMClientGenerationConfig"],
+    "agents.environments": ["Environment", "DefaultEnvironment", "CodeAgentEnvironment","VLLMClientGenerationConfig"],
     "scripts": ["init_zero_verbose", "ScriptArguments", "TrlParser"],
     "data_utils": [
         "apply_chat_template",
@@ -139,7 +139,7 @@ if TYPE_CHECKING:
         create_reference_model,
         setup_chat_format,
     )
-    from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
+    from .agents.environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
     from .scripts import ScriptArguments, TrlParser, init_zero_verbose
     from .trainer import (
         AlignPropConfig,

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -1,8 +1,10 @@
 from .environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
+from .utils import E2BExecutor
 
 __all__ = [
     "Environment",
     "DefaultEnvironment",
     "CodeAgentEnvironment",
     "VLLMClientGenerationConfig",
+    "E2BExecutor"
 ]

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -1,10 +1,13 @@
 from .environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
-from .utils import E2BExecutor
+from .utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
 
 __all__ = [
     "Environment",
     "DefaultEnvironment",
     "CodeAgentEnvironment",
     "VLLMClientGenerationConfig",
-    "E2BExecutor"
+    "E2BExecutor",
+    "LocalExecutor",
+    "prepare_data_for_e2b_agent",
+    "prepare_data_for_local_agent",
 ]

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
-from .utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
+from .utils import E2Bexecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
 
 
 __all__ = [
@@ -21,8 +21,8 @@ __all__ = [
     "DefaultEnvironment",
     "CodeAgentEnvironment",
     "VLLMClientGenerationConfig",
-    "E2BExecutor",
-    "LocalExecutor",
+    "E2Bexecuter",
+    "Localexecuter",
     "prepare_data_for_e2b_agent",
     "prepare_data_for_local_agent",
 ]

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -1,7 +1,8 @@
-from .environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
+from .environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
 
 __all__ = [
     "Environment",
-    "DefaultEnvironment", 
+    "DefaultEnvironment",
+    "CodeAgentEnvironment",
     "VLLMClientGenerationConfig",
 ]

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -1,5 +1,20 @@
-from .environments import Environment, DefaultEnvironment, CodeAgentEnvironment, VLLMClientGenerationConfig
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
 from .utils import E2BExecutor, LocalExecutor, prepare_data_for_e2b_agent, prepare_data_for_local_agent
+
 
 __all__ = [
     "Environment",

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .environments import CodeAgentEnvironment, DefaultEnvironment, Environment, VLLMClientGenerationConfig
-from .utils import E2Bexecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
+from .utils import E2BExecuter, Localexecuter, prepare_data_for_e2b_agent, prepare_data_for_local_agent
 
 
 __all__ = [
@@ -21,7 +21,7 @@ __all__ = [
     "DefaultEnvironment",
     "CodeAgentEnvironment",
     "VLLMClientGenerationConfig",
-    "E2Bexecuter",
+    "E2BExecuter",
     "Localexecuter",
     "prepare_data_for_e2b_agent",
     "prepare_data_for_local_agent",

--- a/trl/agents/__init__.py
+++ b/trl/agents/__init__.py
@@ -1,0 +1,7 @@
+from .environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
+
+__all__ = [
+    "Environment",
+    "DefaultEnvironment", 
+    "VLLMClientGenerationConfig",
+]

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -108,12 +108,13 @@ class CodeAgentEnvironment(Environment):
         """
         # Store original prompts for later use
         original_prompts = prompts.copy()
-        
+        # a buncha debug print statements
+        print(f"Original prompts: {original_prompts}")
         # Duplicate prompts to match the requested number of generations (n)
         expanded_prompts = []
         for prompt in prompts:
             expanded_prompts.extend([prompt] * generation_config.n)
-        
+        print(f"Expanded prompts: {expanded_prompts}")
         # Create a modified generation config with n=1 for individual generations
         single_gen_config = VLLMClientGenerationConfig(
             n=1,
@@ -124,20 +125,24 @@ class CodeAgentEnvironment(Environment):
             min_p=generation_config.min_p,
             max_tokens=generation_config.max_tokens,
             guided_decoding_regex=generation_config.guided_decoding_regex,
+            # Ensure stop string is always included for code parsing
             stop=[self.stop_string] if generation_config.stop is None else 
-                 generation_config.stop + [self.stop_string]
+                    list(set(generation_config.stop + [self.stop_string])) # Use set to avoid duplicates
         )
-        
+        print(f"Single generation config: {single_gen_config}")
         # Track current conversations for each prompt
         current_conversations = expanded_prompts.copy()
         completed_conversations = []
-        
+        print(f"Initial Current conversations: {current_conversations}")
+        print(f"Initial Completed conversations: {completed_conversations}")
         # Continue code execution loop until all conversations are completed
         while current_conversations:
+            print(f"\n--- Starting Generation Loop ---")
+            print(f"Current conversations ({len(current_conversations)}): {current_conversations}")
             # Generate next response segment
             outputs = vllm_client.generate(
                 prompts=current_conversations,
-                n=1,
+                n=1, # Already handled expansion, generate 1 per conversation
                 repetition_penalty=single_gen_config.repetition_penalty,
                 temperature=single_gen_config.temperature,
                 top_p=single_gen_config.top_p,
@@ -147,42 +152,92 @@ class CodeAgentEnvironment(Environment):
                 guided_decoding_regex=single_gen_config.guided_decoding_regex,
                 stop=single_gen_config.stop
             )
+            print(f"Generated outputs (token ids): {outputs}")
             
-            next_conversations = []
-            code_batch = []
-            code_conversations = []
-            
+            next_conversations_for_llm = [] # Conversations needing more generation
+            code_batch = [] # Code snippets to execute
+            code_conversations_map = {} # Map index to conversation needing code exec
+
             # Process outputs
-            for conversation, output in zip(current_conversations, outputs):
-                # Get the full conversation by combining original + generated text
-                full_conversation = output["prompt"] + output["text"]
+            for idx, (conversation_prompt, output_ids) in enumerate(zip(current_conversations, outputs)):
+                # output is a list of token ids; decode it
+                # Important: Decode carefully, handle potential stop tokens like stop_string
+                generated_text = self.tokenizer.decode(output_ids, skip_special_tokens=True)
                 
-                # Check if code execution is needed
-                if self.parsing_string in full_conversation and self.stop_string in full_conversation:
-                    # Extract code for execution
-                    code = self.extract_code(full_conversation)
+                # Check if generation stopped exactly at the stop_string
+                stopped_at_code_end = False
+                if single_gen_config.stop:
+                    # Check if the last decoded token corresponds to any stop sequence
+                    # This is tricky, a simpler check might be needed depending on tokenizer behavior
+                    # For now, check if the decoded text ends with the stop_string
+                    if generated_text.endswith(self.stop_string.strip()): # Strip potential whitespace
+                            stopped_at_code_end = True
+                            # Remove the stop string itself if needed, or keep it based on desired format
+                            # generated_text = generated_text[:-len(self.stop_string)] # Optional: remove stop string
+
+                print(f"\nProcessing conversation index {idx}:")
+                print(f"  Prompt: '{conversation_prompt}'")
+                print(f"  Generated text: '{generated_text}'")
+                print(f"  Stopped at code end: {stopped_at_code_end}")
+
+                # Check if code execution is indicated IN THE NEWLY GENERATED TEXT
+                # And if the generation actually stopped because of the stop_string
+                if self.parsing_string in generated_text and stopped_at_code_end:
+                    # Construct the full conversation up to this point
+                    full_conversation_segment = conversation_prompt + generated_text 
+                    
+                    # Extract code ONLY from the generated part for safety
+                    code = self.extract_code(generated_text) # Pass only generated text
+                    print(f"  Extracted code: {code}")
                     if code:
                         code_batch.append(code)
-                        code_conversations.append(full_conversation)
+                        # Store the conversation *before* adding output tag, map by original index
+                        code_conversations_map[idx] = full_conversation_segment + self.stop_string # Add stop string back if removed
+                    else:
+                            # Code tags present but extraction failed? Treat as complete for now.
+                            print(f"  Warning: Code tags found but extraction failed. Completing conversation.")
+                            completed_conversations.append(full_conversation_segment)
+
                 else:
-                    # No code to execute, conversation is complete
+                    # No code block detected in the new text OR didn't stop at stop_string
+                    # Conversation is considered complete for this agent logic
+                    full_conversation = conversation_prompt + generated_text
                     completed_conversations.append(full_conversation)
+                    print(f"  No code detected or not stopped correctly. Conversation completed.")
             
-            # Execute code if needed
+            print(f"\n--- After Processing Generations ---")
+            print(f"Code batch ({len(code_batch)}): {code_batch}")
+            print(f"Code conversations map ({len(code_conversations_map)}): {code_conversations_map.keys()}")
+            print(f"Completed conversations ({len(completed_conversations)}): {[c[-100:]+'...' for c in completed_conversations]}") # Show ends
+
+            # Execute code batch if any code was extracted
             if code_batch:
+                print(f"\n--- Executing Code Batch ---")
                 execution_results = self.code_executor.execute(code_batch)
+                print(f"Execution results: {execution_results}")
                 
-                # Add execution results to conversations
-                for conversation, result in zip(code_conversations, execution_results):
-                    updated_conversation = conversation + f"<output>{result}</output>"
-                    next_conversations.append(updated_conversation)
-            
-            # Update current conversations for next iteration
-            current_conversations = next_conversations
-        
+                # Add execution results back to the corresponding conversations
+                result_idx = 0
+                for original_idx, conversation_segment in code_conversations_map.items():
+                    result = execution_results[result_idx]
+                    # Append the output tag and result
+                    updated_conversation = conversation_segment + f"<output>{result}</output>"
+                    next_conversations_for_llm.append(updated_conversation) # Add to list for next LLM call
+                    print(f"  Appended output to conversation index {original_idx}. Ready for next generation.")
+                    result_idx += 1
+            else:
+                    print(f"\n--- No Code to Execute ---")
+
+            # Update current conversations for the next iteration of the loop
+            current_conversations = next_conversations_for_llm
+            print(f"\n--- End of Loop Iteration ---")
+            print(f"Next conversations for LLM ({len(current_conversations)}): {[c[-100:]+'...' for c in current_conversations]}") # Show ends
+
         # Return the final completed conversations
+        print(f"\n--- Agent Run Finished ---")
+        print(f"Final Completed conversations ({len(completed_conversations)}): {completed_conversations}")
         return completed_conversations
-    
+         
     def generate(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List:
         """Generate responses with code execution and return token IDs
 

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -192,7 +192,7 @@ class CodeAgentEnvironment(Environment):
                     if code:
                         code_batch.append(code)
                         # Store the conversation *before* adding output tag, map by original index
-                        code_conversations_map[idx] = full_conversation_segment + self.stop_string # Add stop string back if removed
+                        code_conversations_map[idx] = full_conversation_segment
                     else:
                             # Code tags present but extraction failed? Treat as complete for now.
                             print(f"  Warning: Code tags found but extraction failed. Completing conversation.")

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -80,7 +80,7 @@ class CodeAgentEnvironment(Environment):
 
     def __init__(
         self,
-        code_executor: Any,
+        code_executer: Any,
         tokenizer: PreTrainedTokenizerBase,
         parsing_string: str = "<code>",
         stop_string: str = "</code>",
@@ -91,7 +91,7 @@ class CodeAgentEnvironment(Environment):
         """Initialize the code agent environment
 
         Args:
-            code_executor: The executor to run code (like LocalExecutor or E2BExecutor)
+            code_executer: The executer to run code (like Localexecuter or E2Bexecuter)
             tokenizer: Tokenizer for encoding/decoding text
             parsing_string: String that marks the beginning of code blocks
             stop_string: String that marks the end of code blocks
@@ -99,10 +99,10 @@ class CodeAgentEnvironment(Environment):
             output_parsing_string: String marking the beginning of code output.
             output_stop_string: String marking the end of code output.
         """
-        if not hasattr(code_executor, "execute"):
-            raise ValueError("code_executor must have an 'execute' method.")
+        if not hasattr(code_executer, "execute"):
+            raise ValueError("code_executer must have an 'execute' method.")
 
-        self.code_executor = code_executor
+        self.code_executer = code_executer
         self.tokenizer = tokenizer
         self.parsing_string = parsing_string
         self.stop_string = stop_string
@@ -230,7 +230,7 @@ class CodeAgentEnvironment(Environment):
             # Execute code batch if any code was extracted
             if code_batch:
                 try:
-                    execution_results = self.code_executor.execute(code_batch)
+                    execution_results = self.code_executer.execute(code_batch)
                     if len(execution_results) != len(conversations_pending_code):
                         raise ValueError(
                             f"Mismatch between code batch size ({len(code_batch)}) and results ({len(execution_results)})"

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -56,7 +56,7 @@ class DefaultEnvironment(Environment):
         )
 
 class CodeAgentEnvironment(Environment):
-    """Environment that supports code execution during generation, simplified implementation."""
+    """Environment that supports code execution during generation"""
 
     def __init__(
         self,

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -80,7 +80,7 @@ class CodeAgentEnvironment(Environment):
     Environment that supports code execution during generation.
 
     This environment enables an agent to generate text that include code blocks,
-    execute those code blocks using a provided code executer (such as Localexecuter or E2Bexecuter),
+    execute those code blocks using a provided code executer (such as Localexecuter or E2BExecuter),
     and insert the execution results back into the conversation. It is designed to work with
     conversational models that can output code delimited by specific tags (e.g., <code>...</code>).
 
@@ -90,7 +90,7 @@ class CodeAgentEnvironment(Environment):
 
     Args:
         code_executer: An object with an `execute` method that takes a list of code strings and returns a list of results.
-            This is used to run the extracted code blocks (e.g., Localexecuter or E2Bexecuter).
+            This is used to run the extracted code blocks (e.g., Localexecuter or E2BExecuter).
         tokenizer: A PreTrainedTokenizerBase instance for encoding and decoding text and completions.
         parsing_string: String that marks the beginning of code blocks in the generated text (default: "<code>").
         stop_string: String that marks the end of code blocks in the generated text (default: "</code>").
@@ -113,7 +113,7 @@ class CodeAgentEnvironment(Environment):
         """Initialize the code agent environment
 
         Args:
-            code_executer: The executer to run code (like Localexecuter or E2Bexecuter)
+            code_executer: The executer to run code (like Localexecuter or E2BExecuter)
             tokenizer: Tokenizer for encoding/decoding text
             parsing_string: String that marks the beginning of code blocks
             stop_string: String that marks the end of code blocks

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -52,15 +52,7 @@ class DefaultEnvironment(Environment):
             
         return vllm_client.generate(
             prompts=prompts,
-            n=generation_config.n,
-            repetition_penalty=generation_config.repetition_penalty,
-            temperature=generation_config.temperature,
-            top_p=generation_config.top_p,
-            top_k=generation_config.top_k,
-            min_p=generation_config.min_p,
-            max_tokens=generation_config.max_tokens,
-            guided_decoding_regex=generation_config.guided_decoding_regex,
-            stop=generation_config.stop
+            **vars(generation_config),
         )
 
 class CodeAgentEnvironment(Environment):

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass 
 from typing import List, Any, Optional
+import abc
 
 @dataclass
 class VLLMClientGenerationConfig:
@@ -13,26 +14,52 @@ class VLLMClientGenerationConfig:
     max_tokens: int
     guided_decoding_regex: Optional[str] = None
 
-class Environment:
+class Environment(abc.ABC):
     """Base environment that implements standard VLLM generation"""
     
+    def __init__(self, vllm_client: Any):
+        """Initialize environment with VLLM client
+        
+        Args:
+            vllm_client: VLLM client instance
+        """
+        self.vllm_client = vllm_client
+    
+    @abc.abstractmethod
     def generate(
         self,
-        vllm_client: Any,
         prompts: List[str],
         generation_config: VLLMClientGenerationConfig, 
     ) -> List:
         """Generate responses using VLLM
 
         Args:
-            vllm_client: VLLM client instance
             prompts: Input prompts for generation
             generation_config: VLLM generation parameters
             
         Returns:
             completion_ids: Generated token ids
         """
-        return vllm_client.generate(
+        pass
+
+class DefaultEnvironment(Environment):
+    """Default environment that implements standard VLLM generation"""
+    
+    def generate(
+        self,
+        prompts: List[str],
+        generation_config: VLLMClientGenerationConfig, 
+    ) -> List:
+        """Generate responses using VLLM
+
+        Args:
+            prompts: Input prompts for generation
+            generation_config: VLLM generation parameters
+            
+        Returns:
+            completion_ids: Generated token ids
+        """
+        return self.vllm_client.generate(
             prompts=prompts,
             **vars(generation_config)
         )

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass 
+from typing import List, Any, Optional
+
+@dataclass
+class VLLMClientGenerationConfig:
+    """Configuration for VLLM client generation parameters"""
+    n: int
+    repetition_penalty: float
+    temperature: float
+    top_p: float
+    top_k: Optional[int]
+    min_p: float
+    max_tokens: int
+    guided_decoding_regex: Optional[str] = None
+
+class Environment:
+    """Base environment that implements standard VLLM generation"""
+    
+    def generate(
+        self,
+        vllm_client: Any,
+        prompts: List[str],
+        generation_config: VLLMClientGenerationConfig, 
+    ) -> List:
+        """Generate responses using VLLM
+
+        Args:
+            vllm_client: VLLM client instance
+            prompts: Input prompts for generation
+            generation_config: VLLM generation parameters
+            
+        Returns:
+            completion_ids: Generated token ids
+        """
+        return vllm_client.generate(
+            prompts=prompts,
+            **vars(generation_config)
+        )

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass 
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Union, Dict
 import abc
+from transformers import PreTrainedTokenizerBase
 
 @dataclass
 class VLLMClientGenerationConfig:
@@ -61,3 +62,165 @@ class DefaultEnvironment(Environment):
             guided_decoding_regex=generation_config.guided_decoding_regex,
             stop=generation_config.stop
         )
+
+class CodeAgentEnvironment(Environment):
+    """Environment that supports code execution during generation"""
+    
+    def __init__(
+        self, 
+        code_executor: Any,
+        tokenizer: PreTrainedTokenizerBase,
+        parsing_string: str = "<code>",
+        stop_string: str = "</code>",
+        tools_script: Optional[str] = None
+    ):
+        """Initialize the code agent environment
+        
+        Args:
+            code_executor: The executor to run code (like LocalExecutor or E2BExecutor)
+            tokenizer: Tokenizer for encoding/decoding text
+            parsing_string: String that marks the beginning of code blocks
+            stop_string: String that marks the end of code blocks
+            tools_script: Optional script to prepend to extracted code
+        """
+        self.code_executor = code_executor
+        self.tokenizer = tokenizer
+        self.parsing_string = parsing_string
+        self.stop_string = stop_string
+        self.tools_script = tools_script
+    
+    def extract_code(self, text: str) -> str:
+        """Extract code from generated text"""
+        if self.parsing_string not in text:
+            return None
+            
+        code_parts = text.split(self.parsing_string)[-1]
+        if self.stop_string in code_parts:
+            code_parts = code_parts.split(self.stop_string)[0]
+        
+        if self.tools_script:
+            code_parts = f"{self.tools_script}\n{code_parts}"
+            
+        return code_parts
+    
+    def run_agent(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List[str]:
+        """Run the agent with code execution and return completed text responses
+
+        Args:
+            vllm_client: VLLM client instance
+            generation_config: Configuration for generation parameters
+            prompts: Input prompts for generation
+            
+        Returns:
+            List[str]: Completed text responses with code execution results
+        """
+        # Store original prompts for later use
+        original_prompts = prompts.copy()
+        
+        # Duplicate prompts to match the requested number of generations (n)
+        expanded_prompts = []
+        for prompt in prompts:
+            expanded_prompts.extend([prompt] * generation_config.n)
+        
+        # Create a modified generation config with n=1 for individual generations
+        single_gen_config = VLLMClientGenerationConfig(
+            n=1,
+            repetition_penalty=generation_config.repetition_penalty,
+            temperature=generation_config.temperature,
+            top_p=generation_config.top_p,
+            top_k=generation_config.top_k,
+            min_p=generation_config.min_p,
+            max_tokens=generation_config.max_tokens,
+            guided_decoding_regex=generation_config.guided_decoding_regex,
+            stop=[self.stop_string] if generation_config.stop is None else 
+                 generation_config.stop + [self.stop_string]
+        )
+        
+        # Track current conversations for each prompt
+        current_conversations = expanded_prompts.copy()
+        completed_conversations = []
+        
+        # Continue code execution loop until all conversations are completed
+        while current_conversations:
+            # Generate next response segment
+            outputs = vllm_client.generate(
+                prompts=current_conversations,
+                n=1,
+                repetition_penalty=single_gen_config.repetition_penalty,
+                temperature=single_gen_config.temperature,
+                top_p=single_gen_config.top_p,
+                top_k=single_gen_config.top_k,
+                min_p=single_gen_config.min_p,
+                max_tokens=single_gen_config.max_tokens,
+                guided_decoding_regex=single_gen_config.guided_decoding_regex,
+                stop=single_gen_config.stop
+            )
+            
+            next_conversations = []
+            code_batch = []
+            code_conversations = []
+            
+            # Process outputs
+            for conversation, output in zip(current_conversations, outputs):
+                # Get the full conversation by combining original + generated text
+                full_conversation = output["prompt"] + output["text"]
+                
+                # Check if code execution is needed
+                if self.parsing_string in full_conversation and self.stop_string in full_conversation:
+                    # Extract code for execution
+                    code = self.extract_code(full_conversation)
+                    if code:
+                        code_batch.append(code)
+                        code_conversations.append(full_conversation)
+                else:
+                    # No code to execute, conversation is complete
+                    completed_conversations.append(full_conversation)
+            
+            # Execute code if needed
+            if code_batch:
+                execution_results = self.code_executor.execute(code_batch)
+                
+                # Add execution results to conversations
+                for conversation, result in zip(code_conversations, execution_results):
+                    updated_conversation = conversation + f"<output>{result}</output>"
+                    next_conversations.append(updated_conversation)
+            
+            # Update current conversations for next iteration
+            current_conversations = next_conversations
+        
+        # Return the final completed conversations
+        return completed_conversations
+    
+    def generate(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List:
+        """Generate responses with code execution and return token IDs
+
+        Args:
+            vllm_client: VLLM client instance
+            generation_config: Configuration for generation parameters
+            prompts: Input prompts for generation
+            
+        Returns:
+            completion_ids: Generated token ids
+        """
+        # Get completed text responses from the agent
+        completed_conversations = self.run_agent(vllm_client, generation_config, prompts)
+        
+        # Recreate expanded prompts for completion extraction
+        expanded_prompts = []
+        for prompt in prompts:
+            expanded_prompts.extend([prompt] * generation_config.n)
+        
+        # Extract completion IDs (just the generated part without the original prompt)
+        completion_ids = []
+        for original_prompt, final_output in zip(expanded_prompts, completed_conversations):
+            # Extract just the completion (everything after the original prompt)
+            completion_text = final_output[len(original_prompt):]
+            
+            # Encode to get token IDs
+            completion_token_ids = self.tokenizer.encode(
+                completion_text, 
+                add_special_tokens=False
+            )
+            completion_ids.append(completion_token_ids)
+        
+        return completion_ids

--- a/trl/agents/environments.py
+++ b/trl/agents/environments.py
@@ -56,127 +56,236 @@ class DefaultEnvironment(Environment):
         )
 
 class CodeAgentEnvironment(Environment):
-    """Environment that supports code execution during generation"""
-    
+    """Environment that supports code execution during generation, simplified implementation."""
+
     def __init__(
-        self, 
+        self,
         code_executor: Any,
         tokenizer: PreTrainedTokenizerBase,
         parsing_string: str = "<code>",
         stop_string: str = "</code>",
-        tools_script: Optional[str] = None
+        tools_script: Optional[str] = None,
+        output_parsing_string: str = "<output>",
+        output_stop_string: str = "</output>",
     ):
-        """Initialize the code agent environment"""
+        """Initialize the code agent environment
+
+        Args:
+            code_executor: The executor to run code (like LocalExecutor or E2BExecutor)
+            tokenizer: Tokenizer for encoding/decoding text
+            parsing_string: String that marks the beginning of code blocks
+            stop_string: String that marks the end of code blocks
+            tools_script: Optional script to prepend to extracted code
+            output_parsing_string: String marking the beginning of code output.
+            output_stop_string: String marking the end of code output.
+        """
+        if not hasattr(code_executor, "execute"):
+             raise ValueError("code_executor must have an 'execute' method.")
+        if not hasattr(tokenizer, "decode") or not hasattr(tokenizer, "encode"):
+             raise ValueError("tokenizer must have 'decode' and 'encode' methods.")
+
         self.code_executor = code_executor
         self.tokenizer = tokenizer
         self.parsing_string = parsing_string
         self.stop_string = stop_string
         self.tools_script = tools_script
-    
-    def extract_code(self, text: str) -> str:
-        """Extract code from generated text"""
+        self.output_parsing_string = output_parsing_string
+        self.output_stop_string = output_stop_string
+
+    def extract_code(self, text: str) -> Optional[str]:
+        """Extract code from the *last* code block in the generated text."""
         if self.parsing_string not in text:
             return None
-            
-        code_parts = text.split(self.parsing_string)[-1]
-        if self.stop_string in code_parts:
-            code_parts = code_parts.split(self.stop_string)[0]
-        
+
+        # Find the last occurrence of the parsing string
+        last_code_start_index = text.rfind(self.parsing_string)
+        if last_code_start_index == -1:
+             return None # Should not happen if parsing_string is in text, but safety check
+
+        code_segment = text[last_code_start_index + len(self.parsing_string):]
+
+        # Find the first occurrence of the stop string *after* the last parsing string
+        stop_index = code_segment.find(self.stop_string)
+        if stop_index != -1:
+            code_parts = code_segment[:stop_index]
+        else:
+             # If stop string is not found after the last parsing string,
+             # maybe the generation stopped exactly at the stop string.
+             # Or maybe the stop string is missing. Assume it's the end for now.
+             # This might need adjustment based on typical model behavior.
+             code_parts = code_segment # Or handle error?
+
+        # Prepend tools script if available
         if self.tools_script:
             code_parts = f"{self.tools_script}\n{code_parts}"
-            
-        return code_parts
-    
+
+        # Basic cleaning (optional, adjust as needed)
+        code_parts = code_parts.strip()
+
+        return code_parts if code_parts else None
+
     def run_agent(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List[str]:
-        """Run the agent with code execution and return completed text responses"""
-        # Configure stop tokens to include the code stop string
-        modified_gen_config = VLLMClientGenerationConfig(
-            **{k: v for k, v in vars(generation_config).items()},
-        )
-        modified_gen_config.stop = [self.stop_string] if modified_gen_config.stop is None else list(set(modified_gen_config.stop + [self.stop_string]))
-        
-        # Handle multiple generations per prompt (n>1)
-        expanded_prompts = []
+        """Run the agent with code execution and return completed text responses.
+
+        Args:
+            vllm_client: VLLM client instance.
+            generation_config: Configuration for generation parameters.
+            prompts: Input prompts for generation.
+
+        Returns:
+            List[str]: Completed text responses with code execution results.
+        """
+        completed_conversations = []
+        active_conversations = []
+
+        # Expand initial prompts based on n
         for prompt in prompts:
-            expanded_prompts.extend([prompt] * generation_config.n)
-        
-        completed_conversations = []  # Fully completed conversations
-        current_batch = expanded_prompts  # Current batch of prompts/conversations
-        
-        # Continue until all conversations are complete
-        while current_batch:
-            # Generate outputs for current batch
+            active_conversations.extend([prompt] * generation_config.n)
+
+        # Ensure stop_string is always in the stop sequences for generation
+        stop_sequences = [self.stop_string]
+        if generation_config.stop:
+            stop_sequences = list(set(stop_sequences + generation_config.stop))
+
+        # Create a generation config for individual steps (n=1)
+        step_gen_config = VLLMClientGenerationConfig(
+            n=1,
+            repetition_penalty=generation_config.repetition_penalty,
+            temperature=generation_config.temperature,
+            top_p=generation_config.top_p,
+            top_k=generation_config.top_k,
+            min_p=generation_config.min_p,
+            max_tokens=generation_config.max_tokens,
+            guided_decoding_regex=generation_config.guided_decoding_regex,
+            stop=stop_sequences
+        )
+
+        while active_conversations:
             outputs = vllm_client.generate(
-                prompts=current_batch,
-                n=1,  # We already expanded the prompts
-                repetition_penalty=modified_gen_config.repetition_penalty,
-                temperature=modified_gen_config.temperature,
-                top_p=modified_gen_config.top_p,
-                top_k=modified_gen_config.top_k,
-                min_p=modified_gen_config.min_p,
-                max_tokens=modified_gen_config.max_tokens,
-                guided_decoding_regex=modified_gen_config.guided_decoding_regex,
-                stop=modified_gen_config.stop
+                prompts=active_conversations,
+                **vars(step_gen_config)
             )
-            
-            next_batch = []  # For conversations needing more processing
-            code_batch = []  # Code snippets to execute
-            conversations = []  # To track conversations for code execution
-            
-            # Process all outputs
-            for prompt, output_ids in zip(current_batch, outputs):
-                generated_text = self.tokenizer.decode(output_ids, skip_special_tokens=True)
-                full_conversation = prompt + generated_text
-                
-                # Check if generation stopped at code block
-                has_code_block = self.parsing_string in generated_text
-                stopped_at_code = generated_text.endswith(self.stop_string.strip())
-                
-                if has_code_block and stopped_at_code:
-                    # Extract code for execution
-                    code = self.extract_code(generated_text)
+
+            next_active_conversations = []
+            code_batch = []
+            conversations_pending_code = []
+
+            # --- MODIFICATION START ---
+            # Check if the structure of outputs is as expected (list of lists)
+            if not isinstance(outputs, list) or (outputs and not all(isinstance(item, list) for item in outputs)):
+                    print(f"Warning: Unexpected output structure from vllm_client.generate. Expected List[List[int]], got: {type(outputs)}. Attempting to proceed.")
+                    # Depending on the actual structure, this might still fail later.
+
+            for i, generated_token_ids in enumerate(outputs): # Assume 'output' is directly the list of token IDs
+                current_prompt = active_conversations[i]
+
+                # Check if the generated_token_ids list is valid
+                if not isinstance(generated_token_ids, list):
+                    print(f"Warning: Invalid token list received for prompt index {i}. Skipping. Got: {type(generated_token_ids)}")
+                    completed_conversations.append(current_prompt)
+                    continue
+                # We no longer have direct access to 'finish_reason' in this assumed structure.
+                # --- MODIFICATION END ---
+
+                # Decode the newly generated part
+                generated_text = self.tokenizer.decode(generated_token_ids, skip_special_tokens=True)
+
+                full_conversation_segment = current_prompt + generated_text
+
+                # --- MODIFICATION START ---
+                # Check if the generation stopped because of our specific code stop string
+                # Rely solely on the text ending with the stop string
+                stopped_by_code_tag = generated_text.rstrip().endswith(self.stop_string.rstrip())
+                # --- MODIFICATION END ---
+
+                # Check if code execution is requested IN THE NEWLY GENERATED TEXT
+                # Use rfind on the full segment to find the *last* code block start
+                last_code_start_in_segment = full_conversation_segment.rfind(self.parsing_string)
+                # Check if the *last* code block start is within the *newly generated* part
+                # Ensure last_code_start_in_segment is found before comparing index
+                is_code_in_new_text = last_code_start_in_segment != -1 and last_code_start_in_segment >= len(current_prompt)
+
+                if is_code_in_new_text and stopped_by_code_tag:
+                    # Extract code from the full segment, as extract_code finds the last block
+                    code = self.extract_code(full_conversation_segment)
                     if code:
                         code_batch.append(code)
-                        conversations.append(full_conversation)
+                        # Store the conversation *including* the generated code block ending with stop_string
+                        conversations_pending_code.append(full_conversation_segment)
                     else:
-                        # Code tags present but extraction failed
-                        completed_conversations.append(full_conversation)
+                        # Parsing string found, but extraction failed. Treat as complete.
+                        print(f"Warning: Code parsing string found but extraction failed for segment: ...{generated_text[-50:]}")
+                        completed_conversations.append(full_conversation_segment)
                 else:
-                    # No code block or didn't stop at code end - conversation is complete
-                    completed_conversations.append(full_conversation)
-            
-            # Execute all code snippets in batch if any
+                    # Generation finished (max tokens, other stop word) or no code detected in the new part
+                    completed_conversations.append(full_conversation_segment)
+
+            # Execute code batch if any code was extracted
             if code_batch:
-                execution_results = self.code_executor.execute(code_batch)
-                
-                # Add results back to conversations and continue
-                for conversation, result in zip(conversations, execution_results):
-                    updated_conversation = conversation + f"<output>{result}</output>"
-                    next_batch.append(updated_conversation)
-            
-            # Update current batch for next iteration
-            current_batch = next_batch
-        
+                try:
+                    execution_results = self.code_executor.execute(code_batch)
+                    if len(execution_results) != len(conversations_pending_code):
+                            raise ValueError(f"Mismatch between code batch size ({len(code_batch)}) and results ({len(execution_results)})")
+
+                    # Append results and add back to active conversations for the next round
+                    for conversation, result in zip(conversations_pending_code, execution_results):
+                        updated_conversation = conversation + f"{self.output_parsing_string}{result}{self.output_stop_string}"
+                        next_active_conversations.append(updated_conversation)
+                except Exception as e:
+                        print(f"Error during code execution batch: {e}")
+                        completed_conversations.extend(conversations_pending_code) # Add pending as completed on error
+
+            # Update the list of conversations for the next iteration
+            active_conversations = next_active_conversations
+
         return completed_conversations
-    
-    def generate(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List:
-        """Generate responses with code execution and return token IDs"""
-        # Get completed text responses
+
+    # ... generate method remains the same ...
+
+    def generate(self, vllm_client: Any, generation_config: VLLMClientGenerationConfig, prompts: List[str]) -> List[List[int]]:
+        """Generate responses with code execution and return token IDs of the completions.
+
+        Args:
+            vllm_client: VLLM client instance.
+            generation_config: Configuration for generation parameters.
+            prompts: Input prompts for generation.
+
+        Returns:
+            List[List[int]]: List of generated token ID lists (completions only).
+        """
+        # Get completed text responses from the agent logic
         completed_conversations = self.run_agent(vllm_client, generation_config, prompts)
-        
-        # Recreate expanded prompts for proper extraction
+
+        # Recreate the list of original prompts expanded by 'n' to match the output count
         expanded_prompts = []
         for prompt in prompts:
             expanded_prompts.extend([prompt] * generation_config.n)
-        
-        # Extract completion IDs (just the generated part)
+
+        if len(expanded_prompts) != len(completed_conversations):
+             # This indicates a potential issue in run_agent or prompt expansion
+             print(f"Warning: Mismatch between expanded prompts ({len(expanded_prompts)}) and completed conversations ({len(completed_conversations)}). Returning completions based on available conversations.")
+             # Adjust the shorter list to match the longer one? Or raise error?
+             # For robustness, let's process based on the number of completed conversations
+             expanded_prompts = expanded_prompts[:len(completed_conversations)]
+
+
         completion_ids = []
         for original_prompt, final_output in zip(expanded_prompts, completed_conversations):
-            completion_text = final_output[len(original_prompt):]
+            # Ensure the final output actually starts with the prompt
+            if final_output.startswith(original_prompt):
+                completion_text = final_output[len(original_prompt):]
+            else:
+                # Handle cases where the output might not perfectly match the start (e.g., due to tokenization differences)
+                # Or if the conversation somehow got corrupted. Fallback to using the whole output as completion?
+                print(f"Warning: Final output does not start with the original prompt. Using entire final output as completion.")
+                completion_text = final_output # Or potentially try a fuzzy match / diff?
+
+            # Encode the completion text to get token IDs
+            # add_special_tokens=False is typical for training completions
             completion_token_ids = self.tokenizer.encode(
-                completion_text, 
+                completion_text,
                 add_special_tokens=False
             )
             completion_ids.append(completion_token_ids)
-        
+
         return completion_ids

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -1,0 +1,354 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# from __future__ import annotations
+
+import asyncio
+from inspect import getsource
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, List
+
+# from dataclasses import dataclass
+# from e2b_code_interpreter import AsyncSandbox
+from ..import_utils import is_e2b_available, is_langchain_experimental_available
+
+
+if is_e2b_available():
+    from e2b_code_interpreter import AsyncSandbox
+
+if is_langchain_experimental_available():
+    from langchain_experimental.utilities import PythonREPL
+
+if TYPE_CHECKING:
+    from vllm import LLM, SamplingParams
+
+default_system_prompt = "You can answer questions and solve problems. If running code helps, write it inside <code> </code>, and you will see the result. Example: To calculate 2 + 2, write <code> print(2 + 2) </code>."
+
+default_environment_prompt = "This is a user-provided script containing tools that you can use to help complete tasks. It will be added to the sandbox environment so you can call its functions. If you are unsure how to use the available tools, you can use the `help()` function to inspect them."
+
+
+def get_code(chat: str, tools_script: str = None, parsing_string: str = "<code>") -> str:
+    """
+    Extracts and optionally prepends a tools script to a code snippet from a chat message.
+
+    Args:
+        chat (`str`):
+            Chat message containing the code snippet.
+        tools_script (`str` or `None`, *optional*, defaults to `None`):
+            A script to prepend to the extracted code snippet.
+        parsing_string (`str`, *optional*, defaults to `"<code>"`):
+            String used to identify the start of the code snippet in the chat message.
+
+    Returns:
+        `str`:
+            Extracted code snippet, optionally prepended with the tools script.
+    """
+    code = chat.split(parsing_string)[-1]
+    if tools_script:
+        code = f"{tools_script}\n{code}"
+    return code
+
+
+def read_script(user_script_path: str) -> str:
+    """
+    Reads and returns the content of the provided script.
+
+    Args:
+        user_script_path (`str`):
+            Path to the user-provided script.
+
+    Returns:
+        `str`:
+            The content of the script.
+    """
+    return Path(user_script_path).read_text()
+
+
+class LocalExecutor:
+    def execute(self, codes: List[str]) -> List[str]:
+        """
+        Executes multiple code snippets using PythonREPL sequentially.
+
+        Args:
+            codes (List[str]): List of code snippets to execute.
+
+        Returns:
+            List[str]: List of execution results in same order as input snippets.
+        """
+        results = []
+        repl = PythonREPL()
+        for code in codes:
+            try:
+                result = repl.run(code)
+                results.append(str(result))
+            except Exception as e:
+                results.append(f"Error executing code: {str(e)}")
+        return results
+
+
+class E2BExecutor:
+    def __init__(self, api_key: str, template: str = None, max_concurrent: int = 5):
+        """
+        Initialize the E2BExecutor for parallel code execution.
+
+        Args:
+            api_key (`str`): Your E2B API Key.
+            template (`str`, *optional*, defaults to None): Template ID for the sandbox environment.
+            max_concurrent (`int`, *optional*, defaults to 5): Maximum number of concurrent executions.
+        """
+        self.api_key = api_key
+        self.template = template
+        self.max_concurrent = max_concurrent
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _execute_single(self, code: str) -> str:
+        """Execute a single code snippet in a sandbox"""
+        async with self.semaphore:
+            try:
+                sandbox = await AsyncSandbox.create(api_key=self.api_key, template=self.template)
+                try:
+                    response = await sandbox.run_code(code)
+                    return str(response)
+                finally:
+                    await sandbox.kill()
+            except Exception as e:
+                return f"Error: {str(e)}"
+
+    def execute(self, codes: List[str]) -> List[str]:
+        """
+        Executes multiple code snippets in parallel.
+
+        Args:
+            codes (List[str]): List of code snippets to execute.
+
+        Returns:
+            List[str]: List of execution results in same order as input snippets.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        async def run_batch():
+            tasks = [self._execute_single(code) for code in codes]
+            return await asyncio.gather(*tasks)
+
+        if loop.is_running():
+            # We're in a notebook or similar environment
+            import nest_asyncio
+
+            nest_asyncio.apply()
+            return loop.run_until_complete(run_batch())
+        else:
+            # We're in a regular Python environment
+            return loop.run_until_complete(run_batch())
+
+
+def prepare_data_for_e2b_agent(
+    dataset,
+    tokenizer,
+    prompt_column: str = "prompt",
+    system_prompt: str = default_system_prompt,
+    environment_prompt: str = default_environment_prompt,
+    tools_script_path: str = None,
+) -> list:
+    """
+    Prepares the Hugging Face dataset for the e2b agent by constructing conversations
+    and applying the system prompt.
+
+    Args:
+        dataset (`Dataset`):
+            A Hugging Face dataset object
+        tokenizer (`PreTrainedTokenizer`):
+            A tokenizer with an `apply_chat_template` method to process conversations
+        prompt_column (`str`, *optional*, defaults to `"prompt"`):
+            Name of the column containing prompts.
+        system_prompt (`str`, *optional*, defaults to `default_system_prompt`):
+            The base system prompt.
+        environment_prompt (`str`, *optional*, defaults to `default_environment_prompt`):
+            Description to prepend before the tools script
+        tools_script_path (`str` or `None`, *optional*, defaults to `None`):
+            File path to a tools script to include in system prompt
+
+    Returns:
+        `Dataset`:
+            Modified dataset with processed prompts in the prompt column
+    """
+    # Convert dataset prompts to conversational format
+    conversations = [[{"role": "user", "content": prompt}] for prompt in dataset[prompt_column]]
+
+    # If a tools script path is provided, read its content and append with the environment prompt
+    if tools_script_path:
+        try:
+            tool_script = read_script(tools_script_path)
+            system_prompt += "\n" + environment_prompt + "\n" + tool_script
+        except Exception as e:
+            raise RuntimeError(f"Error reading the tools script: {e}") from e
+
+    # Create the system prompt message
+    system_message = {"role": "system", "content": system_prompt}
+
+    # Prepend the system message to each conversation
+    for convo in conversations:
+        if not convo or convo[0].get("role") != "system":
+            convo.insert(0, system_message)
+
+    # Apply the tokenizer's chat template
+    processed_prompts = tokenizer.apply_chat_template(conversations, tokenize=False, add_generation_prompt=True)
+
+    # Create a new dataset with processed prompts
+    return dataset.map(lambda x, idx: {prompt_column: processed_prompts[idx]}, with_indices=True)
+
+
+def prepare_data_for_local_agent(
+    dataset,
+    tokenizer,
+    prompt_column: str = "prompt",
+    system_prompt: str = default_system_prompt,
+    tools: List[Callable] = None,
+    include_source_code: bool = True,
+) -> list:
+    """
+    Prepares the Hugging Face dataset for the local agent by constructing conversations
+    and applying the system prompt.
+
+    Args:
+        dataset (`Dataset`):
+            A Hugging Face dataset object
+        tokenizer (`PreTrainedTokenizer`):
+            A tokenizer with an `apply_chat_template` method to process conversations
+        prompt_column (`str`, *optional*, defaults to `"prompt"`):
+            Name of the column containing prompts.
+        system_prompt (`str`, *optional*, defaults to `default_system_prompt`):
+            The base system prompt.
+        tools (`List[Callable]` or `None`, *optional*, defaults to `None`):
+            List of callable functions to include in system prompt
+        include_source_code (`bool`, *optional*, defaults to `True`):
+            If True, includes source code of tools, else includes docstrings
+
+    Returns:
+        `Dataset`:
+            Modified dataset with processed prompts in the prompt column
+    """
+    # Convert dataset prompts to conversational format
+    conversations = [[{"role": "user", "content": prompt}] for prompt in dataset[prompt_column]]
+
+    # Process tools if provided
+    if tools:
+        tools_documentation = "\nAvailable tools:\n\n"
+        for tool in tools:
+            tools_documentation += f"Tool: {tool.__name__}\n"
+            if include_source_code:
+                try:
+                    tools_documentation += f"Source code:\n{getsource(tool)}\n\n"
+                except Exception as e:
+                    tools_documentation += f"Error getting source: {str(e)}\n\n"
+            else:
+                doc = tool.__doc__ or "No documentation available"
+                tools_documentation += f"Documentation:\n{doc}\n\n"
+
+        system_prompt += tools_documentation
+
+    # Create the system prompt message
+    system_message = {"role": "system", "content": system_prompt}
+
+    # Prepend the system message to each conversation
+    for convo in conversations:
+        if not convo or convo[0].get("role") != "system":
+            convo.insert(0, system_message)
+
+    # Apply the tokenizer's chat template
+    processed_prompts = tokenizer.apply_chat_template(conversations, tokenize=False, add_generation_prompt=True)
+
+    # Create a new dataset with processed prompts
+    return dataset.map(lambda x, idx: {prompt_column: processed_prompts[idx]}, with_indices=True)
+
+
+def generate_agent_responses(
+    dataset: list,
+    llm: "LLM",
+    sampling_params: "SamplingParams",
+    tools_script_path: str = None,
+    parsing_string: str = "<code>",
+    stop_string: str = "</code>",
+    code_executer=None,
+) -> list:
+    """
+    Generates responses for the agent with potential code execution.
+
+    Args:
+        dataset (`list`):
+            List of preprocessed prompts (strings).
+        llm (`LLM`):
+            The language model to use for generation.
+        sampling_params (`SamplingParams`):
+            Sampling parameters for the llm.generate method.
+        tools_script_path (`str` or `None`, *optional*, defaults to `None`):
+            Path to script to prepend to code extracted.
+        parsing_string (`str`, *optional*, defaults to `"<code>"`):
+            String used to locate the code in the conversation.
+        stop_string (`str`, *optional*, defaults to `"</code>"`):
+            String used to stop generation.
+        code_executer (`LocalExecutor`, *optional*, defaults to `LocalExecutor()`):
+            Executor to run the code.
+
+    Returns:
+        `list`:
+            A list of complete conversations (strings).
+    """
+    if code_executer is None:
+        code_executer = LocalExecutor()
+
+    # adding stop string to sampling params
+    sampling_params.stop = [stop_string]
+    # Read the tools script if provided.
+    tools_script = read_script(tools_script_path) if tools_script_path else None
+
+    completed_chats = []  # Chats that are fully complete.
+    current_batch = dataset  # Start with your initial batch of prompts.
+
+    while current_batch:
+        # Generate outputs for the current batch.
+        outputs = llm.generate(current_batch, sampling_params, use_tqdm=False)
+        next_batch = []  # To store chats that still need code execution.
+        code_batch = []  # To collect code snippets for batch execution
+        conversations = []  # To keep track of conversations for each code
+
+        # First pass: collect all codes that need execution
+        for output in outputs:
+            conversation = output.prompt + output.outputs[0].text
+            if output.outputs[0].stop_reason == stop_string:
+                code = get_code(conversation, tools_script=tools_script, parsing_string=parsing_string)
+                code_batch.append(code)
+                conversations.append(conversation)
+            else:
+                completed_chats.append(conversation)
+
+        # Execute all collected codes in one batch
+        if code_batch:
+            executed_results = code_executer.execute(code_batch)
+
+            # Process results and update conversations
+            for conv, result in zip(conversations, executed_results):
+                updated_conversation = conv + f"{stop_string}<output>" + result + "</output>"
+                next_batch.append(updated_conversation)
+
+        # Process next batch.
+        current_batch = next_batch
+
+    return completed_chats
+
+# parsing and tokenizing the completion since outputs with use_agent is the full chat
+#completion_ids = [tuple(self.processing_class.encode(output[len(prompt) :].strip(), add_special_tokens=False))for prompt, output in zip(all_prompts_text, outputs)
+                    ]

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -83,7 +83,7 @@ def read_script(user_script_path: str) -> str:
     return Path(user_script_path).read_text()
 
 
-class LocalExecutor:
+class Localexecuter:
     def execute(self, codes: list[str]) -> list[str]:
         """
         Executes multiple code snippets using PythonREPL sequentially.
@@ -105,10 +105,10 @@ class LocalExecutor:
         return results
 
 
-class E2BExecutor:
+class E2Bexecuter:
     def __init__(self, api_key: str, template: str = None, max_concurrent: int = 5):
         """
-        Initialize the E2BExecutor for parallel code execution.
+        Initialize the E2Bexecuter for parallel code execution.
         Tests the connection by running a simple print statement.
 
         Args:

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -83,10 +83,10 @@ class Localexecuter:
         return results
 
 
-class E2Bexecuter:
+class E2BExecuter:
     def __init__(self, api_key: str, template: str = None, max_concurrent: int = 20):
         """
-        Initialize the E2Bexecuter for parallel code execution.
+        Initialize the E2BExecuter for parallel code execution.
         Tests the connection by running a simple print statement.
 
         Args:

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Copyright 2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +30,7 @@
 import asyncio
 from inspect import getsource
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, List
+from typing import Callable
 
 from ..import_utils import is_e2b_available, is_langchain_experimental_available
 
@@ -70,15 +84,15 @@ def read_script(user_script_path: str) -> str:
 
 
 class LocalExecutor:
-    def execute(self, codes: List[str]) -> List[str]:
+    def execute(self, codes: list[str]) -> list[str]:
         """
         Executes multiple code snippets using PythonREPL sequentially.
 
         Args:
-            codes (List[str]): List of code snippets to execute.
+            codes (list[str]): list of code snippets to execute.
 
         Returns:
-            List[str]: List of execution results in same order as input snippets.
+            list[str]: list of execution results in same order as input snippets.
         """
         results = []
         repl = PythonREPL()
@@ -95,7 +109,7 @@ class E2BExecutor:
     def __init__(self, api_key: str, template: str = None, max_concurrent: int = 5):
         """
         Initialize the E2BExecutor for parallel code execution.
-        Tests the connection by running a simple hello world code.
+        Tests the connection by running a simple print statement.
 
         Args:
             api_key (`str`): Your E2B API Key.
@@ -113,8 +127,6 @@ class E2BExecutor:
         # Check if the result contains the expected output
         if "successful" not in result:
             raise ConnectionError(f"E2B connection test failed. Response: {result}")
-        
-        print("E2B connection validated successfully.")
 
     async def _execute_single(self, code: str) -> str:
         """Execute a single code snippet in a sandbox"""
@@ -129,15 +141,15 @@ class E2BExecutor:
             except Exception as e:
                 return f"Error: {str(e)}"
 
-    def execute(self, codes: List[str]) -> List[str]:
+    def execute(self, codes: list[str]) -> list[str]:
         """
         Executes multiple code snippets in parallel.
 
         Args:
-            codes (List[str]): List of code snippets to execute.
+            codes (list[str]): list of code snippets to execute.
 
         Returns:
-            List[str]: List of execution results in same order as input snippets.
+            list[str]: list of execution results in same order as input snippets.
         """
         try:
             loop = asyncio.get_event_loop()
@@ -221,7 +233,7 @@ def prepare_data_for_local_agent(
     tokenizer,
     prompt_column: str = "prompt",
     system_prompt: str = default_system_prompt,
-    tools: List[Callable] = None,
+    tools: list[Callable] = None,
     include_source_code: bool = True,
 ) -> list:
     """
@@ -237,8 +249,8 @@ def prepare_data_for_local_agent(
             Name of the column containing prompts.
         system_prompt (`str`, *optional*, defaults to `default_system_prompt`):
             The base system prompt.
-        tools (`List[Callable]` or `None`, *optional*, defaults to `None`):
-            List of callable functions to include in system prompt
+        tools (`list[Callable]` or `None`, *optional*, defaults to `None`):
+            list of callable functions to include in system prompt
         include_source_code (`bool`, *optional*, defaults to `True`):
             If True, includes source code of tools, else includes docstrings
 

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -18,19 +18,19 @@ from inspect import getsource
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List
 
-# from dataclasses import dataclass
-# from e2b_code_interpreter import AsyncSandbox
-from ..import_utils import is_e2b_available, is_langchain_experimental_available
+from dataclasses import dataclass
+from e2b_code_interpreter import AsyncSandbox
+#from ..import_utils import is_e2b_available, is_langchain_experimental_available
 
 
-if is_e2b_available():
-    from e2b_code_interpreter import AsyncSandbox
+#if is_e2b_available():
+#    from e2b_code_interpreter import AsyncSandbox
 
-if is_langchain_experimental_available():
-    from langchain_experimental.utilities import PythonREPL
+#if is_langchain_experimental_available():
+#    from langchain_experimental.utilities import PythonREPL
 
-if TYPE_CHECKING:
-    from vllm import LLM, SamplingParams
+#if TYPE_CHECKING:
+#    from vllm import LLM, SamplingParams
 
 default_system_prompt = "You can answer questions and solve problems. If running code helps, write it inside <code> </code>, and you will see the result. Example: To calculate 2 + 2, write <code> print(2 + 2) </code>."
 
@@ -100,6 +100,7 @@ class E2BExecutor:
     def __init__(self, api_key: str, template: str = None, max_concurrent: int = 5):
         """
         Initialize the E2BExecutor for parallel code execution.
+        Tests the connection by running a simple hello world code.
 
         Args:
             api_key (`str`): Your E2B API Key.
@@ -110,6 +111,15 @@ class E2BExecutor:
         self.template = template
         self.max_concurrent = max_concurrent
         self.semaphore = asyncio.Semaphore(max_concurrent)
+
+        # Run a test code to validate connection
+        validation_code = "print('Hello, E2B connection test successful')"
+        result = self.execute([validation_code])[0]
+        
+        if "successful" not in result:
+            raise ConnectionError(f"E2B connection test failed. Response: {result}")
+        
+        print("E2B connection validated successfully.")
 
     async def _execute_single(self, code: str) -> str:
         """Execute a single code snippet in a sandbox"""
@@ -351,4 +361,3 @@ def generate_agent_responses(
 
 # parsing and tokenizing the completion since outputs with use_agent is the full chat
 #completion_ids = [tuple(self.processing_class.encode(output[len(prompt) :].strip(), add_special_tokens=False))for prompt, output in zip(all_prompts_text, outputs)
-                    ]

--- a/trl/agents/utils.py
+++ b/trl/agents/utils.py
@@ -36,36 +36,14 @@ from ..import_utils import is_e2b_available, is_langchain_experimental_available
 
 
 if is_e2b_available():
-    from e2b_code_interpreter import AsyncSandbox
+    from e2b_code_interpreter import AsyncSandbox  # used for E2B async code execution
 
 if is_langchain_experimental_available():
-    from langchain_experimental.utilities import PythonREPL
+    from langchain_experimental.utilities import PythonREPL  # used for local code execution
 
 default_system_prompt = "You can answer questions and solve problems. If running code helps, write it inside <code> </code>, and you will see the result. Example: To calculate 2 + 2, write <code> print(2 + 2) </code>."
 
 default_environment_prompt = "This is a user-provided script containing tools that you can use to help complete tasks. It will be added to the sandbox environment so you can call its functions. If you are unsure how to use the available tools, you can use the `help()` function to inspect them."
-
-
-def get_code(chat: str, tools_script: str = None, parsing_string: str = "<code>") -> str:
-    """
-    Extracts and optionally prepends a tools script to a code snippet from a chat message.
-
-    Args:
-        chat (`str`):
-            Chat message containing the code snippet.
-        tools_script (`str` or `None`, *optional*, defaults to `None`):
-            A script to prepend to the extracted code snippet.
-        parsing_string (`str`, *optional*, defaults to `"<code>"`):
-            String used to identify the start of the code snippet in the chat message.
-
-    Returns:
-        `str`:
-            Extracted code snippet, optionally prepended with the tools script.
-    """
-    code = chat.split(parsing_string)[-1]
-    if tools_script:
-        code = f"{tools_script}\n{code}"
-    return code
 
 
 def read_script(user_script_path: str) -> str:
@@ -106,7 +84,7 @@ class Localexecuter:
 
 
 class E2Bexecuter:
-    def __init__(self, api_key: str, template: str = None, max_concurrent: int = 5):
+    def __init__(self, api_key: str, template: str = None, max_concurrent: int = 20):
         """
         Initialize the E2Bexecuter for parallel code execution.
         Tests the connection by running a simple print statement.

--- a/trl/extras/__init__.py
+++ b/trl/extras/__init__.py
@@ -19,10 +19,12 @@ from ..import_utils import _LazyModule
 
 _import_structure = {
     "best_of_n_sampler": ["BestOfNSampler"],
+    "vllm_client": ["VLLMClient"],
 }
 
 if TYPE_CHECKING:
     from .best_of_n_sampler import BestOfNSampler
+    from .vllm_client import VLLMClient
 else:
     import sys
 

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -140,6 +140,7 @@ class VLLMClient:
         min_p: float = 0.0,
         max_tokens: int = 16,
         guided_decoding_regex: Optional[str] = None,
+        stop: Optional[list[str]] = None,
     ) -> list[list[int]]:
         """
         Generates model completions for the provided prompts.
@@ -163,6 +164,8 @@ class VLLMClient:
                 Maximum number of tokens to generate for each prompt.
             guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
                 Regular expression to guide the decoding process.
+            stop (`list[str]` or `None`, *optional*, defaults to `None`):
+                List of stop sequences. The generation will stop when any of these sequences is encountered.
 
         Returns:
             `list[list[int]]`:
@@ -181,6 +184,7 @@ class VLLMClient:
                 "min_p": min_p,
                 "max_tokens": max_tokens,
                 "guided_decoding_regex": guided_decoding_regex,
+                "stop": stop,
             },
         )
         if response.status_code == 200:

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -38,7 +38,7 @@ _unsloth_available = _is_package_available("unsloth")
 _uvicorn_available = _is_package_available("uvicorn")
 _vllm_available = _is_package_available("vllm")
 _joblib_available = _is_package_available("joblib")
-_e2b_available = _is_package_available("e2b-code-interpreter")
+_e2b_available = _is_package_available("e2b_code_interpreter")
 _langchain_experimental_available = _is_package_available("langchain_experimental")
 
 
@@ -93,11 +93,14 @@ def is_vllm_available() -> bool:
 def is_joblib_available() -> bool:
     return _joblib_available
 
+
 def is_e2b_available() -> bool:
     return _e2b_available
 
+
 def is_langchain_experimental_available() -> bool:
     return _langchain_experimental_available
+
 
 class _LazyModule(ModuleType):
     """

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -38,6 +38,8 @@ _unsloth_available = _is_package_available("unsloth")
 _uvicorn_available = _is_package_available("uvicorn")
 _vllm_available = _is_package_available("vllm")
 _joblib_available = _is_package_available("joblib")
+_e2b_available = _is_package_available("e2b-code-interpreter")
+_langchain_experimental_available = _is_package_available("langchain_experimental")
 
 
 def is_deepspeed_available() -> bool:
@@ -91,6 +93,11 @@ def is_vllm_available() -> bool:
 def is_joblib_available() -> bool:
     return _joblib_available
 
+def is_e2b_available() -> bool:
+    return _e2b_available
+
+def is_langchain_experimental_available() -> bool:
+    return _langchain_experimental_available
 
 class _LazyModule(ModuleType):
     """

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -285,6 +285,7 @@ def main(script_args: ScriptArguments):
         min_p: float = 0.0
         max_tokens: int = 16
         guided_decoding_regex: Optional[str] = None
+        stop: Optional[list[str]] = None
 
     class GenerateResponse(BaseModel):
         completion_ids: list[list[int]]
@@ -329,6 +330,7 @@ def main(script_args: ScriptArguments):
             min_p=request.min_p,
             max_tokens=request.max_tokens,
             guided_decoding=guided_decoding,
+            stop=request.stop,
         )
         all_outputs = llm.generate(request.prompts, sampling_params=sampling_params)
         completion_ids = [list(output.token_ids) for outputs in all_outputs for output in outputs.outputs]

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -14,12 +14,10 @@
 
 from typing import TYPE_CHECKING
 
-from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
 from ..import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffusers_available
 
 
 _import_structure = {
-    "agents.environments": ["Environment", "DefaultEnvironment", "VLLMClientGenerationConfig"],
     "alignprop_config": ["AlignPropConfig"],
     "alignprop_trainer": ["AlignPropTrainer"],
     "bco_config": ["BCOConfig"],
@@ -91,7 +89,6 @@ else:
     _import_structure["ddpo_trainer"] = ["DDPOTrainer"]
 
 if TYPE_CHECKING:
-    from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
     from .alignprop_config import AlignPropConfig
     from .alignprop_trainer import AlignPropTrainer
     from .bco_config import BCOConfig

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -14,10 +14,12 @@
 
 from typing import TYPE_CHECKING
 
+from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
 from ..import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffusers_available
 
 
 _import_structure = {
+    "agents.environments": ["Environment", "DefaultEnvironment", "VLLMClientGenerationConfig"],
     "alignprop_config": ["AlignPropConfig"],
     "alignprop_trainer": ["AlignPropTrainer"],
     "bco_config": ["BCOConfig"],
@@ -89,6 +91,7 @@ else:
     _import_structure["ddpo_trainer"] = ["DDPOTrainer"]
 
 if TYPE_CHECKING:
+    from .agents.environments import Environment, DefaultEnvironment, VLLMClientGenerationConfig
     from .alignprop_config import AlignPropConfig
     from .alignprop_trainer import AlignPropTrainer
     from .bco_config import BCOConfig

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -320,6 +320,10 @@ class GRPOTrainer(Trainer):
             types within the list (e.g., a string model ID and a custom reward function) is allowed.
         args ([`GRPOConfig`], *optional*, defaults to `None`):
             Configuration for this trainer. If `None`, a default configuration is used.
+        environment (`Optional[Environment]`, *optional*, defaults to `None`):
+            Custom environment for generation. If `None`, uses the default environment.
+            This can be used to override the default generation behavior, for example to support
+            code execution or other custom logic during generation.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`]):
             Dataset to use for training. It must include a column `"prompt"`. Any additional columns in the dataset is
             ignored. The format of the samples can be either:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -410,7 +410,12 @@ class GRPOTrainer(Trainer):
                     "You passed `model_init_kwargs` to the `GRPOConfig`, but your model is already instantiated. "
                     "This argument can only be used when the `model` argument is a string."
                 )
-
+        # Raise error if environment is provided but vllm is set to false
+        if environment is not None and not args.use_vllm:
+            raise ValueError(
+                "You provided an environment, but `use_vllm` is set to False. "
+                "Environments are only supported with vLLM. Please set `use_vllm` to True."
+            )
         # Initialize the default environment if none provided
         self.environment = environment if environment is not None else DefaultEnvironment()
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -283,7 +283,7 @@ class GRPOTrainer(Trainer):
         model: Union[str, PreTrainedModel],
         reward_funcs: Union[RewardFunc, list[RewardFunc]],
         args: Optional[GRPOConfig] = None,
-        environment: Optional[Environment] = DefaultEnvironment,
+        environment: Optional[Environment] = DefaultEnvironment(),
         train_dataset: Optional[Union[Dataset, IterableDataset]] = None,
         eval_dataset: Optional[Union[Dataset, IterableDataset, dict[str, Union[Dataset, IterableDataset]]]] = None,
         processing_class: Optional[PreTrainedTokenizerBase] = None,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -328,7 +328,7 @@ class GRPOTrainer(Trainer):
                 )
             
         # Initialize the default environment if none provided
-        self.environment = environment()
+        self.environment = environment
 
         if peft_config is not None:
             if not is_peft_available():

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -786,7 +786,7 @@ class GRPOTrainer(Trainer):
             
                 # Set up the vLLM generation configuration
                 generation_config = VLLMClientGenerationConfig(
-                    n=self.num_generations,
+                    n=self.num_generations, 
                     repetition_penalty=self.repetition_penalty,
                     temperature=self.temperature,
                     top_p=self.top_p,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -283,7 +283,7 @@ class GRPOTrainer(Trainer):
         model: Union[str, PreTrainedModel],
         reward_funcs: Union[RewardFunc, list[RewardFunc]],
         args: Optional[GRPOConfig] = None,
-        environment: Optional[Environment] = DefaultEnvironment(),
+        environment: Optional[Environment] = DefaultEnvironment,
         train_dataset: Optional[Union[Dataset, IterableDataset]] = None,
         eval_dataset: Optional[Union[Dataset, IterableDataset, dict[str, Union[Dataset, IterableDataset]]]] = None,
         processing_class: Optional[PreTrainedTokenizerBase] = None,


### PR DESCRIPTION
# Environments for Customized Rollouts with VLLM and GRPO

Environments allows for **customized rollouts and usage** of the model during training with **VLLM** and **GRPO**.

## Example: Creating a Custom Environment

```python
from trl import Environment

class MyCustomEnv(Environment):
    def __init__(self, ...):
        # Initialize anything your agent needs, like code execution,
        # tool calls, or external APIs.
        pass

    def tool_call(self, ...):
        # Define any environment-specific methods you want to use.
        pass

    def generate(self, vllm_client, generation_config: VLLMClientGenerationConfig, prompts: list[str]) -> list:
        # This is the method GRPO training uses to generate responses.
        # It must return a list of completion IDs (tokenized responses).
        return completion_ids
```

---

## `CodeAgentEnvironment`

A built-in `CodeAgentEnvironment` is included, which can be used with either:
- [E2B code interpreter](https://e2b.dev/)
- A local code interpreter

Example setup:

```python
from trl import CodeAgentEnvironment, E2BExecutor

code_executor = E2BExecutor(api_key="YOUR_E2B_TOKEN")
my_env = CodeAgentEnvironment(
    code_executor=code_executor,
    tokenizer=tokenizer,
    parsing_string="<code>",
    stop_string="</code>",
)
```

---

## Running the Environment

You can **use the environment manually** with a VLLM server to test and observe:

Start a VLLM server:
```bash
trl vllm-serve --model "your_model"
```

Then run the agent:

```python
from trl import VLLMClientGenerationConfig, VLLMClient

client = VLLMClient()
gen_config = VLLMClientGenerationConfig(
    n=8,
    repetition_penalty=1.0,
    temperature=0.8,
    top_p=0.9,
    top_k=10,
    min_p=0.0,
    max_tokens=256,
)

responses = my_env.run_agent(  # Main method in CodeAgentEnvironment to generate responses
    vllm_client=client,
    generation_config=gen_config,
    prompts=prompts
)
```

Or, **use the environment for training**:

```python
from trl import GRPOConfig, GRPOTrainer

training_args = GRPOConfig(
    output_dir="code_agent",
    use_vllm=True,
    # ... other config options ...
)

trainer = GRPOTrainer(
    model=...,                # Your model or model name
    reward_funcs=...,         # Your reward function(s)
    args=training_args,
    environment=my_env,       # Your custom or built-in environment
    # ... other trainer args ...
)
```

---

## Related Work

While finishing this PR, ByteDance published [*ReTool: Reinforcement Learning for Strategic Tool Use in LLMs*](https://arxiv.org/pdf/2504.11536).  
This PR with `CodeAgentEnvironment` is a similar idea, with two key differences:
1. **ReTool uses PPO**, while we use **GRPO**.
2. **ReTool masks interpreter feedback** — an idea I'll be investigating and possibly adding later.

---

## Other Notes

- I added a `stop_string` parameter to the VLLM CLI — it’s critical for agentic workflows where you want to cleanly delimit model outputs.

---

## Demo Run

To test, I set up a simple math task with a one-shot prompt for `Qwen-0.5B-instruct`.
The reward function checked if the agent **used the code interpreter** during its response.

- Here's the [wandb run](https://wandb.ai/moh-murr/Code_Agent/runs/buoluckd?nw=nwusermohmurr).
- You can specifically check:
  - `train/rewards/count_function_calls_per_response/mean`
  - [Code Interpreter Call Frequency](https://wandb.ai/moh-murr/Code_Agent/runs/buoluckd/panel/ckfy8s8wy?nw=nwusermohmurr) (a custom evaluation trace with a larger `n` for lower noise)

![W B Code Interpreter Call Frequency](https://github.com/user-attachments/assets/f2eae012-3e1e-4c21-a625-b91ef03a5d8b)


**Results**:  
The base model had a 14% code interpreter call frequency.  
After **24 training steps**, the frequency increased to **almost 100%**.

