### PR TITLE
[fix] type error of quantile

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1392,7 +1392,7 @@ class GRPOTrainer(Trainer):
             entropies = logps_and_entropies["entropies"]
             # compute the entropy threshold across all tokens in the batch
 
-            entropy_threshold = torch.quantile(entropies.flatten(), self.token_entropy_percentile_threshold)
+            entropy_threshold = torch.quantile(entropies.flatten().float(), self.token_entropy_percentile_threshold)
             entropy_mask = entropies >= entropy_threshold
         else:
             per_token_logps = self._get_per_token_logps_and_entropies(


### PR DESCRIPTION
# What does this PR do?

Entropies is a bfloat16 tensor when training with bf16, but quantile() input tensor must be either float or double dtype.
https://github.com/huggingface/trl/blob/6a6d4345c9e0ded5bdcfc67ca2d8d20ecb75d309/trl/trainer/grpo_trainer.py#L1395

Fixes #3666 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.