### PR TITLE
Replace remaining trainer.tokenizer with trainer.processing_class in GRPO test

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1882,7 +1882,7 @@ class TestUpdateWithReplayBuffer(unittest.TestCase):
         Test with inputs where the sequence lengths are different from the prepopulated buffer.
         """
         self._prepopulate_buffer()
-        pad_token_id = self.trainer.tokenizer.pad_token_id
+        pad_token_id = self.trainer.processing_class.pad_token_id
         group_advantages = torch.tensor([[0.6, 0.6], [0.3, 0.45]])  # one no-variance, one variance
         inputs = {
             "group_advantages": group_advantages,


### PR DESCRIPTION
Replace remaining `trainer.tokenizer` with `trainer.processing_class` in GRPO `TestUpdateWithReplayBuffer`.

For context, `trainer.tokenizer` was removed in upstream `transformers`:
- https://github.com/huggingface/transformers/pull/41128

Follow-up to:
- #4185