### PR TITLE
📋 Allow calling trl cli in sft mode with config file

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,7 @@ class TestCLI(unittest.TestCase):
             output_dir = os.path.join(tmp_dir, "output")
 
             # Create a temporary config file
+            config_path = os.path.join(tmp_dir, "config.yaml")
             config_content = {
                 "model_name_or_path": "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
                 "dataset_name": "trl-internal-testing/zen",
@@ -85,24 +86,16 @@ class TestCLI(unittest.TestCase):
                 "output_dir": output_dir,
                 "lr_scheduler_type": "cosine_with_restarts",
             }
-
-            # Use NamedTemporaryFile to create a temporary file that will be automatically deleted
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as config_file:
+            with open(config_path, "w") as config_file:
                 yaml.dump(config_content, config_file)
-                config_path = config_file.name
 
-            try:
-                # Test the CLI with config file
-                command = f"trl sft --config {config_path}"
-                with patch("sys.argv", command.split(" ")):
-                    main()
+            # Test the CLI with config file
+            command = f"trl sft --config {config_path}"
+            with patch("sys.argv", command.split(" ")):
+                main()
 
-                # Verify that output directory was created
-                self.assertTrue(os.path.exists(output_dir))
-            finally:
-                # Clean up the temporary file even if the test fails
-                if os.path.exists(config_path):
-                    os.unlink(config_path)
+            # Verify that output directory was created
+            self.assertTrue(os.path.exists(output_dir))
 
 
 if __name__ == "__main__":

--- a/trl/cli.py
+++ b/trl/cli.py
@@ -45,13 +45,8 @@ def main():
     make_sft_parser(subparsers)
     make_vllm_serve_parser(subparsers)
 
-    # Check if --config is in the arguments
-    if "--config" in sys.argv:
-        # Use the custom parse_args_and_config method to handle the config file
-        args = parser.parse_args_and_config()[0]
-    else:
-        # Parse the arguments normally if no config file is specified
-        args = parser.parse_args()
+    # Parse the arguments
+    args = parser.parse_args_and_config()[0]
 
     if args.command == "chat":
         (chat_args,) = parser.parse_args_and_config()

--- a/trl/cli.py
+++ b/trl/cli.py
@@ -45,8 +45,13 @@ def main():
     make_sft_parser(subparsers)
     make_vllm_serve_parser(subparsers)
 
-    # Parse the arguments
-    args = parser.parse_args()
+    # Check if --config is in the arguments
+    if "--config" in sys.argv:
+        # Use the custom parse_args_and_config method to handle the config file
+        args = parser.parse_args_and_config()[0]
+    else:
+        # Parse the arguments normally if no config file is specified
+        args = parser.parse_args()
 
     if args.command == "chat":
         (chat_args,) = parser.parse_args_and_config()

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -51,7 +51,7 @@ class ScriptArguments:
             type, inplace operation. See https://github.com/huggingface/transformers/issues/22482#issuecomment-1595790992.
     """
 
-    dataset_name: str = field(metadata={"help": "Dataset name."})
+    dataset_name: Optional[str] = field(default=None, metadata={"help": "Dataset name."})
     dataset_config: Optional[str] = field(
         default=None,
         metadata={


### PR DESCRIPTION
# What does this PR do?
This PR makes it possible to specify all required arguments in a config.yaml file and call this via cli, e.g.
```bash
trl sft --config examples/cli_configs/example_config_dummy.yaml --output_dir test-trl-cli --lr_scheduler_type cosine_with_restarts
```
This line is directly from [the trl docs](https://huggingface.co/docs/trl/main/en/clis) but didn't work since `config` is no known argument of the `TrlParser` when calling `parse_args` which is always called.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #3102


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- ~[ ] Did you make sure to update the documentation with your changes?~
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.