### PR TITLE
Fix LoRA params in Python in LoRA without regret

### DIFF
--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -42,7 +42,7 @@ from trl import SFTTrainer, SFTConfig
 
 dataset = load_dataset("open-thoughts/OpenThoughts-114k", split="train")
 
-peft_config = LoraConfig(lora_r=256, lora_alpha=16, lora_target_modules="all-linear")
+peft_config = LoraConfig(r=256, lora_alpha=16, target_modules="all-linear")
 
 training_args = SFTConfig(
     learning_rate=2e-4,
@@ -245,9 +245,9 @@ def strip_reasoning_accuracy_reward(completions, **kwargs):
     ... 
 
 peft_config = LoraConfig(
-    lora_r=1,
+    r=1,
     lora_alpha=32,
-    lora_target_modules="all-linear"
+    target_modules="all-linear"
 )
 
 training_args = GRPOConfig(


### PR DESCRIPTION
# What does this PR do?

Update LoRA params in Python

`lora_r` is `r` in `LoraConfig`. Same for `lora_target_modules`. It's `target_modules`. It's correct for the rest of the cases since it goes through TRL.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

@burtenshaw 