### PR TITLE
Update grpo.py to fix bugs for cli grpo --reward_funcs my_lib.my_reward

### DIFF
--- a/trl/scripts/grpo.py
+++ b/trl/scripts/grpo.py
@@ -16,6 +16,8 @@ import argparse
 import importlib
 from dataclasses import dataclass, field
 from typing import Optional
+import sys
+import os
 
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
@@ -82,6 +84,7 @@ def main(script_args, training_args, model_args):
                 reward_funcs.append(reward_funcs_registry[func_name])
             elif "." in func_name:
                 module_path, func_name = func_name.rsplit(".", 1)
+                sys.path.insert(0, os.getcwd())
                 module = importlib.import_module(module_path)
                 reward_func = getattr(module, func_name)
                 reward_funcs.append(reward_func)


### PR DESCRIPTION
# What does this PR do?

Fix bugs when use custom reward function in Command Line Interfaces (CLIs) GRPO, like command below `cli grpo --reward_funcs my_lib.my_reward`

Current path doesn't exist in sys.path, as a result, custom reward function in current path can not works well. This PR is to fix  it.

Fixes # 3448


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case. https://github.com/huggingface/trl/issues/3448
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?
@qgallouedec 