### PR TITLE
♻️ Avoids redundant calculation of ref logps in the new policy update loop

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1143,7 +1143,7 @@ class GRPOTrainer(Trainer):
                 )
             else:
                 old_per_token_logps = None
-            
+
             # Compute the per-token log probabilities for the reference model
             if self.beta != 0.0:
                 if self.ref_model is not None:


### PR DESCRIPTION
# What does this PR do?

Avoids redundant calculation of the reference policy's log probabilities in the new policy update loop.
The reference policy remains unchanged in the μ loop. The corresponding logps can therefore be cached in _buffered_inputs, as was the case before v0.18.0.
This behaviour was changed in #3355 and subsequently reverted (partially) in #3260.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@kashif 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.