### PR TITLE
BUG: Mask out pad token entropies for threshold calculation

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1430,9 +1430,11 @@ class GRPOTrainer(Trainer):
             return self._compute_loss(model, inputs)
 
     def _compute_entropy_mask(self, entropies, completion_mask):
-        entropies = entropies * completion_mask
         # compute the entropy threshold across all tokens in the batch
-        entropy_threshold = torch.quantile(entropies.flatten().float(), self.token_entropy_percentile_threshold)
+        non_pad_entropies = entropies[completion_mask.bool()]
+        # disregard pad tokens when computing the entropy threshold
+        entropy_threshold = torch.quantile(non_pad_entropies.float(), self.token_entropy_percentile_threshold)
+        entropies = entropies * completion_mask.float()  # mask out the padding tokens
         entropy_mask = entropies >= entropy_threshold
         return entropy_mask
 


### PR DESCRIPTION
# What does this PR do?

Fixes #3709 

The entropies corresponding to pad-tokens can be non-zero values. This means that the entropy of pad tokens can affect the entropy threshold. 

This PR fixes the bug by disregarding the indices corresponding to the pad-tokens from the entropy threshold calculation. Once the threshold is identified we also 0-out the entropies corresponding to the pad-tokens to correctly compute the mask.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.