### PR TITLE
Align slow tests with regular tests

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -20,7 +20,7 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       TEST_TYPE: "single_gpu"
     container:
-      image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel
+      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
       options: --gpus all --shm-size "16gb"
     defaults:
       run:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -14,90 +14,106 @@ env:
 
 jobs:
   run_all_tests_single_gpu:
-    strategy:
-      fail-fast: false
-      matrix:
-        docker-image-name:
-          [
-            "huggingface/trl",
-            "huggingface/trl:dev",
-          ]
     runs-on:
       group: aws-g4dn-2xlarge
     env:
       CUDA_VISIBLE_DEVICES: "0"
-      TEST_TYPE: "single_gpu_${{ matrix.docker-image-name }}"
+      TEST_TYPE: "single_gpu"
     container:
-      image: ${{ matrix.docker-image-name }}
-      options: --gpus all --shm-size "16gb" -e NVIDIA_DISABLE_REQUIRE=true
+      image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel
+      options: --gpus all --shm-size "16gb"
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - name: Pip install
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
         run: |
-          source activate trl
-          pip install -e ".[test,vlm]" --no-deps
-          pip install pytest-reportlog parameterized
+          apt-get update && apt-get install -y make git curl
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Create Python virtual environment
+        run: |
+          uv venv
+          uv pip install --upgrade setuptools wheel
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install ".[dev]"
+          uv pip install pytest-reportlog parameterized
 
       - name: Run slow SFT tests on single GPU
         if: always()
         run: |
-          source activate trl
+          source .venv/bin/activate
           make slow_tests
 
       - name: Generate Report
         if: always()
         run: |
-          pip install slack_sdk tabulate
+          source .venv/bin/activate
+          uv pip install slack_sdk tabulate
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
   run_all_tests_multi_gpu:
-    strategy:
-      fail-fast: false
-      matrix:
-        docker-image-name:
-          [
-            "huggingface/trl",
-            "huggingface/trl:dev",
-          ]
     runs-on:
       group: aws-g4dn-2xlarge
     env:
       CUDA_VISIBLE_DEVICES: "0,1"
-      TEST_TYPE: "multi_gpu_${{ matrix.docker-image-name }}"
+      TEST_TYPE: "multi_gpu"
     container:
-      image: ${{ matrix.docker-image-name }}
-      options: --gpus all --shm-size "16gb" -e NVIDIA_DISABLE_REQUIRE=true
+      image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel
+      options: --gpus all --shm-size "16gb"
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - name: Pip install
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
         run: |
-          source activate trl
-          pip install -e ".[test,vlm]" --no-deps
-          pip install pytest-reportlog parameterized
+          apt-get update && apt-get install -y make git curl
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Create Python virtual environment
+        run: |
+          uv venv
+          uv pip install --upgrade setuptools wheel
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install ".[dev]"
+          uv pip install pytest-reportlog parameterized
 
       - name: Run slow SFT tests on Multi GPU
         if: always()
         run: |
-          source activate trl
+          source .venv/bin/activate
           make slow_tests
 
       - name: Run end-to-end examples tests on multi GPU
         if: always()
         run: |
-          source activate trl
-          pip install deepspeed
+          source .venv/bin/activate
+          uv pip install deepspeed
           make test_examples
 
       - name: Generate Reports
         if: always()
         run: |
-          pip install slack_sdk tabulate
+          source .venv/bin/activate
+          uv pip install slack_sdk tabulate
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
           python scripts/log_example_reports.py --text_file_name temp_results_sft_tests.txt >> $GITHUB_STEP_SUMMARY
           python scripts/log_example_reports.py --text_file_name temp_results_dpo_tests.txt >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Align slow tests with regular tests.

This PR:
- Aligns slow tests with regular tests architecture for consistency and maintainability
- Replaces custom Docker images (`huggingface/trl-latest-gpu`, `huggingface/trl-source-gpu`) with standard `pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel`
- Removes problematic `--no-deps` flag that prevented VLM dependencies from being installed

## Problem

See previous PR addressing the issue of misaligned dependencies:
- #4064

The slow tests used custom Docker images with pre-installed dependencies and `--no-deps` to avoid conflicts. When VLM extras were added to the install command, the `--no-deps` flag prevented Pillow and other VLM dependencies from being installed, causing import errors.

## Solution

- Use the same proven approach as regular tests: standard PyTorch image + `uv pip install ".[dev]"`
- Eliminates custom Docker image usage burden
- Ensures all extras (including VLM) are properly installed
- Provides consistency across all test workflows

## Additional problem
Also note that `conda` `trl` venv is no longer present in the Docker images after the merge of:
- #3931

and the slow tests (which use the Docker containers) now raise: https://github.com/huggingface/trl/actions/runs/17713423927/job/50335140091
```python
EnvironmentNameNotFound: Could not find conda environment: trl
You can list all discoverable environments with `conda info --envs`.
```
