### PR TITLE
🛠️ Initialize reward_kwargs to prevent UnboundLocalError in GRPOTrainer

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1139,6 +1139,8 @@ class GRPOTrainer(Trainer):
             completions = completions_text
 
         rewards_per_func = torch.zeros(len(prompts), len(self.reward_funcs), device=device)
+
+        reward_kwargs = {} # Initialize reward_kwargs to an empty dict to prevent UnboundLocalError
         for i, (reward_func, reward_processing_class, reward_func_name) in enumerate(
             zip(self.reward_funcs, self.reward_processing_classes, self.reward_func_names)
         ):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1140,14 +1140,15 @@ class GRPOTrainer(Trainer):
 
         rewards_per_func = torch.zeros(len(prompts), len(self.reward_funcs), device=device)
 
-        reward_kwargs = {} # Initialize reward_kwargs to an empty dict to prevent UnboundLocalError
+        # Repeat all input columns (but "prompt", "completion", and "completion_ids") to match the num of generations
+        keys = [key for key in inputs[0] if key not in ["prompt", "completion", "completion_ids"]]
+        reward_kwargs = {key: [example[key] for example in inputs] for key in keys}
+
         for i, (reward_func, reward_processing_class, reward_func_name) in enumerate(
             zip(self.reward_funcs, self.reward_processing_classes, self.reward_func_names)
         ):
             with profiling_context(self, reward_func_name):
-                if isinstance(
-                    reward_func, nn.Module
-                ):  # Module instead of PretrainedModel for compat with compiled models
+                if isinstance(reward_func, nn.Module):  # Module (no PretrainedModel) for compat with compiled models
                     if is_conversational(inputs[0]):
                         messages = [{"messages": p + c} for p, c in zip(prompts, completions)]
                         texts = [apply_chat_template(x, reward_processing_class)["text"] for x in messages]
@@ -1160,10 +1161,6 @@ class GRPOTrainer(Trainer):
                     with torch.inference_mode():
                         rewards_per_func[:, i] = reward_func(**reward_inputs).logits[:, 0]  # Shape (B*G,)
                 else:
-                    # Repeat all input columns (but "prompt", "completion", and "completion_ids") to match the number
-                    # of generations
-                    keys = [key for key in inputs[0] if key not in ["prompt", "completion", "completion_ids"]]
-                    reward_kwargs = {key: [example[key] for example in inputs] for key in keys}
                     output_reward_func = reward_func(
                         prompts=prompts, completions=completions, completion_ids=completion_ids_list, **reward_kwargs
                     )


### PR DESCRIPTION
This change initializes the reward_kwargs variable as an empty dictionary to avoid potential UnboundLocalError during its usage in the GRPOTrainer class. This ensures that the variable is defined before it is accessed.

# What does this PR do?

This PR addresses a potential `UnboundLocalError` that can occur in `trl.trainer.GRPOTrainer._generate_and_score_completions`.

The `reward_kwargs` dictionary is intended to store additional arguments (beyond prompt and completion) that are passed to custom, non-module-based reward functions. This dictionary is populated within an `else` block when iterating through `self.reward_funcs`.

If `self.reward_funcs` is empty (e.g., when a downstream library or user provides an empty list, intending to bypass TRL's internal reward calculation and supply pre-computed rewards/advantages) or if all provided reward functions are instances of `torch.nn.Module`, the `else` block that defines `reward_kwargs` is never entered.

Later in the same method, there's a warning mechanism that checks if all reward functions returned `None` for a sample. This warning message attempts to access `reward_kwargs` to provide context:
`row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items()}`.
If `reward_kwargs` was not initialized due to the conditions mentioned above, this access results in an `UnboundLocalError`, crashing the process.

This PR fixes the error by ensuring `reward_kwargs` is always defined by initializing it to an empty dictionary (`{}`) before the loop that processes reward functions. This allows the warning logic to execute safely, even if no custom reward functions populate `reward_kwargs`.
