### PR TITLE
Install peft from main for CI tests with dev dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
           uv pip install -U git+https://github.com/huggingface/accelerate.git
           uv pip install -U git+https://github.com/huggingface/datasets.git
           uv pip install -U git+https://github.com/huggingface/transformers.git
-          
+          uv pip install -U git+https://github.com/huggingface/peft.git
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
Install peft from main for CI tests with dev dependencies.

This PR updates the CI tests with dev dependencies and aligns `peft` with the rest of the Hugging Face libraries, installing its dev version from the GH repo main branch.

Additionally, this PR fixes the CI AttributeError: type object 'DynamicCache' has no attribute 'from_legacy_cache': the fix is already on `peft` main branch:
- https://github.com/huggingface/peft/pull/2767

Fix #4248.