### PR TITLE
🌵 Refactor entropy_from_logits for memory efficiency

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -661,14 +661,14 @@ class RepeatRandomSamplerTester(TrlTestCase):
 class TestEntropyFromLogits(TrlTestCase):
     @parameterized.expand(
         [
-            (dtype, chunk_size)
+            (dtype, chunk_size, shape)
             for dtype in (torch.float64, torch.float32, torch.float16, torch.bfloat16)
             for chunk_size in (1, 16)
+            for shape in [(768,), (32, 768), (8, 16, 768), (2, 4, 8, 768)]
         ]
     )
-    def test_entropy_from_logits(self, dtype, chunk_size):
-        batch_size, seq_len, vocab_size = 64, 384, 768
-        logits = torch.randn(batch_size, seq_len, vocab_size, dtype=dtype)
+    def test_entropy_from_logits_2_dims(self, dtype, chunk_size, shape):
+        logits = torch.randn(*shape, dtype=dtype)
         if dtype in (torch.float64, torch.float32):
             p = logits.softmax(-1)
             entropy = -torch.sum(p * p.log(), dim=-1)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1473,7 +1473,7 @@ def selective_log_softmax(logits, index) -> torch.Tensor:
     return per_token_logps
 
 
-def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 1024) -> torch.Tensor:
+def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
     """
     Compute the Shannon entropy (in nats) for each row of *logits* in a memory-efficient way.
 
@@ -1486,7 +1486,7 @@ def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 1024) -> torch.T
         logits (`torch.Tensor`):
             Logits tensor of shape `(..., num_classes)`. Entropy is taken along the last axis; all leading dimensions
             are preserved in the output.
-        chunk_size (`int`, *optional*, defaults to `1024`):
+        chunk_size (`int`, *optional*, defaults to `128`):
             Number of rows from the flattened logits to process per iteration. Smaller values reduce memory usage at
             the cost of more iterations.
 

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1473,31 +1473,41 @@ def selective_log_softmax(logits, index) -> torch.Tensor:
     return per_token_logps
 
 
-def entropy_from_logits(logits, chunk_size: int = 1) -> torch.Tensor:
+def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 1024) -> torch.Tensor:
     """
-    Compute the Shannon entropy (in nats) for each row of *logits* without materialising the full soft-max in memory.
-    The batch dimension is processed in chunks of size `chunk_size` so that only a subset of rows is expanded to
-    probabilities at any one time.
+    Compute the Shannon entropy (in nats) for each row of *logits* in a memory-efficient way.
+
+    Instead of materializing the full softmax for all rows at once, the logits are flattened to shape (N, num_classes),
+    where N is the product of all leading dimensions. Computation is then performed in chunks of size `chunk_size`
+    along this flattened dimension, reducing peak memory usage. The result is reshaped back to match the input's
+    leading dimensions.
 
     Args:
         logits (`torch.Tensor`):
             Logits tensor of shape `(..., num_classes)`. Entropy is taken along the last axis; all leading dimensions
-            are preserved.
-        chunk_size (`int`, *optional*, defaults to `1`):
-            Number of rows to process per iteration.
+            are preserved in the output.
+        chunk_size (`int`, *optional*, defaults to `1024`):
+            Number of rows from the flattened logits to process per iteration. Smaller values reduce memory usage at
+            the cost of more iterations.
 
     Returns:
         `torch.Tensor`:
             Entropy values with shape `logits.shape[:-1]`.
     """
-    per_token_entropies = []
-    for logits_chunk in logits.split(chunk_size, dim=0):
-        logps = F.log_softmax(logits_chunk, dim=-1)
-        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
-        per_token_entropies.extend(chunk_entropy)
+    original_shape = logits.shape[:-1]  # all dims except num_classes
+    num_classes = logits.shape[-1]
 
-    per_token_entropies = torch.stack(per_token_entropies)
-    return per_token_entropies
+    # Flatten all leading dimensions into one
+    flat_logits = logits.reshape(-1, num_classes)
+
+    entropies = []
+    for chunk in flat_logits.split(chunk_size, dim=0):
+        logps = F.log_softmax(chunk, dim=-1)
+        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
+        entropies.append(chunk_entropy)
+
+    entropies = torch.cat(entropies, dim=0)
+    return entropies.reshape(original_shape)
 
 
 def print_prompt_completions_sample(


### PR DESCRIPTION
In SFT and GRPO, the entropy computation induces huge memory spike when training on long context. This PR fixes it, basically from 80 GB spike to around 0.23 GB spike. No significant slowdown observed.

<img width="640" height="480" alt="peak_memory_comparison" src="https://github.com/user-attachments/assets/3d78ef0e-0ce5-4682-9c30-e0ed1ae1d276" />

<img width="640" height="480" alt="entropy_from_logits_benchmark" src="https://github.com/user-attachments/assets/6f8135b9-d5e2-4f71-ac64-26d2153dc695" />

```python
import torch
import torch.nn.functional as F

def entropy_from_logits_before(logits, chunk_size: int = 1) -> torch.Tensor:
    per_token_entropies = []
    for logits_chunk in logits.split(chunk_size, dim=0):
        logps = F.log_softmax(logits_chunk, dim=-1)
        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
        per_token_entropies.extend(chunk_entropy)

    per_token_entropies = torch.stack(per_token_entropies)
    return per_token_entropies


def entropy_from_logits_after(logits: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
    original_shape = logits.shape[:-1]
    num_classes = logits.shape[-1]

    flat_logits = logits.reshape(-1, num_classes)
    entropies = []
    for chunk in flat_logits.split(chunk_size, dim=0):
        logps = F.log_softmax(chunk, dim=-1)
        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
        entropies.append(chunk_entropy)

    return torch.cat(entropies, dim=0).reshape(original_shape)


if __name__ == "__main__":
    device = "cuda"

    peak_before = []
    peak_after_64 = []
    peak_after_128 = []
    peak_after_256 = []

    for seq_len in [1024, 2048, 4096, 8192, 16384, 32768]:
        # Example: batch=1, seq_len=16k, vocab=50k
        batch_size, seq_len, vocab_size = 1, seq_len, 150_000
        logits = torch.randn(batch_size, seq_len, vocab_size, device=device).contiguous()

        torch.cuda.empty_cache()
        mem_before = torch.cuda.memory_allocated(device)
        torch.cuda.reset_peak_memory_stats(device)
        entropy_from_logits_before(logits)
        mem_peak_total = torch.cuda.max_memory_allocated(device)
        mem_peak = mem_peak_total - mem_before
        peak_before.append(mem_peak / 1e9)

        torch.cuda.empty_cache()
        mem_before = torch.cuda.memory_allocated(device)
        torch.cuda.reset_peak_memory_stats(device)
        entropy_from_logits_after(logits, chunk_size=64)
        mem_peak_total = torch.cuda.max_memory_allocated(device)
        mem_peak = mem_peak_total - mem_before
        peak_after_64.append(mem_peak / 1e9)

        torch.cuda.empty_cache()
        mem_before = torch.cuda.memory_allocated(device)
        torch.cuda.reset_peak_memory_stats(device)
        entropy_from_logits_after(logits, chunk_size=128)
        mem_peak_total = torch.cuda.max_memory_allocated(device)
        mem_peak = mem_peak_total - mem_before
        peak_after_128.append(mem_peak / 1e9)

        torch.cuda.empty_cache()
        mem_before = torch.cuda.memory_allocated(device)
        torch.cuda.reset_peak_memory_stats(device)
        entropy_from_logits_after(logits, chunk_size=256)
        mem_peak_total = torch.cuda.max_memory_allocated(device)
        mem_peak = mem_peak_total - mem_before
        peak_after_256.append(mem_peak / 1e9)
    
    import matplotlib.pyplot as plt

    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], peak_before, label="Before")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], peak_after_64, label="After (chunk_size=64)")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], peak_after_128, label="After (chunk_size=128 (default))")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], peak_after_256, label="After (chunk_size=256)")
    plt.xlabel("Sequence Length")
    plt.ylabel("Peak Memory (GB)")
    plt.title("Peak Memory Usage Before and After Refactor")
    plt.legend()
    plt.ylim(0, 10)
    plt.grid()
    plt.savefig("peak_memory_comparison.png")
```



```python
import torch
import torch.nn.functional as F


import torch
import torch.nn.functional as F
import timeit
def entropy_from_logits_before(logits, chunk_size: int = 1) -> torch.Tensor:
    per_token_entropies = []
    for logits_chunk in logits.split(chunk_size, dim=0):
        logps = F.log_softmax(logits_chunk, dim=-1)
        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
        per_token_entropies.extend(chunk_entropy)

    per_token_entropies = torch.stack(per_token_entropies)
    return per_token_entropies


def entropy_from_logits_after(logits: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
    original_shape = logits.shape[:-1]
    num_classes = logits.shape[-1]

    flat_logits = logits.reshape(-1, num_classes)
    entropies = []
    for chunk in flat_logits.split(chunk_size, dim=0):
        logps = F.log_softmax(chunk, dim=-1)
        chunk_entropy = -(torch.exp(logps) * logps).sum(-1)
        entropies.append(chunk_entropy)

    return torch.cat(entropies, dim=0).reshape(original_shape)


if __name__ == "__main__":
    device = "cuda"
    N=25

    time_before = []
    time_after_64 = []
    time_after_128 = []
    time_after_256 = []
    time_after_512 = []
    time_after_1024 = []
    time_after_2048 = []

    for seq_len in [1024, 2048, 4096, 8192, 16384, 32768]:
        # Example: batch=1, seq_len=16k, vocab=50k
        batch_size, seq_len, vocab_size = 1, seq_len, 150_000
        logits = torch.randn(batch_size, seq_len, vocab_size, device=device).contiguous()

        ###################################################################
        def timed_fn():
            torch.cuda.synchronize()  # wait for all previous CUDA ops
            entropy = entropy_from_logits_before(logits)
            torch.cuda.synchronize()  # wait until entropy computation finishes
            return entropy

        elapsed_time = timeit.timeit(timed_fn, number=N)/N
        time_before.append(elapsed_time)

        ###################################################################
        def timed_fn():
            torch.cuda.synchronize()  # wait for all previous CUDA ops
            entropy = entropy_from_logits_after(logits, chunk_size=64)
            torch.cuda.synchronize()  # wait until entropy computation finishes
            return entropy

        elapsed_time = timeit.timeit(timed_fn, number=N)/N
        time_after_64.append(elapsed_time)

        ###################################################################
        def timed_fn():
            torch.cuda.synchronize()  # wait for all previous CUDA ops
            entropy = entropy_from_logits_after(logits, chunk_size=128)
            torch.cuda.synchronize()  # wait until entropy computation finishes
            return entropy

        elapsed_time = timeit.timeit(timed_fn, number=N)/N
        time_after_128.append(elapsed_time)

        ###################################################################
        def timed_fn():
            torch.cuda.synchronize()  # wait for all previous CUDA ops
            entropy = entropy_from_logits_after(logits, chunk_size=256)
            torch.cuda.synchronize()  # wait until entropy computation finishes
            return entropy

        elapsed_time = timeit.timeit(timed_fn, number=N)/N
        time_after_256.append(elapsed_time)

    import matplotlib.pyplot as plt

    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], time_before, label="Before")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], time_after_64, label="After (chunk_size=64)")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], time_after_128, label="After (chunk_size=128 (default))")
    plt.plot(["1024", "2048", "4096", "8192", "16384", "32768"], time_after_256, label="After (chunk_size=256)")
    plt.xlabel("Sequence Length")
    plt.ylabel("Time per call (s)")
    plt.title("Entropy from logits computation time")
    plt.legend()
    plt.grid()
    plt.savefig("entropy_from_logits_benchmark.png")
```


