### PR TITLE
🩹 [Hotfix] Fix pynccl communicator assertion error with VLLMClient

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -794,7 +794,7 @@ class GRPOTrainer(Trainer):
                 else:
                     base_url = f"http://{args.vllm_server_host}:{args.vllm_server_port}"
                 self.vllm_client = VLLMClient(base_url=base_url, connection_timeout=args.vllm_server_timeout)
-                self.vllm_client.init_communicator(device=self.accelerator.device)
+                self.vllm_client.init_communicator(device=torch.cuda.current_device())
 
             elif self.vllm_mode == "colocate":
                 # Make sure vllm_tensor_parallel_size group size evenly divides the world size - each group should have


### PR DESCRIPTION
# What does this PR do?

In my previous PR merged today (PR #3762), one of the change was to pass the device of the main training process as an argument to `VLLMClient.init_communicator`, instead of the hardcoded `0` that was set before:

```python
# grpo_trainer.py:797
self.vllm_client.init_communicator(device=self.accelerator.device)
```
This is valid since this argument is used to instantiate the `PyNcclCommunicator` class, that accepts this argument as `str`, `int` or `torch.device`.

But in some scenarios that I was doing experiments I started to get this error:
```
Traceback (most recent call last):
  File "/workspace/trl/main.py", line 32, in <module>
    trainer = GRPOTrainer(
  File "/workspace/trl/trl/trainer/grpo_trainer.py", line 797, in __init__
    self.vllm_client.init_communicator(device=self.accelerator.device)
  File "/workspace/trl/trl/extras/vllm_client.py", line 291, in init_communicator
    self.pynccl_comm = PyNcclCommunicator(pg, device=device)
  File "/workspace/trl/.venv/lib/python3.10/site-packages/vllm/distributed/device_communicators/pynccl.py", line 108, in __init__
    self.all_reduce(data)
  File "/workspace/trl/.venv/lib/python3.10/site-packages/vllm/distributed/device_communicators/pynccl.py", line 126, in all_reduce
    assert in_tensor.device == self.device, (
AssertionError: this nccl communicator is created to work on cuda, but the input tensor is on cuda:0
```

Turns out that to broadcast a tensor to the group vllm pynccl is doing an assertion test like this:
```python
assert in_tensor.device == self.device, (
            f"this nccl communicator is created to work on {self.device}, "
            f"but the input tensor is on {in_tensor.device}")
```

The problem is being caused because the `in_tensor.device` is torch.device('cuda') and `self.device` (device passed by argument by `init_communicator` method) is torch.device('cuda:0'), both are of the type cuda and refer to the same physical device in this situation, but one has an index (0) and the other doesn't. And it turns out pytorch doesn't return True in their comparison even if they refer to the same device:

```python
>>> torch.device('cuda')==torch.device('cuda:0')
False
>>> str(torch.cuda.get_device_properties('cuda').uuid)
'2f90175d-a8af-5859-de9b-73d07d77028f'
>>> str(torch.cuda.get_device_properties('cuda:0').uuid)
'2f90175d-a8af-5859-de9b-73d07d77028f'
```

So to avoid this error being raised when using the GRPO trainer, I've made this change:
```python
self.vllm_client.init_communicator(device=torch.cuda.current_device())
```

This will pass the current device as an integer and will be interpreted just as before, not raising the assertion error.

I believe this may be an unintended behavior by the vLLM function, so I may open an issue or PR in the vLLM page to see if it would be viable to improve this checking, but in the meantime it's important to change this argument so it doesn't raise the assertion error.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.