### PR TITLE
🌊 Add MLflow metrics in profiling context

### DIFF
--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -17,11 +17,14 @@ import functools
 import time
 from collections.abc import Generator
 
-from transformers import Trainer, is_wandb_available
-
+from transformers import Trainer
+from transformers.integrations import is_mlflow_available, is_wandb_available
 
 if is_wandb_available():
     import wandb
+
+if is_mlflow_available():
+    import mlflow
 
 
 @contextlib.contextmanager
@@ -54,8 +57,24 @@ def profiling_context(trainer: Trainer, name: str) -> Generator[None, None, None
     end_time = time.perf_counter()
     duration = end_time - start_time
 
-    if "wandb" in trainer.args.report_to and wandb.run is not None and trainer.accelerator.is_main_process:
-        wandb.log({f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration})
+    if (
+        "wandb" in trainer.args.report_to
+        and wandb.run is not None
+        and trainer.accelerator.is_main_process
+    ):
+        wandb.log(
+            {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration}
+        )
+
+    if (
+        "mlflow" in trainer.args.report_to
+        and mlflow.run is not None
+        and trainer.accelerator.is_main_process
+    ):
+        mlflow.log_metrics(
+            {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration},
+            step=trainer.state.global_step,
+        )
 
 
 def profiling_decorator(func: callable) -> callable:

--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -20,6 +20,7 @@ from collections.abc import Generator
 from transformers import Trainer
 from transformers.integrations import is_mlflow_available, is_wandb_available
 
+
 if is_wandb_available():
     import wandb
 
@@ -30,7 +31,8 @@ if is_mlflow_available():
 @contextlib.contextmanager
 def profiling_context(trainer: Trainer, name: str) -> Generator[None, None, None]:
     """
-    A context manager function for profiling a block of code. Results are logged to Weights & Biases if enabled.
+    A context manager function for profiling a block of code. Results are logged to Weights & Biases or MLflow
+    depending on the trainer's configuration.
 
     Args:
         trainer (`~transformers.Trainer`):
@@ -57,24 +59,12 @@ def profiling_context(trainer: Trainer, name: str) -> Generator[None, None, None
     end_time = time.perf_counter()
     duration = end_time - start_time
 
-    if (
-        "wandb" in trainer.args.report_to
-        and wandb.run is not None
-        and trainer.accelerator.is_main_process
-    ):
-        wandb.log(
-            {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration}
-        )
+    profiling_metrics = {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration}
+    if "wandb" in trainer.args.report_to and wandb.run is not None and trainer.accelerator.is_main_process:
+        wandb.log(profiling_metrics)
 
-    if (
-        "mlflow" in trainer.args.report_to
-        and mlflow.run is not None
-        and trainer.accelerator.is_main_process
-    ):
-        mlflow.log_metrics(
-            {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration},
-            step=trainer.state.global_step,
-        )
+    if "mlflow" in trainer.args.report_to and mlflow.run is not None and trainer.accelerator.is_main_process:
+        mlflow.log_metrics(profiling_metrics, step=trainer.state.global_step)
 
 
 def profiling_decorator(func: callable) -> callable:


### PR DESCRIPTION
# What does this PR do?

Bring parity between MLFlow and Wandb in terms of metrics populated for profiling the training run. This gets used in the grpo trainer. 

<img width="1013" alt="MLFlow UI view of some new metrics" src="https://github.com/user-attachments/assets/28435f76-51e9-43f6-b0a9-353a4285f46d" />

# Testing 

Made changes locally, and verified metrics being populated on the MLFlow UI 

# Who can review?

@qgallouedec 