### PR TITLE
Update transformers minimum version to 4.56.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,7 +235,7 @@ jobs:
           uv pip install ".[dev]"
           uv pip install accelerate==1.4.0
           uv pip install datasets==3.0.0
-          uv pip install transformers==4.56.0
+          uv pip install transformers==4.56.1
 
       - name: Test with pytest
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 accelerate>=1.4.0
 datasets>=3.0.0
-transformers>=4.56.0
+transformers>=4.56.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 install_requires =
     accelerate>=1.4.0
     datasets>=3.0.0
-    transformers>=4.56.0
+    transformers>=4.56.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Update transformers minimum version to 4.56.1.

That patch version includes the fix:
- https://github.com/huggingface/transformers/pull/40668

This should fix the CI tests with minimum versions: https://github.com/huggingface/trl/actions/runs/17571124955/job/49907398546
```python
AttributeError: 'Accelerator' object has no attribute 'parallelism_config'
```