### PR TITLE
Fix: list-typed tags handling in `Trainer::create_model_card`

### DIFF
--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -432,7 +432,7 @@ class AlignPropTrainer(PyTorchModelHubMixin):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -427,9 +427,13 @@ class AlignPropTrainer(PyTorchModelHubMixin):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -1494,9 +1494,13 @@ class BCOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -1499,7 +1499,7 @@ class BCOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -1062,9 +1062,13 @@ class CPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -1067,7 +1067,7 @@ class CPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/ddpo_trainer.py
+++ b/trl/trainer/ddpo_trainer.py
@@ -628,9 +628,13 @@ class DDPOTrainer(PyTorchModelHubMixin):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/ddpo_trainer.py
+++ b/trl/trainer/ddpo_trainer.py
@@ -633,7 +633,7 @@ class DDPOTrainer(PyTorchModelHubMixin):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1879,9 +1879,13 @@ class DPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1884,7 +1884,7 @@ class DPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -327,7 +327,7 @@ class GKDTrainer(SFTTrainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -322,9 +322,13 @@ class GKDTrainer(SFTTrainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1489,7 +1489,7 @@ class GRPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1484,9 +1484,13 @@ class GRPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/iterative_sft_trainer.py
+++ b/trl/trainer/iterative_sft_trainer.py
@@ -492,7 +492,7 @@ class IterativeSFTTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/iterative_sft_trainer.py
+++ b/trl/trainer/iterative_sft_trainer.py
@@ -487,9 +487,13 @@ class IterativeSFTTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1682,9 +1682,13 @@ class KTOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1687,7 +1687,7 @@ class KTOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -509,9 +509,13 @@ class NashMDTrainer(OnlineDPOTrainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -514,7 +514,7 @@ class NashMDTrainer(OnlineDPOTrainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -770,9 +770,13 @@ class OnlineDPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -775,7 +775,7 @@ class OnlineDPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -1047,7 +1047,7 @@ class ORPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -1042,9 +1042,13 @@ class ORPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -782,9 +782,13 @@ class PPOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -787,7 +787,7 @@ class PPOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -333,7 +333,7 @@ class PRMTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -328,9 +328,13 @@ class PRMTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -404,7 +404,7 @@ class RewardTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -399,9 +399,13 @@ class RewardTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -680,7 +680,7 @@ class RLOOTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -675,9 +675,13 @@ class RLOOTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -806,9 +806,13 @@ class SFTTrainer(Trainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -811,7 +811,7 @@ class SFTTrainer(Trainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -555,9 +555,13 @@ class XPOTrainer(OnlineDPOTrainer):
         else:
             base_model = None
 
-        tags = tags or set()
-        if isinstance(tags, str):
+        # normalize `tags` to a mutable set
+        if tags is None:
+            tags = set()
+        elif isinstance(tags, str):
             tags = {tags}
+        else:                    
+            tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):
             tags.add("unsloth")

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -560,7 +560,7 @@ class XPOTrainer(OnlineDPOTrainer):
             tags = set()
         elif isinstance(tags, str):
             tags = {tags}
-        else:                    
+        else:
             tags = set(tags)
 
         if hasattr(self.model.config, "unsloth_version"):


### PR DESCRIPTION
## Motivation

`*Trainer::create_model_card()` fails to convert a list of tags into a set, causing an `AttributeError` for users who pass tags as a list.

## What this PR does

Properly normalize tags -> set, for all allowed input types.

Fixes #3610 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.