### PR TITLE
👋 Remove `--bf16` value in scripts

### DIFF
--- a/examples/scripts/bco.py
+++ b/examples/scripts/bco.py
@@ -42,7 +42,7 @@ python examples/scripts/bco.py \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
     --warmup_ratio 0.1 \
-    --bf16 \
+    --bf16 True \
     --report_to wandb
 
 # QLoRA:
@@ -65,7 +65,7 @@ python examples/scripts/bco.py \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
     --warmup_ratio 0.1 \
-    --bf16 \
+    --bf16 True \
     --use_peft \
     --load_in_4bit \
     --lora_target_modules=all-linear \

--- a/examples/scripts/bco.py
+++ b/examples/scripts/bco.py
@@ -42,7 +42,6 @@ python examples/scripts/bco.py \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
     --warmup_ratio 0.1 \
-    --bf16 True \
     --report_to wandb
 
 # QLoRA:
@@ -65,7 +64,6 @@ python examples/scripts/bco.py \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
     --warmup_ratio 0.1 \
-    --bf16 True \
     --use_peft \
     --load_in_4bit \
     --lora_target_modules=all-linear \

--- a/examples/scripts/cpo.py
+++ b/examples/scripts/cpo.py
@@ -35,7 +35,6 @@ python examples/scripts/cpo.py \
     --output_dir="gpt2-aligned-cpo" \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns
 
@@ -52,7 +51,6 @@ python examples/scripts/cpo.py \
     --optim rmsprop \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns \
     --use_peft \

--- a/examples/scripts/cpo.py
+++ b/examples/scripts/cpo.py
@@ -35,7 +35,7 @@ python examples/scripts/cpo.py \
     --output_dir="gpt2-aligned-cpo" \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns
 
@@ -52,7 +52,7 @@ python examples/scripts/cpo.py \
     --optim rmsprop \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns \
     --use_peft \

--- a/examples/scripts/grpo_vlm.py
+++ b/examples/scripts/grpo_vlm.py
@@ -59,7 +59,6 @@ accelerate launch \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 2 \
     --num_generations 2  \
-    --bf16 True
 
 """
 

--- a/examples/scripts/gspo.py
+++ b/examples/scripts/gspo.py
@@ -41,7 +41,6 @@ accelerate launch \
     --log_completions \
     --per_device_train_batch_size 8 \
     --num_generations 8 \
-    --bf16 True \
     --importance_sampling_level sequence \
     --epsilon 3e-4 \
     --epsilon_high 4e-4 \

--- a/examples/scripts/gspo_vlm.py
+++ b/examples/scripts/gspo_vlm.py
@@ -39,7 +39,6 @@ accelerate launch \
     --log_completions \
     --per_device_train_batch_size 8 \
     --num_generations 8 \
-    --bf16 True \
     --importance_sampling_level sequence \
     --epsilon 3e-4 \
     --epsilon_high 4e-4 \

--- a/examples/scripts/kto.py
+++ b/examples/scripts/kto.py
@@ -35,7 +35,7 @@ python trl/scripts/kto.py \
     --output_dir=kto-aligned-model \
     --warmup_ratio 0.1 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step
 
 # QLoRA:
@@ -51,7 +51,7 @@ python trl/scripts/kto.py \
     --output_dir=kto-aligned-model-lora \
     --warmup_ratio 0.1 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step \
     --use_peft \
     --load_in_4bit \

--- a/examples/scripts/kto.py
+++ b/examples/scripts/kto.py
@@ -35,7 +35,6 @@ python trl/scripts/kto.py \
     --output_dir=kto-aligned-model \
     --warmup_ratio 0.1 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step
 
 # QLoRA:
@@ -51,7 +50,6 @@ python trl/scripts/kto.py \
     --output_dir=kto-aligned-model-lora \
     --warmup_ratio 0.1 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step \
     --use_peft \
     --load_in_4bit \

--- a/examples/scripts/mpo_vlm.py
+++ b/examples/scripts/mpo_vlm.py
@@ -35,7 +35,6 @@ python examples/scripts/mpo_vlm.py \
     --lora_target_modules down_proj, o_proj, k_proj, q_proj, gate_proj, up_proj, v_proj \
     --loss_type sigmoid bco_pair sft \
     --loss_weights 0.8 0.2 1.0 \
-    --bf16 True
 """
 
 import torch

--- a/examples/scripts/orpo.py
+++ b/examples/scripts/orpo.py
@@ -35,7 +35,7 @@ python examples/scripts/orpo.py \
     --output_dir="gpt2-aligned-orpo" \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns
 
@@ -52,7 +52,7 @@ python examples/scripts/orpo.py \
     --optim rmsprop \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 \
+    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns \
     --use_peft \

--- a/examples/scripts/orpo.py
+++ b/examples/scripts/orpo.py
@@ -35,7 +35,6 @@ python examples/scripts/orpo.py \
     --output_dir="gpt2-aligned-orpo" \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns
 
@@ -52,7 +51,6 @@ python examples/scripts/orpo.py \
     --optim rmsprop \
     --warmup_steps 150 \
     --report_to wandb \
-    --bf16 True \
     --logging_first_step \
     --no_remove_unused_columns \
     --use_peft \

--- a/examples/scripts/sft_video_llm.py
+++ b/examples/scripts/sft_video_llm.py
@@ -31,7 +31,6 @@ accelerate launch \
     --model_name_or_path=Qwen/Qwen2-VL-7B-Instruct \
     --per_device_train_batch_size=1 \
     --output_dir=video-llm-output \
-    --bf16=True \
     --tf32=True \
     --gradient_accumulation_steps=4 \
     --num_train_epochs=4 \

--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -31,7 +31,6 @@ accelerate launch
     --per_device_train_batch_size 8 \
     --gradient_accumulation_steps 8 \
     --output_dir sft-llava-1.5-7b-hf \
-    --bf16 True \
     --torch_dtype bfloat16 \
     --gradient_checkpointing
 

--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -31,7 +31,7 @@ accelerate launch
     --per_device_train_batch_size 8 \
     --gradient_accumulation_steps 8 \
     --output_dir sft-llava-1.5-7b-hf \
-    --bf16 \
+    --bf16 True \
     --torch_dtype bfloat16 \
     --gradient_checkpointing
 

--- a/examples/scripts/sft_vlm_gemma3.py
+++ b/examples/scripts/sft_vlm_gemma3.py
@@ -30,7 +30,6 @@ accelerate launch \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir gemma-3-4b-it-trl-sft-llava-instruct-mix-vsft \
-    --bf16 True \
     --torch_dtype bfloat16 \
     --use_peft \
     --lora_target_modules all-linear \
@@ -47,7 +46,6 @@ accelerate launch \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir gemma-3-4b-it-trl-sft-MMIU-Benchmark \
-    --bf16 True \
     --torch_dtype bfloat16 \
     --use_peft \
     --lora_target_modules all-linear

--- a/examples/scripts/sft_vlm_gemma3.py
+++ b/examples/scripts/sft_vlm_gemma3.py
@@ -30,7 +30,7 @@ accelerate launch \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir gemma-3-4b-it-trl-sft-llava-instruct-mix-vsft \
-    --bf16 \
+    --bf16 True \
     --torch_dtype bfloat16 \
     --use_peft \
     --lora_target_modules all-linear \
@@ -47,7 +47,7 @@ accelerate launch \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir gemma-3-4b-it-trl-sft-MMIU-Benchmark \
-    --bf16 \
+    --bf16 True \
     --torch_dtype bfloat16 \
     --use_peft \
     --lora_target_modules all-linear

--- a/examples/scripts/sft_vlm_smol_vlm.py
+++ b/examples/scripts/sft_vlm_smol_vlm.py
@@ -31,7 +31,6 @@ accelerate launch
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir sft-smol-vlm-hf \
-    --bf16 True \
     --torch_dtype bfloat16 \
     --gradient_checkpointing \
     --use_peft \

--- a/examples/scripts/sft_vlm_smol_vlm.py
+++ b/examples/scripts/sft_vlm_smol_vlm.py
@@ -31,7 +31,7 @@ accelerate launch
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 1 \
     --output_dir sft-smol-vlm-hf \
-    --bf16 \
+    --bf16 True \
     --torch_dtype bfloat16 \
     --gradient_checkpointing \
     --use_peft \


### PR DESCRIPTION
# What does this PR do?

~~The argument parser needs that `bf16` is explicitly set so adding `True` to the scripts.~~
Removing `bf16` in scripts since it's True by default.

If only passing `--bf16`:

```bash
error: argument --bf16: expected one argument
```

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.