### PR TITLE
🔭 Fix package discovery configuration in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.13
 
 [options]
-packages = find:
+packages = find_namespace:
 python_requires = >=3.9
 include_package_data = True
 install_requires =
@@ -34,11 +34,6 @@ install_requires =
 [options.packages.find]
 exclude =
     tests*
-
-[options.package_data]
-trl = 
-    templates/*.md
-    accelerate_configs/*.yaml
 
 [options.extras_require]
 bco =


### PR DESCRIPTION
Before this fix I'd get this warning when building the package (`python -m build`):

```
/tmp/build-env-xjot1w65/lib/python3.12/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'trl.accelerate_configs' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'trl.accelerate_configs' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'trl.accelerate_configs' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'trl.accelerate_configs' to be distributed and are
        already explicitly excluding 'trl.accelerate_configs' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
/tmp/build-env-xjot1w65/lib/python3.12/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'trl.templates' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'trl.templates' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'trl.templates' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'trl.templates' to be distributed and are
        already explicitly excluding 'trl.templates' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
creating build/lib/trl/accelerate_configs
```