### PR TITLE
Fix PEFT interlinks in docstrings

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -201,7 +201,7 @@ trainer = SFTTrainer(
 trainer.train()
 ```
 
-You can also continue training your [`peft.PeftModel`]. For that, first load a `PeftModel` outside [`SFTTrainer`] and pass it directly to the trainer without the `peft_config` argument being passed.
+You can also continue training your [`~peft.PeftModel`]. For that, first load a `PeftModel` outside [`SFTTrainer`] and pass it directly to the trainer without the `peft_config` argument being passed.
 
 ```python
 from datasets import load_dataset

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -85,7 +85,7 @@ class GKDTrainer(SFTTrainer):
         preprocess_logits_for_metrics (`Callable`, *optional*):
             Function to preprocess the logits before computing the metrics. Must take in the `logits` and `labels` and
             return the logits to be used for metrics computation.
-        peft_config ([`~peft.config.PeftConfig`], *optional*):
+        peft_config ([`~peft.PeftConfig`], *optional*):
             PEFT configuration to use PEFT for training. If `None`, PEFT is not used. If provided, the `model` will be
             wrapped with the specified PEFT adapter.
         formatting_func (`Callable`, *optional*):

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -123,7 +123,7 @@ class PPOTrainer(BaseTrainer):
             [`~transformers.Trainer.create_optimizer_and_scheduler`] method.
         callbacks (`list` of [`~transformers.TrainerCallback`], *optional*):
             Callbacks to use during training.
-        peft_config ([`~peft.config.PeftConfig`], *optional*):
+        peft_config ([`~peft.PeftConfig`], *optional*):
             PEFT configuration to use PEFT for training. If `None`, PEFT is not used. If provided, the policy `model`
             will be wrapped with the specified PEFT adapter.
     """


### PR DESCRIPTION
Fix PEFT interlinks in docstrings

The interlink will be properly rendered (as it is already the case for other HF libs, like `transformers` or `datasets`) once this PR in `doc-builder` is merged:
- https://github.com/huggingface/doc-builder/pull/628
