### PR TITLE
Add pre-commit as dev dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ liger =
     liger-kernel>=0.6.2
 peft =
     peft>=0.8.0
+quality =
+    pre-commit
 quantization =
     bitsandbytes
 scikit =
@@ -81,6 +83,7 @@ dev =
     %(judges)s
     %(liger)s
     %(peft)s
+    %(quality)s
     %(quantization)s
     %(scikit)s
     %(test)s


### PR DESCRIPTION
Add `pre-commit` as `dev` dependency within a new `quality` extra:
- Add pre-commit as a new `quality` extra dependency in `setup.cfg`
- Include pre-commit in the `dev` extra for comprehensive development setup
- Enables consistent code quality checks across the project

Note that `pre-commit` was previously removed as dev dependency in PR:
- #803