### PR TITLE
Fix mislabeling: "First-fit decreasing" is actually "Best-fit-decreasing"

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -497,7 +497,7 @@ class TestPackDatasetWrapped(unittest.TestCase):
         self.assertEqual(next(iter(dataset.batch(batch_size=num_examples))), expected_output)
 
 
-class TestPackDatasetFfd(unittest.TestCase):
+class TestPackDatasetBfd(unittest.TestCase):
     def test_simple(self):
         examples = {
             "input_ids": [[1, 2, 3], [4, 5, 6, 7], [8]],
@@ -510,7 +510,7 @@ class TestPackDatasetFfd(unittest.TestCase):
             "attention_mask": [[0, 0, 1, 1], [0, 1, 1, 1]],
             "seq_lengths": [[4], [3, 1]],
         }
-        dataset = pack_dataset(dataset, seq_length, strategy="ffd")
+        dataset = pack_dataset(dataset, seq_length, strategy="bfd")
         self.assertEqual(dataset.to_dict(), expected_output)
 
     def test_with_iterable_dataset(self):
@@ -525,7 +525,7 @@ class TestPackDatasetFfd(unittest.TestCase):
             "attention_mask": [[0, 0, 1, 1], [0, 1, 1, 1]],
             "seq_lengths": [[4], [3, 1]],
         }
-        dataset = pack_dataset(dataset, seq_length, strategy="ffd")
+        dataset = pack_dataset(dataset, seq_length, strategy="bfd")
         num_examples = len(examples[next(iter(examples))])
         self.assertEqual(next(iter(dataset.batch(batch_size=num_examples))), expected_output)
 
@@ -541,7 +541,7 @@ class TestPackDatasetFfd(unittest.TestCase):
             "attention_mask": [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1]],
             "seq_lengths": [[4], [4], [2, 1]],
         }
-        dataset = pack_dataset(dataset, seq_length, strategy="ffd")
+        dataset = pack_dataset(dataset, seq_length, strategy="bfd")
         self.assertEqual(dataset.to_dict(), expected_output)
 
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -130,7 +130,7 @@ class TestDataCollatorForLanguageModeling(unittest.TestCase):
         """Test that when using packing with position_ids, attention_mask is dropped with fa2."""
         collator = DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True, return_position_ids=True)
 
-        # Simulate packed sequences with position_ids that restart (typical of FFD packing)
+        # Simulate packed sequences with position_ids that restart (typical of BFD packing)
         examples = [
             {
                 "input_ids": [1, 2, 3, 4, 5, 6, 7, 8],  # Packed: [1,2,3] + [4,5] + [6,7,8]
@@ -1396,7 +1396,7 @@ class SFTTrainerTester2(unittest.TestCase):
                 new_param = trainer.model.get_parameter(n)
                 self.assertFalse(torch.allclose(param, new_param), f"Parameter {n} has not changed")
 
-    @parameterized.expand([("ffd",), ("wrapped",)])
+    @parameterized.expand([("bfd",), ("wrapped",)])
     def test_train_packing(self, packing_strategy):
         # Get the dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -65,13 +65,13 @@ class SFTConfig(TrainingArguments):
         packing (`bool`, *optional*, defaults to `False`):
             Whether to group multiple sequences into fixed-length blocks to improve computational efficiency and reduce
             padding. Uses `max_length` to define sequence length.
-        packing_strategy (`str`, *optional*, defaults to `"ffd"`):
-            Strategy for packing sequences. Can be either `"ffd"` (first-fit decreasing, default), or `"wrapped"`.
+        packing_strategy (`str`, *optional*, defaults to `"bfd"`):
+            Strategy for packing sequences. Can be either `"bfd"` (best-fit decreasing, default), or `"wrapped"`.
         padding_free (`bool`, *optional*, defaults to `False`):
             Whether to perform forward passes without padding by flattening all sequences in the batch into a single
             continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
             supported with the `flash_attention_2` attention implementation, which can efficiently handle the flattened
-            batch structure. When packing is enabled with strategy `"ffd"`, padding-free is enabled, regardless of the
+            batch structure. When packing is enabled with strategy `"bfd"`, padding-free is enabled, regardless of the
             value of this parameter.
         pad_to_multiple_of (`int` or `None`, *optional*, defaults to `None`):
             If set, the sequences will be padded to a multiple of this value.
@@ -187,9 +187,9 @@ class SFTConfig(TrainingArguments):
         },
     )
     packing_strategy: str = field(
-        default="ffd",
+        default="bfd",
         metadata={
-            "help": "Strategy for packing sequences. Can be either `'ffd'` (first-fit decreasing, default), or "
+            "help": "Strategy for packing sequences. Can be either `'bfd'` (best-fit decreasing, default), or "
             "`'wrapped'`."
         },
     )
@@ -199,7 +199,7 @@ class SFTConfig(TrainingArguments):
             "help": "Whether to perform forward passes without padding by flattening all sequences in the batch into "
             "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, "
             "this is only supported with the `flash_attention_2` attention implementation, which can efficiently "
-            "handle the flattened batch structure. When packing is enabled with strategy `'ffd'`, padding-free is "
+            "handle the flattened batch structure. When packing is enabled with strategy `'bfd'`, padding-free is "
             "enabled, regardless of the value of this parameter."
         },
     )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -411,9 +411,9 @@ class SFTTrainer(Trainer):
             model = self._prepare_peft_model(model, peft_config, args)
 
         # Data collator
-        # FFD packing requires padding-free mode; otherwise, the collator outputs padded attention masks, causing
+        # BFD packing requires padding-free mode; otherwise, the collator outputs padded attention masks, causing
         # FlashAttention to ignore position_ids and recompute them incorrectly from the padded attention mask.
-        self.padding_free = args.padding_free or (args.packing and args.packing_strategy == "ffd")
+        self.padding_free = args.padding_free or (args.packing and args.packing_strategy == "bfd")
         if self.padding_free:
             if data_collator is not None:
                 raise ValueError("Passing a custom data collator is not supported when using padding-free.")
@@ -466,7 +466,7 @@ class SFTTrainer(Trainer):
 
         if (
             args.packing
-            and args.packing_strategy == "ffd"
+            and args.packing_strategy == "bfd"
             and model.config._attn_implementation != "flash_attention_2"
         ):
             warnings.warn(


### PR DESCRIPTION
## Motivation

PR #3645 correctly identifies that our current default packing implementation (`ffd`) is actually an implementation of the Best-fit decreasing algorithm. We're querying for the "tightest" bin fit rather than the first open one.  

## What does this PR do?

Rename to Best-fit decreasing (BFD).

Fixes #3645.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.