### PR TITLE
💽 [TRLParser] Fail when unknown args are provided in the config file.

### DIFF
--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -233,7 +233,7 @@ class TestTrlParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             parser.parse_args_and_config(args)
 
-        parser.parse_args_and_config(args, allow_unknown_args=True)
+        parser.parse_args_and_config(args, fail_with_unknown_args=False)
 
     @patch("builtins.open", mock_open(read_data="arg1: 2\narg2: config_value"))
     @patch("yaml.safe_load")

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -233,6 +233,8 @@ class TestTrlParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             parser.parse_args_and_config(args)
 
+        parser.parse_args_and_config(args, allow_unknown_args=True)
+
     @patch("builtins.open", mock_open(read_data="arg1: 2\narg2: config_value"))
     @patch("yaml.safe_load")
     def test_subparsers_multiple_with_config_defaults(self, mock_yaml_load):

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -213,6 +213,26 @@ class TestTrlParser(unittest.TestCase):
         self.assertEqual(result_args[0].arg1, 3)
         self.assertEqual(result_args[0].arg2, "config_value")  # Still from config
 
+    @patch("builtins.open", mock_open(read_data="arg1: 2\nthis_arg_does_not_exist: config_value"))
+    @patch("yaml.safe_load")
+    def test_subparsers_with_config_defaults_and_arg_override_wrong_name(self, mock_yaml_load):
+        """Test that config defaults are applied to all subparsers."""
+        mock_yaml_load.return_value = {"arg1": 2, "this_arg_does_not_exist": "config_value"}
+
+        # Create the main parser
+        parser = TrlParser()
+
+        # Add subparsers
+        subparsers = parser.add_subparsers(dest="command", parser_class=TrlParser)
+
+        # Create a subparser for a specific command
+        subparsers.add_parser("subcommand", dataclass_types=[MyDataclass])
+
+        # Test with command line arguments overriding config
+        args = ["subcommand", "--arg1", "3", "--config", "config.yaml"]
+        with self.assertRaises(ValueError):
+            parser.parse_args_and_config(args)
+
     @patch("builtins.open", mock_open(read_data="arg1: 2\narg2: config_value"))
     @patch("yaml.safe_load")
     def test_subparsers_multiple_with_config_defaults(self, mock_yaml_load):

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -214,13 +214,12 @@ class TrlParser(HfArgumentParser):
         if return_remaining_strings:
             args_remaining_strings = output[-1]
             return output[:-1] + (config_remaining_strings + args_remaining_strings,)
+        elif fail_with_unknown_args and config_remaining_strings:
+            raise ValueError(
+                f"Unknown arguments from config file: {config_remaining_strings}. Please remove them, add them to the "
+                "dataclass, or set `fail_with_unknown_args=False`."
+            )
         else:
-            if fail_with_unknown_args:
-                if config_remaining_strings:
-                    raise ValueError(
-                        f"Unknown arguments from config file: {config_remaining_strings}. "
-                        "Please remove them or add them to the dataclass."
-                    )
             return output
 
     def set_defaults_with_config(self, **kwargs) -> list[str]:

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -172,7 +172,10 @@ class TrlParser(HfArgumentParser):
         super().__init__(dataclass_types=dataclass_types, **kwargs)
 
     def parse_args_and_config(
-        self, args: Optional[Iterable[str]] = None, return_remaining_strings: bool = False
+        self,
+        args: Optional[Iterable[str]] = None,
+        return_remaining_strings: bool = False,
+        fail_with_unknown_args: bool = True,
     ) -> tuple[DataClass, ...]:
         """
         Parse command-line args and config file into instances of the specified dataclass types.
@@ -212,6 +215,12 @@ class TrlParser(HfArgumentParser):
             args_remaining_strings = output[-1]
             return output[:-1] + (config_remaining_strings + args_remaining_strings,)
         else:
+            if fail_with_unknown_args:
+                if config_remaining_strings:
+                    raise ValueError(
+                        f"Unknown arguments from config file: {config_remaining_strings}. "
+                        "Please remove them or add them to the dataclass."
+                    )
             return output
 
     def set_defaults_with_config(self, **kwargs) -> list[str]:


### PR DESCRIPTION
When a config.yaml file is parsed by the `TRLParser` there is an option to return remaining strings. But otherwise we do not check that all of the parsed args have been consumed by the config classes. 

It would be easy for a user to mistype an argument in a config file and not be aware that the parameter was not set correctly.

This PR adds an option to the `TRLParser` `fail_with_unknown_args`, which is `True` by default. This ensures that errors in the config file are quickly flagged to the user.