### PR TITLE
Fix link in docstring of RLOOTrainer

### DIFF
--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -97,8 +97,8 @@ RewardFunc = Union[str, PreTrainedModel, Callable[[list, list], list[float]]]
 class RLOOTrainer(BaseTrainer):
     """
     Trainer for the Reinforce Leave One Out (RLOO) method. This algorithm was initially proposed in the paper [Back to
-    Basics: Revisiting REINFORCE Style Optimization for Learning from Human Feedback in LLMs]
-    (https://huggingface.co/papers/2402.14740).
+    Basics: Revisiting REINFORCE Style Optimization for Learning from Human Feedback in
+    LLMs](https://huggingface.co/papers/2402.14740).
 
     Example:
 


### PR DESCRIPTION
Fix link in docstring of `RLOOTrainer`: https://huggingface.co/docs/trl/rloo_trainer#trl.RLOOTrainer

<img width="888" height="112" alt="Screenshot from 2025-09-30 15-39-59" src="https://github.com/user-attachments/assets/d65804ff-998e-475a-9382-2834974a11c4" />
