### PR TITLE
fix wrong logit slicing in grpo _get_per_token_logps_and_entropies

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -881,7 +881,9 @@ class GRPOTrainer(Trainer):
                 attention_mask=attention_mask_batch,
                 logits_to_keep=logits_to_keep + 1,
             ).logits
-            logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
+            # Correctly slice the logits to only include the parts corresponding to the completions.
+            # The logits for the completion tokens are at the end of the sequence.
+            logits = logits[:, -logits_to_keep-1:-1, :]
             # Divide logits by sampling temperature.
             # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
             logits = logits / self.temperature

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -883,7 +883,7 @@ class GRPOTrainer(Trainer):
             ).logits
             # Correctly slice the logits to only include the parts corresponding to the completions.
             # The logits for the completion tokens are at the end of the sequence.
-            logits = logits[:, -logits_to_keep-1:-1, :]
+            logits = logits[:, -logits_to_keep - 1 : -1, :]
             # Divide logits by sampling temperature.
             # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
             logits = logits / self.temperature


### PR DESCRIPTION
# What does this PR do?

[_get_per_token_logps_and_entropies](https://github.com/huggingface/trl/blob/e04f7eb3b993b5278733a793853ed3a85d1c69c8/trl/trainer/grpo_trainer.py#L867) incorrectly assumes that the sequence length of the `logits` tensor should just be reduced by one. However, what's needed is to select only the `logits` that correspond to the `completion_ids`. Since the `logits` for the entire `prompt + completion` sequence are returned, we need to slice out only the part that aligns with the completions.

Fixes #3681.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review? 

@shirinyamani @qgallouedec 
