### PR TITLE
🏗️ Refactor top-entropy in GRPO

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -896,7 +896,7 @@ class GRPOTrainerTester(unittest.TestCase):
                 num_generations=3,  # reduce the number of generations to reduce memory usage
                 max_completion_length=8,  # reduce the completion length to reduce memory usage
                 report_to="none",
-                top_entropy_quantile=0.8,
+                top_entropy_quantile=0.2,
             )
             trainer = GRPOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -242,20 +242,28 @@ class GetHighEntropyMaskTester(unittest.TestCase):
         expected_mask = torch.tensor([[0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 0, 0]], dtype=torch.bool)
         torch.testing.assert_close(entropy_mask, expected_mask)
 
-    def test_compute_entropy_mask_all_tokens(self):
-        # For a threshold of 0.0 we expect all non-pad tokens to be unmasked.
+    def test_compute_entropy_threshold_0(self):
+        # If the threshold is 0.0 then we expect the mask to be all ones for non-pad tokens.
         entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
         mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
         entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.0)
         expected_mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]], dtype=torch.bool)
         torch.testing.assert_close(entropy_mask, expected_mask)
 
-    def test_compute_entropy_mask_no_tokens(self):
-        # If there are no non-pad tokens we expect the mask to be all zeros BUT ONE VALUE.
+    def test_compute_entropy_threshold_1(self):
+        # If the threshold is 1.0 then we expect the mask to be all zeros BUT ONE VALUE.
         entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
         mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
         entropy_mask = get_high_entropy_mask(entropies, mask, threshold=1.0)
         expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
+
+    def test_compute_entropy_all_masked(self):
+        # If there are no non-pad tokens we expect the mask to be all zeros BUT ONE VALUE.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
+        mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.5)
+        expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]], dtype=torch.bool)
         torch.testing.assert_close(entropy_mask, expected_mask)
 
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -24,7 +24,7 @@ from transformers.testing_utils import require_peft
 from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
-from trl.trainer.grpo_trainer import RepeatSampler, shuffle_tensor_dict, split_tensor_dict
+from trl.trainer.grpo_trainer import RepeatSampler, get_high_entropy_mask, shuffle_tensor_dict, split_tensor_dict
 
 from .testing_utils import require_vllm
 
@@ -211,6 +211,52 @@ class RepeatRandomSamplerTester(unittest.TestCase):
         assert sampled[0:4] == sampled[4:8] == sampled[8:12]
         assert sampled[12:16] == sampled[16:20] == sampled[20:24]
         assert sampled[24:28] == sampled[28:32] == sampled[32:36]
+
+
+class GetHighEntropyMaskTester(unittest.TestCase):
+    def test_compute_entropy_mask_0(self):
+        # We have a total of 12 tokens out of which 10 are non-pad.
+        # for a token_entropy_percentile_threshold of 0.8, we expect the top 20% i.e 2 non-pad tokens corresponding to
+        # the highest entropy to be unmasked.
+        # In our example these will be the tokens corresponding to the entropies 0.9 and 1.0 since 1.1 and 1.2 are pad
+        # tokens they are excluded from the entropy threshold calculation.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.8)
+        expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 1, 1, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
+
+    def test_compute_entropy_mask_1(self):
+        # Another example with a different set of entropies and a different mask.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 1.4, 0.5, 0.14], [0.5, 0.6, 0.7, 0.8, 0.9, 1.0]])
+        mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.8)
+        expected_mask = torch.tensor([[0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
+
+    def test_compute_entropy_mask_lower_threshold(self):
+        # For a threshold of 0.5 we expect the top half of the non-pad tokens to be unmasked.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.5)
+        expected_mask = torch.tensor([[0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
+
+    def test_compute_entropy_mask_all_tokens(self):
+        # For a threshold of 0.0 we expect all non-pad tokens BUT ONE to be unmasked.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=0.0)
+        expected_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
+
+    def test_compute_entropy_mask_no_tokens(self):
+        # If there are no non-pad tokens we expect an empty mask.
+        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
+        entropy_mask = get_high_entropy_mask(entropies, mask, threshold=1.0)
+        expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]], dtype=torch.bool)
+        torch.testing.assert_close(entropy_mask, expected_mask)
 
 
 class GRPOTrainerTester(unittest.TestCase):
@@ -1297,35 +1343,3 @@ class GRPOTrainerTester(unittest.TestCase):
                 train_dataset=dataset,
             )
             trainer.train()
-
-    def test_compute_entropy_mask(self):
-        """Test the _compute_entropy_mask method."""
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=GRPOConfig(token_entropy_percentile_threshold=0.8),
-        )
-
-        # Create dummy entropies and completion mask
-        entropies = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1.0, 1.1, 1.2]])
-        completion_mask = torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]])
-
-        entropy_mask = trainer._compute_entropy_mask(entropies, completion_mask)
-
-        self.assertEqual(entropy_mask.shape, entropies.shape)
-
-        # We have a total of 12 tokens out of which 10 are non-pad,
-        # for a token_entropy_percentile_threshold of 0.8,
-        # we expect the top 20% i.e 2 non-pad tokens corresponding to the highest entropy to be unmasked.
-        # In our example these will be the tokens corresponding to the entropies 0.9 and 1.0
-        # since 1.1 and 1.2 are pad tokens they are excluded from the entropy threshold calculation.
-        expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 1, 1, 0, 0]], dtype=torch.bool)
-        self.assertTrue(torch.equal(entropy_mask, expected_mask))
-
-        entropies = torch.tensor([[0.1, 0.2, 0.3, 1.4, 0.5, 0.14], [0.5, 0.6, 0.7, 0.8, 0.9, 1.0]])
-        completion_mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 0, 0]])
-
-        expected_mask = torch.tensor([[0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0]], dtype=torch.bool)
-        entropy_mask = trainer._compute_entropy_mask(entropies, completion_mask)
-
-        self.assertTrue(torch.equal(entropy_mask, expected_mask))

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -192,9 +192,9 @@ class GRPOConfig(TrainingArguments):
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
         top_entropy_quantile (`float`, *optional*, defaults to `0.0`):
-            ρ parameter from [Beyond the 80/20 Rule](https://huggingface.co/papers/2506.01939). Keeps only the top-ρ
-            quantile of tokens by entropy of the probability distribution at each sequence position in the policy
-            loss term, improving results. Range: `[0.0-1.0]`. A value of `1.0` masks all but the highest entropy token;
+            ρ parameter from [Beyond the 80/20 Rule](https://huggingface.co/papers/2506.01939). Keeps in the policy
+            loss term only the top-ρ quantile of tokens by entropy of the probability distribution at each sequence 
+            position, improving results. Range: `[0.0-1.0]`. A value of `1.0` masks all but the highest entropy token;
             `0.0` keeps all tokens. The paper recommends a value of `0.2`.
             If used with `mask_truncated_completions=True`, only tokens from non-truncated completions are considered.
         use_liger_loss (`bool`, *optional*, defaults to `False`):
@@ -523,10 +523,10 @@ class GRPOConfig(TrainingArguments):
     top_entropy_quantile: float = field(
         default=0.0,
         metadata={
-            "help": "ρ parameter from Beyond the 80/20 Rule. Keeps only the top-ρ quantile of tokens by entropy of "
-            "the probability distribution at each sequence position in the policy loss term, improving results. "
-            "Range: [0.0-1.0]. A value of `1.0` masks all but the highest entropy token; `0.0` keeps all tokens. The "
-            "paper recommends a value of `0.2`. If used with `mask_truncated_completions=True`, only tokens from "
+            "help": "ρ parameter from Beyond the 80/20 Rule. Keeps in the policy loss term only the top-ρ quantile of "
+            "tokens by entropy of the probability distribution at each sequence position, improving results. Range: "
+            "[0.0-1.0]. A value of `1.0` masks all but the highest entropy token; `0.0` keeps all tokens. The paper "
+            "recommends a value of `0.2`. If used with `mask_truncated_completions=True`, only tokens from "
             "non-truncated completions are considered."
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -194,8 +194,8 @@ class GRPOConfig(TrainingArguments):
         top_entropy_quantile (`float`, *optional*, defaults to `1.0`):
             ρ parameter from [Beyond the 80/20 Rule](https://huggingface.co/papers/2506.01939). Keeps in the policy
             loss term only the top-ρ quantile of tokens by entropy of the probability distribution at each sequence
-            position, improving results. Range: `[0.0-1.0]`. A value of `1.0` masks all but the highest entropy token;
-            `0.0` keeps all tokens. The paper recommends a value of `0.2`.
+            position, improving results. Range: `[0.0-1.0]`. A value of `0.0` masks all but the highest entropy token;
+            `1.0` keeps all tokens. The paper recommends a value of `0.2`.
             If used with `mask_truncated_completions=True`, only tokens from non-truncated completions are considered.
         use_liger_loss (`bool`, *optional*, defaults to `False`):
             Whether to use the Liger GRPO loss.

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -191,9 +191,9 @@ class GRPOConfig(TrainingArguments):
             τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
-        top_entropy_quantile (`float`, *optional*, defaults to `0.0`):
+        top_entropy_quantile (`float`, *optional*, defaults to `1.0`):
             ρ parameter from [Beyond the 80/20 Rule](https://huggingface.co/papers/2506.01939). Keeps in the policy
-            loss term only the top-ρ quantile of tokens by entropy of the probability distribution at each sequence 
+            loss term only the top-ρ quantile of tokens by entropy of the probability distribution at each sequence
             position, improving results. Range: `[0.0-1.0]`. A value of `1.0` masks all but the highest entropy token;
             `0.0` keeps all tokens. The paper recommends a value of `0.2`.
             If used with `mask_truncated_completions=True`, only tokens from non-truncated completions are considered.
@@ -521,7 +521,7 @@ class GRPOConfig(TrainingArguments):
         },
     )
     top_entropy_quantile: float = field(
-        default=0.0,
+        default=1.0,
         metadata={
             "help": "ρ parameter from Beyond the 80/20 Rule. Keeps in the policy loss term only the top-ρ quantile of "
             "tokens by entropy of the probability distribution at each sequence position, improving results. Range: "

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -191,12 +191,12 @@ class GRPOConfig(TrainingArguments):
             τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
-        token_entropy_percentile_threshold (`float`, *optional*, defaults to `0.0`):
-            τ parameter from the [Beyond the 80/20 Rule](https://huggingface/papers/2506.01939) paper, which finds that
-            masking out the bottom τ percentile of tokens based on the entropy of the probability distribution at a
-            given sequence position, in the policy loss term yields better results. The range of the parameter is
-            [0.0-1.0] a value of 0.0 means that none the tokens are filtered out and 1.0 means that all the tokens are
-            masked. Recommended value is `0.8`.
+        top_entropy_quantile (`float`, *optional*, defaults to `0.0`):
+            ρ parameter from [Beyond the 80/20 Rule](https://huggingface.co/papers/2506.01939). Keeps only the top-ρ
+            quantile of tokens by entropy of the probability distribution at each sequence position in the policy
+            loss term, improving results. Range: `[0.0-1.0]`. A value of `1.0` masks all but the highest entropy token;
+            `0.0` keeps all tokens. The paper recommends a value of `0.2`.
+            If used with `mask_truncated_completions=True`, only tokens from non-truncated completions are considered.
         use_liger_loss (`bool`, *optional*, defaults to `False`):
             Whether to use the Liger GRPO loss.
 
@@ -520,12 +520,14 @@ class GRPOConfig(TrainingArguments):
             "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
         },
     )
-    token_entropy_percentile_threshold: float = field(
+    top_entropy_quantile: float = field(
         default=0.0,
         metadata={
-            "help": "Percentile threshold for filtering out tokens in the policy loss based on entropy."
-            "Positions in the completion with entropy below this percentile are masked out."
-            "0.8 is the recommended value if you'd like to enable entropy based masking."
+            "help": "ρ parameter from Beyond the 80/20 Rule. Keeps only the top-ρ quantile of tokens by entropy of "
+            "the probability distribution at each sequence position in the policy loss term, improving results. "
+            "Range: [0.0-1.0]. A value of `1.0` masks all but the highest entropy token; `0.0` keeps all tokens. The "
+            "paper recommends a value of `0.2`. If used with `mask_truncated_completions=True`, only tokens from "
+            "non-truncated completions are considered."
         },
     )
     use_liger_loss: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -308,6 +308,8 @@ def get_high_entropy_mask(entropies: torch.Tensor, mask: torch.Tensor, threshold
             `False` otherwise.
     """
     non_pad_entropies = entropies[mask.bool()].float()
+    if non_pad_entropies.numel() == 0:
+        return torch.zeros_like(entropies, dtype=torch.bool)
     entropy_threshold = torch.quantile(non_pad_entropies, threshold)
     masked_entropies = entropies * mask.float()
     entropy_mask = masked_entropies >= entropy_threshold

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1471,7 +1471,7 @@ class GRPOTrainer(Trainer):
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
 
-        # Compute the per_token_logps the entropy if necessary at each position in the completion
+        # Compute the per_token_logps and the entropy (if necessary) at each position in the completion
         per_token_logps, entropies = self._get_per_token_logps_and_entropies(
             model, input_ids, attention_mask, logits_to_keep, compute_entropy=self.top_entropy_quantile < 1.0
         )


### PR DESCRIPTION
# What does this PR do?

Some minor change, late review from https://github.com/huggingface/trl/pull/3563

1. Don't use/unittest private method: `_compute_entropy_mask` -> `get_high_entropy_mask`
2. `token_entropy_percentile_threshold` -> `top_entropy_quantile` top better align with the _top-20%_ message (its more a quantile than a percentile here.
3. Fix the doc: link and var name (rho, not tau)
4. I better like `_get_per_token_logps_and_entropies` returning a tuple, but personal preference

cc @pramodith happy to have you thoughts on this