### PR TITLE
Fix CI ValueError: Unknown loss type: dapo

### DIFF
--- a/tests/slow/test_grpo_slow.py
+++ b/tests/slow/test_grpo_slow.py
@@ -79,6 +79,7 @@ class GRPOTrainerSlowTester(TrlTestCase):
             max_completion_length=self.max_length,
             report_to="none",
             logging_strategy="no",
+            loss_type="bnpo",  # liger-kernel does not support "dapo" default; see https://github.com/linkedin/Liger-Kernel/issues/620
         )
 
         model = AutoModelForCausalLM.from_pretrained(model_name)


### PR DESCRIPTION
Fix CI ValueError: Unknown loss type: dapo:
- Set 'bnpo' loss_type in test with liger

This PR makes a minor update to the `test_training_with_liger_grpo_loss` test to ensure compatibility with the `liger-kernel` library. The loss type is explicitly set to `"bnpo"` to avoid issues with the default `"dapo"` setting. See comment in associated issue: https://github.com/huggingface/trl/issues/4172#issuecomment-3350271951

Fix #4172.