### PR TITLE
Exclude vllm dependencies from dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,26 +90,32 @@ vlm = [
     "num2words==0.5.14"
 ]
 dev = [
+    # bco
     "scikit-learn",
     "joblib",
+    # deepspeed
     "deepspeed>=0.14.4",
+    # judges
     "openai>=1.23.2",
     "llm-blender>=0.0.2",
+    # liger
     "liger-kernel>=0.6.2",
+    # peft
     "peft>=0.8.0",
+    # quality
     "pre-commit",
     "hf-doc-builder",
+    # quantization
     "bitsandbytes",
+    # scikit: included in bco
+    # test
     "parameterized",
     "pytest-cov",
     "pytest-rerunfailures==15.1",
     "pytest-xdist",
     "pytest",
-    "vllm==0.10.2",
-    "fastapi",
-    "pydantic",
-    "requests",
-    "uvicorn",
+    # vllm: not included in dev by default due to CUDA error; see GH-4228
+    # vlm
     "Pillow",
     "torchvision",
     "num2words==0.5.14"


### PR DESCRIPTION
Exclude `vllm` extra dependencies from `dev` extra, as it used to be the case before the merge of:
- #4194

Before that PR, the `vllm` extra dependencies were not included in `dev` extra. See: 
https://github.com/huggingface/trl/blob/529101537feafa84d7b99acde715badc356b7172/setup.cfg#L76-L87

This PR updates the `dev` dependencies in the `pyproject.toml` file, so `vllm` extra dependencies are not included in the `dev` extra.

Fix #4228.