### PR TITLE
fix CI docs and grpo slow test

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -2,7 +2,7 @@ name: Slow tests (on push)
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       # Run only when python files are modified
       - "trl/**.py"
@@ -12,13 +12,16 @@ env:
   IS_GITHUB_CI: "1"
   SLACK_API_TOKEN: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
-
 jobs:
   run_all_tests_single_gpu:
     strategy:
       fail-fast: false
       matrix:
-        docker-image-name: ["huggingface/trl-latest-gpu:latest", "huggingface/trl-source-gpu:latest"]
+        docker-image-name:
+          [
+            "huggingface/trl-latest-gpu:latest",
+            "huggingface/trl-source-gpu:latest",
+          ]
     runs-on:
       group: aws-g4dn-2xlarge
     env:
@@ -35,7 +38,7 @@ jobs:
       - name: Pip install
         run: |
           source activate trl
-          pip install -e ".[test]" --no-deps
+          pip install -e ".[test,vlm]" --no-deps
           pip install pytest-reportlog parameterized
 
       - name: Run slow SFT tests on single GPU
@@ -43,19 +46,22 @@ jobs:
         run: |
           source activate trl
           make slow_tests
-      
+
       - name: Generate Report
         if: always()
         run: |
           pip install slack_sdk tabulate
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
-
   run_all_tests_multi_gpu:
     strategy:
       fail-fast: false
       matrix:
-        docker-image-name: ["huggingface/trl-latest-gpu:latest", "huggingface/trl-source-gpu:latest"]
+        docker-image-name:
+          [
+            "huggingface/trl-latest-gpu:latest",
+            "huggingface/trl-source-gpu:latest",
+          ]
     runs-on:
       group: aws-g4dn-2xlarge
     env:
@@ -72,7 +78,7 @@ jobs:
       - name: Pip install
         run: |
           source activate trl
-          pip install -e ".[test]" --no-deps
+          pip install -e ".[test,vlm]" --no-deps
           pip install pytest-reportlog parameterized
 
       - name: Run slow SFT tests on Multi GPU
@@ -87,7 +93,7 @@ jobs:
           source activate trl
           pip install deepspeed
           make test_examples
-      
+
       - name: Generate Reports
         if: always()
         run: |

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -163,7 +163,7 @@ training_args = SFTConfig(assistant_only_loss=True)
 ![train_on_assistant](https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/train_on_assistant.png)
 
 > [!WARNING]
-> This functionality is only available for chat templates that support returning the assistant tokens mask via the `{% generation %}` and `{% endgeneration %}` keywords. For an example of such a template, see [HugggingFaceTB/SmolLM3-3B](https://huggingface.co/HuggingFaceTB/SmolLM3-3B/blob/main/chat_template.jinja#L76-L82).
+> This functionality is only available for chat templates that support returning the assistant tokens mask via the `{% raw %}{% generation %}{% endraw %}` and `{% raw %}{% endgeneration %}{% endraw %}` keywords. For an example of such a template, see [HugggingFaceTB/SmolLM3-3B](https://huggingface.co/HuggingFaceTB/SmolLM3-3B/blob/main/chat_template.jinja#L76-L82).
 
 ### Train on completion only
 


### PR DESCRIPTION
# What does this PR do?

Fix the CI docs failure now that we have the liquid tags escaped:

<img width="900" height="198" alt="Screenshot 2025-07-30 at 20 11 42" src="https://github.com/user-attachments/assets/9dca1a16-ff8e-46d4-97d8-710e658ca52b" />

