### PR TITLE
Fix #3982: Fix DPO Trainer support for Gemma 3 vision models

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -48,7 +48,10 @@ from transformers.integrations import (
     is_mlflow_available,
     is_wandb_available,
 )
-from transformers.models.auto.modeling_auto import MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES
+from transformers.models.auto.modeling_auto import (
+    MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+    MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES,
+)
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalLoopOutput
 from transformers.utils import is_liger_kernel_available, is_peft_available
@@ -330,7 +333,10 @@ class DPOTrainer(Trainer):
             )
 
         self.is_encoder_decoder = model.config.is_encoder_decoder
-        self.is_vision_model = model.config.model_type in MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES.keys()
+        self.is_vision_model = (
+            model.config.model_type in MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES
+            or model.config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+        )
         self.is_peft_model = is_peft_available() and isinstance(model, PeftModel)
         self.model_adapter_name = args.model_adapter_name
         self.ref_adapter_name = args.ref_adapter_name
@@ -788,6 +794,8 @@ class DPOTrainer(Trainer):
                 "prompt_input_ids",
                 "chosen_input_ids",
                 "rejected_input_ids",
+                "pixel_values",
+                "pixel_attention_mask",
                 "image_sizes",
                 "ref_chosen_logps",
                 "ref_rejected_logps",


### PR DESCRIPTION
## [WIP] Fix DPO Trainer support for Gemma 3 vision models

**Note: This is a work in progress. Additional testing is being completed. Will ping maintainers when ready for review.**

This PR addresses an issue with the DPO Trainer's handling of vision-language models, specifically for Gemma 3. The changes enhance model type detection to properly support image-text-to-text models.

### Changes made:
- Import `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES` from transformers' modeling_auto
- Update the `is_vision_model` check to include both vision-to-sequence and image-text-to-text model types
- Add `pixel_values` and `pixel_attention_mask` to the signature columns to properly process vision inputs

### Why this change is needed
Gemma 3 vision models use a processor format that wasn't properly detected in the current implementation, causing failures when using these models with DPO training.

### Testing
Currently testing with Gemma 3 vision models to ensure proper processor dispatch and integration. Will update with more comprehensive test results before requesting review.

Fixes #3982
