### PR TITLE
[SFT][Bugfix] sets average_tokens_across_devices to true in SFTConfig

### DIFF
--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -80,7 +80,11 @@ class SFTConfig(TrainingArguments):
             the full sequence for [language modeling](#language-modeling) datasets.
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
-
+        average_tokens_across_devices (`bool`, *optional*, defaults to `True`):
+            Whether or not to average tokens across devices. If enabled, will use all_reduce to synchronize
+            num_tokens_in_batch for precise loss calculation. Reference:
+            https://github.com/huggingface/transformers/issues/34242
+            Overrides the `average_tokens_across_devices` parameter in [`~transformers.TrainingArguments`].
     """
 
     # Parameters that control the model
@@ -184,6 +188,14 @@ class SFTConfig(TrainingArguments):
         default=None,
         metadata={
             "help": "This parameter is deprecated and will be removed in version 0.20.0. Use `max_length` instead."
+        },
+    )
+    average_tokens_across_devices: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether or not to average tokens across devices. If enabled, will use all_reduce to synchronize "
+            "num_tokens_in_batch for precise loss calculation. Reference: https://github.com/huggingface/transformers/issues/34242 "
+            "Overrides the `average_tokens_across_devices` parameter in [`~transformers.TrainingArguments`]."
         },
     )
 


### PR DESCRIPTION
# What does this PR do?
Sets average_tokens_across_devices to true in SFTConfig

But defautl In a multi-device setting, the training loss is not compariable even you use the same effective batch size. (world_size * per_device_train_batch_size * gradient_accumulation_steps)

Example loss curves for 8,4,2,1 nodes (green, pink, grey, peach respectively).
![image](https://github.com/user-attachments/assets/2b1f9ff7-2e1a-4480-9383-e7b561598b2b)


This is because in `transformers.TrainingArguments` `average_tokens_across_devices=False` by default. Setting this to true achieves parity and lower training loss in different multi-device / node. Shown in the additional blue curve below. I tested 8 vs 64 GPUs (1 vs 8 nodes) and the training curves were near identical.
![image](https://github.com/user-attachments/assets/d1730ac8-a546-4162-a40c-2578a6c29099)

