### PR TITLE
[GRPO] Fix: Processing ref logprobs in batches

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1306,12 +1306,12 @@ class GRPOTrainer(Trainer):
             if self.beta != 0.0:
                 if self.ref_model is not None:
                     ref_per_token_logps = self._get_per_token_logps_and_entropies(
-                        self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep
+                        self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep, batch_size
                     )["logps"]
                 else:
                     with self.accelerator.unwrap_model(self.model).disable_adapter():
                         ref_per_token_logps = self._get_per_token_logps_and_entropies(
-                            self.model, prompt_completion_ids, attention_mask, logits_to_keep
+                            self.model, prompt_completion_ids, attention_mask, logits_to_keep, batch_size
                         )["logps"]
             else:
                 ref_per_token_logps = None


### PR DESCRIPTION
Until commit d6a969f, ref_per_token_logps was calculated inside _compute_loss or compute_liger_loss, which gets input of size per_device_batch_size. 
Since it moved to _generate_and_score_completions it now need to be passed a batch_size. Without it, memory consumption is not independent of the number of gradient accumulations and can spike when beta != 0
