### PR TITLE
docs: correct option name to enable vllm sleep mode

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -257,7 +257,7 @@ We provide a [HF Space](https://huggingface.co/spaces/trl-lib/recommend-vllm-mem
 
 If the recommended value does not work in your environment, we suggest adding a small buffer (e.g., +0.05 or +0.1) to the recommended value to ensure stability.
 
-If you still find you are getting out-of-memory errors set `vllm_sleep_enabled` to True and the vllm parameters and cache will be offloaded during the optimization step. For more information, see [Reducing Memory Usage with vLLM Sleep Mode](reducing_memory_usage#vllm-sleep-mode).
+If you still find you are getting out-of-memory errors set `vllm_enable_sleep_mode` to True and the vllm parameters and cache will be offloaded during the optimization step. For more information, see [Reducing Memory Usage with vLLM Sleep Mode](reducing_memory_usage#vllm-sleep-mode).
 
 </Tip>
 

--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -272,7 +272,7 @@ When using vLLM as the generation backend, you can enable _sleep mode_ to offloa
 ```python
 from trl import GRPOConfig
 
-training_args = GRPOConfig(..., vllm_sleep_enabled=True)
+training_args = GRPOConfig(..., vllm_enable_sleep_mode=True)
 ```
 
 </hfoption>
@@ -281,7 +281,7 @@ training_args = GRPOConfig(..., vllm_sleep_enabled=True)
 ```python
 from trl import RLOOConfig
 
-training_args = RLOOConfig(..., vllm_sleep_enabled=True)
+training_args = RLOOConfig(..., vllm_enable_sleep_mode=True)
 ```
 
 </hfoption>


### PR DESCRIPTION
# What does this PR do?

The option `vllm_sleep_enabled` mentioned in the docs does not exist. It seems like `vllm_enable_sleep_mode` is the correct one. This PR fixes this. https://github.com/huggingface/trl/blob/20cc58d7772ae660792c7b5249d8b817986a547d/trl/trainer/grpo_config.py#L143C9-L143C31

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.