### PR TITLE
[#3647] Fix: Assign default values in the GKDTrainer's constructor only when …

### DIFF
--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -77,8 +77,9 @@ class GKDTrainer(SFTTrainer):
         peft_config: Optional["PeftConfig"] = None,
         formatting_func: Optional[Callable] = None,
     ):
-        # add remove_unused_columns=False to the dataclass args
         if args is not None:
+            # Adds remove_unused_columns=False to the dataclass args.
+            # TODO(seungduk-yanolja): Please describe why this is necessary.
             args.remove_unused_columns = False
         if data_collator is None:
             data_collator = DataCollatorForChatML(tokenizer=processing_class, max_length=args.max_length)

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -78,8 +78,10 @@ class GKDTrainer(SFTTrainer):
         formatting_func: Optional[Callable] = None,
     ):
         # add remove_unused_columns=False to the dataclass args
-        args.remove_unused_columns = False
-        data_collator = DataCollatorForChatML(tokenizer=processing_class, max_length=args.max_length)
+        if args is not None:
+            args.remove_unused_columns = False
+        if data_collator is None:
+            data_collator = DataCollatorForChatML(tokenizer=processing_class, max_length=args.max_length)
 
         super().__init__(
             model,

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -63,6 +63,8 @@ class GKDTrainer(SFTTrainer):
         self,
         model: Optional[Union[PreTrainedModel, nn.Module, str]] = None,
         teacher_model: Union[PreTrainedModel, nn.Module, str] = None,
+        # Cannot be None but is optional because the prior arguments have default values
+        # and we cannot reorder them without breaking compatibility.
         args: Optional[GKDConfig] = None,
         data_collator: Optional[DataCollator] = None,  # type: ignore
         train_dataset: Optional[Dataset] = None,
@@ -77,10 +79,12 @@ class GKDTrainer(SFTTrainer):
         peft_config: Optional["PeftConfig"] = None,
         formatting_func: Optional[Callable] = None,
     ):
-        if args is not None:
-            # Adds remove_unused_columns=False to the dataclass args.
-            # TODO(seungduk-yanolja): Please describe why this is necessary.
-            args.remove_unused_columns = False
+        if args is None:
+            raise ValueError("`args` must be provided and cannot be None.")
+
+        # Adds remove_unused_columns=False to the dataclass args.
+        # TODO(seungduk-yanolja): Please describe why this is necessary.
+        args.remove_unused_columns = False
         if data_collator is None:
             data_collator = DataCollatorForChatML(tokenizer=processing_class, max_length=args.max_length)
 


### PR DESCRIPTION
Fixes #3647


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

```python
        args.remove_unused_columns = False
        data_collator = DataCollatorForChatML(tokenizer=processing_class, max_length=args.max_length)
```

These values must have been guarded in case the given arguments are not set.
Added guarding to avoid any errors.