### PR TITLE
📦 Wrapping the main execution code to avoid multi-processing issues from vLLM

### DIFF
--- a/examples/scripts/evals/judge_tldr.py
+++ b/examples/scripts/evals/judge_tldr.py
@@ -78,32 +78,33 @@ class ScriptArguments:
     num_examples: Optional[int] = field(default=None, metadata={"help": "Number of examples to evaluate."})
 
 
-# Parse the arguments
-parser = HfArgumentParser(ScriptArguments)
-script_args = parser.parse_args_into_dataclasses()[0]
+if __name__ == "__main__":
+    # Parse the arguments
+    parser = HfArgumentParser(ScriptArguments)
+    script_args = parser.parse_args_into_dataclasses()[0]
 
-# Load the dataset
-dataset = load_dataset("trl-lib/tldr", split="validation")
-if script_args.num_examples is not None:
-    dataset = dataset.select(range(script_args.num_examples))
+    # Load the dataset
+    dataset = load_dataset("trl-lib/tldr", split="validation")
+    if script_args.num_examples is not None:
+        dataset = dataset.select(range(script_args.num_examples))
 
-# Extract the prompts and reference completions
-prompts = dataset["prompt"]
-reference_completions = dataset["completion"]
+    # Extract the prompts and reference completions
+    prompts = dataset["prompt"]
+    reference_completions = dataset["completion"]
 
-# Generate the model completions
-sampling_params = SamplingParams(temperature=0.0, top_p=0.95, max_tokens=200)  # very generous max token length
-llm = LLM(model=script_args.model_name_or_path, tensor_parallel_size=1)
-outputs = llm.generate(prompts, sampling_params)
-model_completions = [output.outputs[0].text.strip() for output in outputs]
+    # Generate the model completions
+    sampling_params = SamplingParams(temperature=0.0, top_p=0.95, max_tokens=200)  # very generous max token length
+    llm = LLM(model=script_args.model_name_or_path, tensor_parallel_size=1)
+    outputs = llm.generate(prompts, sampling_params)
+    model_completions = [output.outputs[0].text.strip() for output in outputs]
 
-# Judge the outputs
-if "gpt" in script_args.judge_model:
-    judge = OpenAIPairwiseJudge(script_args.judge_model)
-else:
-    judge = HfPairwiseJudge(script_args.judge_model)
+    # Judge the outputs
+    if "gpt" in script_args.judge_model:
+        judge = OpenAIPairwiseJudge(script_args.judge_model)
+    else:
+        judge = HfPairwiseJudge(script_args.judge_model)
 
-completions = [[c0, c1] for c0, c1 in zip(reference_completions, model_completions)]
-best_idxs = judge.judge(prompts, completions)
-model_win_rate = best_idxs.count(1) / len(best_idxs)
-print(f"Model win rate: {model_win_rate * 100:.2f}%")
+    completions = [[c0, c1] for c0, c1 in zip(reference_completions, model_completions)]
+    best_idxs = judge.judge(prompts, completions)
+    model_win_rate = best_idxs.count(1) / len(best_idxs)
+    print(f"Model win rate: {model_win_rate * 100:.2f}%")


### PR DESCRIPTION
When running this example code with vllm, it returns error like
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 291, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/root/trl/examples/scripts/evals/judge_tldr.py", line 96, in <module>
    llm = LLM(model=script_args.model_name_or_path, tensor_parallel_size=1)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/entrypoints/llm.py", line 285, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/llm_engine.py", line 153, in from_engine_args
    return cls(vllm_config=vllm_config,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/llm_engine.py", line 104, in __init__
    self.engine_core = EngineCoreClient.make_client(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core_client.py", line 80, in make_client
    return SyncMPClient(vllm_config, executor_class, log_stats)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core_client.py", line 600, in __init__
    super().__init__(
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/core_client.py", line 446, in __init__
    with launch_core_engines(vllm_config, executor_class,
  File "/usr/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/utils.py", line 689, in launch_core_engines
    local_engine_manager = CoreEngineProcManager(
                           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/vllm/v1/engine/utils.py", line 133, in __init__
    proc.start()
  File "/usr/lib/python3.11/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/multiprocessing/context.py", line 288, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/usr/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/usr/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 164, in get_preparation_data
    _check_not_importing_main()
  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 140, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
```
After wrapping the code with `if __name__ == "__main__":`, this error will be fixed.