### PR TITLE
Fix docstring interlink to parent class for NashMDTrainer and XPOTrainer

### DIFF
--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -57,7 +57,7 @@ if is_peft_available():
 
 class NashMDTrainer(OnlineDPOTrainer):
     r"""
-    Initialize NashMDTrainer as a subclass of [`OnlineDPOConfig`].
+    Initialize NashMDTrainer as a subclass of [`OnlineDPOTrainer`].
 
     Args:
         model (`transformers.PreTrainedModel`):

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -56,8 +56,10 @@ if is_peft_available():
 
 
 class NashMDTrainer(OnlineDPOTrainer):
-    r"""
-    Initialize NashMDTrainer as a subclass of [`OnlineDPOTrainer`].
+    """
+    Trainer for the Nash-MD method.
+
+    It is implemented as a subclass of [`OnlineDPOTrainer`].
 
     Args:
         model (`transformers.PreTrainedModel`):

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -56,8 +56,10 @@ if is_peft_available():
 
 
 class XPOTrainer(OnlineDPOTrainer):
-    r"""
-    Initialize XPOTrainer as a subclass of [`OnlineDPOTrainer`].
+    """
+    Trainer for Exploratory Preference Optimization (XPO).
+
+    It is implemented as a subclass of [`OnlineDPOTrainer`].
 
     Args:
         model (`transformers.PreTrainedModel`):

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -57,7 +57,7 @@ if is_peft_available():
 
 class XPOTrainer(OnlineDPOTrainer):
     r"""
-    Initialize XPOTrainer as a subclass of [`OnlineDPOConfig`].
+    Initialize XPOTrainer as a subclass of [`OnlineDPOTrainer`].
 
     Args:
         model (`transformers.PreTrainedModel`):


### PR DESCRIPTION
Fix docstring interlink to parent class for NashMDTrainer and XPOTrainer.

Note that they were linking to the `OnlineDPOConfig` config class, instead of the `OnlineDPOTrainer` trainer class as their parent class.

Follow-up to:
- #4174