### PR TITLE
Remove unused Path import in __init__.py

### DIFF
--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .import_utils import _LazyModule


### PR DESCRIPTION
Remove unused `Path` import in `__init__.py` file.

This PR removes an unused import that remained after:
- [Refactor version retrieval to use importlib.metadata for improved reliability](https://github.com/huggingface/trl/commit/39faf36a91e25d0b333eb9ef3dc9ebd3dd270aa2)