### PR TITLE
Fix generate_tiny_models for Qwen2_5_VLConfig

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -306,6 +306,10 @@ for model_id, model_class in [
 
     if issubclass(model_class.config_class, Qwen2_5_VLConfig):
         vision_config["out_hidden_size"] = 16
+        # Different dict object at the config root; see GH-4101 and transformers#41020
+        kwargs["num_hidden_layers"] = 2
+        kwargs["hidden_size"] = 16
+        kwargs["num_attention_heads"] = 4
 
     if issubclass(model_class.config_class, Idefics2Config):
         kwargs["perceiver_config"] = {"hidden_size": 16}


### PR DESCRIPTION
Fix CI: torch.AcceleratorError: CUDA error
- Fix generate_tiny_models for Qwen2_5_VLConfig

After the investigation in
- #4132 

this PR fixes `trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration`:
- https://huggingface.co/trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration/discussions/4/files

The underlying issue is the same as previously reported to `transformers` for `rope_scaling`:
- https://github.com/huggingface/transformers/issues/41020

Fix #4131