### PR TITLE
Add warn0 utility and replace warnings.warn with rank-aware warnings in trainer

### DIFF
--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import random
 import textwrap
-import warnings
 from collections import defaultdict
 from contextlib import contextmanager, nullcontext
 from operator import itemgetter

--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -66,6 +66,7 @@ from .utils import (
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
+    warn0,
 )
 
 
@@ -495,7 +496,7 @@ class BCOTrainer(Trainer):
                 "max_length or a processing_class must be specified when using the default DPODataCollatorWithPadding"
             )
         if args.max_length is None:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding, you should set `max_length` in the `BCOConfig`. "
                 "It will be set to `512` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -505,7 +506,7 @@ class BCOTrainer(Trainer):
             max_length = args.max_length
 
         if args.max_prompt_length is None:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding, you should set `max_prompt_length` in the `BCOConfig`. "
                 "It will be set to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -516,7 +517,7 @@ class BCOTrainer(Trainer):
 
         max_completion_length = None
         if args.max_completion_length is None and self.is_encoder_decoder:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding with an encoder decoder architecture, you should set `max_completion_length` in the BCOTrainer's init"
                 " it will be set to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -535,7 +536,7 @@ class BCOTrainer(Trainer):
             if args.remove_unused_columns:
                 args.remove_unused_columns = False
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using DPODataCollatorWithPadding, you should set `remove_unused_columns=False` in your BCOConfig"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
@@ -573,7 +574,7 @@ class BCOTrainer(Trainer):
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            warnings.warn(
+            warn0(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
                 "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -60,6 +60,7 @@ from .utils import (
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
+    warn0,
 )
 
 
@@ -226,7 +227,7 @@ class CPOTrainer(Trainer):
         if processing_class is None:
             raise ValueError("processing_class must be specified to tokenize a CPO dataset.")
         if args.max_length is None:
-            warnings.warn(
+            warn0(
                 "`max_length` is not set in the CPOConfig's init"
                 " it will default to `512` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -235,7 +236,7 @@ class CPOTrainer(Trainer):
         else:
             max_length = args.max_length
         if args.max_prompt_length is None:
-            warnings.warn(
+            warn0(
                 "`max_prompt_length` is not set in the CPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -250,7 +251,7 @@ class CPOTrainer(Trainer):
             )
 
         if args.max_completion_length is None and self.is_encoder_decoder:
-            warnings.warn(
+            warn0(
                 "When using an encoder decoder architecture, you should set `max_completion_length` in the CPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -269,7 +270,7 @@ class CPOTrainer(Trainer):
             if args.remove_unused_columns:
                 args.remove_unused_columns = False
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using DPODataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
@@ -293,7 +294,7 @@ class CPOTrainer(Trainer):
         self.processing_class = processing_class
 
         if args.loss_type in ["hinge", "ipo"] and args.label_smoothing > 0:
-            warnings.warn(
+            warn0(
                 f"You are using the {args.loss_type} loss type that does not support label smoothing. The "
                 "`label_smoothing` parameter will be ignored. Set `label_smoothing` to `0.0` to remove this warning.",
                 UserWarning,
@@ -308,7 +309,7 @@ class CPOTrainer(Trainer):
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            warnings.warn(
+            warn0(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
                 "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import random
 import textwrap
-import warnings
 from collections import defaultdict
 from contextlib import nullcontext
 from pathlib import Path

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import random
 import textwrap
-import warnings
 from collections import defaultdict
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -73,6 +73,7 @@ from .utils import (
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
+    warn0,
 )
 
 
@@ -298,7 +299,7 @@ class DPOTrainer(Trainer):
             )
 
         if args.model_init_kwargs is not None and not isinstance(model, str):
-            warnings.warn(
+            warn0(
                 "You passed model_init_kwargs to the `DPOConfig`, but your model is already instantiated. "
                 "The `model_init_kwargs` will be ignored."
             )
@@ -306,7 +307,7 @@ class DPOTrainer(Trainer):
             model = self._create_model_from_path(model, args)
 
         if args.ref_model_init_kwargs is not None and not isinstance(ref_model, str):
-            warnings.warn(
+            warn0(
                 "You passed ref_model_init_kwargs to the `DPOConfig`, but your ref_model is already instantiated. "
                 "The `ref_model_init_kwargs` will be ignored."
             )
@@ -385,7 +386,7 @@ class DPOTrainer(Trainer):
 
         if args.padding_free:
             if model.config._attn_implementation != "flash_attention_2":
-                warnings.warn(
+                warn0(
                     "Padding-free training is enabled, but the attention implementation is not set to "
                     "'flash_attention_2'. Padding-free training flattens batches into a single sequence, and "
                     "'flash_attention_2' is the only known attention mechanism that reliably supports this. Using "
@@ -394,7 +395,7 @@ class DPOTrainer(Trainer):
                     "attention mechanism can handle flattened sequences."
                 )
             if args.per_device_train_batch_size == 1:
-                warnings.warn(
+                warn0(
                     "You are using a per_device_train_batch_size of 1 with padding-free training. Using a batch size "
                     "of 1 anihilate the benefits of padding-free training. Please consider increasing the batch size "
                     "to at least 2."
@@ -410,7 +411,7 @@ class DPOTrainer(Trainer):
             args.loss_type in ["hinge", "ipo", "bco_pair", "sppo_hard", "nca_pair", "apo_zero", "apo_down"]
             and args.label_smoothing > 0
         ):
-            warnings.warn(
+            warn0(
                 f"You are using the {args.loss_type} loss type that does not support label smoothing. The "
                 "`label_smoothing` parameter will be ignored. Set `label_smoothing` to `0.0` to remove this warning.",
                 UserWarning,
@@ -425,7 +426,7 @@ class DPOTrainer(Trainer):
         self.use_weighting = args.use_weighting
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            warnings.warn(
+            warn0(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
                 "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "

--- a/trl/trainer/iterative_sft_trainer.py
+++ b/trl/trainer/iterative_sft_trainer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import warnings
 from pathlib import Path
 from typing import Callable, Optional, Union
 

--- a/trl/trainer/iterative_sft_trainer.py
+++ b/trl/trainer/iterative_sft_trainer.py
@@ -40,7 +40,7 @@ from transformers.utils import is_peft_available
 
 from ..core import PPODecorators
 from .iterative_sft_config import IterativeSFTConfig
-from .utils import generate_model_card, get_comet_experiment_url
+from .utils import generate_model_card, get_comet_experiment_url, warn0
 
 
 if is_peft_available():
@@ -118,21 +118,21 @@ class IterativeSFTTrainer(Trainer):
         deprecated_params = {}
         if max_length is not None:
             deprecated_params["max_length"] = max_length
-            warnings.warn(
+            warn0(
                 "The `max_length` parameter is deprecated and will be removed in version 0.20. "
                 "Pass it through the `args` parameter using `IterativeSFTConfig(max_length=...)` instead.",
                 DeprecationWarning,
             )
         if truncation_mode is not None:
             deprecated_params["truncation_mode"] = truncation_mode
-            warnings.warn(
+            warn0(
                 "The `truncation_mode` parameter is deprecated and will be removed in version 0.20. "
                 "Pass it through the `args` parameter using `IterativeSFTConfig(truncation_mode=...)` instead.",
                 DeprecationWarning,
             )
         if optimize_device_cache is not None:
             deprecated_params["optimize_device_cache"] = optimize_device_cache
-            warnings.warn(
+            warn0(
                 "The `optimize_device_cache` parameter is deprecated and will be removed in version 0.20  "
                 "Pass it through the `args` parameter using `IterativeSFTConfig(optimize_device_cache=...)` instead.",
                 DeprecationWarning,
@@ -160,7 +160,7 @@ class IterativeSFTTrainer(Trainer):
 
         # Model
         if args.model_init_kwargs is not None and not isinstance(model, str):
-            warnings.warn(
+            warn0(
                 "You passed model_init_kwargs to the `IterativeSFTConfig`, but your model is already instantiated. "
                 "The `model_init_kwargs` will be ignored."
             )
@@ -349,7 +349,7 @@ class IterativeSFTTrainer(Trainer):
         if input_ids is None and texts is None:
             raise ValueError("Step should include `input_ids` or `texts` as keyword arguments.")
         elif input_ids is not None and texts is not None:
-            warnings.warn(
+            warn0(
                 "Both `input_ids` and `texts` argument are provided. `input_ids` will be ignored. "
                 "Please provide only one of the two.",
                 UserWarning,

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -63,6 +63,7 @@ from .utils import (
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
+    warn0,
 )
 
 
@@ -480,7 +481,7 @@ class KTOTrainer(Trainer):
                 "max_length or a processing_class must be specified when using the default DPODataCollatorWithPadding"
             )
         if args.max_length is None:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding, you should set `max_length` in the KTOTrainer's init"
                 " it will be set to `512` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -490,7 +491,7 @@ class KTOTrainer(Trainer):
             max_length = args.max_length
 
         if args.max_prompt_length is None:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding, you should set `max_prompt_length` in the KTOTrainer's init"
                 " it will be set to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -501,7 +502,7 @@ class KTOTrainer(Trainer):
 
         max_completion_length = None
         if args.max_completion_length is None and self.is_encoder_decoder:
-            warnings.warn(
+            warn0(
                 "When using DPODataCollatorWithPadding with an encoder decoder architecture, you should set `max_completion_length` in the KTOTrainer's init"
                 " it will be set to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -520,7 +521,7 @@ class KTOTrainer(Trainer):
             if args.remove_unused_columns:
                 args.remove_unused_columns = False
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using DPODataCollatorWithPadding, you should set `remove_unused_columns=False` in your KTOConfig"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
@@ -567,7 +568,7 @@ class KTOTrainer(Trainer):
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            warnings.warn(
+            warn0(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
                 "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -14,7 +14,6 @@
 
 import os
 import textwrap
-import warnings
 from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Optional, Union

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -61,6 +61,7 @@ from .utils import (
     get_reward,
     prepare_deepspeed,
     truncate_right,
+    warn0,
 )
 
 
@@ -161,7 +162,7 @@ class OnlineDPOTrainer(Trainer):
         self.ref_model = ref_model
 
         if reward_model is not None and judge is not None:
-            warnings.warn(
+            warn0(
                 "Both `reward_model` and `judge` are provided. Please choose provide only one of them. "
                 "Ignoring `judge` and using `reward_model`.",
                 UserWarning,

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -61,6 +61,7 @@ from .utils import (
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
+    warn0,
 )
 
 
@@ -230,7 +231,7 @@ class ORPOTrainer(Trainer):
         if processing_class is None:
             raise ValueError("processing_class must be specified to tokenize a ORPO dataset.")
         if args.max_length is None:
-            warnings.warn(
+            warn0(
                 "`max_length` is not set in the ORPOConfig's init"
                 " it will default to `512` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -239,7 +240,7 @@ class ORPOTrainer(Trainer):
         else:
             max_length = args.max_length
         if args.max_prompt_length is None:
-            warnings.warn(
+            warn0(
                 "`max_prompt_length` is not set in the ORPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -249,7 +250,7 @@ class ORPOTrainer(Trainer):
             max_prompt_length = args.max_prompt_length
 
         if args.max_completion_length is None and self.is_encoder_decoder:
-            warnings.warn(
+            warn0(
                 "When using an encoder decoder architecture, you should set `max_completion_length` in the ORPOConfig's init"
                 " it will default to `128` by default, but you should do it yourself in the future.",
                 UserWarning,
@@ -268,7 +269,7 @@ class ORPOTrainer(Trainer):
             if args.remove_unused_columns:
                 args.remove_unused_columns = False
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using DPODataCollatorWithPadding, you should set `remove_unused_columns=False` in your TrainingArguments"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,
@@ -294,7 +295,7 @@ class ORPOTrainer(Trainer):
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            warnings.warn(
+            warn0(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
                 "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "
@@ -897,9 +898,10 @@ class ORPOTrainer(Trainer):
         ignore_keys: Optional[list[str]] = None,
     ):
         if not self.use_dpo_data_collator:
-            warnings.warn(
+            warn0(
                 "prediction_step is only implemented for DPODataCollatorWithPadding, and you passed a datacollator that is different than "
-                "DPODataCollatorWithPadding - you might see unexpected behavior. Alternatively, you can implement your own prediction_step method if you are using a custom data collator"
+                "DPODataCollatorWithPadding - you might see unexpected behavior. Alternatively, you can implement your own prediction_step method if you are using a custom data collator",
+                state=self.accelerator.state,
             )
         if ignore_keys is None:
             if hasattr(model, "config"):

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import random
 import textwrap
-import warnings
 from collections import defaultdict
 from contextlib import nullcontext
 from pathlib import Path

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -34,6 +34,7 @@ from transformers import (
     ProcessorMixin,
     Trainer,
     is_wandb_available,
+    warn0,
 )
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
@@ -124,7 +125,7 @@ class PRMTrainer(Trainer):
                     prepare_model_kwargs = {"use_gradient_checkpointing": args.gradient_checkpointing}
 
                     if not _supports_gc_kwargs and args.gradient_checkpointing_kwargs is not None:
-                        warnings.warn(
+                        warn0(
                             "You passed `gradient_checkpointing_kwargs` in the trainer's kwargs, but your peft version does not support it. "
                             "please update to the latest version of peft to use `gradient_checkpointing_kwargs`."
                         )

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -15,7 +15,6 @@
 import inspect
 import os
 import textwrap
-import warnings
 from itertools import chain
 from pathlib import Path
 from typing import Callable, Optional, Union

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -52,6 +52,7 @@ from .utils import (
     get_comet_experiment_url,
     log_table_to_comet_experiment,
     print_rich_table,
+    warn0,
 )
 
 
@@ -154,7 +155,7 @@ class RewardTrainer(Trainer):
                     prepare_model_kwargs = {"use_gradient_checkpointing": args.gradient_checkpointing}
 
                     if not _supports_gc_kwargs and args.gradient_checkpointing_kwargs is not None:
-                        warnings.warn(
+                        warn0(
                             "You passed `gradient_checkpointing_kwargs` in the trainer's kwargs, but your peft version does not support it. "
                             "please update to the latest version of peft to use `gradient_checkpointing_kwargs`.",
                             UserWarning,
@@ -189,7 +190,7 @@ class RewardTrainer(Trainer):
                 except FrozenInstanceError:
                     args = replace(args, remove_unused_columns=False)
                 # warn users
-                warnings.warn(
+                warn0(
                     "When using RewardDataCollatorWithPadding, you should set `remove_unused_columns=False` in your RewardConfig"
                     " we have set it for you, but you should do it yourself in the future.",
                     UserWarning,

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -14,7 +14,6 @@
 
 import inspect
 import os
-import warnings
 from collections import defaultdict
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from dataclasses import dataclass, field
 from typing import Any, Optional
 

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -18,6 +18,8 @@ from typing import Any, Optional
 
 from transformers import TrainingArguments
 
+from .utils import warn0
+
 
 @dataclass
 class SFTConfig(TrainingArguments):
@@ -254,7 +256,7 @@ class SFTConfig(TrainingArguments):
         super().__post_init__()
 
         if self.max_seq_length is not None:
-            warnings.warn(
+            warn0(
                 "`max_seq_length` is deprecated and will be removed in version 0.20.0. Use `max_length` instead.",
                 DeprecationWarning,
             )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -60,6 +60,7 @@ from .utils import (
     get_comet_experiment_url,
     pad,
     peft_module_casting_to_bf16,
+    warn0,
 )
 
 
@@ -392,7 +393,7 @@ class SFTTrainer(Trainer):
 
         # Model
         if args.model_init_kwargs is not None and not isinstance(model, str):
-            warnings.warn(
+            warn0(
                 "You passed model_init_kwargs to the `SFTConfig`, but your model is already instantiated. "
                 "The `model_init_kwargs` will be ignored."
             )
@@ -418,12 +419,12 @@ class SFTTrainer(Trainer):
             if data_collator is not None:
                 raise ValueError("Passing a custom data collator is not supported when using padding-free.")
             if args.packing and args.packing_strategy == "wrapped":
-                warnings.warn(
+                warn0(
                     "You are passing `padding_free=True` with the 'wrapped' packing strategy, which is not "
                     "recommended. Please refer to the documentation to understand why this is not recommended."
                 )
             if model.config._attn_implementation != "flash_attention_2":
-                warnings.warn(
+                warn0(
                     "Padding-free training is enabled, but the attention implementation is not set to "
                     "'flash_attention_2'. Padding-free training flattens batches into a single sequence, and "
                     "'flash_attention_2' is the only known attention mechanism that reliably supports this. Using "
@@ -432,7 +433,7 @@ class SFTTrainer(Trainer):
                     "attention mechanism can handle flattened sequences."
                 )
             if args.per_device_train_batch_size == 1 and not args.packing:
-                warnings.warn(
+                warn0(
                     "You are using a per_device_train_batch_size of 1 with padding-free training. Using a batch size "
                     "of 1 anihilate the benefits of padding-free training. Please consider increasing the batch size "
                     "to at least 2."
@@ -469,7 +470,7 @@ class SFTTrainer(Trainer):
             and args.packing_strategy == "bfd"
             and model.config._attn_implementation != "flash_attention_2"
         ):
-            warnings.warn(
+            warn0(
                 "You are using packing, but the attention implementation is not set to 'flash_attention_2'. Packing "
                 "flattens batches into a single sequence, and 'flash_attention_2' is the only known attention "
                 "mechanism that reliably supports this. Using other implementations may lead to cross-contamination "

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1892,3 +1892,13 @@ def print_prompt_completions_sample(
 
     panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
     console.print(panel)
+
+
+def warn0(message, *args, state=None, **kwargs):
+    """
+    A wrapper for warnings.warn that only emits warnings on the main process (rank 0).
+    """
+    if state is None:
+        state = PartialState()
+    if state.is_main_process:
+        warnings.warn(message, *args, **kwargs)


### PR DESCRIPTION
# What does this PR do?

### Summary

This PR introduces a new utility function `warn0`, which wraps `warnings.warn` to ensure that warnings are only emitted on the main process (rank 0). This helps reduce noise in distributed training environments.

### Changes

- Added `warn0` to `trainer/utils.py`
- Replaced instances of `warnings.warn` in the `trainer` module with `warn0`
- Ensured compatibility with `PartialState` for rank detection

### Motivation

In distributed training, emitting the same warning from every process can clutter logs and make debugging harder. This change ensures that warnings are only shown once, from the main process.

### Example

```python
from trainer.utils import warn0

warn0("This warning will only appear on rank 0.")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.