### PR TITLE
Fix handling of f_divergence_type in DPO

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -396,7 +396,7 @@ class DPOConfig(TrainingArguments):
             "Higher β means less deviation from the reference model."
         },
     )
-    f_divergence_type: FDivergenceType = field(
+    f_divergence_type: Union[FDivergenceType, str] = field(
         default=FDivergenceType.REVERSE_KL,
         metadata={
             "help": "Type of f-divergence regularization function to compute divergence between policy and reference "
@@ -496,6 +496,7 @@ class DPOConfig(TrainingArguments):
 
     def __post_init__(self):
         self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
+        self.f_divergence_type = FDivergenceType(self.f_divergence_type)
 
         # Normalize loss_type to string format for internal use
         if hasattr(self.loss_type, "__len__") and len(self.loss_type) == 1:

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1065,7 +1065,7 @@ class DPOTrainer(BaseTrainer):
         chosen_logratios = chosen_logps.to(device) - (not self.reference_free) * ref_chosen_logps.to(device)
         rejected_logratios = rejected_logps.to(device) - (not self.reference_free) * ref_rejected_logps.to(device)
 
-        if self.f_divergence_type == FDivergenceType.ALPHA_DIVERGENCE.value:
+        if self.f_divergence_type == FDivergenceType.ALPHA_DIVERGENCE:
             # The alpha-divergence formula: (1 - u^-alpha) / alpha
             # The divergence difference between the chosen and rejected sample is:
             #     (1 - u[w]^-alpha) / alpha - (1 - u[l]^-alpha) / alpha
@@ -1087,7 +1087,7 @@ class DPOTrainer(BaseTrainer):
             ref_logratios = ref_logratios.to(self.accelerator.device)
             logits = logratios - ref_logratios
 
-            if self.f_divergence_type == FDivergenceType.JS_DIVERGENCE.value:
+            if self.f_divergence_type == FDivergenceType.JS_DIVERGENCE:
                 # The js-divergence formula: log(2 * u / (1 + u))
                 # The divergence difference between the chosen and rejected sample is:
                 #     log(2 * u[w] / (1 + u[w])) - log(2 * u[l] / (1 + u[l]))


### PR DESCRIPTION
Fix handling `f_divergence_type` in DPO.

This PR improves the handling of the `f_divergence_type` configuration in the DPO trainer by consistently using the `FDivergenceType` enum internally, while allowing flexibility in input types. It also adds new tests to ensure correct normalization and serialization of the `f_divergence_type` field.

Note that currently:
- The expected type of the provided `f_divergence_type` in `DPOConfig` is a `str`, since the trainer logic compares its value against the string representations (`.value`) of the `FDivergenceType` enum: https://github.com/huggingface/trl/blob/864e593e9fd9916ce8ec5d777c8faf092e983133/trl/trainer/dpo_trainer.py#L1068 https://github.com/huggingface/trl/blob/864e593e9fd9916ce8ec5d777c8faf092e983133/trl/trainer/dpo_trainer.py#L1090
- However, if no value is explicitly passed, the config defaults to `FDivergenceType.REVERSE_KL`, of `FDivergenceType` enum type: https://github.com/huggingface/trl/blob/864e593e9fd9916ce8ec5d777c8faf092e983133/trl/trainer/dpo_config.py#L399-L400

This inconsistency can lead to confusion and potential type mismatches during usage. The proposed changes aim to standardize the handling of f_divergence_type, ensuring consistent type normalization and comparison throughout the codebase.

Follow-up to:
- #4165

## Changes

**Config normalization and input handling:**

* Updated the `f_divergence_type` field in `DPOConfig` to accept both `FDivergenceType` enum members and strings, improving flexibility for users. (`trl/trainer/dpo_config.py`)
* Added normalization in the `__post_init__` method of `DPOConfig` to always convert `f_divergence_type` to an `FDivergenceType` enum member, ensuring consistent internal usage. (`trl/trainer/dpo_config.py`)

**Loss function logic update:**

* Modified checks in the `dpo_loss` function to compare `f_divergence_type` directly with enum members instead of their string values, leveraging the normalized config. 

**Testing improvements:**

* Added a new test class `TestDPOConfig` to verify normalization and serialization of `f_divergence_type`, including parameterized tests for both enum and string inputs. (`tests/test_dpo_trainer.py`)