### PR TITLE
Pass required token_type_ids

### DIFF
--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -413,6 +413,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                     image_grid_thw=prompt_inputs.get("image_grid_thw"),
                     pixel_attention_mask=prompt_inputs.get("pixel_attention_mask"),
                     image_sizes=prompt_inputs.get("image_sizes"),
+                    token_type_ids=prompt_inputs.get("token_type_ids"),
                     image_split_sizes=image_split_sizes,
                 )
             else:
@@ -438,6 +439,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                         image_grid_thw=prompt_inputs.get("image_grid_thw"),
                         pixel_attention_mask=prompt_inputs.get("pixel_attention_mask"),
                         image_sizes=prompt_inputs.get("image_sizes"),
+                        token_type_ids=prompt_inputs.get("token_type_ids"),
                         image_split_sizes=image_split_sizes,
                     )
                 else:
@@ -452,6 +454,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                             image_grid_thw=prompt_inputs.get("image_grid_thw"),
                             pixel_attention_mask=prompt_inputs.get("pixel_attention_mask"),
                             image_sizes=prompt_inputs.get("image_sizes"),
+                            token_type_ids=prompt_inputs.get("token_type_ids"),
                             image_split_sizes=image_split_sizes,
                         )
             else:
@@ -617,6 +620,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 "image_grid_thw",
                 "pixel_attention_mask",
                 "image_sizes",
+                "token_type_ids",
             ]
             for field in optional_vision_fields:
                 if field in prompt_inputs:

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -41,6 +41,7 @@ class GRPOTrainer(_GRPOTrainer):
             num_images=inputs.get("num_images"),
             pixel_attention_mask=inputs.get("pixel_attention_mask"),
             image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
         )
 
         if self.top_entropy_quantile < 1.0:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -800,6 +800,7 @@ class GRPOTrainer(BaseTrainer):
         num_images=None,
         pixel_attention_mask=None,
         image_sizes=None,
+        token_type_ids=None,
     ) -> dict[str, Optional[torch.Tensor]]:
         """Compute log-probs and (optionally) entropies for each token."""
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
@@ -827,6 +828,8 @@ class GRPOTrainer(BaseTrainer):
                 model_inputs["pixel_attention_mask"] = pixel_attention_mask[start : start + batch_size]
             if image_sizes is not None:
                 model_inputs["image_sizes"] = image_sizes[start : start + batch_size]
+            if token_type_ids is not None:
+                model_inputs["token_type_ids"] = token_type_ids[start : start + batch_size]
 
             # Only add logits_to_keep if the model supports it
             if "logits_to_keep" in self.model_kwarg_keys:
@@ -1421,6 +1424,12 @@ class GRPOTrainer(BaseTrainer):
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)  # (B, P+C)
+        # If token_type_ids are used, extend them with zeros for the completion part
+        if "token_type_ids" in forward_kwargs:
+            token_type_ids = forward_kwargs["token_type_ids"]
+            forward_kwargs["token_type_ids"] = torch.cat(
+                [token_type_ids, token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
 
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
         batch_size = self.args.per_device_train_batch_size if mode == "train" else self.args.per_device_eval_batch_size
@@ -1608,6 +1617,8 @@ class GRPOTrainer(BaseTrainer):
             output["pixel_attention_mask"] = forward_kwargs["pixel_attention_mask"]
         if "image_sizes" in forward_kwargs:
             output["image_sizes"] = forward_kwargs["image_sizes"]
+        if "token_type_ids" in forward_kwargs:
+            output["token_type_ids"] = forward_kwargs["token_type_ids"]
         if images is not None:
             output["num_images"] = num_images
         return output
@@ -1685,6 +1696,7 @@ class GRPOTrainer(BaseTrainer):
             num_images=inputs.get("num_images"),
             pixel_attention_mask=inputs.get("pixel_attention_mask"),
             image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
         )
 
         if self.top_entropy_quantile < 1.0:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -790,6 +790,7 @@ class RLOOTrainer(BaseTrainer):
         num_images=None,
         pixel_attention_mask=None,
         image_sizes=None,
+        token_type_ids=None,  # TODO: align with code in GRPOTrainer; it is ignored for the moment
     ) -> dict[str, Optional[torch.Tensor]]:
         """Compute log-probs and (optionally) entropies for each token."""
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -790,7 +790,7 @@ class RLOOTrainer(BaseTrainer):
         num_images=None,
         pixel_attention_mask=None,
         image_sizes=None,
-        token_type_ids=None,  # TODO: align with code in GRPOTrainer; it is ignored for the moment
+        token_type_ids=None,
     ) -> dict[str, Optional[torch.Tensor]]:
         """Compute log-probs and (optionally) entropies for each token."""
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
@@ -819,6 +819,8 @@ class RLOOTrainer(BaseTrainer):
                 model_inputs["pixel_attention_mask"] = pixel_attention_mask[start : start + batch_size]
             if image_sizes is not None:
                 model_inputs["image_sizes"] = image_sizes[start : start + batch_size]
+            if token_type_ids is not None:
+                model_inputs["token_type_ids"] = token_type_ids[start : start + batch_size]
 
             # Only add logits_to_keep if the model supports it
             if "logits_to_keep" in self.model_kwarg_keys:
@@ -1382,6 +1384,12 @@ class RLOOTrainer(BaseTrainer):
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)  # (B, P+C)
+        # If token_type_ids are used, extend them with zeros for the completion part
+        if "token_type_ids" in forward_kwargs:
+            token_type_ids = forward_kwargs["token_type_ids"]
+            forward_kwargs["token_type_ids"] = torch.cat(
+                [token_type_ids, token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
 
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
         batch_size = self.args.per_device_train_batch_size if mode == "train" else self.args.per_device_eval_batch_size
@@ -1522,6 +1530,8 @@ class RLOOTrainer(BaseTrainer):
             output["pixel_attention_mask"] = forward_kwargs["pixel_attention_mask"]
         if "image_sizes" in forward_kwargs:
             output["image_sizes"] = forward_kwargs["image_sizes"]
+        if "token_type_ids" in forward_kwargs:
+            output["token_type_ids"] = forward_kwargs["token_type_ids"]
         if images is not None:
             output["num_images"] = num_images
         return output
@@ -1552,6 +1562,7 @@ class RLOOTrainer(BaseTrainer):
             num_images=inputs.get("num_images"),
             pixel_attention_mask=inputs.get("pixel_attention_mask"),
             image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
         )
 
         logps = (per_token_logps * completion_mask).sum(1)  # mask out padding and tokens after EOS


### PR DESCRIPTION
Pass required `token_type_ids`.

Follow-up to `transformers` PR:
- https://github.com/huggingface/transformers/pull/40917
> 🚨 BC-breaking: `paligemma` processor now returns `token_type_ids` by default. This is required to disambiguate forward passes, due to the bidirectional attention mask in the prompt. Advanced generation methods may run forward passes with prompt + generated tokens, so they will fail without `token_type_ids`.

Fix #4142, fix #4150.

This PR extends support for the `token_type_ids` input across the GRPO and RLOO trainers, ensuring that models using token type information can correctly handle these inputs during training, evaluation, and loss computation. 

The changes are applied consistently to:
- GRPO
- RLOO

## Changes

**Token type IDs support:**

* Added `token_type_ids` as an optional argument to the `_get_per_token_logps_and_entropies` method in both `grpo_trainer.py` and `rloo_trainer.py`, allowing the trainers to process token type information.
* Updated batching logic to include `token_type_ids` when present, ensuring correct slicing and passing of token type IDs during batched forward passes.

**Integration with completions and output:**

* In the `_generate_and_score_completions` method, extended `token_type_ids` with zeros for the completion tokens and ensured they are passed through the forward arguments and included in the output dictionary.

**Loss computation:**

* Updated the `_compute_loss` method in both trainers to pass `token_type_ids` when available, ensuring that loss calculations take token type information into account. 

CC: @gante