### PR TITLE
Fix CI slow test ValueError: Backward pass should have cleared tracker of all tensors

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -230,6 +230,7 @@ class OffloadActivations(saved_tensors_hooks):
 
             # clear tensor from tracking
             del self.tracker[unpack_tensor_id]
+            # Only set is_first_forward_call to True when all tensors have been unpacked
             if len(self.tracker) == 0:
                 self.is_first_forward_call = True
             return maybe_accelerator_tensor


### PR DESCRIPTION
 tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_train_offloading_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2

ValueError: Backward pass should have cleared tracker of all tensors

fix TestSFTTrainerSlow::test_train_offloading_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 case error, callstack like

=================================================================== FAILURES ====================================================================
___________________________ TestSFTTrainerSlow.test_train_offloading_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 ___________________________

a = (<tests.slow.test_sft_slow.TestSFTTrainerSlow object at 0x7fad7a300310>,), kw = {}

    @wraps(func)
    def standalone_func(*a, **kw):
>       return func(*(a + p.args), **p.kwargs, **kw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/parameterized/parameterized.py:620:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/slow/test_sft_slow.py:444: in test_train_offloading
    trainer.train()
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/transformers/trainer.py:2197: in train
    return inner_training_loop(
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/transformers/trainer.py:2532: in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
trl/trainer/sft_trainer.py:1185: in training_step
    return super().training_step(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/transformers/trainer.py:3850: in training_step
    self.accelerator.backward(loss, **kwargs)
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/accelerate/accelerator.py:2734: in backward
    loss.backward(**kwargs)
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/_tensor.py:647: in backward
    torch.autograd.backward(
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/autograd/__init__.py:354: in backward
    _engine_run_backward(
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/autograd/graph.py:829: in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/autograd/function.py:311: in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/checkpoint.py:302: in backward
    outputs = ctx.run_function(*detached_inputs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/nn/modules/module.py:1773: in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/nn/modules/module.py:1784: in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/transformers/models/llama/modeling_llama.py:289: in forward
    hidden_states = self.input_layernorm(hidden_states)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/nn/modules/module.py:1773: in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/nn/modules/module.py:1784: in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/transformers/models/llama/modeling_llama.py:64: in forward
    variance = hidden_states.pow(2).mean(-1, keepdim=True)
               ^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

activation = tensor([[[-0.0341, -0.6027,  2.1095,  ..., -1.0907, -0.4306,  0.0524],
         [-0.7375, -0.5478,  1.9543,  ..., -1.7...],
         [ 0.1073, -0.0110,  0.8452,  ...,  0.4391,  0.6782,  0.0650]]],
       device='cuda:0', requires_grad=True)

    def pack_tensor(activation: torch.Tensor) -> int:
        # activations are passed in during forward pass - from here we take over and return a unique id
        if self.is_first_forward_call:
            if len(self.tracker) != 0:
>               raise ValueError("Backward pass should have cleared tracker of all tensors")
E               ValueError: Backward pass should have cleared tracker of all tensors

trl/models/activation_offloading.py:150: ValueError


