### PR TITLE
Add support for testing experimental features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test precommit common_tests slow_tests test_examples tests_gpu
+.PHONY: test precommit common_tests slow_tests test_examples tests_gpu test_experimental
 
 check_dirs := examples tests trl
 
@@ -28,3 +28,6 @@ test_examples:
 		TRL_ACCELERATE_CONFIG=$${file} bash $(COMMAND_FILES_PATH)/run_dpo.sh; \
 		echo $$?','$${file} >> temp_results_dpo_tests.txt; \
 	done
+
+test_experimental:
+	pytest -k "experimental"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ known-first-party = ["trl"]
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "low-priority: marks tests as low priority (deselect with '-m \"not low-priority\"')"
 ]
 addopts = [
     "-k", "not experimental",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,5 +27,5 @@ known-first-party = ["trl"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 addopts = [
-    "-k", "not experimental",
+    "-k", "not experimental"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ known-first-party = ["trl"]
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 addopts = [
     "-k", "not experimental"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 addopts = [
-    "-k", "not experimental"
+    "-k", "not experimental",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,6 @@ known-first-party = ["trl"]
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "low-priority: marks tests as low priority (deselect with '-m \"not low-priority\"')"
+addopts = [
+    "-k", "not experimental",
 ]


### PR DESCRIPTION
Add support for testing experimental features.

This PR introduces a minimal testing workflow for the new `experimental` submodule:
- Default behavior unchanged: pytest and make test now exclude experimental tests automatically via `addopts = ["-k", "not experimental"]` in pyproject.toml
- New target: `make test_experimental`: runs only the experimental tests
- Directory structure: All tests for features under the `trl.experimental` namespace should be placed in the directory:
  - `tests/experimental/`

This setup keeps CI fast and stable (running only the main test suite) while making it easy for contributors to run experimental tests locally (or in a future separate CI job).

Follow-up to:
- #4073