### PR TITLE
[DOCS] Lora without regret

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -49,8 +49,6 @@
     title: Unsloth
   - local: vllm_integration
     title: vLLM
-  - local: lora_without_regret
-    title: LoRA Without Regret
   title: Integrations
 - sections:
   - local: example_overview
@@ -65,6 +63,8 @@
     title: Detoxifying a Language Model
   - local: multi_adapter_rl
     title: Multi Adapter RLHF
+  - local: lora_without_regret
+    title: LoRA Without Regret
   title: Examples
 - sections:
   - sections: # Sorted alphabetically

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -25,6 +25,8 @@
     title: Training using Jobs
   - local: customization
     title: Customizing the Training
+  - local: lora_without_regret
+    title: LoRA Without Regret
   - local: reducing_memory_usage
     title: Reducing Memory Usage
   - local: speeding_up_training

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -55,6 +55,8 @@
     title: Example Overview
   - local: community_tutorials
     title: Community Tutorials
+  - local: lora_without_regret
+    title: LoRA Without Regret
   - local: sentiment_tuning
     title: Sentiment Tuning
   - local: using_llama_models
@@ -63,8 +65,6 @@
     title: Detoxifying a Language Model
   - local: multi_adapter_rl
     title: Multi Adapter RLHF
-  - local: lora_without_regret
-    title: LoRA Without Regret
   title: Examples
 - sections:
   - sections: # Sorted alphabetically

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -25,8 +25,6 @@
     title: Training using Jobs
   - local: customization
     title: Customizing the Training
-  - local: lora_without_regret
-    title: LoRA Without Regret
   - local: reducing_memory_usage
     title: Reducing Memory Usage
   - local: speeding_up_training
@@ -51,6 +49,8 @@
     title: Unsloth
   - local: vllm_integration
     title: vLLM
+  - local: lora_without_regret
+    title: LoRA Without Regret
   title: Integrations
 - sections:
   - local: example_overview

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -15,7 +15,7 @@ LoRA adds adapter layers on top of the base model, which contains significantly 
 
 ## Examples with TRL
 
-Those are the core findings of the blog post. Let's implement them in TRL scripts to train LoRA adapters.
+Let's implement and train LoRA adapters in TRL scripts based on the core findings of the blog post. Afterwards, we'll revisit each finding in light of the TRL results.
 
 ### Supervised Fine-Tuning (SFT)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -101,7 +101,7 @@ The blog post performs GRPO on a range of models and datasets from the Hub, and 
 | [Llama-3.1-8B-Base](https://huggingface.co/meta-llama/Llama-3.2-1B) | [DeepMath-103K](https://huggingface.co/datasets/zwhe99/DeepMath-103K) |
 | [Qwen3-8b-base](https://huggingface.co/Qwen/Qwen3-8b-base) | [DeepMath-103K](https://huggingface.co/datasets/zwhe99/DeepMath-103K) |
 
-For reinforcement learning the blog uses a a math reasoning task which we can reproduce as a python function.
+For reinforcement learning, the blog uses a math reasoning task that we can reproduce as a Python function.
 
 <details>
 <summary>Reward function</summary>

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -267,6 +267,12 @@ The reinforcement learning script with GRPO is implemented as custom scripts in 
 
 The authors recommend applying LoRA to all weight matrices rather than limiting it to attention layers, as increasing the rank does not compensate for this restriction. In TRL, this can be configured using `--lora_target_modules all-linear` to apply LoRA to all weight matrices.
 
+We were able to reproduce the results of the blog post using TRL, the Hugging Face Jobs platform, and the SmolLM3 model. We trained the model for 200 steps on the [Math 220k dataset](https://huggingface.co/datasets/HuggingFaceH4/OpenR1-Math-220k-default-verified) with the reward function and configuration above. As you can see in the figure below, the LoRA model's average train reward curve matches the full fine-tuning curve.
+
+![train reward](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/5.png)
+
+Let's break down the key findings of the blog post and how we were able to reproduce them.
+
 ### 1. *LoRA performs better when applied to all weight matrices*
 
 The authors recommend applying LoRA to all weight matrices rather than limiting it to attention layers, as increasing the rank does not compensate for this restriction. 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -271,7 +271,7 @@ To run the script locally, you will need to have `uv` installed. Check out the [
 </hfoption>
 </hfoptions>
 
-The reinforcement learning script with GRPO is implemented as custom scripts in TRL which uses the reward function shown above. You can review it at [`grpo.py`](https://huggingface.co/datasets/burtenshaw/lora-without-regrets/blob/main/grpo.py) - Reinforcement learning with LoRA best practices
+The reinforcement learning script with GRPO is implemented as a custom script in TRL, which uses the reward function shown above. You can review it at [`grpo.py`](https://huggingface.co/datasets/burtenshaw/lora-without-regrets/blob/main/grpo.py) - Reinforcement learning with LoRA best practices
 
 ## Key findings in optimizing LoRA
 
@@ -307,7 +307,7 @@ The authors recommend applying LoRA to all weight matrices rather than limiting 
 
 ![all layers](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/1.png)
 
-Attention-only LoRA underperforms even when using higher rank to match parameter count. In TRL, this can be configured using `--lora_target_modules all-linear` to apply LoRA to all weight matrices.  In python, we can do this like so:
+Attention-only LoRA underperforms even when using a higher rank to match parameter count. In TRL, this can be configured using `--lora_target_modules all-linear` to apply LoRA to all weight matrices.  In Python, we can do this like so:
 
 ```python
 from peft import LoraConfig  
@@ -317,15 +317,15 @@ peft_config = LoraConfig(target_modules="all-linear")
 
 ### 2. *The adapter needs sufficient capacity to learn from the dataset*
 
-The blog post recommends use a sufficient LoRA rank to learn from the dataset. The rank determines the number of trainable parameters in the LoRA adapter. Therefore, "For datasets that exceed LoRA capacity, LoRA underperforms FullFT". 
+The blog post recommends using a sufficient LoRA rank to learn from the dataset. The rank determines the number of trainable parameters in the LoRA adapter. Therefore, "For datasets that exceed LoRA capacity, LoRA underperforms FullFT". 
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/3.png)
 
-In TRL script, we could use `--lora_r` to set the rank and adapt it based on the task and dataset we're training on. The blog post recommends the following ranks based on the task and dataset size:
+In the TRL script, we could use `--lora_r` to set the rank and adapt it based on the task and dataset we're training on. The blog post recommends the following ranks based on the task and dataset size:
 
 Reinforcement learning tasks typically require lower capacity, so smaller LoRA ranks can be used. This is because policy gradient algorithms extract roughly ~1 bit of information per episode, demanding minimal parameter capacity.  
 
-The blog post defines the ideal dataset size for LoRA to match full fine-tuning as "Post-training scale". Which we can use to determine the recommended rank for SFT and RL LoRA's as:
+The blog post defines the ideal dataset size for LoRA to match full fine-tuning as "Post-training scale". Which we can use to determine the recommended rank for SFT and RL LoRAs as:
 
 | Task Type | Dataset Size | Recommended Rank |
 |-----------|-------------|------------------|
@@ -340,7 +340,7 @@ Counter-intuitively, the blog post recommends using similar learning rates to fu
 
 ### 4. *"In some scenarios, LoRA is less tolerant of large batch sizes than full fine-tuning."*
 
-The blog post recommends using effective batch size < 32 because the authors found LoRA to be less tolerant of large batch sizes. This could not be mitigated by increasing the LoRA rank. In TRL script, we could use `--per_device_train_batch_size` and `--gradient_accumulation_steps` to set the batch size.
+The blog post recommends using an effective batch size < 32 because the authors found LoRA to be less tolerant of large batch sizes. This could not be mitigated by increasing the LoRA rank. In the TRL script, we could use `--per_device_train_batch_size` and `--gradient_accumulation_steps` to set the batch size.
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/4.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -430,7 +430,7 @@ The blog post defines the ideal dataset size for LoRA to match full fine-tuning 
 
 ### 3. *"FullFT and high-rank LoRAs have similar learning curves"*
 
-Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. The  \\( \frac{1}{r} \\) scaling in LoRA makes optimal learning rate approximately rank-independent. In TRL script, we could use `--learning_rate` to set the learning rate.
+Counterintuitively, the blog post recommends using similar learning rates to full fine-tuning. In the TRL script, we could use `--learning_rate` to set the learning rate. The  \\( \frac{1}{r} \\) scaling in LoRA makes the optimal learning rate approximately rank-independent.
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/2.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -340,6 +340,10 @@ The blog post recommends using effective batch size < 32 because the authors fou
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/4.png)
 
+## Takeaways
+
+Using TRL, you can efficiently implement LoRA adapters to match full fine-tuning performance, applying the core insights (targeting all weight matrices, choosing the right rank, and managing batch size and learning rate) without the heavy compute cost of FullFT.
+
 ## Citation
 
 ```bibtex

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -201,27 +201,32 @@ hf jobs uv run \
     --timeout 4h \
     --secrets HF_TOKEN \
     --env PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
-    "https://huggingface.co/datasets/burtenshaw/lora-without-regrets/resolve/main/grpo_full.py" \
+    "https://huggingface.co/datasets/burtenshaw/lora-without-regrets/resolve/main/grpo.py" \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --dataset_name HuggingFaceH4/OpenR1-Math-220k-default-verified \
     --output_dir grpo-full-qwen3-0.6b \
-    --learning_rate 1.0e-5 \
+    --learning_rate 1.0e-6 \
     --lr_scheduler_type cosine \
     --warmup_ratio 0.0 \
     --max_grad_norm 1.0 \
     --beta 0.0 \
     --max_prompt_length 1024 \
-    --max_completion_length 8192 \
-    --num_generations 8 \
-    --generation_batch_size 8 \
-    --gradient_accumulation_steps 16 \
+    --max_completion_length 4096 \
+    --num_generations 16 \
+    --generation_batch_size 16 \
+    --gradient_accumulation_steps 8 \
     --per_device_train_batch_size 1 \
     --num_train_epochs 1 \
+    --lora_r 1 \
+    --lora_alpha 32 \
+    --lora_dropout 0.0 \
+    --lora_target_modules all-linear \
     --vllm_mode colocate \
     --save_strategy steps \
-    --save_steps 100 \
+    --save_steps 50 \
     --save_total_limit 1 \
     --logging_steps 1 \
+    --max_steps 200 \
     --report_to trackio
 ```
 
@@ -232,27 +237,32 @@ To use Hugging Face Jobs, you will need to be logged in to the Hugging Face Hub 
 
 ```bash
 
-uv run "https://huggingface.co/datasets/burtenshaw/lora-without-regrets/resolve/main/grpo_full.py" \
+uv run "https://huggingface.co/datasets/burtenshaw/lora-without-regrets/resolve/main/grpo.py" \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --dataset_name HuggingFaceH4/OpenR1-Math-220k-default-verified \
     --output_dir grpo-full-qwen3-0.6b \
-    --learning_rate 1.0e-5 \
+    --learning_rate 1.0e-6 \
     --lr_scheduler_type cosine \
     --warmup_ratio 0.0 \
     --max_grad_norm 1.0 \
     --beta 0.0 \
     --max_prompt_length 1024 \
-    --max_completion_length 8192 \
-    --num_generations 8 \
-    --generation_batch_size 8 \
-    --gradient_accumulation_steps 16 \
+    --max_completion_length 4096 \
+    --num_generations 16 \
+    --generation_batch_size 16 \
+    --gradient_accumulation_steps 8 \
     --per_device_train_batch_size 1 \
     --num_train_epochs 1 \
+    --lora_r 1 \
+    --lora_alpha 32 \
+    --lora_dropout 0.0 \
+    --lora_target_modules all-linear \
     --vllm_mode colocate \
     --save_strategy steps \
-    --save_steps 100 \
+    --save_steps 50 \
     --save_total_limit 1 \
     --logging_steps 1 \
+    --max_steps 200 \
     --report_to trackio
 ```
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -227,7 +227,7 @@ def strip_reasoning_accuracy_reward(
 
 <hfoptions id="grpo">
 
-<hfoption id="jobs">
+<hfoption id="python">
 
 We can implement these recommendations with the TRL Python API like so:
 
@@ -272,7 +272,7 @@ trainer.train()
 
 ```
 
-[!WARNING]
+> [!WARNING]
 > This snippet skips the reward function which is defined above to keep the example concise.
 
 </hfoption>

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -330,7 +330,7 @@ The blog post defines the ideal dataset size for LoRA to match full fine-tuning 
 | Task Type | Dataset Size | Recommended Rank |
 |-----------|-------------|------------------|
 | **SFT** | Post-training scale | 256 |
-| **RL** | Any size | 8-32 |
+| **RL** | Any size | 1-32 |
 
 ### 3. *"FullFT and high-rank LoRAs have similar learning curves"*
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -267,7 +267,7 @@ The reinforcement learning script with GRPO is implemented as custom scripts in 
 
 The authors recommend applying LoRA to all weight matrices rather than limiting it to attention layers, as increasing the rank does not compensate for this restriction. In TRL, this can be configured using `--lora_target_modules all-linear` to apply LoRA to all weight matrices.
 
-We were able to reproduce the results of the blog post using TRL, the Hugging Face Jobs platform, and the SmolLM3 model. We trained the model for 200 steps on the [Math 220k dataset](https://huggingface.co/datasets/HuggingFaceH4/OpenR1-Math-220k-default-verified) with the reward function and configuration above. As you can see in the figure below, the LoRA model's average train reward curve matches the full fine-tuning curve.
+We were able to reproduce the results of the blog post using TRL, the Hugging Face Jobs platform, and the SmolLM3 model. We trained the model for 500 steps on the [Math 220k dataset](https://huggingface.co/datasets/HuggingFaceH4/OpenR1-Math-220k-default-verified) with the reward function and configuration above. As you can see in the figure below, the LoRA model's average train reward curve matches the full fine-tuning curve.
 
 ![train reward](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/5.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -271,6 +271,20 @@ We were able to reproduce the results of the blog post using TRL and the SmolLM3
 
 ![train reward](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/5.png)
 
+Here are the parameters we used to train the above models
+
+| Parameter                       | LoRA                                               | Full FT                        |
+|----------------------------------|----------------------------------------------------|-------------------------------|
+| `--model_name_or_path`           | HuggingFaceTB/SmolLM3-3B                           | HuggingFaceTB/SmolLM3-3B      |
+| `--dataset_name`                 | HuggingFaceH4/OpenR1-Math-220k-default-verified    | HuggingFaceH4/OpenR1-Math-220k-default-verified |
+| `--learning_rate`                | 1.0e-6                                             | 1.0e-5                        |
+| `--max_prompt_length`            | 1024                                               | 1024                          |
+| `--max_completion_length`        | 4096                                               | 4096                          |
+| `--lora_r`                       | 1                                                  | -                           |
+| `--lora_alpha`                   | 32                                                 | -                           |
+| `--lora_dropout`                 | 0.0                                                | -                           |
+| `--lora_target_modules`          | all-linear                                         | -                           |
+
 Let's break down the key findings of the blog post and how we were able to reproduce them.
 
 ### 1. *LoRA performs better when applied to all weight matrices*

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -267,7 +267,7 @@ The reinforcement learning script with GRPO is implemented as custom scripts in 
 
 The authors recommend applying LoRA to all weight matrices rather than limiting it to attention layers, as increasing the rank does not compensate for this restriction. In TRL, this can be configured using `--lora_target_modules all-linear` to apply LoRA to all weight matrices.
 
-We were able to reproduce the results of the blog post using TRL, the Hugging Face Jobs platform, and the SmolLM3 model. We trained the model for 500 steps on the [Math 220k dataset](https://huggingface.co/datasets/HuggingFaceH4/OpenR1-Math-220k-default-verified) with the reward function and configuration above. As you can see in the figure below, the LoRA model's average train reward curve matches the full fine-tuning curve.
+We were able to reproduce the results of the blog post using TRL and the SmolLM3 model. We trained the model for 500 steps on the [Math 220k dataset](https://huggingface.co/datasets/HuggingFaceH4/OpenR1-Math-220k-default-verified) with the reward function and configuration above. As you can see in the figure below, the LoRA model's average train reward curve matches the full fine-tuning curve.
 
 ![train reward](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/5.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -38,20 +38,18 @@ We can integrate these findings with the TRL Python API like so:
 
 from datasets import load_dataset
 from peft import LoraConfig
-from trl import SFTTrainer, GRPOConfig
+from trl import SFTTrainer, SFTConfig
 
 dataset = load_dataset("open-thoughts/OpenThoughts-114k", split="train")
 
 peft_config = LoraConfig(lora_r=256, lora_alpha=16, lora_target_modules="all-linear")
 
 training_args = SFTConfig(
-    learning_rate=1e-6,
+    learning_rate=2e-4,
     per_device_train_batch_size=1,
     gradient_accumulation_steps=4,
     num_train_epochs=1,
-    gradient_checkpointing=True,
     report_to=["trackio"],
-    bf16=True,
 )
 
 trainer = SFTTrainer(
@@ -83,8 +81,6 @@ hf jobs uv run \
     --packing \
     --per_device_train_batch_size 2 \
     --gradient_accumulation_steps 16 \
-    --gradient_checkpointing \
-    --eval_strategy no \
     --use_peft \
     --lora_r 256 \
     --lora_alpha 16 \
@@ -248,11 +244,6 @@ def strip_reasoning_accuracy_reward(completions, **kwargs):
 
     ... 
 
-    if correct:
-        return 1.0
-    else:
-        return 0.0
-
 peft_config = LoraConfig(
     lora_r=1,
     lora_alpha=32,
@@ -260,15 +251,13 @@ peft_config = LoraConfig(
 )
 
 training_args = GRPOConfig(
-    learning_rate=1e-6,
+    learning_rate=5e-5,
     per_device_train_batch_size=1,
     gradient_accumulation_steps=4,
     num_train_epochs=1,
-    gradient_checkpointing=True,
     num_generations=8,
     generation_batch_size=8,
     report_to=["trackio"],
-    bf16=True,
 )
 
 trainer = GRPOTrainer(

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -281,6 +281,10 @@ We were able to reproduce the results of the blog post using TRL and the SmolLM3
 
 ![train reward](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/5.png)
 
+And most importantly, the LoRA model uses significantly less memory than the full fine-tuning model, as we can see in the figure below.
+
+![memory usage](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/6.png)
+
 Here are the parameters we used to train the above models
 
 | Parameter                       | LoRA                                               | Full FT                        |

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -89,7 +89,7 @@ To run the script locally, you will need to have `uv` installed. Check out the [
 </hfoption>
 </hfoptions>
 
-Once training starts, you can monitor the progress in [Trackio](https://huggingface.co/trackio) which will log the url.
+Once training starts, you can monitor the progress in [Trackio](https://huggingface.co/trackio), which will log the URL.
 
 ### Reinforcement Learning (GRPO)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -334,7 +334,7 @@ The blog post defines the ideal dataset size for LoRA to match full fine-tuning 
 
 ### 3. *"FullFT and high-rank LoRAs have similar learning curves"*
 
-Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. In TRL script, we could use `--learning_rate` to set the learning rate. The  \\( \frac{1}{r} \\) scaling in LoRA makes optimal learning rate approximately rank-independent.
+Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. The  \\( \frac{1}{r} \\) scaling in LoRA makes optimal learning rate approximately rank-independent. In TRL script, we could use `--learning_rate` to set the learning rate.
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/2.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -300,7 +300,7 @@ The blog post defines the ideal dataset size for LoRA to match full fine-tuning 
 
 ### 3. *"FullFT and high-rank LoRAs have similar learning curves"*
 
-Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. In TRL script, we could use `--learning_rate` to set the learning rate. The 1/r scaling in LoRA makes optimal learning rate approximately rank-independent.
+Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. In TRL script, we could use `--learning_rate` to set the learning rate. The  \\( \frac{1}{r} \\) scaling in LoRA makes optimal learning rate approximately rank-independent.
 
 ![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/2.png)
 

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -1,0 +1,158 @@
+# LoRA Without Regret
+
+Recent research from the team at [Thinking Machines Lab](https://thinkingmachines.ai/blog/lora/) (Schulman et al., 2025) shows that **LoRA can match full fine-tuning performance** when configured correctly, while using only ~67% of the compute. These findings are exciting to TRL users because they're straight forward to implement and can improve model performance on smaller budgets.
+
+This guide provides simple instructions to reproduce the results of the blog post in TRL.
+
+## Benefits of LoRA over full fine-tuning
+
+First of all, let's remind ourselves of the benefits of [LoRA over full fine-tuning](https://huggingface.co/docs/trl/en/peft_integration).
+
+LoRA trains an adapter layer on top of the base model, which contains significantly fewer parameters than the base model itself. This allows us to train the model on less GPU memory. It has generally been accepted that this comes with a trade-off in performance. The [blog post](https://thinkingmachines.ai/blog/lora/) proposes that with the correct configuration, LoRA can overcome this tradeoff and match full fine-tuning performance.
+
+## Key findings in optimizing LoRA
+
+Let's dive into the key findings of the blog post one by one and see how we can implement them in TRL scripts. Below, we will reproduce the results of the blog post using complete the TRL scripts that you can run locally or on Hugging Face Jobs.
+
+### 1. *LoRA performs better when applied to all weight matrices*
+
+The authors recommend applying LoRA to all weight matrices instead of attention-only LoRA targeted at attention layers, and this is not overcome by increasing the rank. In TRL script, we could use `--lora_target_modules all-linear` to apply LoRA to all weight matrices.
+
+![all layers](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/1.png)
+
+Attention-only LoRA underperforms even when using higher rank to match parameter count.
+
+### 2. *We can estimate trainable parameters from dataset size to determine LoRA rank*
+
+The blog post recommends choosing LoRA rank based on task and dataset size. LoRA rank controls the number of trainable parameters in the LoRA adapter. And the post proposes that LoRA works well when the number of parameters exceeds the amount of information to be learned, which we should estimate from the dataset size.
+
+![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/3.png)
+
+In TRL script, we could use `--lora_r` to set the rank and adapt it based on the task and dataset we're training on. The blog post recommends the following ranks based on the task and dataset size:
+
+| Task Type | Dataset Size | Recommended Rank |
+|-----------|-------------|------------------|
+| **SFT** - Small instruction | <10K examples | 32-64 |
+| **SFT** - Medium instruction | 10K-1M examples | 64-128 |
+| **SFT** - Large reasoning | >1M examples | 256+ |
+| **RL** - All tasks | Any size | 8-32 |
+
+Reinforcement learning requires minimal capacity, so we can use lower ranks. This is because policy gradient algorithms learn only ~1 bit per episode, requiring minimal capacity.
+
+### 3. *"FullFT and high-rank LoRAs have similar learning curves"*
+
+Counter-intuitively, the blog post recommends using similar learning rates to full fine-tuning. In TRL script, we could use `--learning_rate` to set the learning rate. The 1/r scaling in LoRA makes optimal learning rate approximately rank-independent.
+
+![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/2.png)
+
+### 4. *"In some scenarios, LoRA is less tolerant of large batch sizes than full fine-tuning."*
+
+The blog post recommends using effective batch size < 256 because the authors found LoRA to be less tolerant of large batch sizes. This could not be mitigated by increasing the LoRA rank. In TRL script, we could use `--per_device_train_batch_size` and `--gradient_accumulation_steps` to set the batch size.
+
+![learning rate](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lora_without_regret/4.png)
+
+## Examples with TRL
+
+Those are the core findings of the blog post. Let's implement them in TRL scripts to train LoRA adapters.
+
+### Supervised Fine-Tuning (SFT)
+
+The blog post performs SFT on a range of models and datasets from the Hub, which we can reproduce in TRL.
+
+| Model | Dataset |
+|-------|---------|
+| [Llama-3.2-1B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B) | [allenai/tulu-3-sft-mixture](https://huggingface.co/datasets/allenai/tulu-3-sft-mixture) |
+| [Llama-3.2-1B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B) | [open-thoughts/OpenThoughts-114k](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k) |
+| [Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B) | [allenai/tulu-3-sft-mixture](https://huggingface.co/datasets/allenai/tulu-3-sft-mixture) |
+| [Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B) | [open-thoughts/OpenThoughts-114k](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k) |
+
+<hfoptions id="sft">
+<hfoption id="jobs">
+
+```bash
+
+# Medium dataset (Tulu3) - use rank 128
+# TODO: add hf jobs command
+```
+
+To use Hugging Face Jobs, you will need to be logged in to the Hugging Face Hub (`hf auth login`) and have a [Pro](https://hf.co/pro), [Team](https://hf.co/enterprise), or [Enterprise](https://hf.co/enterprise) plan. Check out the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for more details.
+
+</hfoption>
+<hfoption id="local">
+
+```bash
+
+# Medium dataset (Tulu3) - use rank 128
+# TODO: local command
+```
+
+To run th script locally, you will need to have `uv` installed. Check out the [uv documentation](https://docs.astral.sh/uv/) for more details.
+
+</hfoption>
+</hfoptions>
+
+Once training starts, you can monitor the progress in [Trackio](https://huggingface.co/trackio) which will log the url.
+
+<!-- TODO: @burtenshaw - add trackio iframe -->
+
+### Reinforcement Learning (GRPO)
+
+The blog post performs GRPO on a range of models and datasets from the Hub, and once again we can reproduce the results in TRL.
+
+<!-- TODO: @edbeeching - describe rl function -->
+
+
+| Model | Dataset |
+|-------|---------|
+| [Llama-3.1-8B-Base](https://huggingface.co/meta-llama/Llama-3.2-1B) | [GSM8k](https://huggingface.co/datasets/openai/gsm8k) |
+| [Llama-3.1-8B-Base](https://huggingface.co/meta-llama/Llama-3.2-1B) | [DeepMath-103K](https://huggingface.co/datasets/zwhe99/DeepMath-103K) |
+| [Qwen3-8b-base](https://huggingface.co/Qwen/Qwen3-8b-base) | [DeepMath-103K](https://huggingface.co/datasets/zwhe99/DeepMath-103K) |
+
+<hfoptions id="sft">
+<hfoption id="jobs">
+
+```bash
+
+# Medium dataset (Tulu3) - use rank 128
+# TODO: add hf jobs command
+```
+
+To use Hugging Face Jobs, you will need to be logged in to the Hugging Face Hub (`hf auth login`) and have a [Pro](https://hf.co/pro), [Team](https://hf.co/enterprise), or [Enterprise](https://hf.co/enterprise) plan. Check out the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for more details.
+
+</hfoption>
+<hfoption id="local">
+
+```bash
+
+# Medium dataset (Tulu3) - use rank 128
+# TODO: local command
+```
+
+To run th script locally, you will need to have `uv` installed. Check out the [uv documentation](https://docs.astral.sh/uv/) for more details.
+
+</hfoption>
+</hfoptions>
+
+<!-- TODO: @burtenshaw - add trackio iframe -->
+
+## Scripts
+
+The above commands are both implement as custom scripts in TRL based on the configurations recommended by the blog post.
+
+- [`sft_lora.py`]() - Supervised fine-tuning with LoRA best practices
+- [`grpo_lora.py`]() - Reinforcement learning with LoRA best practices
+
+<!-- TODO: @burtenshaw - add scripts links -->
+
+## Citation
+
+```bibtex
+@article{schulman2025lora,
+  author = {John Schulman and Thinking Machines Lab},
+  title = {LoRA Without Regret},
+  journal = {Thinking Machines Lab: Connectionism},
+  year = {2025},
+  note = {https://thinkingmachines.ai/blog/lora/},
+  doi = {10.64434/tml.20250929},
+}
+```


### PR DESCRIPTION
This is draft PR for a docs page to implement the blog post 'lora without regret' in TRL. 

@edbeeching is going to review and share a script.
@sergiopaniego 

# example with sft

```
hf jobs uv run \
    --flavor a100-large \
    --timeout 8h \
    --secrets HF_TOKEN \
    "https://gist.githubusercontent.com/burtenshaw/fce24305833f2ecacfe8da181901d345/raw/sft_lora.py" \
    --model_name_or_path Qwen/Qwen2.5-3B-Instruct \
    --dataset_name open-thoughts/OpenThoughts-114k \
    --learning_rate 2.0e-5 \
    --num_train_epochs 1 \
    --packing \
    --per_device_train_batch_size 2 \
    --gradient_accumulation_steps 16 \
    --gradient_checkpointing \
    --eval_strategy no \
    --use_peft \
    --lora_r 256 \
    --lora_alpha 16 \
    --lora_target_modules all-linear \
    --output_dir Qwen2.5-3B-OpenThoughts-LoRA \
    --report_to trackio \
    --push_to_hub
```

# example with grpo

```
hf jobs uv run \
    --flavor a100-large \
    --timeout 6h \
    --secrets HF_TOKEN \
    "https://gist.githubusercontent.com/burtenshaw/f3fd519cb7efd647254c60b6b904cbcb/raw/c688abe1a9487090bb931b51ecec12c6737cdc52/grpo_lora.py" \
    --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct \
    --output_dir grpo-Qwen2.5-VL-3B-Instruct-LoRA \
    --learning_rate 1e-5 \
    --gradient_checkpointing \
    --torch_dtype bfloat16 \
    --max_prompt_length 2048 \
    --max_completion_length 1024 \
    --use_vllm \
    --vllm_mode colocate \
    --use_peft \
    --lora_r 16 \
    --lora_alpha 16 \
    --lora_target_modules all-linear \
    --log_completions \
    --report_to trackio \
    --push_to_hub
```