### PR TITLE
Enable saving and loading precomputed reference log probabilities in …

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -319,6 +319,18 @@ class DPOConfig(TrainingArguments):
             "`per_device_train_batch_size` for training and `per_device_eval_batch_size` for evaluation."
         },
     )
+
+    save_ref_logps_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Directory to save the precomputed reference model log probabilities."
+            }) 
+            
+    load_ref_logps_dir: Optional[str] = field(
+        default=None,
+        metadata={"help": "Directory to load the precomputed reference model log probabilities from."
+        })
+
     tools: Optional[list[Union[dict, Callable]]] = field(
         default=None,
         metadata={


### PR DESCRIPTION
- Added two new DPOConfig arguments: `load_ref_logps_dir` and `save_ref_logps_dir`
- Allows DPOTrainer to reuse precomputed `ref_chosen_logps` and `ref_rejected_logps` from disk
- Saves new log probabilities during training/evaluation when configured
- Added safeguards for distributed training (save only on main process, synchronize with wait_for_everyone)
- Improves reproducibility and avoids expensive recomputation across runs

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #3985


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.