### PR TITLE
🧬 Add `generation_kwargs` as a property of `GRPOConfig` to support additional generation arguments.

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -223,6 +223,21 @@ class GRPOTrainerTester(unittest.TestCase):
             train_dataset=dataset,
         )
 
+    def test_init_with_generation_kwargs(self):
+        # Test that GRPOTrainer can be instantiated with generation_kwargs
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        generation_kwargs = {"do_sample": True, "top_k": 50}
+        training_args = GRPOConfig(
+            generation_kwargs=generation_kwargs,
+            bf16=False,
+        )
+        GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            train_dataset=dataset,
+            args=training_args,
+        )
+
     @parameterized.expand([("standard_prompt_only",), ("conversational_prompt_only",)])
     def test_training(self, config_name):
         dataset = load_dataset("trl-internal-testing/zen", config_name, split="train")

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -174,6 +174,7 @@ class VLLMClient:
         min_p: float = 0.0,
         max_tokens: int = 16,
         guided_decoding_regex: Optional[str] = None,
+        generation_kwargs: Optional[dict] = None,
     ) -> list[list[int]]:
         """
         Generates model completions for the provided prompts.
@@ -197,6 +198,10 @@ class VLLMClient:
                 Maximum number of tokens to generate for each prompt.
             guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
                 Regular expression to guide the decoding process.
+            generation_kwargs (`dict` or `None`, *optional*, defaults to `None`):
+                Additional generation parameters to pass to the vLLM `SamplingParams`. This can include parameters like
+                `seed`, `frequency_penalty`, etc. If it contains keys that conflict with the other parameters, they
+                will override them.
 
         Returns:
             `list[list[int]]`:
@@ -215,6 +220,7 @@ class VLLMClient:
                 "min_p": min_p,
                 "max_tokens": max_tokens,
                 "guided_decoding_regex": guided_decoding_regex,
+                "generation_kwargs": generation_kwargs or {},
             },
         )
         if response.status_code == 200:

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -487,8 +487,7 @@ def main(script_args: ScriptArguments):
             "max_tokens": request.max_tokens,
             "guided_decoding": guided_decoding,
         }
-        if request.generation_kwargs is not None:
-            generation_kwargs.update(request.generation_kwargs)
+        generation_kwargs.update(request.generation_kwargs)
         sampling_params = SamplingParams(**generation_kwargs)
 
         # Evenly distribute prompts across DP ranks

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -433,6 +433,7 @@ def main(script_args: ScriptArguments):
         min_p: float = 0.0
         max_tokens: int = 16
         guided_decoding_regex: Optional[str] = None
+        generation_kwargs: dict = field(default_factory=dict)
 
     class GenerateResponse(BaseModel):
         completion_ids: list[list[int]]
@@ -445,6 +446,15 @@ def main(script_args: ScriptArguments):
         Args:
             request (`GenerateRequest`):
                 - `prompts` (list of `str`): A list of prompts (text strings) for the model to generate completions.
+                - `n` (`int`, *optional*, defaults to `1`): Number of completions to generate for each prompt.
+                - `repetition_penalty` (`float`, *optional*, defaults to `1.0`): Repetition penalty to apply during generation.
+                - `temperature` (`float`, *optional*, defaults to `1.0`): Temperature for sampling. Higher values lead to more random outputs.
+                - `top_p` (`float`, *optional*, defaults to `1.0`): Top-p (nucleus) sampling parameter. It controls the diversity of the generated text.
+                - `top_k` (`int`, *optional*, defaults to `-1`): Top-k sampling parameter. If set to `-1`, it disables top-k sampling.
+                - `min_p` (`float`, *optional*, defaults to `0.0`): Minimum probability threshold for sampling.
+                - `max_tokens` (`int`, *optional*, defaults to `16`): Maximum number of tokens to generate for each completion.
+                - `guided_decoding_regex` (`str`, *optional*): A regex pattern for guided decoding. If provided, the model will only generate tokens that match this regex pattern.
+                - `generation_kwargs` (`dict`, *optional*): Additional generation parameters to pass to the vLLM `SamplingParams`. This can include parameters like `seed`, `frequency_penalty`, etc. If it contains keys that conflict with the other parameters, they will override them.
 
         Returns:
             `GenerateResponse`:
@@ -467,17 +477,19 @@ def main(script_args: ScriptArguments):
         else:
             guided_decoding = None
 
-        # Sampling parameters
-        sampling_params = SamplingParams(
-            n=request.n,
-            repetition_penalty=request.repetition_penalty,
-            temperature=request.temperature,
-            top_p=request.top_p,
-            top_k=request.top_k,
-            min_p=request.min_p,
-            max_tokens=request.max_tokens,
-            guided_decoding=guided_decoding,
-        )
+        generation_kwargs = {
+            "n": request.n,
+            "repetition_penalty": request.repetition_penalty,
+            "temperature": request.temperature,
+            "top_p": request.top_p,
+            "top_k": request.top_k,
+            "min_p": request.min_p,
+            "max_tokens": request.max_tokens,
+            "guided_decoding": guided_decoding,
+        }
+        generation_kwargs.update(request.generation_kwargs)
+        sampling_params = SamplingParams(**generation_kwargs)
+
         # Evenly distribute prompts across DP ranks
         chunked_prompts = chunk_list(request.prompts, script_args.data_parallel_size)
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -487,7 +487,8 @@ def main(script_args: ScriptArguments):
             "max_tokens": request.max_tokens,
             "guided_decoding": guided_decoding,
         }
-        generation_kwargs.update(request.generation_kwargs)
+        if request.generation_kwargs is not None:
+            generation_kwargs.update(request.generation_kwargs)
         sampling_params = SamplingParams(**generation_kwargs)
 
         # Evenly distribute prompts across DP ranks

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -85,13 +85,13 @@ class GRPOConfig(TrainingArguments):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
-        generation_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
-            "Additional keyword arguments to pass to `GenerationConfig` or `SamplingParams` (if using vLLM) when sampling responses."
-            "If `None`, it defaults to an empty dictionary. This can be used to customize the generation behavior, such as setting "
-            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended generation configs and "
-            "any generation config passed like min_p."
         cache_implementation (`str` or `None`, *optional*, defaults to `None`):
             Implementation of the cache method for faster generation when use_vllm is set to False.
+        generation_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
+            Additional keyword arguments to pass to `GenerationConfig` (if using transformers) or `SamplingParams` (if
+            using vLLM) when sampling completions. This can be used to further customize the generation behavior, such
+            as setting `supress_tokens`, `num_beams`, etc. If it contains keys that conflict with the other generation
+            parameters (like `min_p`, `top_p`, etc.), they will override them.
 
         > Parameters that control generation acceleration powered by vLLM
 
@@ -327,10 +327,10 @@ class GRPOConfig(TrainingArguments):
     generation_kwargs: Optional[dict] = field(
         default=None,
         metadata={
-            "help": "Additional keyword arguments to pass to `GenerationConfig` or `SamplingParams` (if using vLLM) when sampling responses."
-            "If `None`, it defaults to an empty dictionary. This can be used to customize the generation behavior, such as setting "
-            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended generation configs and "
-            "any generation config passed like min_p."
+            "help": "Additional keyword arguments to pass to `GenerationConfig` (if using transformers) or "
+            "`SamplingParams` (if using vLLM) when sampling completions. This can be used to further customize the "
+            "generation behavior, such as setting `supress_tokens`, `num_beams`, etc. If it contains keys that "
+            "conflict with the other generation parameters (like `min_p`, `top_p`, etc.), they will override them."
         },
     )
     repetition_penalty: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -85,6 +85,10 @@ class GRPOConfig(TrainingArguments):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
+        generation_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
+            Additional keyword arguments to pass to the model's `generate` method. If `None`, it defaults to an empty
+            dictionary. This can be used to customize the generation behavior, such as setting `supress_tokens`,
+            `num_beams`, etc. These generation arguments will override the default recommended generation arguments.
         cache_implementation (`str` or `None`, *optional*, defaults to `None`):
             Implementation of the cache method for faster generation when use_vllm is set to False.
 
@@ -317,6 +321,15 @@ class GRPOConfig(TrainingArguments):
         metadata={
             "help": "Minimum token probability, which will be scaled by the probability of the most likely token. It "
             "must be a value between 0.0 and 1.0. Typical values are in the 0.01-0.2 range."
+        },
+    )
+    generation_kwargs: Optional[dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional keyword arguments to pass to the model's `generate` method. If `None`, it defaults to "
+            "an empty dictionary. This can be used to customize the generation behavior, such as setting "
+            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended "
+            "generation arguments."
         },
     )
     repetition_penalty: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -86,9 +86,10 @@ class GRPOConfig(TrainingArguments):
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
         generation_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
-            Additional keyword arguments to pass to the model's `generate` method. If `None`, it defaults to an empty
-            dictionary. This can be used to customize the generation behavior, such as setting `supress_tokens`,
-            `num_beams`, etc. These generation arguments will override the default recommended generation arguments.
+            "Additional keyword arguments to pass to `GenerationConfig` or `SamplingParams` (if using vLLM) when sampling responses."
+            "If `None`, it defaults to an empty dictionary. This can be used to customize the generation behavior, such as setting "
+            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended generation configs and "
+            "any generation config passed like min_p."
         cache_implementation (`str` or `None`, *optional*, defaults to `None`):
             Implementation of the cache method for faster generation when use_vllm is set to False.
 
@@ -326,10 +327,10 @@ class GRPOConfig(TrainingArguments):
     generation_kwargs: Optional[dict] = field(
         default=None,
         metadata={
-            "help": "Additional keyword arguments to pass to the model's `generate` method. If `None`, it defaults to "
-            "an empty dictionary. This can be used to customize the generation behavior, such as setting "
-            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended "
-            "generation arguments."
+            "help": "Additional keyword arguments to pass to `GenerationConfig` or `SamplingParams` (if using vLLM) when sampling responses."
+            "If `None`, it defaults to an empty dictionary. This can be used to customize the generation behavior, such as setting "
+            "`supress_tokens`, `num_beams`, etc. These generation arguments will override the default recommended generation configs and "
+            "any generation config passed like min_p."
         },
     )
     repetition_penalty: float = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -691,7 +691,8 @@ class GRPOTrainer(Trainer):
                 "repetition_penalty": self.repetition_penalty,
                 "cache_implementation": args.cache_implementation,
             }
-            generation_kwargs.update(args.generation_kwargs)
+            if args.generation_kwargs is not None:
+                generation_kwargs.update(args.generation_kwargs)
             self.generation_config = GenerationConfig(**generation_kwargs)
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -510,19 +510,19 @@ class GRPOTrainer(Trainer):
         self.generation_kwargs = args.generation_kwargs or {}
 
         if self.generation_kwargs:
-                default_args = [
-                    ("top_p", self.top_p),
-                    ("top_k", self.top_k),
-                    ("temperature", self.temperature),
-                    ("min_p", self.min_p),
-                    ("repetition_penalty", self.repetition_penalty),
-                    ("max_new_tokens", self.max_completion_length),
-                    ("do_sample", True),
-                ]
-                for key, value in default_args:
-                    if key not in self.generation_kwargs:
-                        self.generation_kwargs[key] = value
-            
+            default_args = [
+                ("top_p", self.top_p),
+                ("top_k", self.top_k),
+                ("temperature", self.temperature),
+                ("min_p", self.min_p),
+                ("repetition_penalty", self.repetition_penalty),
+                ("max_new_tokens", self.max_completion_length),
+                ("do_sample", True),
+            ]
+            for key, value in default_args:
+                if key not in self.generation_kwargs:
+                    self.generation_kwargs[key] = value
+
         # Datasets
         self.shuffle_dataset = args.shuffle_dataset
 
@@ -686,7 +686,7 @@ class GRPOTrainer(Trainer):
             # desynchronization and seems to lead to DeepSpeed hanging during initialization. To prevent this, we
             # synchronize all processes after vLLM has been fully initialized.
             self.accelerator.wait_for_everyone()
-        else:    
+        else:
             self.generation_config = GenerationConfig(
                 pad_token_id=processing_class.pad_token_id,
                 bos_token_id=processing_class.bos_token_id,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -506,21 +506,16 @@ class GRPOTrainer(Trainer):
         self.loss_type = args.loss_type
         self.scale_rewards = args.scale_rewards
         self.mask_truncated_completions = args.mask_truncated_completions
-        self.generation_kwargs = args.generation_kwargs or {}
-
-        if self.generation_kwargs:
-            default_args = [
-                ("top_p", self.top_p),
-                ("top_k", self.top_k),
-                ("temperature", self.temperature),
-                ("min_p", self.min_p),
-                ("repetition_penalty", self.repetition_penalty),
-                ("max_new_tokens", self.max_completion_length),
-                ("do_sample", True),
-            ]
-            for key, value in default_args:
-                if key not in self.generation_kwargs:
-                    self.generation_kwargs[key] = value
+        self.generation_kwargs = {
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "temperature": self.temperature,
+            "min_p": self.min_p,
+            "repetition_penalty": self.repetition_penalty,
+            "max_new_tokens": self.max_completion_length,
+            "do_sample": True,
+        }
+        self.generation_kwargs.update(args.generation_kwargs)
 
         # Datasets
         self.shuffle_dataset = args.shuffle_dataset


### PR DESCRIPTION
# What does this PR do?

This PR is an attempt to address #3562 to allow users to specify additional arguments that can be passed to either vllms `SamplingParams` or HFs `GenerationConfig` to give a user more control over how the old policy generates sample responses.

Fixes #3562


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
