### PR TITLE
Fix VLM configs in generate_tiny_models

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -279,17 +279,21 @@ for model_id, model_class in [
     ("Qwen/Qwen2.5-VL-3B-Instruct", Qwen2_5_VLForConditionalGeneration),
 ]:
     processor = AutoProcessor.from_pretrained(model_id)
-    config = AutoConfig.from_pretrained(model_id)
 
-    config.text_config.num_hidden_layers = 2
-    config.text_config.hidden_size = 16
-    config.text_config.num_attention_heads = 4
-    config.text_config.num_key_value_heads = 2
-
-    config.vision_config.num_hidden_layers = 2
-    config.vision_config.hidden_size = 16
-    config.vision_config.num_attention_heads = 4
-    config.vision_config.num_key_value_heads = 2
+    text_config = {
+        "num_hidden_layers": 2,
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "layer_types": None,  # Set it automatically from num_hidden_layers
+    }
+    vision_config = {
+        "num_hidden_layers": 2,
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+    }
+    config = AutoConfig.from_pretrained(model_id, text_config=text_config, vision_config=vision_config)
 
     if isinstance(config, (Qwen2VLConfig)):
         config.vision_config.depth = 2

--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -300,6 +300,7 @@ for model_id, model_class in [
 
     if isinstance(config, (Qwen2VLConfig, Qwen2_5_VLConfig)):
         config.text_config.rope_scaling["mrope_section"] = [2]
+        config.rope_scaling["mrope_section"] = [2]  # different dict object from text_config; see GH-4101
 
     if isinstance(config, (Qwen2_5_VLConfig)):
         config.vision_config.out_hidden_size = 16


### PR DESCRIPTION
This PR fixes the configs for VLMs within `scripts/generate_tiny_models.py`. The main change is switching from direct attribute assignment on the config object to passing configuration dictionaries as arguments to `AutoConfig.from_pretrained`, which streamlines and clarifies the configuration process.

Configuration refactoring:

* Replace manual assignment of individual attributes on `config.text_config` and `config.vision_config` with `text_config` and `vision_config` dictionaries passed directly to `AutoConfig.from_pretrained`. This makes the code cleaner and less error-prone.
* Add a `"layer_types": None` entry to `text_config`, indicating it should be set automatically based on `num_hidden_layers`, so we avoid a ValueError


Fix #4099.

## Validation
We can check that the fix works.
Before the fix:
```python
from transformers import AutoModelForSequenceClassification

AutoModelForSequenceClassification.from_pretrained('trl-internal-testing/tiny-Gemma3ForConditionalGeneration')

ValueError: `num_hidden_layers` (2) must be equal to the number of layer types (34)
```
After the fix: We opened a PR in 'trl-internal-testing/tiny-Gemma3ForConditionalGeneration' with the fix: https://huggingface.co/trl-internal-testing/tiny-Gemma3ForConditionalGeneration/discussions/2
```python
from transformers import AutoModelForSequenceClassification

AutoModelForSequenceClassification.from_pretrained('trl-internal-testing/tiny-Gemma3ForConditionalGeneration', revision='refs/pr/2')
```