### PR TITLE
add xpu support for mergekit

### DIFF
--- a/trl/mergekit_utils.py
+++ b/trl/mergekit_utils.py
@@ -273,6 +273,7 @@ def merge_models(config: MergeConfig, out_path: str):
         config,
         out_path=out_path,
         options=MergeOptions(
+            device="auto",
             cuda=torch.cuda.is_available(),
             copy_tokenizer=True,
             lazy_unpickle=False,


### PR DESCRIPTION
from `mergekit` 0.1.3, we added a `device` field into `MergeOptions` to support other pytorch accelerators as Intel XPU. For versions before 0.1.3, since `MergeOptions` uses the default `ignore`  way to handle extra fields, so it's still OK for these older versions to input extra `device` to it.

@kashif , pls help review and comment, thx very much.