### PR TITLE
Remove Python version < 3.13 constraint from vllm extra dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,13 +62,11 @@ test =
     pytest-xdist
     pytest
 vllm =
-    # vLLM package does not yet support Python 3.13. These constraints can be lifted once support is added:
-    # see https://github.com/vllm-project/vllm/pull/13164
-    vllm>=0.10.0,<=0.10.2; python_version < "3.13"
-    fastapi; python_version < "3.13"
-    pydantic; python_version < "3.13"
-    requests; python_version < "3.13"
-    uvicorn; python_version < "3.13"
+    vllm>=0.10.0,<=0.10.2
+    fastapi
+    pydantic
+    requests
+    uvicorn
 
 vlm =
     Pillow


### PR DESCRIPTION
Remove Python version < 3.13 constraint from `vllm` extra dependencies.

Note:
- Python 3.13 is now supported by vllm
  -  https://github.com/vllm-project/vllm/pull/13164