### PR TITLE
🪪 Remove license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
License classifier are deprecated, see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license