### PR TITLE
Fix non-serializable torch.dtype bug in VLLM weight sync

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -125,7 +125,7 @@ class WeightSyncWorkerExtension:
         if self.pynccl_comm is None:
             raise RuntimeError("Communicator not initialized. Call `init_communicator` first.")
 
-        dtype = torch.__getattribute__(dtype.split(".")[-1])
+        dtype = getattr(torch, dtype.split(".")[-1])
         # Allocate memory for the incoming weight tensor on the correct device.
         weight = torch.empty(shape, dtype=dtype, device=self.device)
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -118,7 +118,7 @@ class WeightSyncWorkerExtension:
             name (`str`):
                 Name of the weight tensor being updated.
             dtype (`str`):
-                Data type of the weight tensor (e.g., `"torch.float32"`).
+                Data type of the weight tensor as a string (e.g., `"torch.float32"`).
             shape (`Sequence[int]`):
                 Shape of the weight tensor.
         """

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -561,7 +561,7 @@ def main(script_args: ScriptArguments):
                 - `shape` (list of `int`): Shape of the weight
 
         """
-        # The function update_named_param is called this way: update_named_param("name", torch.float32, (10, 10))
+        # The function update_named_param is called this way: update_named_param("name", "torch.float32", (10, 10))
         # So with collective_rpc we need to call it this way:
         # llm.collective_rpc("update_named_param", args=("name", torch.float32, (10, 10)))
         kwargs = {"method": "update_named_param", "args": (request.name, request.dtype, tuple(request.shape))}


### PR DESCRIPTION
# What does this PR do?

Fixes [#3676 ](https://github.com/huggingface/trl/issues/3676)

This PR solves the bug reported at the issue #3676. In the issue it was reported a hanging in the training of GRPOTrainer using vllm server. The hanging was identified at a pynccl_comm group barrier called in the client side (trl/extras/vllm_client.py:283) that is hanging the execution until all workers in the group have processed the broadcast of the weights.

The problem that generates this hanging occurs in the vllm server side. The vllm workers are triggered to receive the weights broadcast in the following way:

1. **`trl.extras.vllm_client.VLLClient.update_named_param`**
	- This is the method called during training by GRPOTrainer that will update the weights on the vllm server
	**1.1** Execute a post request to the "update_named_param/" server endpoint
	**1.2** Broadcast the weights to the group
	**1.3** Activate the group barrier (that is causing the hang, but that will be release once all the group workers have processed the broadcast)
2. **`trl.scripts.vllm_serve.main.update_named_param`**
	- This is the endpoint (server side) that receives the post request of the previous method on the client side
	**2.1** The POST request is received
	**2.2** The `request.dtype` attribute (that is a string that comes from the json sent on the body of the post request) is casted to a torch dtype
	**2.3** It calls `WeightSyncWorkerExtension.update_named_param` through an `llm_worker`
	**2.4** It returns success (regardless of an error occuring inside the call make in the previous step)
3. **trl.scripts.vllm_serve.llm_worker**
	- This worker is called by the endpoints to execute the methods in the `WeightSyncWorkerExtension` class
	**3.1** It receives the arguments passed by the update_named_param/ endpoint function and it calls the `WeightSyncWorkerExtension.update_named_param` method (using `collective_rpc` calls) with these arguments **[this is the line causing the hanging]**
4. **trl.scripts.vllm_serve.WeightSyncWorkerExtension.update_named_param**
	- Method called by `vllm_worker` that will actually update the weights
	**4.1** Calls the pynccl_comm broadcast (on the server side)
	**4.2** Wait for all workers to finish processing the broadcast through the group barrier (the same barrier that is causing the hanging on the client side)
	**4.3** Update the model with the received weights
	
The problem occurs in the step **3.1** (trl.scripts.vllm_serve.llm_worker line 323) due the type `torch.dtype` of the argument `dtype` passed in step **2.3** (note that this argument was a string and was converted right before being passed in **2.2**) not being serializable.

It was also mentioned in the issue (#3676) that setting the `VLLM_ALLOW_INSECURE_SERIALIZATION` environment variable to 1 solves the problem, and that is because if this environment variable is set to true VLLM will allow the serialization using pickle. But there is no real need to set this variable in this context, since in complex projects it may interfere with other functionalities and creates this problem of insecure serialization.

So the solution proposed by this PR is very simple, and doesn't change any logic, so it is safe to update and solve the problem:
- Just pass the dtype argument in the call made in step **3.2** as a string (its original type when coming from the request) instead of casting it to a torch dtype right before, cause the string will be able to be safely serialized by vllm.
- Now the trl.scripts.vllm_serve.WeightSyncWorkerExtension.update_named_param will receive the argument `dtype` as a string, and we just perform the exact same casting as it was being done in **3.2** but right before executing the broadcast call. In this way we avoid passing the non serializable torch.dtype object, passing it as a str instead, and converting it to the needed torch dtype inside the function that will use it.

If you want confirm that this problem is caused as it was described here, one simple way is adding a try/except block in the step **3.1** and print the exception:

```python
# trl.scripts.vllm_serve.llm_worker (line 323)
#...
try:
	result = method(*args, **kwargs)
except Exception as e:
	print(f"[llm_worker] Exception during method call '{method_name}': {e}")
#...
```

And you will get the following message:
```
[llm_worker] Exception during method call 'collective_rpc': Object of type <class 'torch.dtype'> is not serializableSet VLLM_ALLOW_INSECURE_SERIALIZATION=1 to allow fallback to pickle-based serialization.
```

For the record, I'm using the following versions:
trl==0.19.0
vllm==0.9.1

I imagine this bug may have been introduced with some update of vllm, but the solution proposed by this PR will be backward compatible since it's a very simple fix just delaying a type cast.

I also checked and the updated function (`trl.scripts.vllm_serve.WeightSyncWorkerExtension.update_named_param`) is not called anywhere else in `trl` other than by the `trl.scripts.vllm_serve.llm_worker`, so this update will also not generate any unexpected behavior by being updated to cast the argument inside it instead of receiving it already casted.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.