### PR TITLE
Add autodoc for AlignPropTrainer and AlignPropConfig

### DIFF
--- a/docs/source/alignprop_trainer.md
+++ b/docs/source/alignprop_trainer.md
@@ -91,3 +91,14 @@ for prompt, image in zip(prompts,results.images):
 
 This work is heavily influenced by the repo [here](https://github.com/mihirp1998/AlignProp/) and the associated paper [Aligning Text-to-Image Diffusion Models with Reward Backpropagation
  by Mihir Prabhudesai, Anirudh Goyal, Deepak Pathak, Katerina Fragkiadaki](https://huggingface.co/papers/2310.03739).
+
+## AlignPropTrainer
+
+[[autodoc]] AlignPropTrainer
+    - train
+    - save_model
+    - push_to_hub
+
+## AlignPropConfig
+
+[[autodoc]] AlignPropConfig

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -42,7 +42,7 @@ class AlignPropTrainer(PyTorchModelHubMixin):
     heavily inspired by the work here: https://github.com/mihirp1998/AlignProp/ As of now only Stable Diffusion based
     pipelines are supported
 
-    Attributes:
+    Args:
         config (`AlignPropConfig`):
             Configuration object for AlignPropTrainer. Check the documentation of `PPOConfig` for more details.
         reward_function (`Callable[[torch.Tensor, tuple[str], tuple[Any]], torch.Tensor]`):


### PR DESCRIPTION
Add autodoc for `AlignPropTrainer` and `AlignPropConfig`.

This PR adds documentation for the AlignProp training components:
- `AlignPropTrainer`
- `AlignPropConfig`

This PR ddds autodoc sections for `AlignPropTrainer` and `AlignPropConfig` in `docs/source/alignprop_trainer.md`, including listing key methods for `AlignPropTrainer`.