### PR TITLE
📥 Set environment variables for vLLM distributed training in GRPOTrainer

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -223,17 +223,6 @@ training_args = GRPOConfig(
     vllm_mode="colocate",
 )
 ```
-Note that in this mode, if you want to run with an accelerate config file of your choice (e.g. [accelerate-configs](https://github.com/huggingface/trl/tree/main/examples/accelerate_configs)), you need to set some environment variable before launching the training script:
-
-```bash
-#required environment variables for vLLM colocate mode on a single node single GPU
-os.environ["RANK"] = "0"
-os.environ["LOCAL_RANK"] = "0"
-os.environ["WORLD_SIZE"] = "1"
-os.environ["MASTER_ADDR"] = "localhost"
-os.environ["MASTER_PORT"] = "12355"
-```
-<Tip>
 
 Depending on the model size and the overall GPU memory requirements for training, you may need to adjust the `vllm_gpu_memory_utilization` parameter in [`GRPOConfig`] to avoid underutilization or out-of-memory errors.
 

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -224,6 +224,8 @@ training_args = GRPOConfig(
 )
 ```
 
+<Tip>
+
 Depending on the model size and the overall GPU memory requirements for training, you may need to adjust the `vllm_gpu_memory_utilization` parameter in [`GRPOConfig`] to avoid underutilization or out-of-memory errors.
 
 We provide a [small script](https://huggingface.co/spaces/trl-lib/recommend-vllm-memory) to help estimate the recommended GPU memory utilization based on your model configuration and experiment settings. Simply use it as follows to get `vllm_gpu_memory_utilization` recommendation:
@@ -237,6 +239,10 @@ We provide a [small script](https://huggingface.co/spaces/trl-lib/recommend-vllm
 
 If the recommended value does not work in your environment, we suggest adding a small buffer (e.g., +0.05 or +0.1) to the recommended value to ensure stability.
 
+</Tip>
+
+<Tip>
+By default, GRPO uses `MASTER_ADDR=localhost` and `MASTER_PORT=12345` for vLLM, but you can override these values by setting the environment variables accordingly.
 </Tip>
 
 For more information, see [Speeding up training with vLLM](speeding_up_training#vllm-for-fast-generation-in-online-methods).

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -670,8 +670,8 @@ class GRPOTrainer(Trainer):
                 os.environ["RANK"] = str(self.accelerator.process_index)
                 os.environ["LOCAL_RANK"] = str(self.accelerator.local_process_index)
                 os.environ["WORLD_SIZE"] = str(self.accelerator.num_processes)
-                os.environ["MASTER_ADDR"] = "localhost"
-                os.environ["MASTER_PORT"] = "12345"
+                os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "localhost")
+                os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "12345")
 
                 self.llm = LLM(
                     model=model.name_or_path,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -666,6 +666,13 @@ class GRPOTrainer(Trainer):
                         ]
                     )
 
+                # vLLM requires the environment variables to be set for distributed training.
+                os.environ["RANK"] = str(self.accelerator.process_index)
+                os.environ["LOCAL_RANK"] = str(self.accelerator.local_process_index)
+                os.environ["WORLD_SIZE"] = str(self.accelerator.num_processes)
+                os.environ["MASTER_ADDR"] = "localhost"
+                os.environ["MASTER_PORT"] = "12345"
+
                 self.llm = LLM(
                     model=model.name_or_path,
                     tensor_parallel_size=args.vllm_tensor_parallel_size,


### PR DESCRIPTION
Late review for #3638

If you've also time to review @toslali-ibm 

```python
from trl import GRPOTrainer, GRPOConfig
from datasets import load_dataset

train_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

def main():
    training_args = GRPOConfig(
        max_completion_length=8,
        per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
        num_generations=3,  # reduce the number of generations to reduce memory usage
        use_vllm=True,
        vllm_mode="colocate",
        report_to="none",
    )

    trainer = GRPOTrainer(
        model="Qwen/Qwen3-0.6B",
        reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
        args=training_args,
        train_dataset=train_dataset,
    )

    trainer.train()

if __name__ == "__main__":
    main()
```

this now work, tested with 2 GPUs