### PR TITLE
CI hotfix: xfail test_training_with_transformers_paged for transformers<4.57.0

### DIFF
--- a/tests/slow/test_grpo_slow.py
+++ b/tests/slow/test_grpo_slow.py
@@ -173,8 +173,8 @@ class GRPOTrainerSlowTester(TrlTestCase):
     @parameterized.expand(MODELS_TO_TEST)
     def test_training_with_transformers_paged(self, model_name):
         """Test that training works with transformers paged implementation (requires GPU)."""
-        if Version(transformers.__version__) < Version("4.56.2"):
-            pytest.xfail("Upstream bug in transformers (GH#40692). Fix merged; awaiting release >= 4.56.2")
+        if Version(transformers.__version__) < Version("4.57.0"):
+            pytest.xfail("Upstream bug in transformers (GH#40692). Fix merged; awaiting release >= 4.57.0")
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # increase the learning rate to speed up the test

--- a/tests/test_online_dpo_trainer.py
+++ b/tests/test_online_dpo_trainer.py
@@ -422,8 +422,8 @@ class TestOnlineDPOTrainer(TrlTestCase):
     @require_torch_accelerator
     @parameterized.expand([("standard_prompt_only",), ("conversational_prompt_only",)])
     def test_training_with_transformers_paged(self, config_name):
-        if Version(transformers.__version__) < Version("4.56.2"):
-            pytest.xfail("Upstream bug in transformers (GH#40692). Fix merged; awaiting release >= 4.56.2")
+        if Version(transformers.__version__) < Version("4.57.0"):
+            pytest.xfail("Upstream bug in transformers (GH#40692). Fix merged; awaiting release >= 4.57.0")
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,


### PR DESCRIPTION
CI hotfix: xfail test_training_with_transformers_paged for transformers<4.57.0 after transformers-4.56.2 release without the fix.

Now, this PR marks tests as expected to fail for transformers < 4.57.0 (instead of 4.56.2).

Fix #4035.
Follow-up to:
- #4046