### PR TITLE
feat: Implement Two-Sided Clipping for GRPO Trainer

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1091,6 +1091,8 @@ class GRPOTrainerTester(unittest.TestCase):
             previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
             trainer.train()
 
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+            
             # Check if the model parameters have changed
             for n, param in previous_trainable_params.items():
                 new_param = trainer.model.get_parameter(n)

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1204,7 +1204,6 @@ class GRPOTrainerTester(unittest.TestCase):
             model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
             tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-            # Load minimal dataset
             dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train[:1]")
 
             # Create trainer

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1209,7 +1209,6 @@ class GRPOTrainerTester(unittest.TestCase):
             # Create trainer
             trainer = self._make_delta_trainer(tmp_dir, tokenizer, dataset)
 
-            # Prepare inputs
             inputs = self._delta_inputs(trainer.accelerator.device)
             inputs.update(
                 {

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1096,11 +1096,6 @@ class GRPOTrainerTester(unittest.TestCase):
                 new_param = trainer.model.get_parameter(n)
                 self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
 
-    def test_training_with_peft(self):
-        # This method is not provided in the original file or the new file
-        # It's assumed to exist as it's called in the test_training_with_mask_truncated_completions method
-        pass
-
     def test_training_with_mask_truncated_completions_all_masked(self):
         """
         Test that when all generated completions are truncated (i.e., none contain an EOS token), and

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1206,7 +1206,6 @@ class GRPOTrainerTester(unittest.TestCase):
 
             dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train[:1]")
 
-            # Create trainer
             trainer = self._make_delta_trainer(tmp_dir, tokenizer, dataset)
 
             inputs = self._delta_inputs(trainer.accelerator.device)

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1201,7 +1201,6 @@ class GRPOTrainerTester(unittest.TestCase):
             expected_loss: Expected loss value
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # Setup model and tokenizer
             model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
             tokenizer = AutoTokenizer.from_pretrained(model_id)
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1204,8 +1204,6 @@ class GRPOTrainerTester(unittest.TestCase):
             # Setup model and tokenizer
             model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
             tokenizer = AutoTokenizer.from_pretrained(model_id)
-            if tokenizer.pad_token is None:
-                tokenizer.pad_token = tokenizer.eos_token
 
             # Load minimal dataset
             dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train[:1]")

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1092,7 +1092,6 @@ class GRPOTrainerTester(unittest.TestCase):
             trainer.train()
 
             self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-            
             # Check if the model parameters have changed
             for n, param in previous_trainable_params.items():
                 new_param = trainer.model.get_parameter(n)

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -393,9 +393,9 @@ class GRPOConfig(TrainingArguments):
         default=0.2,
         metadata={"help": "Epsilon value for clipping."},
     )
-    delta: float = field(
-        default=2.0,
-        metadata={"help": "Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon."},
+    delta: Optional[float] = field(
+        default=None,
+        metadata={"help": "If set to a float value (e.g., 2.0), enables the upper clipping bound in two-sided GRPO loss. If None (default), the standard GRPO clipping is used. Recommended to be > 1 + epsilon when enabled."},
     )
     epsilon_high: Optional[float] = field(
         default=None,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -136,10 +136,8 @@ class GRPOConfig(TrainingArguments):
             Number of iterations per batch (denoted as μ in the algorithm).
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
-        delta: float = field(
-            default=2.0,
-            metadata={"help": "Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon."},
-        )
+        delta: (`float`, *optional*, defaults to `None`):
+            Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon.
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
             Upper-bound epsilon value for clipping. If not specified, it defaults to the same value as the lower-bound
             specified in argument `epsilon`. Paper [DAPO](https://huggingface.co/papers/2503.14476) recommends `0.28`.
@@ -546,3 +544,5 @@ class GRPOConfig(TrainingArguments):
                     "current global eval batch size, the valid values for the number of generations are: "
                     f"{possible_values}."
                 )
+        if self.delta is not None and self.use_liger_loss:
+            raise ValueError("Liger loss does not support two-sided GRPO loss yet.")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -395,7 +395,9 @@ class GRPOConfig(TrainingArguments):
     )
     delta: Optional[float] = field(
         default=None,
-        metadata={"help": "If set to a float value (e.g., 2.0), enables the upper clipping bound in two-sided GRPO loss. If None (default), the standard GRPO clipping is used. Recommended to be > 1 + epsilon when enabled."},
+        metadata={
+            "help": "If set to a float value (e.g., 2.0), enables the upper clipping bound in two-sided GRPO loss. If None (default), the standard GRPO clipping is used. Recommended to be > 1 + epsilon when enabled."
+        },
     )
     epsilon_high: Optional[float] = field(
         default=None,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -137,7 +137,7 @@ class GRPOConfig(TrainingArguments):
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
         delta: (`float`, *optional*, defaults to `None`):
-            Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon.
+            Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon. This method was introduced in the [INTELLECT-2 tech report](https://huggingface.co/papers/2505.07291).
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
             Upper-bound epsilon value for clipping. If not specified, it defaults to the same value as the lower-bound
             specified in argument `epsilon`. Paper [DAPO](https://huggingface.co/papers/2503.14476) recommends `0.28`.

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -136,6 +136,10 @@ class GRPOConfig(TrainingArguments):
             Number of iterations per batch (denoted as μ in the algorithm).
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
+        delta: float = field(
+            default=2.0,
+            metadata={"help": "Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon."},
+        )
         epsilon_high (`float` or `None`, *optional*, defaults to `None`):
             Upper-bound epsilon value for clipping. If not specified, it defaults to the same value as the lower-bound
             specified in argument `epsilon`. Paper [DAPO](https://huggingface.co/papers/2503.14476) recommends `0.28`.
@@ -388,6 +392,10 @@ class GRPOConfig(TrainingArguments):
     epsilon: float = field(
         default=0.2,
         metadata={"help": "Epsilon value for clipping."},
+    )
+    delta: float = field(
+        default=2.0,
+        metadata={"help": "Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon."},
     )
     epsilon_high: Optional[float] = field(
         default=None,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1348,7 +1348,6 @@ class GRPOTrainer(Trainer):
         coef_1 = torch.exp(per_token_logps - old_per_token_logps)
         coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
 
-        # Conditionally apply the upper clipping bound (delta) if specified
         if self.args.delta is not None:
             # Use clamp instead of min to handle tensor-float comparison
             per_token_loss1 = torch.clamp(coef_1, max=self.args.delta) * advantages.unsqueeze(1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1350,7 +1350,8 @@ class GRPOTrainer(Trainer):
 
         # Conditionally apply the upper clipping bound (delta) if specified
         if self.args.delta is not None:
-            per_token_loss1 = torch.min(coef_1, self.args.delta) * advantages.unsqueeze(1)
+            # Use clamp instead of min to handle tensor-float comparison
+            per_token_loss1 = torch.clamp(coef_1, max=self.args.delta) * advantages.unsqueeze(1)
         else:
             # Original GRPO clipping (only lower bound implicitly applied by the final min)
             per_token_loss1 = coef_1 * advantages.unsqueeze(1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1347,7 +1347,17 @@ class GRPOTrainer(Trainer):
         )
         coef_1 = torch.exp(per_token_logps - old_per_token_logps)
         coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
-        per_token_loss1 = coef_1 * advantages.unsqueeze(1)
+
+        # Two-sided GRPO clipping
+        # term1 = min(ratio, delta) * A_hat
+        # term2 = clip(ratio, 1-epsilon, 1+epsilon) * A_hat
+        # loss = -min(term1, term2)
+
+        # coef_1 is the ratio: pi_theta / pi_theta_old
+        # advantages is A_hat
+        # coef_2 is clip(ratio, 1-epsilon_low, 1+epsilon_high)
+
+        per_token_loss1 = torch.min(coef_1, self.args.delta) * advantages.unsqueeze(1)
         per_token_loss2 = coef_2 * advantages.unsqueeze(1)
         per_token_loss = -torch.min(per_token_loss1, per_token_loss2)
         if self.beta != 0.0:


### PR DESCRIPTION
As seen in the new [Prime Intellect's Intellect-2 Technical Report](https://storage.googleapis.com/public-technical-paper/INTELLECT_2_Technical_Report.pdf)
# What does this PR do?

This PR introduces a two-sided clipping mechanism to the GRPO (Group Relative Policy Optimization) trainer. This change aims to address a potential stability issue in the standard GRPO formulation where, for negative advantages (\(\hat{A}_{i,t} < 0\)), the original clipping only applied when the probability ratio was too small. This could lead to extremely large updates if the ratio became very large.

The core modification implements the following objective:
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/72458c69-03e0-4def-98bf-b0097a9c211d" />

A new hyperparameter, `delta`, has been added to `GRPOConfig`. This parameter caps the probability ratio for negative advantages. It is recommended to set \(\delta > 1+\epsilon\) to allow significant updates while preventing extreme changes that could destabilize training.

The changes include:
1.  **`trl/trainer/grpo_config.py`**: Added the `delta` hyperparameter.
2.  **`trl/trainer/grpo_trainer.py`**: Modified `_compute_loss` to implement the two-sided clipping.
3.  **`tests/test_grpo_trainer.py`**: Added `test_two_sided_clipping_loss` to verify the new logic.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #3435 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section? (Assumed based on PR process)
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? (Docstring for `delta` in `GRPOConfig` was added.)
- [X] Did you write any new necessary tests? (The `test_two_sided_clipping_loss` test was added.)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.