### PR TITLE
Remove deprecated `processor.tokenizer`

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -662,7 +662,7 @@ trainer = SFTTrainer(
     args=training_args,
     data_collator=collate_fn,
     train_dataset=train_dataset,
-    processing_class=processor.tokenizer,
+    processing_class=processor,
 )
 ```
 

--- a/examples/scripts/sft_video_llm.py
+++ b/examples/scripts/sft_video_llm.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
         train_dataset=prepared_dataset,
         data_collator=collate_fn,
         peft_config=peft_config,
-        tokenizer=processor.tokenizer,
+        processing_class=processor,
     )
 
     # Train model

--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
         data_collator=collate_fn,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
-        processing_class=processor.tokenizer,
+        processing_class=processor,
         peft_config=get_peft_config(model_args),
     )
 

--- a/examples/scripts/sft_vlm_gemma3.py
+++ b/examples/scripts/sft_vlm_gemma3.py
@@ -205,7 +205,7 @@ def main():
         data_collator=collate_fn,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
-        processing_class=processor.tokenizer,
+        processing_class=processor,
         peft_config=get_peft_config(model_args),
     )
 

--- a/examples/scripts/sft_vlm_smol_vlm.py
+++ b/examples/scripts/sft_vlm_smol_vlm.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         data_collator=collate_fn,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
-        processing_class=processor.tokenizer,
+        processing_class=processor,
         peft_config=get_peft_config(model_args),
     )
 


### PR DESCRIPTION
# What does this PR do?

This PR removes all the deprecated `processor.tokenizer` since VLM would not save `preprocessor_config.json` if `processor.tokenizer` is passed to trainer.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.