### PR TITLE
Replace setup with pyproject in CI tests paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
       - "scripts/**.py"
       - "tests/**.py"
       - "trl/**.py"
-      - "setup.py"
+      - "pyproject.toml"
 
 env:
   TQDM_DISABLE: 1


### PR DESCRIPTION
Replace `setup.py` with `pyproject.toml` in CI tests paths.

This PR makes a minor update to the test workflow trigger configuration, ensuring that changes to the Python project configuration file will correctly trigger CI tests.
* The workflow now triggers on changes to `pyproject.toml` instead of `setup.py`, reflecting a migration to modern Python packaging standards.

Follow-up to:
- #4194