### PR TITLE
feat: Pass trainer state to reward functions

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -334,6 +334,7 @@ The [`GRPOTrainer`] supports using custom reward functions instead of dense rewa
      - `prompts` (contains the prompts),
      - `completions` (contains the generated completions),
      - `completions_ids` (contains the tokenized completions),
+     - `trainer_state` ([`transformers.TrainerState`]): The current state of the trainer. This can be used to implement dynamic reward functions, such as curriculum learning, where the reward is adjusted based on the training progress. For more details on the available attributes, refer to the [`TrainerState`](https://huggingface.co/docs/transformers/main/en/main_classes/callback#transformers.TrainerState) documentation.
      - All columns names (but `prompt`) that the dataset may have. For example, if the dataset contains a column named `ground_truth`, the function will be called with `ground_truth` as a keyword argument.
 
      The easiest way to comply with this requirement is to use `**kwargs` in the function signature.

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1276,8 +1276,9 @@ class GRPOTrainerTester(unittest.TestCase):
         # Test if trainer can handle reward function that accesses the trainer state
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
-        def reward_func(completions, trainer_state, **kwargs):
+        def reward_func(completions, **kwargs):
             # Assert that trainer_state is passed and has the expected attributes
+            trainer_state = kwargs.get("trainer_state")
             assert trainer_state is not None
             assert hasattr(trainer_state, "global_step")
             return [float(len(set(completion))) for completion in completions]

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1273,13 +1273,12 @@ class GRPOTrainerTester(unittest.TestCase):
                 self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
 
     def test_training_with_reward_func_accessing_trainer_state(self):
-        # Test if trainer can handle reward function that accesses the trainer state
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
-            # Assert that trainer_state is passed and has the expected attributes
             trainer_state = kwargs.get("trainer_state")
             assert trainer_state is not None
+            # transformers.TrainerState instance should have a `global_step` property.
             assert hasattr(trainer_state, "global_step")
             return [float(len(set(completion))) for completion in completions]
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1271,3 +1271,29 @@ class GRPOTrainerTester(unittest.TestCase):
             for n, param in previous_trainable_params.items():
                 new_param = trainer.model.get_parameter(n)
                 self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
+
+    def test_training_with_reward_func_accessing_trainer_state(self):
+        # Test if trainer can handle reward function that accesses the trainer state
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func(completions, trainer_state, **kwargs):
+            # Assert that trainer_state is passed and has the expected attributes
+            assert trainer_state is not None
+            assert hasattr(trainer_state, "global_step")
+            return [float(len(set(completion))) for completion in completions]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = GRPOConfig(
+                output_dir=tmp_dir,
+                per_device_train_batch_size=2,
+                num_generations=2,
+                max_completion_length=8,
+                report_to="none",
+            )
+            trainer = GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=reward_func,
+                args=training_args,
+                train_dataset=dataset,
+            )
+            trainer.train()

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -348,7 +348,8 @@ class GRPOTrainer(Trainer):
                   function](#using-a-custom-reward-function).
 
                   The trainer's state is also passed to the reward function. The trainer's state is an
-                  instance of [`transformers.TrainerState`](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState) and can be accessed by adding a `trainer_state` argument
+                  instance of [`transformers.TrainerState`](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState)
+                  and can be accessed by adding a `trainer_state` argument
                   to the reward function's signature.
             - A list of reward functions, where each item can independently be any of the above types. Mixing different
             types within the list (e.g., a string model ID and a custom reward function) is allowed.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -346,6 +346,10 @@ class GRPOTrainer(Trainer):
                   reward function returns None for a sample, that reward function is excluded from the reward
                   calculation for that sample. For more details, see [Using a custom reward
                   function](#using-a-custom-reward-function).
+
+                  The trainer's state is also passed to the reward function. The trainer's state is an
+                  instance of [`transformers.TrainerState`](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState) and can be accessed by adding a `trainer_state` argument
+                  to the reward function's signature.
             - A list of reward functions, where each item can independently be any of the above types. Mixing different
             types within the list (e.g., a string model ID and a custom reward function) is allowed.
         args ([`GRPOConfig`], *optional*, defaults to `None`):
@@ -1024,6 +1028,9 @@ class GRPOTrainer(Trainer):
         # Repeat all input columns (but "prompt", "completion", and "completion_ids") to match the num of generations
         keys = [key for key in inputs[0] if key not in ["prompt", "completion", "completion_ids"]]
         reward_kwargs = {key: [example[key] for example in inputs] for key in keys}
+
+        # This allows for dynamic reward shaping based on training progress.
+        reward_kwargs["trainer_state"] = self.state
 
         for i, (reward_func, reward_processing_class, reward_func_name) in enumerate(
             zip(self.reward_funcs, self.reward_processing_classes, self.reward_func_names)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -349,7 +349,7 @@ class GRPOTrainer(Trainer):
 
                   The trainer's state is also passed to the reward function. The trainer's state is an
                   instance of [`transformers.TrainerState`](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState)
-                  and can be accessed by adding a `trainer_state` argument
+                  and can be accessed by accessing the `trainer_state` argument
                   to the reward function's signature.
             - A list of reward functions, where each item can independently be any of the above types. Mixing different
             types within the list (e.g., a string model ID and a custom reward function) is allowed.


### PR DESCRIPTION
This allows for implementing dynamic reward strategies like curriculum learning, where rewards can be adjusted based on training progress. Fixes #3668