### PR TITLE
⏰ fix: add return to shift_tokens_right

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -103,6 +103,8 @@ def shift_tokens_right(input_ids: torch.Tensor, decoder_start_token_id: int) -> 
     shifted_input_ids[:, 1:] = input_ids[:, :-1].clone()
     shifted_input_ids[:, 0] = decoder_start_token_id
 
+    return shifted_input_ids
+
 
 @dataclass
 class DataCollatorForPreference(DataCollatorMixin):

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -102,7 +102,6 @@ def shift_tokens_right(input_ids: torch.Tensor, decoder_start_token_id: int) -> 
     shifted_input_ids = input_ids.new_zeros(input_ids.shape)
     shifted_input_ids[:, 1:] = input_ids[:, :-1].clone()
     shifted_input_ids[:, 0] = decoder_start_token_id
-
     return shifted_input_ids
 
 


### PR DESCRIPTION
# What does this PR do?
The function `shift_tokens_right` did not return its result, which made it unusable in practice.
- Added `return shifted_input_ids` at the end of the function.
- Ensures `shift_tokens_right` now correctly returns a `torch.Tensor`.
- No breaking changes expected.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.