### PR TITLE
Add deprecation warnings to docstrings

### DIFF
--- a/trl/trainer/online_dpo_config.py
+++ b/trl/trainer/online_dpo_config.py
@@ -63,12 +63,12 @@ class OnlineDPOConfig(TrainingArguments):
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
 
-            <Tip warning="true">
+            <Deprecated version="0.22.0">
 
             This parameter is deprecated and will be removed in version 0.25.0. Since OnlineDPO does not involve
             dataset preparation, you can safely remove it.
 
-            </Tip>
+            </Deprecated>
 
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the model and reference model.

--- a/trl/trainer/online_dpo_config.py
+++ b/trl/trainer/online_dpo_config.py
@@ -62,6 +62,14 @@ class OnlineDPOConfig(TrainingArguments):
 
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
+
+            <Tip warning="true">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Since OnlineDPO does not involve
+            dataset preparation, you can safely remove it.
+
+            </Tip>
+
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the model and reference model.
 

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -170,6 +170,16 @@ class OnlineDPOTrainer(Trainer):
 
         > Deprecated parameters
 
+        reward_model:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_funcs` instead.
+
+            </Deprecated>
+
+        > Deprecated parameters
+
         <Deprecated version="0.22.0">
 
         The following parameters are deprecated and will be removed in version 0.25.0:

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -175,15 +175,6 @@ class OnlineDPOTrainer(Trainer):
             This parameter is deprecated and will be removed in version 0.25.0. Use `reward_funcs` instead.
 
             </Deprecated>
-
-        reward_processing_class:
-
-            <Deprecated version="0.22.0">
-
-            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_processing_classes`
-            instead.
-
-            </Deprecated>
     """
 
     _tag_names = ["trl", "online-dpo"]

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,12 +168,14 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
-    .. deprecated:: 0.22.0
+        <Tip warning="true">
         The following parameters are deprecated and will be removed in a future version:
 
         * `reward_model`: Use `reward_funcs` instead. For example, change `reward_model=model` to `reward_funcs=model`.
         * `reward_processing_class`: Use `reward_processing_classes` instead. For example, change
           `reward_processing_class=tokenizer` to `reward_processing_classes=tokenizer`.
+
+        </Tip>
     """
 
     _tag_names = ["trl", "online-dpo"]

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,6 +168,8 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
+        > Deprecated parameters
+
         <Deprecated version="0.22.0">
 
         The following parameters are deprecated and will be removed in version 0.25.0:

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -170,7 +170,7 @@ class OnlineDPOTrainer(Trainer):
 
         > Deprecated parameters
 
-        reward_model: Description.
+        reward_model (`type`): Description.
 
             <Deprecated version="0.22.0">
 

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,7 +168,7 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
-        reward_model:
+        reward_model
 
             <Deprecated version="0.22.0">
 
@@ -176,27 +176,14 @@ class OnlineDPOTrainer(Trainer):
 
             </Deprecated>
 
-        > Deprecated parameters
-
-        reward_model (`type`): Description.
+        reward_processing_class
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_funcs` instead.
+            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_processing_classes`
+            instead.
 
             </Deprecated>
-
-        > Deprecated parameters
-
-        <Deprecated version="0.22.0">
-
-        The following parameters are deprecated and will be removed in version 0.25.0:
-
-        * `reward_model`: Use `reward_funcs` instead. For example, change `reward_model=model` to `reward_funcs=model`.
-        * `reward_processing_class`: Use `reward_processing_classes` instead. For example, change
-          `reward_processing_class=tokenizer` to `reward_processing_classes=tokenizer`.
-
-        </Deprecated>
     """
 
     _tag_names = ["trl", "online-dpo"]

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,14 +168,15 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
-        <Tip warning="true">
-        The following parameters are deprecated and will be removed in a future version:
+        <Deprecated version="0.22.0">
+
+        The following parameters are deprecated and will be removed in version 0.25.0:
 
         * `reward_model`: Use `reward_funcs` instead. For example, change `reward_model=model` to `reward_funcs=model`.
         * `reward_processing_class`: Use `reward_processing_classes` instead. For example, change
           `reward_processing_class=tokenizer` to `reward_processing_classes=tokenizer`.
 
-        </Tip>
+        </Deprecated>
     """
 
     _tag_names = ["trl", "online-dpo"]

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,7 +168,7 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
-        reward_model
+        reward_model:
 
             <Deprecated version="0.22.0">
 
@@ -176,7 +176,7 @@ class OnlineDPOTrainer(Trainer):
 
             </Deprecated>
 
-        reward_processing_class
+        reward_processing_class:
 
             <Deprecated version="0.22.0">
 

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -168,6 +168,14 @@ class OnlineDPOTrainer(Trainer):
         preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
             The function to use to preprocess the logits before computing the metrics.
 
+        reward_model:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_funcs` instead.
+
+            </Deprecated>
+
         > Deprecated parameters
 
         reward_model (`type`): Description.

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -170,7 +170,7 @@ class OnlineDPOTrainer(Trainer):
 
         > Deprecated parameters
 
-        reward_model:
+        reward_model: Description.
 
             <Deprecated version="0.22.0">
 

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -269,7 +269,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. KL is now computed only at the sequence level.
+            This parameter is deprecated and will be removed in version 0.25.0. KL is now computed only at the sequence
+            level.
 
             </Deprecated>
 
@@ -277,7 +278,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. This parameter was unused, you can safely remove it from your scripts.
+            This parameter is deprecated and will be removed in version 0.25.0. This parameter was unused, you can
+            safely remove it from your scripts.
 
             </Deprecated>
 
@@ -285,7 +287,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. Now it is automatically set to `per_device_train_batch_size` (or `per_device_eval_batch_size` during evaluation).
+            This parameter is deprecated and will be removed in version 0.25.0. Now it is automatically set to
+            `per_device_train_batch_size` (or `per_device_eval_batch_size` during evaluation).
 
             </Deprecated>
 
@@ -293,7 +296,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. Use `logging_steps` to control generation logging frequency.
+            This parameter is deprecated and will be removed in version 0.25.0. Use `logging_steps` to control
+            generation logging frequency.
 
             </Deprecated>
 
@@ -309,7 +313,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. Use `processing_class.eos_token_id` instead.
+            This parameter is deprecated and will be removed in version 0.25.0. Use `processing_class.eos_token_id`
+            instead.
 
             </Deprecated>
 
@@ -317,7 +322,8 @@ class RLOOConfig(TrainingArguments):
 
             <Deprecated version="0.22.0">
 
-            This parameter is deprecated and will be removed in version 0.25.0. Replicate with a custom reward function checking if `eos_token_id` is in `completion_ids`.
+            This parameter is deprecated and will be removed in version 0.25.0. Replicate with a custom reward function
+            checking if `eos_token_id` is in `completion_ids`.
 
             </Deprecated>
     """

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -264,6 +264,62 @@ class RLOOConfig(TrainingArguments):
             This parameter is deprecated and will be removed in version 0.25.0. Use `max_completion_length` instead.
 
             </Deprecated>
+
+        token_level_kl:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. KL is now computed only at the sequence level.
+
+            </Deprecated>
+
+        dataset_num_proc:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. This parameter was unused, you can safely remove it from your scripts.
+
+            </Deprecated>
+
+        local_rollout_forward_batch_size:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Now it is automatically set to `per_device_train_batch_size` (or `per_device_eval_batch_size` during evaluation).
+
+            </Deprecated>
+
+        num_sample_generations:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `logging_steps` to control generation logging frequency.
+
+            </Deprecated>
+
+        stop_token:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0.
+
+            </Deprecated>
+
+        stop_token_id:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `processing_class.eos_token_id` instead.
+
+            </Deprecated>
+
+        missing_eos_penalty:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Replicate with a custom reward function checking if `eos_token_id` is in `completion_ids`.
+
+            </Deprecated>
     """
 
     _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -193,48 +193,75 @@ class RLOOConfig(TrainingArguments):
 
         rloo_k:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `num_generations` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `num_generations` instead.
+
+            </Deprecated>
 
         cliprange:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `epsilon` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `epsilon` instead.
+
+            </Deprecated>
 
         kl_coef:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `beta` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `beta` instead.
+
+            </Deprecated>
 
         exp_name:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `run_name` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `run_name` instead.
+
+            </Deprecated>
 
         normalize_reward:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `normalize_advantages` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `normalize_advantages` instead.
+
+            </Deprecated>
 
         num_ppo_epochs:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `num_iterations` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `num_iterations` instead.
+
+            </Deprecated>
 
         num_mini_batches:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `steps_per_generation` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `steps_per_generation` instead.
+
+            </Deprecated>
 
         total_episodes:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `max_steps` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `max_steps` instead.
+
+            </Deprecated>
 
         response_length:
 
-            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
-            `max_completion_length` instead. </Deprecated>
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `max_completion_length` instead.
+
+            </Deprecated>
     """
 
     _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -190,6 +190,51 @@ class RLOOConfig(TrainingArguments):
         wandb_log_unique_prompts (`bool`, *optional*, defaults to `False`):
             Whether to log unique prompts in wandb. If `True`, only unique prompts are logged. If `False`, all prompts
             are logged.
+
+        rloo_k:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `num_generations` instead. </Deprecated>
+
+        cliprange:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `epsilon` instead. </Deprecated>
+
+        kl_coef:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `beta` instead. </Deprecated>
+
+        exp_name:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `run_name` instead. </Deprecated>
+
+        normalize_reward:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `normalize_advantages` instead. </Deprecated>
+
+        num_ppo_epochs:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `num_iterations` instead. </Deprecated>
+
+        num_mini_batches:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `steps_per_generation` instead. </Deprecated>
+
+        total_episodes:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `max_steps` instead. </Deprecated>
+
+        response_length:
+
+            <Deprecated version="0.22.0"> This parameter is deprecated and will be removed in version 0.25.0. Use
+            `max_completion_length` instead. </Deprecated>
     """
 
     _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -191,6 +191,8 @@ class RLOOConfig(TrainingArguments):
             Whether to log unique prompts in wandb. If `True`, only unique prompts are logged. If `False`, all prompts
             are logged.
 
+        > Deprecated parameters
+
         rloo_k:
 
             <Deprecated version="0.22.0">

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -197,6 +197,47 @@ class RLOOTrainer(Trainer):
             model and a scheduler given by [`get_linear_schedule_with_warmup`] controlled by `args`.
         peft_config ([`~peft.PeftConfig`], *optional*):
             PEFT configuration used to wrap the model. If `None`, the model is not wrapped.
+
+        config:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `args` instead.
+
+            </Deprecated>
+
+        reward_model:
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `reward_funcs` instead.
+
+            </Deprecated>
+
+        policy:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. Use `model` instead.
+
+            </Deprecated>
+
+        ref_policy:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. To use the initial model as the
+            reference model, simply omit this parameter. The parameter is ignored.
+
+            </Deprecated>
+
+        data_collator:
+
+            <Deprecated version="0.22.0">
+
+            This parameter is deprecated and will be removed in version 0.25.0. The RLOOTrainer does not use a data
+            collator, so this parameter is ignored.
+
+            </Deprecated>
     """
 
     _tag_names = ["trl", "rloo"]


### PR DESCRIPTION
Add deprecation warnings to docstrings.

This PR adds deprecation notices to docstrings for documentation consistency: the docstring should match the actual behavior of the code.

This approach is better than removing it entirely because:
- The parameter still exists in the code and will accept values (even if it shows a warning)
- Users need the documentation of the parameter to better understand the deprecation message
