### PR TITLE
Hotfix: Add ParallelismConfig fallback for transformers with old accelerate

### DIFF
--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -31,6 +31,26 @@ from transformers.hf_argparser import DataClass, DataClassType
 from transformers.utils import is_rich_available
 
 
+def _ensure_transformers_parallelism_config() -> None:
+    """
+    Ensure that ``transformers.training_args`` always defines the symbol `ParallelismConfig` so that Python's
+    `typing.get_type_hints` can resolve annotations on `transformers.TrainingArguments` without raising a `NameError`.
+
+    This is needed when running with ``accelerate<1.10.1``, where the module ``accelerate.parallelism_config`` did not
+    exist and therefore the type alias is not imported by Transformers.
+
+    See upstream fix PR in transformers#40818.
+    """
+    from typing import Any
+
+    import transformers.training_args
+
+    if not hasattr(transformers.training_args, "ParallelismConfig"):
+        transformers.training_args.ParallelismConfig = Any
+
+
+_ensure_transformers_parallelism_config()  # before creating HfArgumentParser
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Hotfix: Add ParallelismConfig fallback for transformers with old accelerate.

Fix `TrainingArguments.parallelism_config` NameError with accelerate<1.10.1:
- Tests with minimum versions: https://github.com/huggingface/trl/actions/runs/17635808933/job/50111711153
```python
RuntimeError: Type resolution failed for <class 'trl.trainer.dpo_config.DPOConfig'>. Try declaring the class in global scope or removing line of `from __future__ import annotations` which opts in Postponed Evaluation of Annotations (PEP 563)
```
```python
E           NameError: name 'ParallelismConfig' is not defined
```

## Problem
When accelerate<1.10.1, the module accelerate.parallelism_config does not exist.
Transformers’ TrainingArguments currently annotates:
```python
parallelism_config: Optional["ParallelismConfig"] = field(default=None)
```
This creates a ForwardRef. On Python ≥3.12, when TRL constructs its CLI parsers, transformers.HfArgumentParser calls typing.get_type_hints(TrainingArguments). Since ParallelismConfig is undefined in transformers.training_args, a NameError is raised:
```python
NameError: name 'ParallelismConfig' is not defined
```

## Fix
This PR add a compat helper that pre-binds transformers.training_args.ParallelismConfig = Any if the name is missing. This ensures get_type_hints can always resolve the reference. The helper is called early before any HfArgumentParser is created.

## Upstream
The proper fix is proposed in:
- huggingface/transformers#40818