### PR TITLE
Faster `position_ids` computation for FFD packing

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -508,7 +508,7 @@ class TestPackDatasetFfd(unittest.TestCase):
         expected_output = {
             "input_ids": [[4, 5, 6, 7], [1, 2, 3, 8]],
             "attention_mask": [[0, 0, 1, 1], [0, 1, 1, 1]],
-            "position_ids": [[0, 1, 2, 3], [0, 1, 2, 0]],
+            "seq_lengths": [[4], [3, 1]],
         }
         dataset = pack_dataset(dataset, seq_length, strategy="ffd")
         self.assertEqual(dataset.to_dict(), expected_output)
@@ -523,7 +523,7 @@ class TestPackDatasetFfd(unittest.TestCase):
         expected_output = {
             "input_ids": [[4, 5, 6, 7], [1, 2, 3, 8]],
             "attention_mask": [[0, 0, 1, 1], [0, 1, 1, 1]],
-            "position_ids": [[0, 1, 2, 3], [0, 1, 2, 0]],
+            "seq_lengths": [[4], [3, 1]],
         }
         dataset = pack_dataset(dataset, seq_length, strategy="ffd")
         num_examples = len(examples[next(iter(examples))])
@@ -539,7 +539,7 @@ class TestPackDatasetFfd(unittest.TestCase):
         expected_output = {
             "input_ids": [[1, 2, 3, 4], [8, 9, 10, 11], [6, 7, 12]],
             "attention_mask": [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1]],
-            "position_ids": [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 0]],
+            "seq_lengths": [[4], [4], [2, 1]],
         }
         dataset = pack_dataset(dataset, seq_length, strategy="ffd")
         self.assertEqual(dataset.to_dict(), expected_output)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -141,7 +141,7 @@ class TestDataCollatorForLanguageModeling(unittest.TestCase):
     def test_custom_position_ids(self):
         """Test handling of custom position IDs in examples."""
         self.collator = DataCollatorForLanguageModeling(pad_token_id=0)
-        examples = [{"input_ids": [1, 2, 3], "position_ids": [0, 0, 1]}, {"input_ids": [4, 5], "position_ids": [0, 1]}]
+        examples = [{"input_ids": [1, 2, 3], "seq_lengths": [1, 2]}, {"input_ids": [4, 5], "seq_lengths": [2]}]
 
         result = self.collator(examples)
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -527,12 +527,6 @@ class _SegmentTree:
 
 def _pack_ffd(examples: pa.Table, seq_length: int) -> pa.Table:
     """Pack sequences in a pyarrow Table using First Fit Decreasing strategy."""
-    # Add position_ids to the examples
-    input_ids = examples["input_ids"]
-    position_ids_python = [list(range(len(sequence))) for sequence in input_ids.to_pylist()]
-    position_ids_array = pa.array(position_ids_python, type=examples["input_ids"].type)
-    examples = examples.append_column("position_ids", position_ids_array)
-
     columns = []
     list_column_idx = None
     for idx, column in enumerate(examples.columns):
@@ -545,7 +539,9 @@ def _pack_ffd(examples: pa.Table, seq_length: int) -> pa.Table:
 
     ids = np.arange(len(examples))
     assert list_column_idx is not None
-    lengths = pc.make_struct(pc.list_value_length(examples[list_column_idx]).combine_chunks(), ids)
+    lengths = pc.list_value_length(examples[list_column_idx]).combine_chunks()
+    examples = examples.append_column("seq_lengths", lengths)  # Allows us to later construct `position_ids`
+    lengths = pc.make_struct(lengths, ids)
     lengths = lengths.sort("descending", by=0)
 
     segment_tree = _SegmentTree(seq_length)
@@ -577,15 +573,22 @@ def _pack_ffd(examples: pa.Table, seq_length: int) -> pa.Table:
     offsets = np.array([0] + [bin["length"] for bin in bins])
     offsets = np.cumsum(offsets)
 
+    assert all(
+        column.num_chunks == 1 for column in examples.columns
+    )  # `pc.take` returns a ChunkedArray with a single chunk
+
+    lengths = examples["seq_lengths"].chunks[0]
+    examples = examples.drop_columns("seq_lengths")
+    lengths = pa.ListArray.from_arrays(np.cumsum([0] + [len(bin["ids"]) for bin in bins], dtype=np.int32), lengths)
+
     columns = []
     for column in examples.columns:
-        assert len(column.chunks) == 1  # `pc.take` returns a ChunkedArray with a single chunk
         column = column.chunks[0]
         if pa.types.is_list(column.type) or pa.types.is_large_list(column.type):
             dtype = column.offsets.type.to_pandas_dtype()
             column = type(column).from_arrays(offsets.astype(dtype), column.values)
         columns.append(column)
-    return pa.Table.from_arrays(columns, names=examples.column_names)
+    return pa.Table.from_arrays(columns + [lengths], names=examples.column_names + ["seq_lengths"])
 
 
 def _pack_wrapped(examples: pa.Table, seq_length: int) -> pa.Table:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -188,8 +188,10 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         input_ids = [torch.tensor(example["input_ids"]) for example in examples]
         attention_mask = [torch.ones_like(input_ids) for input_ids in input_ids]
         if self.return_position_ids:
-            if "position_ids" in examples[0]:
-                position_ids = [torch.tensor(example["position_ids"]) for example in examples]
+            if "seq_lengths" in examples[0]:
+                position_ids = self._convert_seq_lengths_to_position_ids(
+                    [example["seq_lengths"] for example in examples]
+                )
             else:
                 position_ids = [torch.arange(len(ids)) for ids in input_ids]
         if "labels" in examples[0]:
@@ -244,6 +246,18 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
                 )
                 output["labels"][assistant_masks == 0] = -100
         return output
+
+    @staticmethod
+    def _convert_seq_lengths_to_position_ids(batch_seq_lengths: list[list[int]]) -> list[torch.Tensor]:
+        example_lengths = [sum(seq_lengths) for seq_lengths in batch_seq_lengths]
+        batch_seq_lengths = torch.tensor(
+            [seq_length for seq_lengths in batch_seq_lengths for seq_length in seq_lengths]
+        )
+        position_ids = torch.ones(sum(example_lengths), dtype=batch_seq_lengths.dtype)
+        position_ids[0] = 0
+        position_ids[batch_seq_lengths[:-1].cumsum(0)] = -(batch_seq_lengths[:-1] - 1)
+        position_ids = position_ids.cumsum(0)
+        return list(position_ids.split(example_lengths))
 
 
 class SFTTrainer(Trainer):


### PR DESCRIPTION
# What does this PR do?

This PR removes the slow conversion from PyArrow to Python needed to compute `position_ids` for FFD packing, which was introduced in https://github.com/huggingface/trl/pull/3526. To do this, it uses `seq_lengths` that save disk space and can be efficiently converted to `position_ids` in a vectorized manner in the SFT collator.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.