### PR TITLE
change doc for `num_iterations` and `steps_per_generation` to hopefully make them more clear and differentiate between them more clearly

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -70,8 +70,9 @@ class GRPOConfig(TrainingArguments):
             `per_device_train_batch_size * num_processes * steps_per_generation`. In other words, there is one
             generation batch processed per optimization step. Mutually exclusive with `steps_per_generation`.
         steps_per_generation: (`int` or `None`, *optional*, defaults to `None`):
-            Number of steps per generation. If `None`, it defaults to `gradient_accumulation_steps`. Mutually exclusive
-            with `generation_batch_size`.
+            Number of mini-steps per generation. generations will be split into `steps_per_generation` steps, for each step a forward pass will be performed on.
+            if `steps_per_generation` > gradient_accumulation_steps, we will have off-policy training.
+            If `None`, it defaults to `gradient_accumulation_steps`. Mutually exclusive with `generation_batch_size`.
         temperature (`float`, defaults to `1.0`):
             Temperature for sampling. The higher the temperature, the more random the completions.
         top_p (`float`, *optional*, defaults to `1.0`):
@@ -145,7 +146,7 @@ class GRPOConfig(TrainingArguments):
             KL coefficient. If `0.0` (default), the reference model is not loaded, reducing memory usage and improving
             training speed.
         num_iterations (`int`, *optional*, defaults to `1`):
-            Number of iterations per batch (denoted as μ in the algorithm).
+            Number of iterations/epochs per generation batch (denoted as μ in the algorithm).
         epsilon (`float`, *optional*, defaults to `0.2`):
             Epsilon value for clipping.
         delta: (`float` or `None`, *optional*, defaults to `None`):
@@ -305,7 +306,9 @@ class GRPOConfig(TrainingArguments):
     )
     steps_per_generation: Optional[int] = field(
         default=None,
-        metadata={"help": "Number of steps per generation. If `None`, it defaults to `gradient_accumulation_steps`."},
+        metadata={"help": "Number of mini-steps per generation. generations will be split into `steps_per_generation` steps, for each step a forward pass will be performed on."
+                          "if `steps_per_generation` > gradient_accumulation_steps, we will have off-policy training."
+                          "If `None`, it defaults to `gradient_accumulation_steps`. Mutually exclusive with `generation_batch_size`."},
     )
     temperature: float = field(
         default=1.0,
@@ -437,7 +440,7 @@ class GRPOConfig(TrainingArguments):
     )
     num_iterations: int = field(
         default=1,
-        metadata={"help": "Number of iterations per batch (denoted as μ in the algorithm)."},
+        metadata={"help": "Number of iterations/epochs per generation batch (denoted as μ in the algorithm)."},
     )
     epsilon: float = field(
         default=0.2,


### PR DESCRIPTION
change the phrasing of docs for `steps_per_generation` and `num_iterations` to make them clearer and to differentiate what they do better.

fixes #3197 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

@qgallouedec as we have discussed in #3197. this is what I think could make the docs clearer. would love to hear your opinion