### PR TITLE
🔭 Align param passing to VLM configs in generate_tiny_models

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -293,20 +293,23 @@ for model_id, model_class in [
         "num_attention_heads": 4,
         "num_key_value_heads": 2,
     }
-    config = AutoConfig.from_pretrained(model_id, text_config=text_config, vision_config=vision_config)
+    kwargs = {}
 
-    if isinstance(config, (Qwen2VLConfig)):
-        config.vision_config.depth = 2
+    if issubclass(model_class.config_class, Qwen2VLConfig):
+        vision_config["depth"] = 2
 
-    if isinstance(config, (Qwen2VLConfig, Qwen2_5_VLConfig)):
-        config.text_config.rope_scaling["mrope_section"] = [2]
-        config.rope_scaling["mrope_section"] = [2]  # different dict object from text_config; see GH-4101
+    if issubclass(model_class.config_class, (Qwen2VLConfig, Qwen2_5_VLConfig)):
+        text_config["rope_scaling"] = {"type": "default", "mrope_section": [2], "rope_type": "default"}
+        # Different dict object from text_config; see GH-4101 and transformers#41020
+        kwargs["rope_scaling"] = {"type": "default", "mrope_section": [2], "rope_type": "default"}
 
-    if isinstance(config, (Qwen2_5_VLConfig)):
-        config.vision_config.out_hidden_size = 16
+    if issubclass(model_class.config_class, Qwen2_5_VLConfig):
+        vision_config["out_hidden_size"] = 16
 
-    if isinstance(config, Idefics2Config):
-        config.perceiver_config.hidden_size = 16
+    if issubclass(model_class.config_class, Idefics2Config):
+        kwargs["perceiver_config"] = {"hidden_size": 16}
+
+    config = AutoConfig.from_pretrained(model_id, text_config=text_config, vision_config=vision_config, **kwargs)
 
     model = model_class(config).to(dtype=torch.bfloat16)
 


### PR DESCRIPTION
Align the remaining VLM config params and pass them as arguments to `AutoConfig.from_pretrained`.

This is the recommended way to update subconfigs: https://github.com/huggingface/transformers/issues/41020#issuecomment-3314879813

Follow-up to:
- #4101