### PR TITLE
[WIP] Fix ppo example accelerator initialization error

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -352,10 +352,6 @@ class PPOTrainer(Trainer):
                     "`non_blocking` is only supported in accelerate v0.30.0 and above. Please upgrade accelerate to use this feature."
                 )
         else:
-            # if non_blocking and not self.args.dataloader_pin_memory:
-            #     logger.warning(
-            #         "`non_blocking` is enabled but `dataloader_pin_memory` is not. For the best performance, it's recommended to enable both."
-            #     )
             dataloader_config.non_blocking = non_blocking
         # this would have been updated above, no need for it anymore
         accelerator_config.pop("gradient_accumulation_kwargs")


### PR DESCRIPTION
# What does this PR do?

This PR leverages the parent class' `create_accelerator_and_postprocess` method to initialize the `accelerator` correctly, without overhauling the `PPOTrainer` initialization flow.
- Uses `create_accelerator_and_postprocess` instead of manual accelerator setup.
- Initialization now succeeds under specific configurations: ZeRO Stage 1 supports any `--gradient_accumulation_steps`, whereas ZeRO Stage 2 and 3 require --gradient_accumulation_steps == 1.

**Note:** With `--gradient_accumulation_steps > 1`, running with ZeRO stage 2 or 3 still trigger the well-known error:
```
[rank0]:   File "/workspace/Projects/trl/examples/scripts/ppo/ppo.py", line 163, in <module>                                                                                                                                12:44:26 [34/1998]
[rank0]:     trainer.train()                                                                                                                                                                                                                  
[rank0]:   File "/workspace/Projects/trl/trl/trainer/ppo_trainer.py", line 668, in train                                                                                                                                                      
[rank0]:     with accelerator.accumulate(model):                                                                                                                                                                                              
[rank0]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__                                                                                                                                                                   
[rank0]:     return next(self.gen)                                                                                                                                                                                                            
[rank0]:            ^^^^^^^^^^^^^^                                                                                                                                                                                                            
[rank0]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 1166, in accumulate                                                                                                               
[rank0]:     cm_stack.enter_context(contextlib.nullcontext() if allow_gradient_sync else self.no_sync(m))                                                                                                                                     
[rank0]:   File "/usr/lib/python3.12/contextlib.py", line 526, in enter_context                                                                                                                                                               
[rank0]:     result = _enter(cm)                                                                                                                                                                                                              
[rank0]:              ^^^^^^^^^^                                                                                                                                                                                                              
[rank0]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__                                                                                                                                                                   
[rank0]:     return next(self.gen)                                                                                                                                                                                                            
[rank0]:            ^^^^^^^^^^^^^^                                                                                                                                                                                                            
[rank0]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 1047, in no_sync                                                                                                                  
[rank0]:     with context():                                                                                                                                                                                                                  
[rank0]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__                                                                                                                                                                   
[rank0]:     return next(self.gen)                                                                                                                                                                                                            
[rank0]:            ^^^^^^^^^^^^^^                                                                                                                                                                                                            
[rank0]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/deepspeed/runtime/engine.py", line 2243, in no_sync                                                                                                                
[rank0]:     assert not self.zero_optimization_partition_gradients(), \                                                                                                                                                                       
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                          
[rank0]: AssertionError: no_sync context manager is incompatible with gradient partitioning logic of ZeRO stage 3                                                                                                                             
[rank1]: Traceback (most recent call last):                                                                                                                                                                                                   
[rank1]:   File "/workspace/Projects/trl/examples/scripts/ppo/ppo.py", line 163, in <module>                                                                                                                                                  
[rank1]:     trainer.train()
[rank1]:   File "/workspace/Projects/trl/trl/trainer/ppo_trainer.py", line 668, in train
[rank1]:     with accelerator.accumulate(model):
[rank1]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
[rank1]:     return next(self.gen)
[rank1]:            ^^^^^^^^^^^^^^
[rank1]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 1166, in accumulate
[rank1]:     cm_stack.enter_context(contextlib.nullcontext() if allow_gradient_sync else self.no_sync(m))
[rank1]:   File "/usr/lib/python3.12/contextlib.py", line 526, in enter_context
[rank1]:     result = _enter(cm)
[rank1]:              ^^^^^^^^^^
[rank1]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
[rank1]:     return next(self.gen)
[rank1]:            ^^^^^^^^^^^^^^
[rank1]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 1047, in no_sync
[rank1]:     with context():
[rank1]:   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
[rank1]:     return next(self.gen)
[rank1]:            ^^^^^^^^^^^^^^
[rank1]:   File "/workspace/Projects/trl/venv/lib/python3.12/site-packages/deepspeed/runtime/engine.py", line 2243, in no_sync
[rank1]:     assert not self.zero_optimization_partition_gradients(), \
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: AssertionError: no_sync context manager is incompatible with gradient partitioning logic of ZeRO stage 3
```

The related issues as follows:
- https://github.com/huggingface/accelerate/issues/3481
- https://github.com/huggingface/accelerate/pull/3656

---

## Request for feedback

1. **Combine fixes?**
should this PR also address the `no_sync` with ZeRO 2/3 compatibility (i.e. implement a workaround or guard), or…

2. **Separate the issue**
open a new issue for the ZeRO compatibility problem and keep this PR focused solely on "accelerator initialization"?

Any guidance or opinions are greatly appreciated -- thank you! 🙏

---

Fixes # (issue)
#2377

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.