### PR TITLE
Suggestions for Decouple gradient accumulation from the number of minibatches generated

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -65,7 +65,7 @@ class GRPOConfig(TrainingArguments):
         > Parameters that control generation
 
         generation_batch_size: (`int` or `None`, *optional*, defaults to `None`):
-            Batch size to use during generation. If `None`, it defaults to the effective training batch size:
+            Batch size to use for generation. If `None`, it defaults to the effective training batch size:
             `per_device_train_batch_size * num_processes * gradient_accumulation_steps`.
         temperature (`float`, defaults to `0.9`):
             Temperature for sampling. The higher the temperature, the more random the completions.
@@ -236,8 +236,8 @@ class GRPOConfig(TrainingArguments):
     generation_batch_size: Optional[int] = field(
         default=None,
         metadata={
-            "help": "Size of the batch to use during generation. If `None`, it defaults to the effective training "
-            "batch size: `per_device_train_batch_size * num_processes * gradient_accumulation_steps`."
+            "help": "Batch size to use for generation. If `None`, it defaults to the effective training batch size: "
+            "`per_device_train_batch_size * num_processes * gradient_accumulation_steps`."
         },
     )
     temperature: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -435,7 +435,7 @@ class GRPOConfig(TrainingArguments):
 
         if self.generation_batch_size % self.per_device_train_batch_size * num_processes != 0:
             raise ValueError(
-                f"generation_batch_size ({self.generation_batch_size}) must be divisible by the effective batch size "
+                f"generation_batch_size ({self.generation_batch_size}) must be divisible by the global batch size "
                 f"({self.per_device_train_batch_size * num_processes})."
             )
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -651,13 +651,14 @@ class GRPOTrainer(Trainer):
             self._signature_columns = ["prompt"]
 
     # This method overrides `Trainer.get_train_dataloader` to support our custom batching strategy.
-    # Instead of returning a standard per-step batch, our dataloader loads an *accumulated* batch
-    # (i.e., `per_device_batch_size × steps_per_generation`). This allows us to generate completions
-    # once per optimization step—rather than once per gradient accumulation step—which is significantly more efficient.
-    # The only change from the original implementation is multiplying the batch size by `steps_per_generation`.
-    # Thus, `_prepare_inputs` is called with the accumulated batch size, and it handles the splitting internally.
+    # Instead of returning a standard per-step batch (i.e., `per_device_batch_size), our dataloader loads an
+    # *generation* batch (i.e., `per_device_batch_size × steps_per_generation`). This allows us to generate completions
+    # once every steps_per_generation step—rather than once per accumulation step—which is significantly more
+    # efficient. The only change from the original implementation is multiplying the batch size by
+    # `steps_per_generation`. Thus, `_prepare_inputs` is called with this *generation* batch, and it handles the
+    # splitting internally.
     # Maintenance note: This method is a copy-paste of the original `Trainer.get_train_dataloader` with only one line
-    # modification.As a result, some parts of the method aren't relevant to GRPO, but we keep them to stay one line
+    # modification. As a result, some parts of the method aren't relevant to GRPO, but we keep them to stay one line
     # apart from the super method, ensuring easier maintenance in the future.
     def get_train_dataloader(self):
         if self.train_dataset is None:
@@ -698,20 +699,20 @@ class GRPOTrainer(Trainer):
         # In the following figure, the values are the prompt indices. The first row shows the first sampled batch, the
         # second row shows the second sampled batch, and so on.
         #
-        #                                        |     Accum step 0      |     Accum step 1      |
-        #                                        |   GPU 0   |   GPU 1   |   GPU 0   |   GPU 1   |
+        #                                      |    Accum step 0     |
+        #                                      |   GPU 0  |   GPU 1  |
         #
-        #                   global_step   step    <-───>  num_generations=2
-        #                                         <-───────> per_device_train_batch_size=3
-        #  steps_per_gen   ▲  ▲  0          0     [0   0   1   1   2   2]  3   3   4   4   5   5    <- Generate for the whole accumulated batch; store the completions; use the first slice to compute the loss
-        #       =2         ▼  |  0          1      0   0   1   1   2   2 [ 3   3   4   4   5   5]   <- Take the stored generations and use the second slice to compute the loss
-        #                     |
-        #                     |  1          2     [0   0   1   1   2   2]  3   3   4   4   5   5    <- Take the stored generations and use the first slice to compute the loss
-        #  num_iterations=2   ▼  1          3      0   0   1   1   2   2 [ 3   3   4   4   5   5]   <- Take the stored generations and use the second slice to compute the loss
+        #                 global_step   step    <-───>  num_generations=2
+        #                                       <-───────> per_device_train_batch_size=3
+        #  grad_accum    ▲  ▲  0          0     0   0   1   1   2   2   <- Generate for the first `steps_per_generation` (prompts 0 to 11); store the completions; use the first slice to compute the loss
+        #     =2         ▼  |  0          1     3   3   4   4   5   5   <- Take the stored generations and use the second slice to compute the loss
+        #                   |
+        #                   |  1          2     6   6   7   7   8   8   <- Take the stored generations and use the third slice to compute the loss
+        #  steps_per_gen=4  ▼  1          3     9   9  10  10  11  11   <- Take the stored generations and use the fourth slice to compute the loss
         #
-        #                        2          4     [6   6   7   7   8   8]  9   9  10  10  11  11    <- Generate for the whole accumulated batch; store the completions; use the first slice to compute the loss
-        #                        2          5      6   6   7   7   8   8 [ 9   9  10  10  11  11]   <- ...
-        #                                            ...
+        #                      2          4    12  12  13  13  14  14   <- Generate for the second `steps_per_generation` (prompts 12 to 23); store the completions; use the first slice to compute the loss
+        #                      2          5    15  15  16  16  17  17   <- Take the stored generations and use the second slice to compute the loss
+        #                                          ...
 
         return RepeatSampler(
             data_source=self.train_dataset,
@@ -835,13 +836,14 @@ class GRPOTrainer(Trainer):
 
     @profiling_decorator
     def _prepare_inputs(
-        self, accumulated_local_batch: dict[str, Union[torch.Tensor, Any]]
+        self, generation_local_batch: dict[str, Union[torch.Tensor, Any]]
     ) -> dict[str, Union[torch.Tensor, Any]]:
         # Prepares inputs for model training/evaluation by managing completion generation and batch handling.
         # During training:
-        #   - Receives the accumulated local batch (Per-GPU batch size × num mini-batches)
+        #   - Receives the generation local batch (Per-GPU batch size × steps per generation)
         #     from the modified training dataloader instead of the standard local batch
-        #   - Generates completions once for the entire accumulated batch and splits it into smaller batches
+        #   - Generates completions once for the entire generation batch and splits it into batches of size
+        #     `per_device_train_batch_size`
         #   - Buffers these completions and returns the appropriate slice for the current accumulation step
         #   - Optimizes by regenerating completions only periodically (every _steps_per_generation * num_iterations)
         # During evaluation:
@@ -854,13 +856,14 @@ class GRPOTrainer(Trainer):
             generate_every = self.args._steps_per_generation * self.num_iterations
             if self._step % generate_every == 0 or self._buffered_inputs is None:
                 # self._buffered_inputs=None can occur when resuming from a checkpoint
-                accumulated_local_batch = self._generate_and_score_completions(accumulated_local_batch)
-                self._buffered_inputs = split_tensor_dict(accumulated_local_batch, self.args._steps_per_generation)
+                generation_local_batch = self._generate_and_score_completions(generation_local_batch)
+                self._buffered_inputs = split_tensor_dict(generation_local_batch, self.args._steps_per_generation)
             inputs = self._buffered_inputs[self._step % self.args._steps_per_generation]
             self._step += 1
         else:
-            # In evaluation, there is neither gradient accumulation, nor multiple iterations
-            inputs = self._generate_and_score_completions(accumulated_local_batch)
+            # In evaluation, there is neither batch grouping for generation, nor multiple iterations, hence
+            # generation_local_batch == local_batch
+            inputs = self._generate_and_score_completions(generation_local_batch)
         return inputs
 
     def _generate_and_score_completions(
@@ -955,10 +958,10 @@ class GRPOTrainer(Trainer):
         batch_size = self.args.per_device_train_batch_size if mode == "train" else self.args.per_device_eval_batch_size
 
         with torch.no_grad():
-            # When using num_iterations == 1 and _steps_per_generation == gradient_accumulation_steps
+            # When using num_iterations == 1 and _steps_per_generation <= gradient_accumulation_steps
             # old_per_token_logps == per_token_logps, so we can skip it's computation here, and use
             # per_token_logps.detach() instead.
-            if self.num_iterations > 1 or self.args._steps_per_generation != self.args.gradient_accumulation_steps:
+            if self.num_iterations > 1 or self.args._steps_per_generation > self.args.gradient_accumulation_steps:
                 old_per_token_logps = self._get_per_token_logps(
                     self.model, prompt_completion_ids, attention_mask, logits_to_keep, batch_size
                 )
@@ -1162,9 +1165,9 @@ class GRPOTrainer(Trainer):
 
         # Compute the loss
         advantages = inputs["advantages"]
-        # When using num_iterations == 1 and steps_per_generation == gradient_accumulation_steps
+        # When using num_iterations == 1 and steps_per_generation <= gradient_accumulation_steps
         # old_per_token_logps == per_token_logps, so we can skip it's computation
-        # (see_generate_and_score_completions) and use per_token_logps.detach() instead.
+        # (see _generate_and_score_completions) and use per_token_logps.detach() instead.
         old_per_token_logps = (
             per_token_logps.detach() if inputs["old_per_token_logps"] is None else inputs["old_per_token_logps"]
         )


### PR DESCRIPTION
Some suggestions for PR #3388:

- Move `generation_batch_size` under the section `Parameters that control generation`
- use `int | None` instead of `int | str` because the the CLI parser doesn't support multi-type (that's why the CI is failing)
- rephrase some comments to be more precise (are we one the same page on these terms?):

| Term | Size |
|----------|----------|
| Local batch | `per_device_train_batch_size` |
| Local accumulated batch | `per_device_train_batch_size * gradient_accumulation_steps` |
| Global batch | `per_device_train_batch_size * world_size` |
| Effective batch | `per_device_train_batch_size * world_size * gradient_accumulation_steps` |
| Local generation batch | `per_device_train_batch_size * steps_per_generation ` |
| Generation batch | `per_device_train_batch_size * world_size  * steps_per_generation ` |

- since `num_generations` will make less sense to use with this PR, I removed it from the figure, and hopefully gained clarity
- support the case `self.args._steps_per_generation < self.args.gradient_accumulation_steps` (not sure why you'd want that, but it just requires to change `!=` into `<`.