### PR TITLE
[SFT] Add `seq_lengths` to signature columns

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -829,7 +829,7 @@ class SFTTrainer(Trainer):
             self._signature_columns = [
                 "input_ids",
                 "labels",
-                "position_ids",
+                "seq_lengths",
                 "completion_mask",
                 "assistant_masks",
             ]

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -806,16 +806,16 @@ class SFTTrainer(Trainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Packing {dataset_name} dataset"
                 dataset = dataset.select_columns("input_ids")
-                # Packing adds new column "position_ids" needed for document aware flash attention
+                # Packing adds new column "seq_lengths" needed for document aware flash attention
                 dataset = pack_dataset(dataset, args.max_length, args.packing_strategy, map_kwargs)
             elif args.max_length is not None:
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Truncating {dataset_name} dataset"
                 dataset = truncate_dataset(dataset, args.max_length, map_kwargs)
-            # For Liger kernel, ensure only input_ids is present
+            # For Liger kernel, ensure only the essential columns
             if args.use_liger_kernel:
                 dataset = dataset.select_columns(
-                    {"input_ids", "position_ids", "completion_mask"}.intersection(dataset.column_names)
+                    {"input_ids", "seq_lengths", "completion_mask"}.intersection(dataset.column_names)
                 )
 
         return dataset


### PR DESCRIPTION
## What does this PR do?

To avoid cross-contamination when training with packed sequences, we pass `position_ids` to FA2. This was introduced in PR #3526, which calculated `position_ids` during packing and added them to the dataset. To ensure these are retained, `position_ids` must be set as a signature column; otherwise, the `Trainer` will discard them as unused.

https://github.com/huggingface/transformers/blob/ca7e1a3756c022bf31429c452b2f313f043f32de/src/transformers/trainer.py#L1007

While this was implemented correctly, PR #3649 introduced an optimized approach where `position_ids` are computed within the data collator using a new dataset column, `seq_lengths`. However, the latter PR failed to update the signature column from `position_ids` to `seq_lengths`. As a result, `seq_lengths` is not passed to the collator, causing it to behave as if the sequences are not packed.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.