### PR TITLE
Fix clone chat template

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -85,7 +85,7 @@ model = AutoModelForCausalLM.from_pretrained("facebook/opt-350m")
 tokenizer = AutoTokenizer.from_pretrained("facebook/opt-350m")
 
 # Set up the chat format
-model, tokenizer = clone_chat_template(model, tokenizer, "Qwen/Qwen3-0.6B")
+model, tokenizer, _ = clone_chat_template(model, tokenizer, "Qwen/Qwen3-0.6B")
 ```
 
 > [!WARNING]

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -149,7 +149,7 @@ def clone_chat_template(
     tokenizer: PreTrainedTokenizer,
     source_tokenizer_path: str,
     resize_to_multiple_of: Optional[int] = 64,
-) -> tuple[PreTrainedModel, PreTrainedTokenizer, list[AddedToken]]:
+) -> tuple[PreTrainedModel, PreTrainedTokenizer, list[int]]:
     """
     Clones a chat template from a source tokenizer to the target tokenizer and updates the model accordingly.
 
@@ -177,7 +177,7 @@ def clone_chat_template(
             Updated model with resized token embeddings and EOS token configured.
         tokenizer (`~transformers.PreTrainedTokenizer`):
             Updated tokenizer with the chat template and special tokens applied.
-        added_tokens (`list[AddedToken]`):
+        added_tokens (`list[int]`):
             List of tokens that were added to the tokenizer from the source tokenizer.
 
     Example:


### PR DESCRIPTION
# What does this PR do?

This PR addresses 2 issues:

- Fix `clone_chat_template` to handle dummy token addition for vocabulary size alignment. Before this change, the returned model and tokenizer may not have the same vocab size, which causes the loading of the trained model to fail.

- Enhance `SFTTrainer` to handle added tokens from chat template cloning: it ensures that both the `lm_head` and the new embed tokens are trainable