### PR TITLE
Hotfix: Exclude transformers 4.57.0 for Python 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     accelerate>=1.4.0
     datasets>=3.0.0
     transformers>=4.56.1
+    transformers!=4.57.0; python_version == "3.9"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Exclude transformers 4.57.0 for Python 3.9.

This PR introduces a compatibility fix for Python 3.9 environments by updating the dependency specification for the `transformers` package.

Dependency management:

* Updated the `install_requires` section in `setup.cfg` to explicitly exclude `transformers` version 4.57.0 when running on Python 3.9, to avoid a compatibility issue with that version.