### PR TITLE
add custom data_collator to GRPOTrainer

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -37,6 +37,7 @@ from transformers import (
     AutoModelForCausalLM,
     AutoModelForSequenceClassification,
     AutoTokenizer,
+    DataCollatorWithPadding,
     GenerationConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
@@ -363,6 +364,8 @@ class GRPOTrainer(Trainer):
             - [Standard](dataset_formats#standard): Each sample contains plain text.
             - [Conversational](dataset_formats#conversational): Each sample contains structured messages (e.g., role
               and content).
+        data_collator ([`DataCollatorWithPadding`], *optional*, defaults to `None`):
+            A custom data collator to apply to minibatches of data.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`] or `dict[str, Union[Dataset, IterableDataset]]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], *optional*, defaults to `None`):
@@ -401,6 +404,7 @@ class GRPOTrainer(Trainer):
         reward_funcs: Union[RewardFunc, list[RewardFunc]],
         args: Optional[GRPOConfig] = None,
         train_dataset: Optional[Union[Dataset, IterableDataset]] = None,
+        data_collator: Optional[DataCollatorWithPadding] = None,
         eval_dataset: Optional[Union[Dataset, IterableDataset, dict[str, Union[Dataset, IterableDataset]]]] = None,
         processing_class: Optional[PreTrainedTokenizerBase] = None,
         reward_processing_classes: Optional[Union[PreTrainedTokenizerBase, list[PreTrainedTokenizerBase]]] = None,
@@ -565,7 +569,7 @@ class GRPOTrainer(Trainer):
         super().__init__(
             model=model,
             args=args,
-            data_collator=identity,  # No data collation is needed in GRPO
+            data_collator=identity if data_collator is None else data_collator,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,


### PR DESCRIPTION
# What does this PR do?

Some use cases (including mine) require custom data collation + GRPO. Before GRPOTrainer could only use a default collation method.

Fixes # (issue)

Makes progress towards #2807
* GPRO for multimodal LLMs requires custom data collation
* Does not fully implement it because multimodal generation also requires passing additional modality features during generation.
* PR #3460 is complementary but is specific to standard vision-language data.