### PR TITLE
[CI] fix CI failure of transformer dev

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1344,13 +1344,15 @@ class DPOVisionTrainerTester(unittest.TestCase):
                         "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                         "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
                     ] and (
-                        n.startswith("vision_tower.vision_model.encoder.layers.1")
-                        or n == "vision_tower.vision_model.post_layernorm.weight"
+                        "vision_tower.vision_model.encoder.layers.1" in n
+                        or "vision_tower.vision_model.post_layernorm.weight" in n
                     ):
                         # For some reason, these params are not updated. This is probably not related to TRL, but to
                         # the model itself. We should investigate this further, but for now we just skip these params.
                         continue
-                    self.assertFalse(torch.allclose(param, new_param, rtol=1e-12, atol=1e-12))
+                    self.assertFalse(
+                        torch.allclose(param, new_param, rtol=1e-12, atol=1e-12), f"Param {n} is not updated"
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

fixes the CI test failure on transformer-dev as the param name now starts with `model.`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.