### PR TITLE
🔔 Add deprecation warnings for `AlignPropTrainer` and `DDPOTrainer`

### DIFF
--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -14,10 +14,10 @@
 
 import os
 import textwrap
+import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
-from warnings import warn
 
 import torch
 from accelerate import Accelerator
@@ -66,8 +66,12 @@ class AlignPropTrainer(PyTorchModelHubMixin):
         sd_pipeline: DDPOStableDiffusionPipeline,
         image_samples_hook: Optional[Callable[[Any, Any, Any], Any]] = None,
     ):
+        warnings.warn(
+            "AlignPropTrainer is deprecated and will be removed in version 0.23.0.",
+            DeprecationWarning,
+        )
         if image_samples_hook is None:
-            warn("No image_samples_hook provided; no images will be logged")
+            warnings.warn("No image_samples_hook provided; no images will be logged")
 
         self.prompt_fn = prompt_function
         self.reward_fn = reward_function

--- a/trl/trainer/ddpo_trainer.py
+++ b/trl/trainer/ddpo_trainer.py
@@ -14,11 +14,11 @@
 
 import os
 import textwrap
+import warnings
 from collections import defaultdict
 from concurrent import futures
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
-from warnings import warn
 
 import torch
 from accelerate import Accelerator
@@ -64,8 +64,12 @@ class DDPOTrainer(PyTorchModelHubMixin):
         sd_pipeline: DDPOStableDiffusionPipeline,
         image_samples_hook: Optional[Callable[[Any, Any, Any], Any]] = None,
     ):
+        warnings.warn(
+            "DDPOTrainer is deprecated and will be removed in version 0.23.0.",
+            DeprecationWarning,
+        )
         if image_samples_hook is None:
-            warn("No image_samples_hook provided; no images will be logged")
+            warnings.warn("No image_samples_hook provided; no images will be logged")
 
         self.prompt_fn = prompt_function
         self.reward_fn = reward_function


### PR DESCRIPTION
# What does this PR do?

Usage for these trainers are very low. We will deprecate them and remove in three versions.