### PR TITLE
Improve docstring of AlignPropTrainer

### DIFF
--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -390,7 +390,11 @@ class AlignPropTrainer(PyTorchModelHubMixin):
 
     def train(self, epochs: Optional[int] = None):
         """
-        Train the model for a given number of epochs
+        Train the model for a given number of epochs.
+
+        Args:
+            epochs (int, *optional*, defaults to `self.config.num_epochs`):
+                Number of epochs to train the model for.
         """
         global_step = 0
         if epochs is None:

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -38,9 +38,14 @@ logger = logging.get_logger(__name__)
 
 class AlignPropTrainer(PyTorchModelHubMixin):
     """
-    The AlignPropTrainer uses Deep Diffusion Policy Optimization to optimise diffusion models. Note, this trainer is
-    heavily inspired by the work here: https://github.com/mihirp1998/AlignProp/ As of now only Stable Diffusion based
-    pipelines are supported.
+    Trainer for Reward Backpropagation (AlignProp) for diffusion models.
+
+    For details, see the paper: [Aligning Text-to-Image Diffusion Models with Reward
+    Backpropagation](https://huggingface.co/papers/2310.03739).
+
+    > [!TIP] > This trainer is heavily inspired by the work here: https://github.com/mihirp1998/AlignProp/
+
+    > [!WARNING] > As of now, only Stable Diffusion based pipelines are supported.
 
     Args:
         config ([`AlignPropConfig`]):

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -51,7 +51,7 @@ class AlignPropTrainer(PyTorchModelHubMixin):
             Function to generate prompts to guide model.
         sd_pipeline ([`DDPOStableDiffusionPipeline`]):
             Stable Diffusion pipeline to be used for training.
-        image_samples_hook (`Optional[Callable[[Any, Any, Any], Any]]`):
+        image_samples_hook (`Callable[[Any, Any, Any], Any]]`, *optional*):
             Hook to be called to log images.
     """
 

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -43,13 +43,13 @@ class AlignPropTrainer(PyTorchModelHubMixin):
     pipelines are supported.
 
     Args:
-        config (`AlignPropConfig`):
-            Configuration object for AlignPropTrainer. Check the documentation of `PPOConfig` for more details.
+        config ([`AlignPropConfig`]):
+            Configuration object for AlignPropTrainer. Check the documentation of [`PPOConfig`] for more details.
         reward_function (`Callable[[torch.Tensor, tuple[str], tuple[Any]], torch.Tensor]`):
             Reward function to be used.
         prompt_function (`Callable[[], tuple[str, Any]]`):
             Function to generate prompts to guide model.
-        sd_pipeline (`DDPOStableDiffusionPipeline`):
+        sd_pipeline ([`DDPOStableDiffusionPipeline`]):
             Stable Diffusion pipeline to be used for training.
         image_samples_hook (`Optional[Callable[[Any, Any, Any], Any]]`):
             Hook to be called to log images.

--- a/trl/trainer/alignprop_trainer.py
+++ b/trl/trainer/alignprop_trainer.py
@@ -40,19 +40,19 @@ class AlignPropTrainer(PyTorchModelHubMixin):
     """
     The AlignPropTrainer uses Deep Diffusion Policy Optimization to optimise diffusion models. Note, this trainer is
     heavily inspired by the work here: https://github.com/mihirp1998/AlignProp/ As of now only Stable Diffusion based
-    pipelines are supported
+    pipelines are supported.
 
     Args:
         config (`AlignPropConfig`):
             Configuration object for AlignPropTrainer. Check the documentation of `PPOConfig` for more details.
         reward_function (`Callable[[torch.Tensor, tuple[str], tuple[Any]], torch.Tensor]`):
-            Reward function to be used
+            Reward function to be used.
         prompt_function (`Callable[[], tuple[str, Any]]`):
-            Function to generate prompts to guide model
+            Function to generate prompts to guide model.
         sd_pipeline (`DDPOStableDiffusionPipeline`):
             Stable Diffusion pipeline to be used for training.
         image_samples_hook (`Optional[Callable[[Any, Any, Any], Any]]`):
-            Hook to be called to log images
+            Hook to be called to log images.
     """
 
     _tag_names = ["trl", "alignprop"]


### PR DESCRIPTION
Improve docstring of `AlignPropTrainer`.

This PR:
- Corrects the description of the trainer: it was mentioning "Deep Diffusion Policy Optimization"
- Fix interlinks and syntax
- Adds parameter description for `train` method
