### PR TITLE
Fix CI IndentationError for Python 3.13.8

### DIFF
--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 
 import pytest
@@ -59,6 +60,9 @@ class TestJudges(TrlTestCase):
         raise ValueError("Failed to load PairRMJudge")
 
     @require_llm_blender
+    @pytest.mark.skipif(
+        sys.version_info == (3, 13, 8), reason="Python 3.13.8 has a bug in inspect.BlockFinder (cpython GH-139783)"
+    )
     def test_pair_rm_judge(self):
         judge = self.load_pair_rm_judge()
         prompts, completions = self._get_prompts_and_pairwise_completions()
@@ -68,6 +72,9 @@ class TestJudges(TrlTestCase):
         assert ranks == [0, 1]
 
     @require_llm_blender
+    @pytest.mark.skipif(
+        sys.version_info == (3, 13, 8), reason="Python 3.13.8 has a bug in inspect.BlockFinder (cpython GH-139783)"
+    )
     def test_pair_rm_judge_return_scores(self):
         judge = self.load_pair_rm_judge()
         prompts, completions = self._get_prompts_and_pairwise_completions()


### PR DESCRIPTION
Fix CI IndentationError for Python 3.13.8 by skipping the impacted tests for Python 3.13.8.

This PR skips `PairRMJudge` tests when running on Python 3.13.8 due to a critical bug in Python's `inspect.BlockFinder` that breaks PyTorch JIT compilation.

Fix #4239.

## Context

Python 3.13.8 introduced a regression in the `inspect` module ([cpython#139783](https://github.com/python/cpython/issues/139783)) that causes `inspect.getsourcelines()` to incorrectly truncate source code when a comment appears between a decorator and a function definition.

This affects:
- ❌ transformers' DeBERTa-v2 and SEW-D models (cannot be imported)
- ❌ `llm-blender` library's PairRM model loading (which triggers DeBERTa-v2 import)
- ❌ TRL's `PairRMJudge` tests

### The Bug Pattern

```python
@torch.jit.script
# Comment here
def function_name(...):
    ...
```

When PyTorch's JIT tries to compile this, Python 3.13.8's BlockFinder incorrectly treats the comment as a lambda/generator expression, truncating the source before the function body, causing an IndentationError.

## Changes

- Added @pytest.mark.skipif decorators to test_pair_rm_judge and test_pair_rm_judge_return_scores
- Tests will skip only on Python 3.13.8 with a clear reason message
- Tests will automatically resume when Python 3.13.9 fixes the issue

### Testing
✅ Tests pass on Python 3.9, 3.10, 3.11, 3.12, 3.13.7
⏭️ Tests skip on Python 3.13.8 with informative message
✅ All other TRL functionality works fine on Python 3.13.8

### Status

- Python 3.13.7 and earlier: ✅ Works
- Python 3.13.8: ❌ Broken (regression)
- Python 3.13.9: 🔄 Expected to fix (remove skipif when released)

### Related Issues
- Upstream Python bug: 
  - https://github.com/python/cpython/issues/139783
- Upstream transformers issue:
  - https://github.com/huggingface/transformers/issues/41472

### Additional Context
- Affects transformers DeBERTa-v2 and SEW-D models
- Workaround: Use Python 3.13.7 or wait for Python 3.13.9