### PR TITLE
📚 Fix doc building by removing vLLM from dev dependencies in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,6 @@ dev =
     %(quantization)s
     %(scikit)s
     %(test)s
-    %(vllm)s
     %(vlm)s
 
 [options.entry_points]


### PR DESCRIPTION
I think the latest release of vLLM introduced dependencies that are too large for our doc builder to support. In any case, vLLM does not need to be installed for the doc builder to work, so we can exclude it from dev.