### PR TITLE
Check rewards shapes in RewardTrainer

### DIFF
--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -35,6 +35,8 @@ class RewardConfig(TrainingArguments):
         max_length (`int` or `None`, *optional*, defaults to `1024`):
             Maximum length of the sequences (prompt + completion) in the batch, filters out entries that exceed the
             limit. This argument is required if you want to use the default data collator.
+        pad_to_multiple_of (`int` or `None`, *optional*, defaults to `None`):
+            If set, the sequences will be padded to a multiple of this value.
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the model.
         dataset_num_proc (`int`, *optional*, defaults to `None`):
@@ -80,6 +82,10 @@ class RewardConfig(TrainingArguments):
             "help": "Maximum length of the sequences (prompt + completion) in the batch, filters out entries that "
             "exceed the limit. This argument is required if you want to use the default data collator."
         },
+    )
+    pad_to_multiple_of: Optional[int] = field(
+        default=None,
+        metadata={"help": "If set, the sequences will be padded to a multiple of this value."},
     )
     disable_dropout: bool = field(
         default=True,

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -175,9 +175,10 @@ class RewardTrainer(Trainer):
                     "A processing_class must be specified when using the default RewardDataCollatorWithPadding"
                 )
 
-            max_length = args.max_length
-
-            data_collator = RewardDataCollatorWithPadding(processing_class)
+            data_collator = RewardDataCollatorWithPadding(
+                tokenizer=processing_class,
+                pad_to_multiple_of=args.pad_to_multiple_of,
+            )
 
             if args.remove_unused_columns:
                 try:  # for bc before https://github.com/huggingface/transformers/pull/25435
@@ -218,7 +219,8 @@ class RewardTrainer(Trainer):
                 # get truncated => noisy signal the chosen/rejected label gets lost. The downside is that the
                 # user might get surprised if N samples are missing from training.
                 train_dataset = train_dataset.filter(
-                    lambda x: len(x["input_ids_chosen"]) <= max_length and len(x["input_ids_rejected"]) <= max_length,
+                    lambda x: len(x["input_ids_chosen"]) <= args.max_length
+                    and len(x["input_ids_rejected"]) <= args.max_length,
                     num_proc=args.dataset_num_proc,
                 )
                 if eval_dataset is not None:
@@ -235,8 +237,8 @@ class RewardTrainer(Trainer):
                     # get truncated => noisy signal the chosen/rejected label gets lost. The downside is that the
                     # user might get surprised if N samples are missing from training.
                     eval_dataset = eval_dataset.filter(
-                        lambda x: len(x["input_ids_chosen"]) <= max_length
-                        and len(x["input_ids_rejected"]) <= max_length,
+                        lambda x: len(x["input_ids_chosen"]) <= args.max_length
+                        and len(x["input_ids_rejected"]) <= args.max_length,
                         num_proc=args.dataset_num_proc,
                     )
 

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -370,9 +370,6 @@ class RewardDataCollatorWithPadding:
         features_rejected = []
         margin = []
 
-        # The length of the longest sequence in either the chosen or rejected samples
-        max_length = 0
-
         # check if we have a margin. If we do, we need to batch it as well
         has_margin = "margin" in features[0]
         for feature in features:
@@ -387,18 +384,12 @@ class RewardDataCollatorWithPadding:
                     "The features should include `input_ids_chosen`, `attention_mask_chosen`, `input_ids_rejected` and `attention_mask_rejected`"
                 )
 
-            if len(feature["input_ids_chosen"]) > max_length:
-                max_length = len(feature["input_ids_chosen"])
-
             features_chosen.append(
                 {
                     "input_ids": feature["input_ids_chosen"],
                     "attention_mask": feature["attention_mask_chosen"],
                 }
             )
-
-            if len(feature["input_ids_rejected"]) > max_length:
-                max_length = len(feature["input_ids_rejected"])
 
             features_rejected.append(
                 {
@@ -412,16 +403,14 @@ class RewardDataCollatorWithPadding:
 
         batch_chosen = self.tokenizer.pad(
             features_chosen,
-            padding="max_length",
-            max_length=max_length,
+            padding=True,
             pad_to_multiple_of=self.pad_to_multiple_of,
             return_tensors=self.return_tensors,
         )
 
         batch_rejected = self.tokenizer.pad(
             features_rejected,
-            padding="max_length",
-            max_length=max_length,
+            padding=True,
             pad_to_multiple_of=self.pad_to_multiple_of,
             return_tensors=self.return_tensors,
         )

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -397,7 +397,7 @@ class RewardDataCollatorWithPadding:
                 }
             )
 
-            if len(feature["input_ids_chosen"]) > max_length:
+            if len(feature["input_ids_rejected"]) > max_length:
                 max_length = len(feature["input_ids_rejected"])
 
             features_rejected.append(


### PR DESCRIPTION
# What does this PR do?

While trying to fine-tune a reward model from a SFT trained model, I kept running into the following error:

```python
  File ".../train_rm.py", line 459, in train_rm
    trainer.train()
  File ".../.venv/lib/python3.11/site-packages/transformers/trainer.py", line 2240, in train
    return inner_training_loop(
           ^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.11/site-packages/transformers/trainer.py", line 2555, in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.11/site-packages/transformers/trainer.py", line 3745, in training_step
    loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.11/site-packages/trl/trainer/reward_trainer.py", line 281, in compute_loss
    loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected).mean()
                                     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
RuntimeError: The size of tensor a (84) must match the size of tensor b (146) at non-singleton dimension 1
```

~~I interpreted this to mean that the sequence lengths of the chosen and rejected chats were incompatible. The issue persisted even with a batch size of 1. I initially tried fixing this with a custom `RewardDataCollatorWithPadding`, but this raised more problems.~~

~~This PR fixes this issue, by padding the chosen and rejected chats to the same sequence length. Specifically, it finds the longest sequence in either batch, and pads all other sequences to that length. This PR also allows for the user to pass custom data collators using the `data_collator` argument in the Trainer's `__init__`.~~

This happens because the model used still output a score per token, and not for the entire sequence. This can happen when the user passes a model with an LM head or token classification head, instead of one with a sequence classification head. Simply put, the output of a reward model should be a scalar, not a sequence. However, since the code is otherwise dimension-agnostic, it only fails here.

This PR tries to prevent this issue by adding a warning when passing the first output of the model has an unexpected shape (i.e., more than 2 dimensions), and raises a descriptive warning when the model output is completely incompatible (i.e., the rewards have different sequence lengths).

This PR also allows for using custom data collators in the RewardTrainer.

## Specifics

### trainer.reward_config.RewardConfig
1. Added a `pad_to_multiple_of` parameter. This was already implemented in the `RewardDataCollatorWithPadding`, but never actually provided when defining the default data collator. This also matches the behavior of the `trainer.sft_config.SFTConfig` config class.

### trainer.reward_trainer.RewardTrainer
1. Replaced the various references to `max_length` with references to the args. Currently, the `max_length` variable is only defined when no data collator is provided (L178), making it impossible to pass a custom data collator despite the function and docs suggesting this is possible
2. Passed the added `pad_to_multiple_of` parameter to the instantiation of the default data collator.
3. On the first training step, raises a warning if the shapes of the chosen and rejected rewards have different lengths. The output should be 2 dimensional. If this differs, it might indicate the model output does not reflect sequence level classification.
4. Added a check for compatible shapes before computing the loss, for example because the rewards have different sequence lengths. The error suggests checking the model configuration.

## Fixes

#3101 
Custom DataCollator Bug in RewardTrainer

#3166
The size of tensor a (882) must match the size of tensor b (568) at non-singleton dimension 1

#686
Confused with Reward Training Data Collator

#376
The issue of reward_model output length

# Submission Checklist
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
	- I did not open an issue, but this has been discussed before
- [x] Did you make sure to update the documentation with your changes?
	- Added some minimal documentation to `RewardDataCollatorWithPadding`, should be covered by autodoc
- [x] Did you write any new necessary tests?
	- Tests added under `test_reward_trainer.py`

This is my first commit to `trl` or another HuggingFace library. I've tried to keep the changes as minimal as possible. Please let me know if anything else is required of me.

*Updates*
- Fixed a bug where only the length of the chosen sequence was checked
- Added some tests
- Realized the mistake was mine, my model was still using its LM head, not the reward regression head (mea culpa)