### PR TITLE
Add local dataset support to TRL CLI

### DIFF
--- a/tests/test_local_dataset.py
+++ b/tests/test_local_dataset.py
@@ -1,0 +1,224 @@
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from trl.scripts.utils import _infer_dataset_format, is_local_dataset, load_dataset_with_local_support
+
+
+class TestLocalDataset(unittest.TestCase):
+    def test_is_local_dataset_relative_paths(self):
+        """Test detection of relative paths."""
+        self.assertTrue(is_local_dataset("./data/train.json"))
+        self.assertTrue(is_local_dataset("./my_dataset.csv"))
+        self.assertTrue(is_local_dataset("./folder/subfolder/data.parquet"))
+
+    def test_is_local_dataset_absolute_paths(self):
+        """Test detection of absolute paths."""
+        self.assertTrue(is_local_dataset("/home/user/data.json"))
+        self.assertTrue(is_local_dataset("/data/train.csv"))
+        self.assertTrue(is_local_dataset("/tmp/dataset.parquet"))
+
+    def test_is_local_dataset_home_paths(self):
+        """Test detection of home directory paths."""
+        self.assertTrue(is_local_dataset("~/data/train.json"))
+        self.assertTrue(is_local_dataset("~user/data.csv"))
+        self.assertTrue(is_local_dataset("~/datasets/my_data.parquet"))
+
+    def test_is_local_dataset_windows_paths(self):
+        """Test detection of Windows drive letter paths."""
+        self.assertTrue(is_local_dataset("C:\\data\\train.json"))
+        self.assertTrue(is_local_dataset("D:\\datasets\\data.csv"))
+        self.assertTrue(is_local_dataset("C:/data/train.json"))
+
+    def test_is_local_dataset_huggingface_names(self):
+        """Test that HuggingFace dataset names are not detected as local."""
+        self.assertFalse(is_local_dataset("squad"))
+        self.assertFalse(is_local_dataset("trl-lib/Capybara"))
+        self.assertFalse(is_local_dataset("huggingface/dataset"))
+        self.assertFalse(is_local_dataset("my-dataset"))
+        self.assertFalse(is_local_dataset("organization/dataset-name"))
+
+    def test_is_local_dataset_edge_cases(self):
+        """Test edge cases that should not be detected as local."""
+        # These might look like they could be local but don't match our patterns
+        self.assertFalse(is_local_dataset("data.json"))  # No path prefix
+        self.assertFalse(is_local_dataset("train.csv"))  # No path prefix
+        self.assertFalse(is_local_dataset("folder/data.parquet"))  # No path prefix
+
+    def test_infer_dataset_format_json(self):
+        """Test format inference for JSON files."""
+        self.assertEqual(_infer_dataset_format("data.json"), "json")
+        self.assertEqual(_infer_dataset_format("./data/train.json"), "json")
+        self.assertEqual(_infer_dataset_format("/home/user/data.JSON"), "json")
+
+    def test_infer_dataset_format_csv(self):
+        """Test format inference for CSV files."""
+        self.assertEqual(_infer_dataset_format("data.csv"), "csv")
+        self.assertEqual(_infer_dataset_format("./data/train.csv"), "csv")
+        self.assertEqual(_infer_dataset_format("/home/user/data.CSV"), "csv")
+
+    def test_infer_dataset_format_parquet(self):
+        """Test format inference for Parquet files."""
+        self.assertEqual(_infer_dataset_format("data.parquet"), "parquet")
+        self.assertEqual(_infer_dataset_format("./data/train.parquet"), "parquet")
+        self.assertEqual(_infer_dataset_format("/home/user/data.PARQUET"), "parquet")
+
+    def test_infer_dataset_format_text(self):
+        """Test format inference for text files."""
+        self.assertEqual(_infer_dataset_format("data.txt"), "text")
+        self.assertEqual(_infer_dataset_format("./data/train.txt"), "text")
+        self.assertEqual(_infer_dataset_format("/home/user/data.TXT"), "text")
+
+    def test_infer_dataset_format_jsonl(self):
+        """Test format inference for JSONL files."""
+        self.assertEqual(_infer_dataset_format("data.jsonl"), "json")
+        self.assertEqual(_infer_dataset_format("./data/train.jsonl"), "json")
+        self.assertEqual(_infer_dataset_format("/home/user/data.JSONL"), "json")
+
+    def test_infer_dataset_format_unknown(self):
+        """Test format inference for unknown file types."""
+        self.assertIsNone(_infer_dataset_format("data.unknown"))
+        self.assertIsNone(_infer_dataset_format("./data/train.xyz"))
+        self.assertIsNone(_infer_dataset_format("/home/user/data"))
+
+    def test_load_dataset_with_local_support_local_json(self):
+        """Test loading a local JSON dataset."""
+        # Create a temporary JSON file
+        sample_data = [
+            {"text": "This is a test sentence.", "label": 0},
+            {"text": "Another test sentence.", "label": 1},
+        ]
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sample_data, f)
+            temp_file = f.name
+
+        try:
+            # Test loading with local path
+            dataset = load_dataset_with_local_support(temp_file)
+
+            # Verify it's a dataset and contains our data
+            self.assertIsNotNone(dataset)
+            self.assertEqual(len(dataset["train"]), 2)
+            self.assertEqual(dataset["train"][0]["text"], "This is a test sentence.")
+            self.assertEqual(dataset["train"][1]["label"], 1)
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_load_dataset_with_local_support_local_csv(self):
+        """Test loading a local CSV dataset."""
+        # Create a temporary CSV file
+        csv_content = "text,label\nThis is a test sentence.,0\nAnother test sentence.,1"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(csv_content)
+            temp_file = f.name
+
+        try:
+            # Test loading with local path
+            dataset = load_dataset_with_local_support(temp_file)
+
+            # Verify it's a dataset and contains our data
+            self.assertIsNotNone(dataset)
+            self.assertEqual(len(dataset["train"]), 2)
+            self.assertEqual(dataset["train"][0]["text"], "This is a test sentence.")
+            self.assertEqual(dataset["train"][1]["label"], 1)  # CSV loads as integers for numeric values
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_load_dataset_with_local_support_file_not_found(self):
+        """Test error handling when local file doesn't exist."""
+        with self.assertRaises(FileNotFoundError):
+            load_dataset_with_local_support("./nonexistent_file.json")
+
+    def test_load_dataset_with_local_support_home_expansion(self):
+        """Test that home directory paths are expanded."""
+        # Create a temporary file in home directory
+        home_dir = os.path.expanduser("~")
+        temp_file = os.path.join(home_dir, "temp_dataset.json")
+
+        sample_data = [{"text": "Home test", "label": 0}]
+
+        with open(temp_file, "w") as f:
+            json.dump(sample_data, f)
+
+        try:
+            # Test loading with ~ path
+            dataset = load_dataset_with_local_support("~/temp_dataset.json")
+
+            # Verify it's a dataset and contains our data
+            self.assertIsNotNone(dataset)
+            self.assertEqual(len(dataset["train"]), 1)
+            self.assertEqual(dataset["train"][0]["text"], "Home test")
+
+        finally:
+            os.unlink(temp_file)
+
+    @patch("trl.scripts.utils.load_dataset")
+    def test_load_dataset_with_local_support_huggingface_dataset(self, mock_load_dataset):
+        """Test that HuggingFace datasets are loaded normally."""
+        # Mock the datasets.load_dataset function
+        mock_load_dataset.return_value = {"train": [{"text": "HF data"}]}
+
+        # Test loading HuggingFace dataset
+        dataset = load_dataset_with_local_support("squad", name="v1.1", streaming=False)
+
+        # Verify the mock was called with correct parameters
+        mock_load_dataset.assert_called_once_with("squad", name="v1.1", streaming=False)
+        self.assertEqual(dataset["train"][0]["text"], "HF data")
+
+    def test_load_dataset_with_local_support_streaming(self):
+        """Test that streaming parameter is passed correctly."""
+        # Create a temporary JSON file
+        sample_data = [{"text": "Streaming test", "label": 0}]
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sample_data, f)
+            temp_file = f.name
+
+        try:
+            # Test loading with streaming=True
+            dataset = load_dataset_with_local_support(temp_file, streaming=True)
+
+            # Verify it's a dataset (streaming datasets work differently)
+            self.assertIsNotNone(dataset)
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_load_dataset_with_local_support_unknown_format(self):
+        """Test loading a local file with unknown format."""
+        # Create a temporary file with unknown extension
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xyz", delete=False) as f:
+            f.write("unknown format content")
+            temp_file = f.name
+
+        try:
+            # This should fail because datasets.load_dataset cannot handle unknown formats
+            with self.assertRaises((ValueError, OSError)):
+                load_dataset_with_local_support(temp_file)
+
+        finally:
+            os.unlink(temp_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trl/scripts/dpo.py
+++ b/trl/scripts/dpo.py
@@ -56,7 +56,6 @@ python trl/scripts/dpo.py \
 import argparse
 
 import torch
-from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl import (
@@ -69,6 +68,7 @@ from trl import (
     get_peft_config,
     get_quantization_config,
 )
+from trl.scripts.utils import load_dataset_with_local_support
 from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
 
 
@@ -114,7 +114,7 @@ def main(script_args, training_args, model_args):
     ################
     # Dataset
     ################
-    dataset = load_dataset(
+    dataset = load_dataset_with_local_support(
         script_args.dataset_name,
         name=script_args.dataset_config,
         streaming=script_args.dataset_streaming,

--- a/trl/scripts/grpo.py
+++ b/trl/scripts/grpo.py
@@ -19,11 +19,11 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
-from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 
 from trl import GRPOConfig, GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
 from trl.rewards import think_format_reward
+from trl.scripts.utils import load_dataset_with_local_support
 
 
 reward_funcs_registry = {
@@ -95,7 +95,9 @@ def main(script_args, training_args, model_args):
                 )
 
     # Load the dataset
-    dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    dataset = load_dataset_with_local_support(
+        script_args.dataset_name, name=script_args.dataset_config, streaming=script_args.dataset_streaming
+    )
 
     # Initialize the GRPO trainer
     trainer = GRPOTrainer(

--- a/trl/scripts/kto.py
+++ b/trl/scripts/kto.py
@@ -59,7 +59,6 @@ python trl/scripts/kto.py \
 
 import argparse
 
-from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl import (
@@ -71,6 +70,7 @@ from trl import (
     get_peft_config,
     setup_chat_format,
 )
+from trl.scripts.utils import load_dataset_with_local_support
 
 
 def main(script_args, training_args, model_args):
@@ -93,7 +93,9 @@ def main(script_args, training_args, model_args):
         model, tokenizer = setup_chat_format(model, tokenizer)
 
     # Load the dataset
-    dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    dataset = load_dataset_with_local_support(
+        script_args.dataset_name, name=script_args.dataset_config, streaming=script_args.dataset_streaming
+    )
 
     # Initialize the KTO trainer
     trainer = KTOTrainer(

--- a/trl/scripts/sft.py
+++ b/trl/scripts/sft.py
@@ -51,11 +51,27 @@ python trl/scripts/sft.py \
     --output_dir Qwen2-0.5B-SFT \
     --push_to_hub
 ```
+
+# Local dataset
+```
+python trl/scripts/sft.py \
+    --model_name_or_path Qwen/Qwen2-0.5B \
+    --dataset_name ./data/my_dataset.json \
+    --learning_rate 2.0e-5 \
+    --num_train_epochs 1 \
+    --packing \
+    --per_device_train_batch_size 2 \
+    --gradient_accumulation_steps 8 \
+    --gradient_checkpointing \
+    --eos_token '<|im_end|>' \
+    --eval_strategy steps \
+    --eval_steps 100 \
+    --output_dir Qwen2-0.5B-SFT
+```
 """
 
 import argparse
 
-from datasets import load_dataset
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.models.auto.modeling_auto import MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
 
@@ -70,6 +86,7 @@ from trl import (
     get_peft_config,
     get_quantization_config,
 )
+from trl.scripts.utils import load_dataset_with_local_support
 
 
 def main(script_args, training_args, model_args):
@@ -112,7 +129,9 @@ def main(script_args, training_args, model_args):
     ################
     # Dataset
     ################
-    dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    dataset = load_dataset_with_local_support(
+        script_args.dataset_name, name=script_args.dataset_config, streaming=script_args.dataset_streaming
+    )
 
     ################
     # Training


### PR DESCRIPTION
# What does this PR do?

This change adds support for loading local datasets in the TRL CLI scripts, allowing users to train models on local files without needing to upload them to HuggingFace Hub first.

Key changes:
- Added `is_local_dataset()` function to detect local file paths
- Added `load_dataset_with_local_support()` wrapper function
- Updated all CLI scripts (SFT, DPO, GRPO, KTO) to use local dataset loading
- Added comprehensive tests for local dataset functionality
- Updated help text to document local dataset support
- Maintained full backward compatibility with existing HuggingFace datasets

The implementation conservatively detects local paths that start with './', '/', '~', or Windows drive letters to avoid false positives with HuggingFace dataset names.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.