### PR TITLE
[SFT] add warning if dataset's input_ids exceed max_length

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -635,7 +635,7 @@ class SFTTrainer(Trainer):
 
                         # Create a completion mask
                         completion_mask = [0] * len(prompt_ids) + [1] * (len(prompt_completion_ids) - len(prompt_ids))
-                        processed = {**processed, "completion_mask": completion_mask, "length":len(processed["input_ids"])}
+                        processed = {**processed, "completion_mask": completion_mask}
 
                     else:  # language modeling case
                         processed = processing_class(
@@ -663,8 +663,9 @@ class SFTTrainer(Trainer):
                 dataset = pack_dataset(dataset, args.max_length, map_kwargs)
             elif args.max_length is not None:
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
-                    if max(dataset["length"]) > args.max_length:
-                        warnings.warn(f"Dataset max sequence length is {max(dataset["length"])} which longer than max_length(={args.max_length}).")
+                    datset_max_length = max(len(ids) for ids in dataset["input_ids"])
+                    if datset_max_length > args.max_length:
+                        warnings.warn(f"Dataset max sequence length is {datset_max_length} which longer than max_length(={args.max_length}).")
                     map_kwargs["desc"] = f"Truncating {dataset_name} dataset with max_length={args.max_length}"
                 dataset = truncate_dataset(dataset, args.max_length, map_kwargs)
             # For Liger kernel, ensure only input_ids is present


### PR DESCRIPTION
# What does this PR do?

setting default max_length=1024 may problem while long text dataset.

user have to know dataset's max_length and truncated with max_length.
 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

@kashif @qgallouedec
