### PR TITLE
ClearML logging of visualization in RewardTrainer evaluation

### DIFF
--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -45,6 +45,9 @@ class RewardConfig(TrainingArguments):
         remove_unused_columns (`bool`, *optional*, defaults to `False`):
             Whether to remove the columns that are not used by the model's forward pass. Can be `True` only if
             the dataset is pretokenized.
+        num_print_samples (`int`, *optional*, defaults to `4`):
+            The number of reward predictions to print during evaluation. Use `0` if no reward predictions
+            should be logged. Use `-1` if predictions for the entire evaluation dataset should be logged.
     """
 
     # Parameters whose default values are overridden from TrainingArguments
@@ -92,5 +95,12 @@ class RewardConfig(TrainingArguments):
         metadata={
             "help": "Whether to remove the columns that are not used by the model's forward pass. Can be `True` only "
             "if the dataset is pretokenized."
+        },
+    )
+    num_print_samples: int = field(
+        default=4,
+        metadata={
+            "help": "The number of reward predictions to print during evaluation. Use `0` if no reward predictions "
+            "should be logged. Use `-1` if predictions for the entire evaluation dataset should be logged."
         },
     )

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -68,7 +68,7 @@ if is_comet_available():
 if is_peft_available():
     from peft import LoraConfig, PeftConfig
 
-if is_peft_available():
+if is_clearml_available():
     import clearml
 
 


### PR DESCRIPTION
# What does this PR do?

Adds very basic support for logging the output of `RewardTrainer.visualize_samples` with ClearML.

Also adds the reward margin to this output, and allows the user to specify how many samples should be visualized using the `TrainingArgs`.

## Specifics
### trainer.reward_config.RewardConfig
1. Added the `num_print_samples` parameter, which should control the number of samples that get printed during evaluation. It can be set to 0 to skip printing altogether.
### trainer.utils
1. Added a `is_clearml_available` function
2. Added a `get_clearml_experiment_url` function
3. Added a `log_table_to_clearml_task` function
### trainer.reward_trainer.RewardTrainer
1. Checks for a `num_print_samples` from the function signature, and then from the trainer args.
4. Adds the margin to the table, if it is available
5. Reports the table to ClearML, if it's available, using the new functions imported from `trainer.utils`

## Fixes

None, I just use ClearML instead of wandb or comet-ml, and I wanted the visualizations logged.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
