### PR TITLE
Make sure chat template isn't lost when truncating prompt.

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1084,7 +1084,7 @@ class GRPOTrainer(Trainer):
             prompt_ids = prompt_ids[:, -self.max_prompt_length :]
             prompt_mask = prompt_mask[:, -self.max_prompt_length :]
             prompts_text = self.processing_class.batch_decode(
-                prompt_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
+                prompt_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False
             )
 
         # Generate completions using either vLLM or regular generation


### PR DESCRIPTION
# What does this PR do?

Skipping special tokens when truncating the prompt leads to the prompt no longer being in a valid chat template, if the input dataset is conversational. 

This PR disables skipping special tokens.

<!-- Remove if not applicable -->

Fixes #3644 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

@LeonEricsson here's the quick fix.

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.