### PR TITLE
⚖️ Remove `average_tokens_across_devices` default replacement

### DIFF
--- a/examples/scripts/sft_vlm.py
+++ b/examples/scripts/sft_vlm.py
@@ -35,10 +35,10 @@ accelerate launch \
     --output_dir LLaVA-1.5-7B-SFT \
     --dtype bfloat16
 
-For LLaVA-NeXT, use: (requires transformers>=4.45)
+For LLaVA-NeXT, use:
     --model_name_or_path llava-hf/llava-v1.6-mistral-7b-hf
 
-For meta-llama/Llama-3.2-11B-Vision-Instruct, use: (requires transformers>=4.45.1)
+For meta-llama/Llama-3.2-11B-Vision-Instruct, use:
     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct
 
 accelerate launch \

--- a/trl/trainer/prm_config.py
+++ b/trl/trainer/prm_config.py
@@ -74,16 +74,6 @@ class PRMConfig(TrainingArguments):
             "`fp16` is not set."
         },
     )
-    # Note: In transformers>=4.54.0, `average_tokens_across_devices` defaults to True. Overriding this setting is only
-    # needed for earlier versions. Once we require transformers>=4.54.0, this line can be safely removed.
-    # See https://github.com/huggingface/transformers/pull/39395
-    average_tokens_across_devices: bool = field(
-        default=True,
-        metadata={
-            "help": "Whether or not to average tokens across devices. If enabled, will use all_reduce to synchronize "
-            "num_tokens_in_batch for precise loss calculation. Reference: https://github.com/huggingface/transformers/issues/34242 "
-        },
-    )
 
     max_length: Optional[int] = field(
         default=1024,

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -69,16 +69,6 @@ class RewardConfig(TrainingArguments):
             "`fp16` is not set."
         },
     )
-    # Note: In transformers>=4.54.0, `average_tokens_across_devices` defaults to True. Overriding this setting is only
-    # needed for earlier versions. Once we require transformers>=4.54.0, this line can be safely removed.
-    # See https://github.com/huggingface/transformers/pull/39395
-    average_tokens_across_devices: bool = field(
-        default=True,
-        metadata={
-            "help": "Whether or not to average tokens across devices. If enabled, will use all_reduce to synchronize "
-            "num_tokens_in_batch for precise loss calculation. Reference: https://github.com/huggingface/transformers/issues/34242 "
-        },
-    )
 
     max_length: Optional[int] = field(
         default=1024,

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -124,16 +124,6 @@ class SFTConfig(TrainingArguments):
             "`fp16` is not set."
         },
     )
-    # Note: In transformers>=4.54.0, `average_tokens_across_devices` defaults to True. Overriding this setting is only
-    # needed for earlier versions. Once we require transformers>=4.54.0, this line can be safely removed.
-    # See https://github.com/huggingface/transformers/pull/39395
-    average_tokens_across_devices: bool = field(
-        default=True,
-        metadata={
-            "help": "Whether or not to average tokens across devices. If enabled, will use all_reduce to synchronize "
-            "num_tokens_in_batch for precise loss calculation. Reference: https://github.com/huggingface/transformers/issues/34242 "
-        },
-    )
 
     # Parameters that control the model
     model_init_kwargs: Optional[dict[str, Any]] = field(


### PR DESCRIPTION
Now we require transformers 4.56