### PR TITLE
[BUG when vllm and prompt_truncation are used]: Strip out pad tokens in truncated prompt text

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1096,6 +1096,7 @@ class GRPOTrainer(Trainer):
             prompts_text = self.processing_class.batch_decode(
                 prompt_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False
             )
+            prompts_text = [text.lstrip(self.processing_class.pad_token) for text in prompts_text]
 
         # Generate completions using either vLLM or regular generation
         if self.use_vllm:


### PR DESCRIPTION
# What does this PR do?

This PR fixes #3686 as mentioned in the discussion, when `pad_tokens` are a part of the original text the tokenizer doesn't set the attention mask corresponding to those tokens to 0, leading to erroneous logit scores and thereby generations.

```
tokenizer = AutoProcessor.from_pretrained("Qwen/Qwen3-0.6B")
tokenizer.pad_token
>>> <|endoftext|>

text_with_pad = "<|endoftext|><|endoftext|><|im_start|>system\nYou are a music teacher<|im_end|>\n<|im_start|>user\nDo re mi fa so la<|im_end|>\n<|im_start|>assistant\n'"
text_without_pad = "<|im_start|>system\nYou are a music teacher<|im_end|>\n<|im_start|>user\nDo re mi fa so la<|im_end|>\n<|im_start|>assistant\n'"

 inputs = tokenizer([text_with_pad, text_without_pad], padding=True, padding_side="left")

assert inputs["input_ids"][0] == inputs["input_ids"][1], "Input ids don't match!"
assert inputs["attention_mask"][0] == inputs["attention_mask"][1], "Attention masks don't match!"
>>> AssertionError: Attention masks don't match!

print(f"Attention masks of original text with pad/eos tokens\n {inputs['attention_mask'][0]}")
print(f"Attention masks of original text without pad/eos tokens\n {inputs['attention_mask'][1]}")
>>> Attention masks of original text with pad/eos tokens
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
Attention masks of original text without pad/eos tokens
 [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
```

This PR addresses the issue by stripping out all the leading `pad_tokens` in the `prompts_text` list after prompt truncation happens and before the prompts are sent to vllm.



Fixes #3686


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.