### PR TITLE
Set Ruff src for first-party imports

### DIFF
--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -18,7 +18,6 @@ from typing import Optional, Union
 
 import pandas as pd
 import torch
-import wandb
 from accelerate import Accelerator
 from accelerate.state import AcceleratorState
 from accelerate.utils import gather_object, is_wandb_available


### PR DESCRIPTION
Set Ruff "src" setting for first-party imports.

This PR updates our Ruff configuration to explicitly declare the project's source directory.