### PR TITLE
Disables bf16 if gpu isn't available

### DIFF
--- a/trl/trainer/bco_config.py
+++ b/trl/trainer/bco_config.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from transformers import TrainingArguments
 
+import torch
 
 @dataclass
 class BCOConfig(TrainingArguments):
@@ -201,6 +202,9 @@ class BCOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+import torch
 from transformers import TrainingArguments
 
 
@@ -187,6 +188,9 @@ class CPOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional, Union
 
 from transformers import TrainingArguments
 
+import torch
 
 class FDivergenceType(Enum):
     REVERSE_KL = "reverse_kl"
@@ -438,6 +439,9 @@ class DPOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass, field
 from typing import Optional, Union
 
+import torch
 import transformers
 from packaging import version
 from transformers import TrainingArguments
@@ -541,7 +542,10 @@ class GRPOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()
 

--- a/trl/trainer/iterative_sft_config.py
+++ b/trl/trainer/iterative_sft_config.py
@@ -17,6 +17,8 @@ from typing import Any, Optional
 
 from transformers import TrainingArguments
 
+import torch
+
 
 @dataclass
 class IterativeSFTConfig(TrainingArguments):
@@ -93,7 +95,10 @@ class IterativeSFTConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()
 

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from transformers import TrainingArguments
 
+import torch
 
 @dataclass
 class KTOConfig(TrainingArguments):
@@ -230,6 +231,9 @@ class KTOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/online_dpo_config.py
+++ b/trl/trainer/online_dpo_config.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from transformers import TrainingArguments
+import torch
 
 
 @dataclass
@@ -177,7 +178,10 @@ class OnlineDPOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()
 

--- a/trl/trainer/orpo_config.py
+++ b/trl/trainer/orpo_config.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from transformers import TrainingArguments
-
+import torch
 
 @dataclass
 class ORPOConfig(TrainingArguments):
@@ -158,6 +158,9 @@ class ORPOConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/prm_config.py
+++ b/trl/trainer/prm_config.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 from transformers import TrainingArguments
 
+import torch
+
 
 @dataclass
 class PRMConfig(TrainingArguments):
@@ -109,6 +111,9 @@ class PRMConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from transformers import TrainingArguments
-
+import
 
 @dataclass
 class RewardConfig(TrainingArguments):
@@ -102,6 +102,9 @@ class RewardConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from transformers import TrainingArguments
-
+import torch
 
 @dataclass
 class SFTConfig(TrainingArguments):
@@ -249,7 +249,10 @@ class SFTConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()
 

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1188,7 +1188,10 @@ class OnPolicyConfig(TrainingArguments):
     )
 
     def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        if not torch.cuda.is_available():
+            self.bf16 = False
+        else:
+            self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
         super().__post_init__()
 


### PR DESCRIPTION
# What does this PR do?
Fixes #3616.

Most of the test cases for the various trainers do not explicitly set fp16/bf16 as a result the default condition in the `__post__init__` function enables bf16 causing most test cases to fail when run on cpu.

Devs and open source contributors might not have access to Ampere GPUs, so its better to disable the bf16 flag for unit-tests if the machine doesn't have any gpus.

This PR first checks if cuda is installed on the machine and if it isn't explicitly sets bf16 to false. Otherwise the previously existing check kicks.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.