### PR TITLE
[SFTTrainer]: Add Aux Loss for MoE models.

### DIFF
--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -36,7 +36,9 @@ class SFTConfig(TrainingArguments):
 
         model_init_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
-            argument of the [`SFTTrainer`] is provided as a string.
+            argument of the [`SFTTrainer`] is provided as a string. If you're training a MoE model and want to include
+            the load balancing/auxilliary loss as a part of the final loss, remember to set `output_router_logits=True` in this
+            dictionary.
         chat_template_path (`str` or `None`, *optional*, defaults to `None`):
             If specified, sets the model's chat template. This can either be the path to a tokenizer (local directory
             or Hugging Face Hub model) or a direct path to a Jinja template file. When using a Jinja file, you must

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -499,7 +499,9 @@ class SFTTrainer(Trainer):
               [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
               using [`~transformers.AutoModelForCausalLM.from_pretrained`] with the keyword arguments in
               `args.model_init_kwargs`.
-            - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported.
+            - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported. If you're training
+            a MoE model and want to include the load balancing/auxilliary loss as a part of the final loss, remember to set
+            the `output_router_logits` config of the model to `True`.
         args ([`SFTConfig`], *optional*, defaults to `None`):
             Configuration for this trainer. If `None`, a default configuration is used.
         data_collator (`DataCollator`, *optional*):
@@ -844,6 +846,16 @@ class SFTTrainer(Trainer):
         if hasattr(self.model, "add_model_tags"):
             self.model.add_model_tags(self._tag_names)
 
+        self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
+        self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
+        if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
+            logger.warning(
+                "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
+                "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
+                "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "
+                "loss.",
+            )
+
     def _prepare_dataset(
         self,
         dataset: Union[Dataset, IterableDataset],
@@ -1042,6 +1054,11 @@ class SFTTrainer(Trainer):
             model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
         )
 
+        # Add auxiliary loss if available
+        if self.aux_loss_enabled and self.aux_loss_coef:
+            aux_loss = self.aux_loss_coef * outputs.aux_loss
+            loss += aux_loss
+
         # Compute entropy
         if not self.args.use_liger_kernel:  # liger doesn't return logits
             with torch.no_grad():
@@ -1103,6 +1120,8 @@ class SFTTrainer(Trainer):
                 total_sum = total_tokens.sum()
                 accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
                 self._metrics[mode]["mean_token_accuracy"].append(accuracy)
+                if self.aux_loss_enabled:
+                    self._metrics[mode]["aux_loss"].append(aux_loss.item())
 
         return (loss, outputs) if return_outputs else loss
 


### PR DESCRIPTION
# What does this PR do?
The `SFTTrainer` currently doesn't account for the load-balancing/auxilliary loss commonly used in training MoE models to ensure that all experts have approximately the same number of tokens routed to them.

This PR adds this loss to the final loss if enabled by the model's config.


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.