### PR TITLE
uses `steps_per_generation` in vllm max_num_seqs

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -677,7 +677,7 @@ class GRPOTrainer(Trainer):
                     gpu_memory_utilization=self.vllm_gpu_memory_utilization,
                     max_num_seqs=self.args.per_device_train_batch_size
                     * self.vllm_tensor_parallel_size
-                    * self.args.gradient_accumulation_steps,
+                    * self.args.steps_per_generation,
                     max_model_len=self.max_prompt_length + self.max_completion_length,
                     distributed_executor_backend="external_launcher",
                     # Feed identical seed for tp groups to ensure sampling results are the same across workers


### PR DESCRIPTION
# What does this PR do?
- vllm `max_num_seqs` should reflect the actual maximum number of sequences that can be passed to vLLM. Since `steps_per_generation` determines the effective batch size with the dataloader, it should be used instead of `gradient_accumulation_steps`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.