### PR TITLE
Remove unnecessary list comprehensions

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -898,8 +898,8 @@ class SFTTrainerTester(TrlTestCase):
         )
 
         # Check the number of sequences in train and eval datasets
-        num_train_seqs = sum([len(x) for x in trainer.train_dataset["seq_lengths"]])
-        num_eval_seqs = sum([len(x) for x in trainer.eval_dataset["seq_lengths"]])
+        num_train_seqs = sum(len(x) for x in trainer.train_dataset["seq_lengths"])
+        num_eval_seqs = sum(len(x) for x in trainer.eval_dataset["seq_lengths"])
         self.assertEqual(num_train_seqs, 17)  # we should still have 17 seqs
         self.assertEqual(num_eval_seqs, 2)  # we should still have 2 seqs
 
@@ -933,7 +933,7 @@ class SFTTrainerTester(TrlTestCase):
         )
 
         # Check the number of sequences in train dataset
-        num_train_seqs = sum([len(x) for x in trainer.train_dataset["seq_lengths"]])
+        num_train_seqs = sum(len(x) for x in trainer.train_dataset["seq_lengths"])
         self.assertEqual(num_train_seqs, 17)  # we should still have 17 seqs
 
         # We expect eval dataset not having "seq_lengths" as eval_packing is False

--- a/trl/trainer/cpo_trainer.py
+++ b/trl/trainer/cpo_trainer.py
@@ -487,7 +487,7 @@ class CPOTrainer(BaseTrainer):
             # Make sure prompts only have one different token at most an
             # and length only differs by 1 at most
             num_diff_tokens = sum(
-                [a != b for a, b in zip(chosen_tokens["prompt_input_ids"], rejected_tokens["prompt_input_ids"])]
+                a != b for a, b in zip(chosen_tokens["prompt_input_ids"], rejected_tokens["prompt_input_ids"])
             )
             num_diff_len = abs(chosen_prompt_len_input_ids - rejected_prompt_len_input_ids)
             if num_diff_tokens > 1 or num_diff_len > 1:

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -463,7 +463,7 @@ class ORPOTrainer(BaseTrainer):
             # Make sure prompts only have one different token at most an
             # and length only differs by 1 at most
             num_diff_tokens = sum(
-                [a != b for a, b in zip(chosen_tokens["prompt_input_ids"], rejected_tokens["prompt_input_ids"])]
+                a != b for a, b in zip(chosen_tokens["prompt_input_ids"], rejected_tokens["prompt_input_ids"])
             )
             num_diff_len = abs(chosen_prompt_len_input_ids - rejected_prompt_len_input_ids)
             if num_diff_tokens > 1 or num_diff_len > 1:


### PR DESCRIPTION
Remove unnecessary list comprehensions.

This PR makes small code cleanups in both trainer and test files, primarily simplifying the way lists are handled in `sum()` calls. These changes improve code readability and efficiency and maintain consistency across the codebase.