### PR TITLE
🗞 bugfix 'TrainerState' object is not subscriptable

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1385,6 +1385,35 @@ class GRPOTrainerTester(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             self.assertTrue(torch.equal(param, new_param), f"Parameter {n} has changed.")
 
+    def test_warning_raised_all_rewards_none(self):
+        """Test that a proper warning is raised when all rewards are None."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def always_none_reward_func(completions, **kwargs):
+            """Reward function that always returns None."""
+            return [None] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # increase the learning rate to speed up the test
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=always_none_reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        with self.assertLogs("trl.trainer.grpo_trainer", level="WARNING") as cm:
+            trainer.train()
+
+        expected_warning = "All reward functions returned None for the following kwargs:"
+        self.assertIn(expected_warning, cm.output[0])
+
     def test_training_num_generations_larger_than_batch_size(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1316,7 +1316,7 @@ class GRPOTrainer(Trainer):
         # If all reward functions return None for a given row, issue a detailed warning
         if torch.isnan(rewards_per_func).all(dim=1).any():
             nan_row_idx = torch.isnan(rewards_per_func).all(dim=1).nonzero(as_tuple=True)[0][0]
-            row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items()}
+            row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items() if key!='trainer_state'}
             row_reward_kwargs["prompt"] = prompts[nan_row_idx]
             row_reward_kwargs["completion"] = completions[nan_row_idx]
             logger.warning(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1316,11 +1316,13 @@ class GRPOTrainer(Trainer):
         # If all reward functions return None for a given row, issue a detailed warning
         if torch.isnan(rewards_per_func).all(dim=1).any():
             nan_row_idx = torch.isnan(rewards_per_func).all(dim=1).nonzero(as_tuple=True)[0][0]
-            row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items() if key!='trainer_state'}
+            row_reward_kwargs = {
+                key: value[nan_row_idx] for key, value in reward_kwargs.items() if key != "trainer_state"
+            }
             row_reward_kwargs["prompt"] = prompts[nan_row_idx]
             row_reward_kwargs["completion"] = completions[nan_row_idx]
             logger.warning(
-                f"All reward functions returned None for the following kwargs: {row_reward_kwargs}. "
+                f"All reward functions returned None for the following kwargs:\n{row_reward_kwargs}\n"
                 "Please ensure that at least one reward function returns a valid reward."
             )
 


### PR DESCRIPTION
# Fix: Prevent TrainerState object from being subscripted in GRPO Trainer

### Description
This PR fixes a bug in `GRPOTrainer` where `TrainerState` objects inside `reward_kwargs` were incorrectly treated as subscriptable, leading to the following error:

```
File ".../trl/trainer/grpo_trainer.py", line 1332, in _calculate_rewards
    row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items()}
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'TrainerState' object is not subscriptable
```
The issue was introduced in [#3669: *feat: Pass trainer state to reward functions*](https://github.com/huggingface/trl/pull/3669), which added `trainer_state` to `reward_kwargs`:

https://github.com/huggingface/trl/blob/e04f7eb3b993b5278733a793853ed3a85d1c69c8/trl/trainer/grpo_trainer.py#L1035

### Fix
This PR ensures that the `trainer_state` entry is excluded from subscripting:
```python
row_reward_kwargs = {key: value[nan_row_idx] for key, value in reward_kwargs.items() if key!='trainer_state'}
```
This prevents the TypeError while preserving the intended reward calculation logic.

Erez Yosef.