### PR TITLE
Fix CI failure in slow GRPO test due to missing pillow dependency

### DIFF
--- a/docker/trl-latest-gpu/Dockerfile
+++ b/docker/trl-latest-gpu/Dockerfile
@@ -55,7 +55,7 @@ RUN source activate trl && \
     transformers \
     accelerate \
     peft \
-    trl[test]@git+https://github.com/huggingface/trl
+    trl[test,vlm]@git+https://github.com/huggingface/trl
 
 RUN source activate trl && \ 
     pip freeze | grep trl

--- a/docker/trl-source-gpu/Dockerfile
+++ b/docker/trl-source-gpu/Dockerfile
@@ -55,7 +55,7 @@ RUN source activate trl && \
     git+https://github.com/huggingface/transformers \
     git+https://github.com/huggingface/accelerate \
     git+https://github.com/huggingface/peft \
-    trl[test]@git+https://github.com/huggingface/trl
+    trl[test,vlm]@git+https://github.com/huggingface/trl
 
 RUN source activate trl && \ 
     pip freeze | grep transformers


### PR DESCRIPTION
Fix CI failure in slow GRPO test due to missing pillow dependency.

The CI was failing on the following slow test: https://github.com/huggingface/trl/actions/runs/17635808922/job/50111710929
```python
tests/slow/test_grpo_slow.py::GRPOTrainerSlowTester::test_vlm_training_0_HuggingFaceTB_SmolVLM_Instruct
```
with the error:
```python
ImportError: 
Idefics3ImageProcessor requires the PIL library but it was not found in your environment. You can install it with pip:
`pip install pillow`. Please note that you may need to restart your runtime after installation.
```

This PR:
- Adds 'vlm' extra to Dockerfiles used for slow tests, ensuring `pillow` is available

Note that a previous attempt addressed this issues, but did not update the Docker files, so the error persists:
- #3814