### PR TITLE
Support dLLM in GRPO reference model creation

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -34,6 +34,7 @@ from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.utils.data import DataLoader, Sampler
 from transformers import (
+    AutoModel,
     AutoModelForCausalLM,
     AutoModelForSequenceClassification,
     AutoTokenizer,
@@ -584,7 +585,7 @@ class GRPOTrainer(Trainer):
             self.ref_model = None
         else:
             # For deepspeed, fsdp or non-distributed models, create a reference model from scratch
-            self.ref_model = AutoModelForCausalLM.from_pretrained(model_id, **model_init_kwargs)
+            self.ref_model = AutoModel.from_pretrained(model_id, **model_init_kwargs)
 
         # Disable dropout in the models
         if args.disable_dropout:


### PR DESCRIPTION
The current `GRPOTrainer` creates a reference model with `AutoModelForCausalLM` when deepspeed zero3 is enabled. This is not compatible with recent diffusion language models like [DiffuCoder](https://github.com/apple/ml-diffucoder). These models need to be loaded using `AutoModel` instead of `AutoModelForCausalLM`. 

The proposed change is a simple one-liner.

Fixes #3742