### PR TITLE
📸 Return `position_ids` for `flash_attention_3`

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -702,6 +702,7 @@ class SFTTrainer(Trainer):
         self.padding_free = args.padding_free or (args.packing and args.packing_strategy == "bfd")
         use_flash_attention = model.config._attn_implementation in [
             "flash_attention_2",
+            "flash_attention_3",
             "kernels-community/vllm-flash-attn3",
         ]
         if self.padding_free:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

The `transformers` package has supported `flash_attention_3` for a few weeks. However, when `--attn_implementation flash_attention_3` is passed to SFTTrainer, the loss becomes 0.0, because the `position_ids` are only passed to the model when attn_implementation is set to `flash_attention_2` or `kernels-community/vllm-flash-attn3`. Simply adding `flash_attention_3` to the `use_flash_attention` list can help solve the problem.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.