### PR TITLE
fix bug when using dataset streaming by accelerate

### DIFF
--- a/examples/scripts/dpo_vlm.py
+++ b/examples/scripts/dpo_vlm.py
@@ -78,6 +78,12 @@ if __name__ == "__main__":
     parser = TrlParser((ScriptArguments, DPOConfig, ModelConfig))
     script_args, training_args, model_args = parser.parse_args_and_config()
 
+    if script_args.dataset_streaming:
+        import os
+
+        # Set environment variable to enable split_batches for streaming datasets
+        os.environ["ACCELERATE_SPLIT_BATCHES"] = "true"
+
     ################
     # Model & Tokenizer
     ################


### PR DESCRIPTION
When running example using cmd line with dataset streaming: 
```
accelerate launch examples/scripts/dpo_vlm.py \
    --dataset_name HuggingFaceH4/rlaif-v_formatted \
    --dataset_streaming \
    --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct \
    --per_device_train_batch_size 2 \
    --max_steps 100 \
    --gradient_accumulation_steps 32 \
    --dataset_num_proc 32 \
    --output_dir dpo_idefics_rlaif-v \
    --torch_dtype bfloat16 \
    --gradient_checkpointing \
    --use_peft \
    --lora_target_modules=all-linear \
    --report_to wandb
```
It will crash and return error:
```
[rank0]: Traceback (most recent call last):
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/data_loader.py", line 822, in _fetch_batches
[rank0]: batch = concatenate(batches, dim=0)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py", line 616, in concatenate
[rank0]: return type(data[0])({k: concatenate([d[k] for d in data], dim=dim) for k in data[0].keys()})
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py", line 616, in <dictcomp>
[rank0]: return type(data[0])({k: concatenate([d[k] for d in data], dim=dim) for k in data[0].keys()})
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py", line 619, in concatenate
[rank0]: return torch.cat(data, dim=dim)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 383 but got size 304 for tensor number 1 in the list.

[rank0]: The above exception was the direct cause of the following exception:

[rank0]: Traceback (most recent call last):
[rank0]: File "/root/trl/examples/scripts/dpo_vlm.py", line 153, in <module>
[rank0]: trainer.train()
[rank0]: File "/usr/local/lib/python3.11/dist-packages/transformers/trainer.py", line 2238, in train
[rank0]: return inner_training_loop(
[rank0]: ^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/transformers/trainer.py", line 2533, in _inner_training_loop
[rank0]: batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator, num_batches, args.device)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/transformers/trainer.py", line 5355, in get_batch_samples
[rank0]: batch_samples.append(next(epoch_iterator))
[rank0]: ^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/data_loader.py", line 866, in iter
[rank0]: next_batch, next_batch_info = self._fetch_batches(main_iterator)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/usr/local/lib/python3.11/dist-packages/accelerate/data_loader.py", line 824, in _fetch_batches
[rank0]: raise RuntimeError(
[rank0]: RuntimeError: You can't use batches of different size with dispatch_batches=True or when using an IterableDataset.either pass dispatch_batches=False and have each process fetch its own batch or pass split_batches=True. By doing so, the main process will fetch a full batch and slice it into num_processes batches for each process.
```
This PR will fix it.