### PR TITLE
Remove custome_container for building the docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,6 +14,5 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: trl
       version_tag_suffix: ""
-      custom_container: huggingface/transformers-doc-builder
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -16,4 +16,3 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: trl
       version_tag_suffix: ""
-      custom_container: huggingface/transformers-doc-builder


### PR DESCRIPTION
Remove `custome_container` for building the docs:
- Fix DDPO ImportError: cannot import name 'FLAX_WEIGHTS_NAME'

This PR makes a small update to the GitHub Actions workflows for building documentation. The change removes the use of a custom Docker container for the documentation build jobs.

Currently the CI GitHub Action to build the main docs is broken, due to an issue with the versions of `diffusers` and `transformers`: https://github.com/huggingface/trl/actions/runs/18184074495/job/51765142515
```python
ImportError: cannot import name 'FLAX_WEIGHTS_NAME' from 'transformers.utils' (/usr/local/lib/python3.10/site-packages/transformers/utils/__init__.py)
```

After investigation:
- the issue is already fixed in diffusers but not released yet: 
  - https://github.com/huggingface/diffusers/pull/12354
- the root cause in transformers is on main but not released yet (as of 4.56.2): 
  - https://github.com/huggingface/transformers/pull/40760
- the issue with our GH Action building the main doc is that it uses a custom Docker container (huggingface/transformers-doc-builder), where transformers is installed from main: transformers-4.57.0.dev0

Traceback:
```python
Building the MDX files:   2%|▏         | 1/55 [00:05<04:52,  5.42s/it]
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/trl/import_utils.py", line 144, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/lib/python3.10/site-packages/trl/models/modeling_sd_base.py", line 25, in <module>
    from diffusers import DDIMScheduler, StableDiffusionPipeline, UNet2DConditionModel
  File "/usr/local/lib/python3.10/site-packages/diffusers/__init__.py", line 911, in <module>
    from .modular_pipelines import ComponentsManager, ComponentSpec, ModularPipeline, ModularPipelineBlocks
  File "/usr/local/lib/python3.10/site-packages/diffusers/modular_pipelines/__init__.py", line 60, in <module>
    from .flux import FluxAutoBlocks, FluxModularPipeline
  File "/usr/local/lib/python3.10/site-packages/diffusers/modular_pipelines/flux/__init__.py", line 44, in <module>
    from .encoders import FluxTextEncoderStep
  File "/usr/local/lib/python3.10/site-packages/diffusers/modular_pipelines/flux/encoders.py", line 27, in <module>
    from ..modular_pipeline import ModularPipelineBlocks, PipelineState
  File "/usr/local/lib/python3.10/site-packages/diffusers/modular_pipelines/modular_pipeline.py", line 31, in <module>
    from ..pipelines.pipeline_loading_utils import _fetch_class_library_tuple, simple_get_class_obj
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/__init__.py", line 504, in <module>
    from .auto_pipeline import (
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/auto_pipeline.py", line 23, in <module>
    from .aura_flow import AuraFlowPipeline
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/aura_flow/__init__.py", line 35, in <module>
    from .pipeline_aura_flow import AuraFlowPipeline
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/aura_flow/pipeline_aura_flow.py", line 35, in <module>
    from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/pipeline_utils.py", line 76, in <module>
    from .pipeline_loading_utils import (
  File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/pipeline_loading_utils.py", line 51, in <module>
    from transformers.utils import FLAX_WEIGHTS_NAME as TRANSFORMERS_FLAX_WEIGHTS_NAME
ImportError: cannot import name 'FLAX_WEIGHTS_NAME' from 'transformers.utils' (/usr/local/lib/python3.10/site-packages/transformers/utils/__init__.py)
```