### PR TITLE
[SFTrainer]: Fix DFT Loss

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -39,6 +39,29 @@ if is_peft_available():
     from peft import LoraConfig, PeftModel, PromptEncoderConfig, TaskType, get_peft_model
 
 
+class DFTLossTester(TrlTestCase):
+    def test_dft_loss(self):
+        batch_size = 2
+        seq_len = 3
+        vocab_size = 2
+        # All tokens have the same probability
+        logits = torch.fill(torch.empty(batch_size, seq_len, vocab_size), torch.rand(1).item())
+        outputs = MagicMock()
+        outputs.logits = logits
+        labels = torch.tensor([[1, 0, 0], [0, 1, -100]])
+        ce_loss = torch.nn.functional.cross_entropy(
+            logits.view(-1, vocab_size), labels.view(-1), ignore_index=-100, reduction="mean"
+        )
+        # We need to account for the logits shift operation so we don't consider the first tokens
+        # in each row of the batch
+        num_items_in_batch = 3
+        # Dft loss
+        predicted_dft_loss = dft_loss(outputs, labels, num_items_in_batch)
+        # If we have just two tokens in our vocab and all logits are the same,
+        # dft scales the ce_loss per token by 0.5. So the dft_loss should be ce_loss/2
+        torch.testing.assert_close(ce_loss / 2.0, predicted_dft_loss, atol=1e-4, rtol=1e-4)
+
+
 class TestDataCollatorForLanguageModeling(TrlTestCase):
     def test_basic_padding(self):
         """Test basic padding functionality without completion masks."""
@@ -333,27 +356,6 @@ class SFTTrainerTester(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             self.assertFalse(torch.allclose(param, new_param), f"Parameter {n} has not changed")
 
-    def test_dft_loss(self):
-        batch_size = 2
-        seq_len = 3
-        vocab_size = 2
-        # All tokens have the same probability
-        logits = torch.fill(torch.empty(batch_size, seq_len, vocab_size), torch.rand(1).item())
-        outputs = MagicMock()
-        outputs.logits = logits
-        labels = torch.tensor([[1, 0, 0], [0, 1, -100]])
-        ce_loss = torch.nn.functional.cross_entropy(
-            logits.view(-1, vocab_size), labels.view(-1), ignore_index=-100, reduction="mean"
-        )
-        # We need to account for the logits shift operation so we don't consider the first tokens
-        # in each row of the batch
-        num_items_in_batch = 3
-        # Dft loss
-        predicted_dft_loss = dft_loss(outputs, labels, num_items_in_batch)
-        # If we have just two tokens in our vocab and all logits are the same,
-        # dft scales the ce_loss per token by 0.5. So the dft_loss should be ce_loss/2
-        torch.testing.assert_close(ce_loss / 2.0, predicted_dft_loss, atol=1e-4, rtol=1e-4)
-
     def test_train_dft_loss(self):
         # Get the dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
@@ -364,7 +366,7 @@ class SFTTrainerTester(TrlTestCase):
             loss_type="dft",
             report_to="none",
             eval_strategy="steps",
-            eval_steps=4,
+            eval_steps=3,
         )
         trainer = SFTTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",


### PR DESCRIPTION
# What does this PR do?
DFT loss training crashes in an eval step because the HF Trainer's `prediction_step` function doesn't pass the `num_items_in_batch` param to the loss function.

This PR fixes it by calculating the `num_items_in_batch` when the model is in `eval` mode. We also additionally add a sanity unit-test for validating that dft loss works as desired.

<!-- Remove if not applicable -->

Fixes #4096 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.