### PR TITLE
Fix callable annotations

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -16,6 +16,7 @@ import functools
 import random
 import signal
 import warnings
+from collections.abc import Callable
 
 import psutil
 import pytest
@@ -73,7 +74,7 @@ class TrlTestCase:
         self.tmp_dir = str(tmp_path)
 
 
-def ignore_warnings(message: str = None, category: type[Warning] = Warning) -> callable:
+def ignore_warnings(message: str = None, category: type[Warning] = Warning) -> Callable:
     """
     Decorator to ignore warnings with a specific message and/or category.
 

--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -15,7 +15,7 @@
 import contextlib
 import functools
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 
 from transformers import Trainer
 from transformers.integrations import is_mlflow_available, is_wandb_available
@@ -68,12 +68,12 @@ def profiling_context(trainer: Trainer, name: str) -> Generator[None, None, None
         mlflow.log_metrics(profiling_metrics, step=trainer.state.global_step)
 
 
-def profiling_decorator(func: callable) -> callable:
+def profiling_decorator(func: Callable) -> Callable:
     """
     Decorator to profile a function and log execution time using [`extras.profiling.profiling_context`].
 
     Args:
-        func (`callable`):
+        func (`Callable`):
             Function to be profiled.
 
     Example:

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+from collections.abc import Callable
 from typing import Optional, Union
 
 import pandas as pd
@@ -583,7 +584,7 @@ class WeaveCallback(TrainerCallback):
         self,
         trainer: Trainer,
         project_name: Optional[str] = None,
-        scorers: Optional[dict[str, callable]] = None,
+        scorers: Optional[dict[str, Callable]] = None,
         generation_config: Optional[GenerationConfig] = None,
         num_prompts: Optional[int] = None,
         dataset_name: str = "eval_dataset",


### PR DESCRIPTION
Fix callable annotations: replace `callable` annotations with `collections.abc.Callable`.

This PR standardizes our type hints to use `typing.Callable` instead of the lowercase `callable`. It updates function signatures and docstrings.

Why this change?
- `callable` is not a type: `callable` is a built-in function used at runtime (`callable(obj) -> bool`), not a type that static type checkers understand in annotations. Using callable in hints either produces errors or is treated as `Any`, defeating the purpose of type checking.
- `collections.abc.Callable` is the correct type: `Callable` is the standard, checker-recognized protocol for “anything you can call,” including functions, lambdas, bound methods, and objects with `__call__`.