### PR TITLE
Prompt Decoding after truncation should not skip special tokens

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1065,7 +1065,7 @@ class GRPOTrainer(Trainer):
             prompt_ids = prompt_ids[:, -self.max_prompt_length :]
             prompt_mask = prompt_mask[:, -self.max_prompt_length :]
             prompts_text = self.processing_class.batch_decode(
-                prompt_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
+                prompt_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False
             )
 
         # Generate completions using either vLLM or regular generation


### PR DESCRIPTION
# What does this PR do?

Quick fix for #3644. Skipping special tokens gets rid of the `<|im_start|>` and `<|im_end|>` chat templating and this text subsequently passed to vllm leads to malformed generations.

However, the way the prompt is currently truncated has a few other issues. For one it gets rid of the very first <|im_start|> if we exceed the `max_prompt_length` configuration. I'll work on a subsequent PR to truncate and reformat the prompt post truncation cleanly and ensure that the chat template remains in-tact post truncation.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.