### PR TITLE
Hotfix wrong formatting of docstrings with blockquote tips

### DIFF
--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -90,6 +90,7 @@ def setup_chat_format(
     format: Optional[Literal["chatml"]] = "chatml",
     resize_to_multiple_of: Optional[int] = None,
 ) -> tuple[PreTrainedModel, PreTrainedTokenizer]:
+    # docstyle-ignore
     """
     Setup chat format by adding special tokens to the tokenizer, setting the correct format, and extending the
     embedding layer of the model based on the new special tokens.

--- a/trl/trainer/judges.py
+++ b/trl/trainer/judges.py
@@ -185,6 +185,7 @@ class BaseBinaryJudge(BaseJudge):
 
 
 class PairRMJudge(BasePairwiseJudge):
+    # docstyle-ignore
     """
     LLM judge based on the PairRM model from AllenAI.
 

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -217,6 +217,7 @@ def ensure_master_addr_port(addr: Optional[str] = None, port: Optional[int] = No
 
 @dataclass
 class RewardDataCollatorWithPadding:
+    # docstyle-ignore
     r"""
     Reward DataCollator class that pads the inputs to the maximum length of the batch.
 
@@ -1251,6 +1252,7 @@ def empty_cache() -> None:
 
 
 def decode_and_strip_padding(inputs: torch.Tensor, tokenizer: PreTrainedTokenizerBase) -> list[str]:
+    # docstyle-ignore
     """
     Decodes the input tensor and strips the padding tokens.
 


### PR DESCRIPTION
Fix wrong formatting done by `make precommit` on docstrings containing blockquote tips (e.g. `> [!WARNING]`):
- Ignore docstyle in docstrings with blockquote tips

Currently, `make precommit` executes `doc-builder style --max_len 119` and this converts
```python
"""
> [!WARNING]
> This is my warning message.
"""
```
to
```python
"""
> [!WARNING] > This is my warning message.
"""
```

I have proposed a fix for hf-doc-builder:
- https://github.com/huggingface/doc-builder/pull/645

In the meantime, consider this PR as a hotfix that we should revert once the upstream issue is fixed.

This PR primarily adds `# docstyle-ignore` comments to the docstrings containing blcokquote tips. This ensures that documentation style checkers will skip these docstrings until the issue is fixed in doc-builder.