### PR TITLE
[GRPO VLM] Update split sizes to generalize

### DIFF
--- a/examples/scripts/grpo_vlm.py
+++ b/examples/scripts/grpo_vlm.py
@@ -64,6 +64,21 @@ accelerate launch \
     --gradient_accumulation_steps 2 \
     --num_generations 2
 
+
+python examples/scripts/grpo_vlm.py \
+    --model_name_or_path HuggingFaceTB/SmolVLM2-2.2B-Instruct \
+    --output_dir grpo-SmolVLM2-2.2B-Instruct \
+    --learning_rate 1e-5 \
+    --dtype bfloat16 \
+    --max_prompt_length 2048 \
+    --max_completion_length 1024 \
+    --use_peft \
+    --lora_target_modules "q_proj", "v_proj" \
+    --log_completions \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 2 \
+    --num_generations 2
+
 """
 
 import os
@@ -72,16 +87,12 @@ import torch
 from datasets import load_dataset
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
+from peft import LoraConfig
 
 from trl import (
     GRPOConfig,
     GRPOTrainer,
-    ModelConfig,
-    ScriptArguments,
-    TrlParser,
     get_kbit_device_map,
-    get_peft_config,
-    get_quantization_config,
 )
 from trl.rewards import think_format_reward
 
@@ -91,19 +102,24 @@ os.environ.setdefault("TRACKIO_SPACE_ID", "trl-trackio")
 
 
 if __name__ == "__main__":
-    parser = TrlParser((ScriptArguments, GRPOConfig, ModelConfig))
-    script_args, training_args, model_args = parser.parse_args_and_config()
     ################
     # Model & Processor
     ################
-    dtype = model_args.dtype if model_args.dtype in ["auto", None] else getattr(torch, model_args.dtype)
-    quantization_config = get_quantization_config(model_args)
-    training_args.model_init_kwargs = dict(
-        revision=model_args.model_revision,
-        attn_implementation=model_args.attn_implementation,
-        dtype=dtype,
-        device_map=get_kbit_device_map() if quantization_config is not None else None,
-        quantization_config=quantization_config,
+    dtype = torch.bfloat16
+    quantization_config = None
+    training_args = GRPOConfig(
+        model_init_kwargs=dict(
+            attn_implementation="sdpa",
+            dtype=dtype,
+            device_map=get_kbit_device_map() if quantization_config is not None else None,
+            quantization_config=quantization_config,
+        ),
+        learning_rate=1e-5,
+        max_prompt_length=4096,
+        max_completion_length=1024,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=2,
+        num_generations=2,
     )
 
     ################
@@ -145,7 +161,7 @@ if __name__ == "__main__":
     dataset = dataset.map(convert_to_rgb)
 
     train_dataset = dataset["train"]
-    eval_dataset = dataset["test"] if training_args.eval_strategy != "no" else None
+    eval_dataset = dataset["test"]
 
     ################
     # Reward Function for Training
@@ -198,18 +214,26 @@ if __name__ == "__main__":
     ################
     # Training
     ################
+    peft_config = LoraConfig(
+        r=8,
+        lora_alpha=8,
+        lora_dropout=0.1,
+        target_modules=["q_proj", "v_proj"],
+        bias="none",
+    )
+
+    # model_id = "HuggingFaceTB/SmolVLM2-2.2B-Instruct"
+    model_id = "llava-hf/llava-onevision-qwen2-0.5b-ov-hf"
     trainer = GRPOTrainer(
-        model=model_args.model_name_or_path,
+        model=model_id,
         args=training_args,
         reward_funcs=[think_format_reward, accuracy_reward],
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
-        peft_config=get_peft_config(model_args),
+        peft_config=peft_config,
     )
 
     trainer.train()
 
     # Save and push to hub
-    trainer.save_model(training_args.output_dir)
-    if training_args.push_to_hub:
-        trainer.push_to_hub(dataset_name=script_args.dataset_name)
+    # trainer.save_model("temp_trained_model")

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1809,10 +1809,10 @@ def split_pixel_values_by_grid(batch: dict[str, torch.Tensor]) -> dict[str, Unio
     Splits `batch["pixel_values"]` into a list of tensors based on the product of each row in
     `batch["image_grid_thw"]`, while keeping other entries unchanged.
     """
-    if "image_grid_thw" not in batch or "pixel_values" not in batch:
+    if "image_split_sizes" not in batch or "pixel_values" not in batch:
         return batch
 
-    lengths = batch["image_grid_thw"].prod(dim=1).tolist()  # [batch_size]
+    lengths = batch["image_split_sizes"]  # [batch_size]
     pixel_values = batch["pixel_values"]  # [total, feature_dim]
 
     if sum(lengths) != pixel_values.size(0):


### PR DESCRIPTION
# What does this PR do?

As discussed internally, we can rely on transformer utilities to split pixels to a list of batches. That way we dont have to handle each edge case manually

The split pixels will always be of length `batch_size`. In most cases the split sizes are a list of ones, if pixels have no patches/crops/uncommon shapes. In other cases, each batch will contain variable sized image crops per single image 