### PR TITLE
Update profiling.py: fix scoping problems for wandb and mlflow

### DIFF
--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -15,18 +15,19 @@
 import contextlib
 import functools
 import time
+import importlib
 from collections.abc import Generator
 
 from transformers import Trainer
 from transformers.integrations import is_mlflow_available, is_wandb_available
 
-
+wandb = None
 if is_wandb_available():
-    import wandb
+    wandb = importlib.import_module("wandb")
 
+mlflow = None
 if is_mlflow_available():
-    import mlflow
-
+    mlflow = importlib.import_module("mlflow")
 
 @contextlib.contextmanager
 def profiling_context(trainer: Trainer, name: str) -> Generator[None, None, None]:


### PR DESCRIPTION
# Fixes scoping problem for wandb and mlflow

In the current version, wandb and mlflow goes out of scope once we exit the if statement. 

When we run train() on GRPOTrainer with report_to=['wandb'] parameter specified in GRPOConfig, the program fails in line 64 (if "wandb" in trainer.args.report_to and wandb.run is not None and trainer.accelerator.is_main_process) with NameError.

This is the error message with the current version: "NameError: name 'wandb' is not defined"

After the patch, the run is successful.

I anticipate the same issue to exist for mlflow so I applied the same fix on that as well.

[HuggingFace Contributor Guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)



for reference, I also reproduce the code I ran and the full stack trace of the error:

```python
import torch
from datasets import load_dataset
from peft import LoraConfig, get_peft_model
from transformers import AutoModelForCausalLM, AutoTokenizer
from trl.trl import GRPOConfig, GRPOTrainer  # trl.trl because I changed the source code and then ran pip install -e .
import wandb
import os


training_args = GRPOConfig(
    output_dir="GRPO",
    learning_rate=2e-5,
    per_device_train_batch_size=8,
    gradient_accumulation_steps=2,
    max_prompt_length=512,
    max_completion_length=96,
    num_generations=8,
    optim="adamw_8bit",
    num_train_epochs=1,
    bf16=True,
    # report_to=["wandb"],
    remove_unused_columns=False,
    logging_steps=1,
)

# trainer
trainer = GRPOTrainer(
    model=model,
    reward_funcs=[reward_len],
    args=training_args,
    train_dataset=dataset["train"],
)

# train model
wandb.init(project="GRPO")
print(trainer.accelerator.is_main_process)
trainer.train()
```


error:
```
NameError Traceback (most recent call last) Cell In[44], line 11 9 # train model 10 wandb.init(project="GRPO") ---> 11 trainer.train() File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/transformers/trainer.py:2206, in Trainer.train(self, resume_from_checkpoint, trial, ignore_keys_for_eval, **kwargs) 2204 hf_hub_utils.enable_progress_bars() 2205 else: -> 2206 return inner_training_loop( 2207 args=args, 2208 resume_from_checkpoint=resume_from_checkpoint, 2209 trial=trial, 2210 ignore_keys_for_eval=ignore_keys_for_eval, 2211 ) File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/transformers/trainer.py:2548, in Trainer._inner_training_loop(self, batch_size, args, resume_from_checkpoint, trial, ignore_keys_for_eval) 2541 context = ( 2542 functools.partial(self.accelerator.no_sync, model=model) 2543 if i != len(batch_samples) - 1 2544 and self.accelerator.distributed_type != DistributedType.DEEPSPEED 2545 else contextlib.nullcontext 2546 ) 2547 with context(): -> 2548 tr_loss_step = self.training_step(model, inputs, num_items_in_batch) 2550 if ( 2551 args.logging_nan_inf_filter 2552 and not is_torch_xla_available() 2553 and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step)) 2554 ): 2555 # if loss is nan or inf simply add the average of previous logged losses 2556 tr_loss = tr_loss + tr_loss / (1 + self.state.global_step - self._globalstep_last_logged) File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/transformers/trainer.py:3743, in Trainer.training_step(self, model, inputs, num_items_in_batch) 3740 if hasattr(self.optimizer, "train") and callable(self.optimizer.train): 3741 self.optimizer.train() -> 3743 inputs = self._prepare_inputs(inputs) 3744 if is_sagemaker_mp_enabled(): 3745 loss_mb = smp_forward_backward(model, inputs, self.args.gradient_accumulation_steps) File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/trl/extras/profiling.py:98, in profiling_decorator.<locals>.wrapper(self, *args, **kwargs) 95 @functools.wraps(func) 96 def wrapper(self, *args, **kwargs): 97 with profiling_context(self, func.__name__): ---> 98 return func(self, *args, **kwargs) File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/trl/trainer/grpo_trainer.py:1279, in GRPOTrainer._prepare_inputs(self, generation_batch) 1276 generate_every = self.args.steps_per_generation * self.num_iterations 1277 if self._step % generate_every == 0 or self._buffered_inputs is None: 1278 # self._buffered_inputs=None can occur when resuming from a checkpoint -> 1279 generation_batch = self._generate_and_score_completions(generation_batch) 1280 generation_batch = split_pixel_values_by_grid(generation_batch) 1281 generation_batch = shuffle_sequence_dict(generation_batch) File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/trl/trainer/grpo_trainer.py:1569, in GRPOTrainer._generate_and_score_completions(self, inputs) 1565 self.model_wrapped.config._attn_implementation = previous_attn 1566 else: 1567 # Regular generation path 1568 with ( -> 1569 profiling_context(self, "transformers.generate"), 1570 unwrap_model_for_generation( 1571 self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation 1572 ) as unwrapped_model, 1573 torch.no_grad(), 1574 FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(), 1575 ): 1576 prompt_inputs["input_ids"], prompt_inputs["attention_mask"] = prompt_ids, prompt_mask 1577 prompt_completion_ids = unwrapped_model.generate( 1578 **prompt_inputs, generation_config=self.generation_config 1579 ) File ~/miniconda3/envs/pdf-marker/lib/python3.12/contextlib.py:144, in _GeneratorContextManager.__exit__(self, typ, value, traceback) 142 if typ is None: 143 try: --> 144 next(self.gen) 145 except StopIteration: 146 return False File ~/miniconda3/envs/pdf-marker/lib/python3.12/site-packages/trl/extras/profiling.py:64, in profiling_context(trainer, name) 61 duration = end_time - start_time 63 profiling_metrics = {f"profiling/Time taken: {trainer.__class__.__name__}.{name}": duration} ---> 64 if "wandb" in trainer.args.report_to and wandb.run is not None and trainer.accelerator.is_main_process: 65 wandb.log(profiling_metrics) 67 if "mlflow" in trainer.args.report_to and mlflow.run is not None and trainer.accelerator.is_main_process: NameError: name 'wandb' is not defined
```
