### PR TITLE
💾 [bugfix] fix PPO save_checkpoint

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -681,7 +681,7 @@ class PPOTrainer(Trainer):
         # HF trainer specifics
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
         if self.control.should_save:
-            self._save_checkpoint(model, trial=None, metrics=None)
+            self._save_checkpoint(model, trial=None)
             self.control = self.callback_handler.on_save(self.args, self.state, self.control)
 
     def generate_completions(self, sampling: bool = False):


### PR DESCRIPTION
PPOTrainer._save_checkpoint is declared as
```python
def _save_checkpoint(self, model, trial):
```
but is invoked with

```python
self._save_checkpoint(model, trial=None, metrics=None)
```

Remove the extra `metrics=None` argument so the call matches the method signature
