### PR TITLE
Enable completion-only loss in SFTTrainer when using Liger Kernel

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -792,7 +792,7 @@ class SFTTrainer(Trainer):
                 dataset = truncate_dataset(dataset, args.max_length, map_kwargs)
             # For Liger kernel, ensure only input_ids is present
             if args.use_liger_kernel:
-                dataset = dataset.select_columns({"input_ids", "position_ids"}.intersection(dataset.column_names))
+                dataset = dataset.select_columns({"input_ids", "position_ids", "completion_mask"}.intersection(dataset.column_names))
 
         return dataset
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #3484, where the `'completion_mask'` column will be stripped from `trainer.train_dataset` and `trainer.eval_dataset` if `args.use_liger_kernel == True`.  This issue makes it impossible to use the SFTTrainer to train on prompt-completion style datasets with the memory-efficient Liger kernel, without preprocessing the dataset manually. 

This issue can be minimally reproduced with the following example:

```python
from trl import SFTTrainer, SFTConfig
from datasets import Dataset

train_dataset = Dataset.from_dict({
    "prompt": ["What is the capital of France?", "What is the capital of Germany?"],
    "completion": [" The capital of France is Paris.", " The capital of Germany is Berlin."]
})

training_args = SFTConfig(
    use_liger_kernel=True,
    completion_only_loss=True
)

trainer = SFTTrainer(
    model="Qwen/Qwen2.5-0.5B",
    train_dataset=train_dataset,
    args=training_args
)

print(trainer.train_dataset)
```
which prints:
```
Dataset({
    features: ['input_ids'],  # this is missing 'completion_mask', so loss will be computed on the prompt as well!
    num_rows: 2
})
```

With this PR, the output will instead be
```
Dataset({
    features: ['completion_mask', 'input_ids'],
    num_rows: 2
})
```
enabling the masking out of prompt tokens from the loss.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ x ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.