### PR TITLE
🪶 [GRPO] PPO Lite: Scale rewards by Std of Batch

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -169,7 +169,9 @@ While training and evaluating, we record the following reward metrics:
 - `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
 - `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
 - `reward`: The overall average reward after applying reward weights.
-- `reward_std`: The standard deviation of the overall reward within each batch after applying reward weights.
+- `reward_std`: The standard deviation of rewards after applying reward weights.  
+  - If `scale_rewards` is `"group"` or `"none"`, this is the average of the per-group standard deviations.
+  - If `scale_rewards` is `"batch"`, this is the standard deviation computed over all rewards in the batch (ignoring groups).
 - `frac_reward_zero_std`: The fraction of samples in the generation batch with a reward std of zero, implying there is little diversity for that prompt (all answers are correct or incorrect).
 - `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -80,6 +80,12 @@ It was shown in the paper [Understanding R1-Zero-Like Training: A Critical Persp
 
 </Tip>
 
+<Tip>
+
+[Part I: Tricks or Traps? A Deep Dive into RL for LLM Reasoning (Lite PPO)](https://huggingface.co/papers/2508.08221) showed that calculating the mean at the local (group) level and the standard deviation at the global (batch) level enables more robust reward shaping. You can use this scaling strategy by setting `scale_rewards="batch"` in [`GRPOConfig`].
+
+</Tip>
+
 ### Estimating the KL divergence
 
 KL divergence is estimated using the approximator introduced by [Schulman et al. (2020)](http://joschu.net/blog/kl-approx.html). The approximator is defined as follows:
@@ -138,6 +144,7 @@ $$
 \mathcal{L}_{\text{DAPO}}(\theta) = - \frac{1}{\sum_{i=1}^G |o_i|} \sum_{i=1}^G \sum_{t=1}^{|o_i|} l_{i,t},
 $$
 
+To use this formulation, set `loss_type="bnpo"` in [`GRPOConfig`]. Note that we do not reproduce the DAPO formulation exactly: when using gradient accumulation, the loss is computed over the total number of tokens in each batch, not over the accumulated batches. `loss_type="bnpo"` is equivalent to the original DAPO formulation only when `gradient_accumulation_steps=1`.
 
 Furthermore, it was demonstrated in the paper [Understanding R1-Zero-Like Training: A Critical Perspective](https://huggingface.co/papers/2503.20783) that the initial GRPO formulation introduces a response length bias. They show that while the DAPO formulation reduces this bias, it does not eliminate it completely. To fully remove this bias, they propose dividing by a constant instead of the sequence length, resulting in the following formulation:
 

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -63,7 +63,8 @@ Here's a brief explanation for the logged metrics provided in the data for the G
 
 * `num_tokens`: Total number of input tokens processed during training so far.
 
-**Completions:**
+#### Completions
+
 * `completions/mean_length`: Mean length of all generated completions (including those not ending with an EOS token).
 * `completions/min_length`: Minimum length among all generated completions.
 * `completions/max_length`: Maximum length among all generated completions.
@@ -72,13 +73,15 @@ Here's a brief explanation for the logged metrics provided in the data for the G
 * `completions/min_terminated_length`: Minimum length among completions that ended with an EOS token.
 * `completions/max_terminated_length`: Maximum length among completions that ended with an EOS token.
 
-**Rewards:**
+#### Rewards
+
 * `rewards/{reward_func_name}/mean`: The mean reward obtained from a specific, named reward function (e.g., `rewards/my_custom_reward/mean`). This is logged for each reward function used.
 * `rewards/{reward_func_name}/std`: The standard deviation of rewards from a specific, named reward function.
 * `reward`: The overall mean of the (potentially weighted and, if `args.scale_rewards` is true, normalized) rewards, after group-wise normalization (advantages).
 * `reward_std`: The standard deviation of the (potentially weighted) rewards *before* group-wise normalization for advantages.
 
-**Policy and Loss Metrics:**
+#### Policy and Loss Metrics
+
 * `kl`: The mean Kullback-Leibler (KL) divergence between the current policy and the reference policy. This is logged only if `beta` (the KL coefficient in `GRPOConfig`) is non-zero.
 * `entropy`: Average entropy of token predictions across generated completions.
 * If Liger GRPOLoss is used (`use_liger_loss: True` in `GRPOConfig`):
@@ -91,6 +94,7 @@ Here's a brief explanation for the logged metrics provided in the data for the G
     *   `clip_ratio/region_mean`: The mean fraction of instances where the probability ratio was clipped at either the lower or upper bound.
 
 ### Crucial GRPO values
+
 During GRPO training, monitor these values for insights into performance and stability:
 
 1.  `reward`: This is the primary objective. It reflects the (group-wise normalized) rewards the policy is achieving. It should generally increase during successful training.

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -77,7 +77,7 @@ TRL supports using these learnings to train a GRPO model by:
 ```python
 from trl import GRPOConfig
 
-config = GRPOConfig(
+training_args = GRPOConfig(
     ...
     scale_rewards="group",
     loss_type="bnpo",

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -62,11 +62,13 @@ trainer = SFTTrainer(
 ```
 
 ## Part I: Tricks or Traps? A Deep Dive into RL for LLM Reasoning (Lite PPO)
+
 **📜 Paper**: https://huggingface.co/papers/2508.08221
 
 The authors of this paper find that the combination of:
-1. scaling rewards by the standard deviation computed over the entire batch 
-2. Aggregating loss over the total number of tokens
+
+1. scaling rewards by the standard deviation computed over the entire batch and
+2. aggregating loss over the total number of tokens
 
 can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and DAPO.
 

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -70,7 +70,7 @@ The authors of this paper find that the combination of:
 1. scaling rewards by the standard deviation computed over the entire batch and
 2. aggregating loss over the total number of tokens
 
-can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and DAPO.
+can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and [DAPO](https://huggingface.co/papers/2503.14476).
 
 TRL supports using these learnings to train a GRPO model by:
 
@@ -80,5 +80,18 @@ from trl import GRPOConfig
 config = GRPOConfig(
     ...
     scale_rewards="group",
-    loss_type="bnpo"
+    loss_type="bnpo",
+    # Other parameters used
+    beta=0.0,  # = init_kl_coef in the paper
+    top_p=0.99,
+    top_k=100,
+    temperature=0.99,
+    num_completions=8, # = num_return_sequences in the paper
+    num_iterations=1,  # = ppo_epochs in the paper
+    per_device_train_batch_size=4
+    gradient_accumulation_steps=32,
+    steps_per_generation=8,  # (rollout_batch_size*num_return_sequences) / (per_device_train_batch_size*gradient_accumulation_steps)
 )
+```
+
+Note that when using gradient accumulation, the loss is aggregated over the total number of tokens in the batch, but not over the accumulated batch. For more details, see the [GRPO Trainer - Loss types](grpo_trainer#loss_types).

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -77,6 +77,6 @@ from trl import GRPOConfig
 
 config = GRPOConfig(
     ...
-    scale_rewards="grpo",
+    scale_rewards="group",
     loss_type="bnpo"
 )

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -60,3 +60,21 @@ trainer = SFTTrainer(
     callbacks=[BEMACallback()],
 )
 ```
+
+## Part I: Tricks or Traps? A Deep Dive into RL for LLM Reasoning (Lite PPO)
+**📜 Paper**: https://huggingface.co/papers/2508.08221
+
+The authors of this paper find that the combination of:
+1. scaling rewards by the standard deviation computed over the entire batch 
+2. Aggregating loss over the total number of tokens
+
+can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and DAPO. To train a model using Lite-PPO
+
+```python
+from trl import GRPOConfig
+
+config = GRPOConfig(
+    ...
+    scale_rewards="grpo",
+    loss_type="bnpo"
+)

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -68,7 +68,9 @@ The authors of this paper find that the combination of:
 1. scaling rewards by the standard deviation computed over the entire batch 
 2. Aggregating loss over the total number of tokens
 
-can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and DAPO. To train a model using Lite-PPO
+can unlock the learning capability of critic-free policies using vanilla PPO loss. Their results demonstrate that this simple combination consistently improves performance, surpassing strategies like GRPO and DAPO.
+
+TRL supports using these learnings to train a GRPO model by:
 
 ```python
 from trl import GRPOConfig

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1267,7 +1267,8 @@ class GRPOTrainerTester(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
 
-    def test_training_no_scale_rewards(self):
+    @parameterized.expand([(False,), ("group",), ("batch",), (True,), ("none",)])
+    def test_training_scale_rewards(self, scale_rewards):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -1276,67 +1277,7 @@ class GRPOTrainerTester(TrlTestCase):
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
-            scale_rewards=False,
-            report_to="none",
-        )
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=training_args,
-            train_dataset=dataset,
-        )
-
-        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
-
-        trainer.train()
-
-        self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-
-        # Check that the params have changed
-        for n, param in previous_trainable_params.items():
-            new_param = trainer.model.get_parameter(n)
-            self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
-
-    def test_training_group_scale_rewards(self):
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-
-        # scale rewards defaults to "group"
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            learning_rate=0.1,  # increase the learning rate to speed up the test
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=8,  # reduce the completion length to reduce memory usage
-            report_to="none",
-        )
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=training_args,
-            train_dataset=dataset,
-        )
-
-        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
-
-        trainer.train()
-
-        self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
-
-        # Check that the params have changed
-        for n, param in previous_trainable_params.items():
-            new_param = trainer.model.get_parameter(n)
-            self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
-
-    def test_training_batch_scale_rewards(self):
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            learning_rate=0.1,  # increase the learning rate to speed up the test
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=8,  # reduce the completion length to reduce memory usage
-            scale_rewards="batch",
+            scale_rewards=scale_rewards,
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1276,7 +1276,37 @@ class GRPOTrainerTester(TrlTestCase):
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
-            scale_rewards=False,
+            scale_rewards="none",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
+
+    def test_training_batch_scale_rewards(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # increase the learning rate to speed up the test
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            scale_rewards="batch",
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1276,7 +1276,37 @@ class GRPOTrainerTester(TrlTestCase):
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
-            scale_rewards="none",
+            scale_rewards=False,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
+
+    def test_training_group_scale_rewards(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        # scale rewards defaults to "group"
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # increase the learning rate to speed up the test
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -501,7 +501,7 @@ class GRPOConfig(TrainingArguments):
             "rewards are weighted equally with weight `1.0`."
         },
     )
-    scale_rewards: Union[str, bool] = field(
+    scale_rewards: str = field(
         default="group",
         metadata={
             "help": "Specifies the scaling strategy for rewards. Supported values are: "

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -166,10 +166,11 @@ class GRPOConfig(TrainingArguments):
         reward_weights (`list[float]` or `None`, *optional*, defaults to `None`):
             Weights for each reward function. Must match the number of reward functions. If `None`, all rewards are
             weighted equally with weight `1.0`.
-        scale_rewards (`bool`, *optional*, defaults to `True`):
-            Whether to scale the rewards by dividing them by their standard deviation. If `True` (default), the rewards
-            are normalized by the standard deviation, ensuring they have unit variance. If `False`, no scaling is
-            applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
+        scale_rewards (`str`, *optional*, defaults to `"group"`):
+            The level at which the standard deviation is computed to scale the rewards. Valid values are `"batch", "group", and "none"`
+            If `"group"` (default), the standard deviation is computed over the group a response belongs to.
+            If `"batch"`, the standard deviation is computed over the entire batch.
+            If `"none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
             as scaling by the standard deviation introduces a question-level difficulty bias.
         loss_type (`str`, *optional*, defaults to `"bnpo"`):
             Specifies the loss formulation to use. Supported values are:
@@ -496,13 +497,14 @@ class GRPOConfig(TrainingArguments):
             "rewards are weighted equally with weight `1.0`."
         },
     )
-    scale_rewards: bool = field(
-        default=True,
+    scale_rewards: str = field(
+        default="group",
         metadata={
-            "help": "Whether to scale the rewards by dividing them by their standard deviation. If `True` (default), "
-            "the rewards are normalized by the standard deviation, ensuring they have unit variance. If `False`, no "
-            "scaling is applied. The Dr. GRPO paper recommends not scaling the rewards, as scaling by the standard "
-            "deviation introduces a question-level difficulty bias."
+            "help": "The level at which the standard deviation is computed to scale the rewards. Valid values are "
+            "`'batch', 'group', and 'none'`. If `'group'` (default), the standard deviation is computed over the group "
+            "a response belongs to. If `'batch'`, the standard deviation is computed over the entire batch. If "
+            "`'none'`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends "
+            "not scaling the rewards, as scaling by the standard deviation introduces a question-level difficulty bias."
         },
     )
     loss_type: str = field(
@@ -637,3 +639,8 @@ class GRPOConfig(TrainingArguments):
 
         if self.delta is not None and self.use_liger_loss:
             raise ValueError("Liger loss does not support two-sided GRPO loss yet.")
+
+        if self.scale_rewards not in ["batch", "group", "none"]:
+            raise ValueError(
+                f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of 'batch', 'group', or 'none'."
+            )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -168,9 +168,10 @@ class GRPOConfig(TrainingArguments):
             weighted equally with weight `1.0`.
         scale_rewards (`str`, *optional*, defaults to `"group"`):
             The level at which the standard deviation is computed to scale the rewards. Valid values are `"batch", "group", and "none"`
-            If `"group"` (default), the standard deviation is computed over the group a response belongs to.
-            If `"batch"`, the standard deviation is computed over the entire batch.
-            If `"none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
+            
+            - If `"group"` (default), the standard deviation is computed over the group a response belongs to.
+            - If `"batch"`, the standard deviation is computed over the entire batch.
+            - If `"none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
             as scaling by the standard deviation introduces a question-level difficulty bias.
         loss_type (`str`, *optional*, defaults to `"bnpo"`):
             Specifies the loss formulation to use. Supported values are:
@@ -501,7 +502,7 @@ class GRPOConfig(TrainingArguments):
         default="group",
         metadata={
             "help": "The level at which the standard deviation is computed to scale the rewards. Valid values are "
-            "`'batch', 'group', and 'none'`. If `'group'` (default), the standard deviation is computed over the group "
+            "`True, False, 'batch', 'group', and 'none'`. If `True or 'group'` (default), the standard deviation is computed over the group "
             "a response belongs to. If `'batch'`, the standard deviation is computed over the entire batch. If "
             "`'none'`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends "
             "not scaling the rewards, as scaling by the standard deviation introduces a question-level difficulty bias."

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -167,8 +167,8 @@ class GRPOConfig(TrainingArguments):
             Weights for each reward function. Must match the number of reward functions. If `None`, all rewards are
             weighted equally with weight `1.0`.
         scale_rewards (`Union[str, bool]`, *optional*, defaults to `"group"`):
-            The level at which the standard deviation is computed to scale the rewards. Valid values are `"batch", "group", and "none"`
-            
+            The level at which the standard deviation is computed to scale the rewards. Valid values are `True, False, "batch", "group", and "none"`
+
             - If `True or "group"` (default), the standard deviation is computed over the group a response belongs to.
             - If `"batch"`, the standard deviation is computed over the entire batch.
             - If `Fale or "none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -505,11 +505,11 @@ class GRPOConfig(TrainingArguments):
         default="group",
         metadata={
             "help": "Specifies the scaling strategy for rewards. Supported values are: "
-            "`True` or 'group' (default): rewards are scaled by the standard deviation within each group, ensuring "
+            "`True` or `group'` (default): rewards are scaled by the standard deviation within each group, ensuring "
             "unit variance within a group. "
             "`'batch'`: rewards are scaled by the standard deviation across the entire batch, as recommended in the "
             "PPO Lite paper. "
-            "`False` or 'none': no scaling is applied. The Dr. GRPO paper recommends not scaling rewards, as "
+            "`False` or `'none'`: no scaling is applied. The Dr. GRPO paper recommends not scaling rewards, as "
             "scaling by the standard deviation introduces a question-level difficulty bias."
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -166,12 +166,12 @@ class GRPOConfig(TrainingArguments):
         reward_weights (`list[float]` or `None`, *optional*, defaults to `None`):
             Weights for each reward function. Must match the number of reward functions. If `None`, all rewards are
             weighted equally with weight `1.0`.
-        scale_rewards (`str`, *optional*, defaults to `"group"`):
+        scale_rewards (`Union[str, bool]`, *optional*, defaults to `"group"`):
             The level at which the standard deviation is computed to scale the rewards. Valid values are `"batch", "group", and "none"`
             
-            - If `"group"` (default), the standard deviation is computed over the group a response belongs to.
+            - If `True or "group"` (default), the standard deviation is computed over the group a response belongs to.
             - If `"batch"`, the standard deviation is computed over the entire batch.
-            - If `"none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
+            - If `Fale or "none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
             as scaling by the standard deviation introduces a question-level difficulty bias.
         loss_type (`str`, *optional*, defaults to `"bnpo"`):
             Specifies the loss formulation to use. Supported values are:
@@ -498,13 +498,13 @@ class GRPOConfig(TrainingArguments):
             "rewards are weighted equally with weight `1.0`."
         },
     )
-    scale_rewards: str = field(
+    scale_rewards: Union[bool, str] = field(
         default="group",
         metadata={
             "help": "The level at which the standard deviation is computed to scale the rewards. Valid values are "
             "`True, False, 'batch', 'group', and 'none'`. If `True or 'group'` (default), the standard deviation is computed over the group "
             "a response belongs to. If `'batch'`, the standard deviation is computed over the entire batch. If "
-            "`'none'`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends "
+            "`False or 'none'`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends "
             "not scaling the rewards, as scaling by the standard deviation introduces a question-level difficulty bias."
         },
     )
@@ -641,7 +641,7 @@ class GRPOConfig(TrainingArguments):
         if self.delta is not None and self.use_liger_loss:
             raise ValueError("Liger loss does not support two-sided GRPO loss yet.")
 
-        if self.scale_rewards not in ["batch", "group", "none"]:
+        if not isinstance(self.scale_rewards, bool) or self.scale_rewards not in ["batch", "group", "none"]:
             raise ValueError(
                 f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of 'batch', 'group', or 'none'."
             )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -641,7 +641,7 @@ class GRPOConfig(TrainingArguments):
         if self.delta is not None and self.use_liger_loss:
             raise ValueError("Liger loss does not support two-sided GRPO loss yet.")
 
-        if not isinstance(self.scale_rewards, bool) or self.scale_rewards not in ["batch", "group", "none"]:
+        if not isinstance(self.scale_rewards, bool) and self.scale_rewards not in ["batch", "group", "none"]:
             raise ValueError(
-                f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of 'batch', 'group', or 'none'."
+                f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of True, False, 'batch', 'group', or 'none'."
             )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -645,8 +645,3 @@ class GRPOConfig(TrainingArguments):
 
         if self.delta is not None and self.use_liger_loss:
             raise ValueError("Liger loss does not support two-sided GRPO loss yet.")
-
-        if not isinstance(self.scale_rewards, bool) and self.scale_rewards not in ["batch", "group", "none"]:
-            raise ValueError(
-                f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of True, False, 'batch', 'group', or 'none'."
-            )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -166,13 +166,16 @@ class GRPOConfig(TrainingArguments):
         reward_weights (`list[float]` or `None`, *optional*, defaults to `None`):
             Weights for each reward function. Must match the number of reward functions. If `None`, all rewards are
             weighted equally with weight `1.0`.
-        scale_rewards (`Union[str, bool]`, *optional*, defaults to `"group"`):
-            The level at which the standard deviation is computed to scale the rewards. Valid values are `True, False, "batch", "group", and "none"`
+        scale_rewards (`str` or `bool`, *optional*, defaults to `"group"`):
+            Specifies the scaling strategy for rewards. Supported values are:
 
-            - If `True or "group"` (default), the standard deviation is computed over the group a response belongs to.
-            - If `"batch"`, the standard deviation is computed over the entire batch.
-            - If `Fale or "none"`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends not scaling the rewards,
-            as scaling by the standard deviation introduces a question-level difficulty bias.
+            - `True` or `"group"` (default): rewards are scaled by the standard deviation within each group, ensuring
+              unit variance within a group.
+            - `"batch"`: rewards are scaled by the standard deviation across the entire batch, as recommended in the
+              [PPO Lite paper](https://huggingface.co/papers/2508.08221).
+            - `False` or `"none"`: no scaling is applied. The [Dr. GRPO
+              paper](https://huggingface.co/papers/2503.20783) recommends not scaling rewards, as scaling by the
+              standard deviation introduces a question-level difficulty bias.
         loss_type (`str`, *optional*, defaults to `"bnpo"`):
             Specifies the loss formulation to use. Supported values are:
 
@@ -501,11 +504,13 @@ class GRPOConfig(TrainingArguments):
     scale_rewards: str = field(
         default="group",
         metadata={
-            "help": "The level at which the standard deviation is computed to scale the rewards. Valid values are "
-            "`True, False, 'batch', 'group', and 'none'`. If `True or 'group'` (default), the standard deviation is computed over the group "
-            "a response belongs to. If `'batch'`, the standard deviation is computed over the entire batch. If "
-            "`False or 'none'`, no scaling is applied. The [Dr. GRPO paper](https://huggingface.co/papers/2503.20783) recommends "
-            "not scaling the rewards, as scaling by the standard deviation introduces a question-level difficulty bias."
+            "help": "Specifies the scaling strategy for rewards. Supported values are: "
+            "`True` or 'group' (default): rewards are scaled by the standard deviation within each group, ensuring "
+            "unit variance within a group. "
+            "`'batch'`: rewards are scaled by the standard deviation across the entire batch, as recommended in the "
+            "PPO Lite paper. "
+            "`False` or 'none': no scaling is applied. The Dr. GRPO paper recommends not scaling rewards, as "
+            "scaling by the standard deviation introduces a question-level difficulty bias."
         },
     )
     loss_type: str = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -501,7 +501,7 @@ class GRPOConfig(TrainingArguments):
             "rewards are weighted equally with weight `1.0`."
         },
     )
-    scale_rewards: str = field(
+    scale_rewards: Union[str, bool] = field(
         default="group",
         metadata={
             "help": "Specifies the scaling strategy for rewards. Supported values are: "

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -498,7 +498,7 @@ class GRPOConfig(TrainingArguments):
             "rewards are weighted equally with weight `1.0`."
         },
     )
-    scale_rewards: Union[bool, str] = field(
+    scale_rewards: str = field(
         default="group",
         metadata={
             "help": "The level at which the standard deviation is computed to scale the rewards. Valid values are "

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -644,7 +644,6 @@ class GRPOTrainer(Trainer):
         self.vllm_tensor_parallel_size = args.vllm_tensor_parallel_size  # only applies to colocation mode
         self.use_liger_loss = args.use_liger_loss
         self.loss_type = args.loss_type
-        self.scale_rewards = args.scale_rewards
         self.importance_sampling_level = args.importance_sampling_level
         self.mask_truncated_completions = args.mask_truncated_completions
         self.top_entropy_quantile = args.top_entropy_quantile
@@ -722,6 +721,11 @@ class GRPOTrainer(Trainer):
             disable_dropout_in_model(model)
             if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
+
+        if isinstance(args.scale_rewards, bool):
+            self.scale_rewards = "group" if args.scale_rewards else "none"
+        else:
+            self.scale_rewards = args.scale_rewards
 
         # Liger loss
         if self.use_liger_loss:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1677,7 +1677,7 @@ class GRPOTrainer(Trainer):
         # Normalize the rewards to compute the advantages
         mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(self.num_generations, dim=0)
         advantages = rewards - mean_grouped_rewards
-        
+
         if self.scale_rewards != "batch":
             # If self.scale_rewards = "none", we'll still log group level std.
             std_rewards = rewards.view(-1, self.num_generations).std(dim=1)
@@ -1685,11 +1685,11 @@ class GRPOTrainer(Trainer):
         else:
             # Compute global std
             std_rewards = self.accelerator.gather(rewards).flatten().std()
-        
-        is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))        
+
+        is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))
         if self.scale_rewards != "none":
             advantages = advantages / (std_rewards + 1e-4)
-        
+
         # Slice to keep only the local part of the data
         process_slice = slice(
             self.accelerator.process_index * len(prompts),


### PR DESCRIPTION
# What does this PR do?

Updates the `scale_rewards` parameter to accept three different valid values `none`, `group` and `batch` to determine the level at which the std of rewards will be aggregated.

With this feature users can now train a model using the PPOLite technique outlined in https://arxiv.org/html/2508.08221v1, by setting `scale_rewards` = `group` and `loss_type='bnpo'` (for token level loss aggregration).

<!-- Remove if not applicable -->

Fixes #3920


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.