### PR TITLE
fix grpo generation_kwargs

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1124,7 +1124,8 @@ class GRPOTrainer(Trainer):
                     "max_tokens": self.max_completion_length,
                     "guided_decoding": guided_decoding,
                 }
-                generation_kwargs.update(self.args.generation_kwargs)
+                if self.args.generation_kwargs is not None: 
+                    generation_kwargs.update(self.args.generation_kwargs)
                 sampling_params = SamplingParams(**generation_kwargs)
 
                 if self.vllm_tensor_parallel_size > 1:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1124,7 +1124,7 @@ class GRPOTrainer(Trainer):
                     "max_tokens": self.max_completion_length,
                     "guided_decoding": guided_decoding,
                 }
-                if self.args.generation_kwargs is not None: 
+                if self.args.generation_kwargs is not None:
                     generation_kwargs.update(self.args.generation_kwargs)
                 sampling_params = SamplingParams(**generation_kwargs)
 


### PR DESCRIPTION
# What does this PR do?

Currently, If the user does not pass `generation_kwargs`, then you should not face any issues (i.e. default values). Yet, this is what you get if you specify `vllm_mode=colocate`:

```
generatigeneration_kwargson_kwargs.update(self.args.)
TypeError: 'NoneType' object is not iterable
```

This PR simply fixes that !

Fixes #3633 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@qgallouedec 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.