### PR TITLE
Fix: undefined `current_gradient_accumulation_steps`

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -418,6 +418,8 @@ class GRPOTrainer(Trainer):
             compute_loss_func="non-None value to disable scaling",
         )
 
+        self.current_gradient_accumulation_steps = args.gradient_accumulation_steps
+
         # Reference model
         self.beta = args.beta
         if self.beta == 0.0:


### PR DESCRIPTION
# What does this PR do?

The GRPO trainer uses `self.current_gradient_accumulation_steps` in its `_compute_loss` method, but this attribute is never initialized. When `eval_on_start=True`, evaluation runs before the training loop starts, causing an `AttributeError` because the attribute doesn't exist yet.

Fixes #4010 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.