### PR TITLE
Fix CI slow test ValueError: Unknown loss type: dapo

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -7,7 +7,6 @@ on:
       # Run only when python files are modified
       - "trl/**.py"
       - "examples/**.py"
-  pull_request:
 env:
   RUN_SLOW: "yes"
   IS_GITHUB_CI: "1"
@@ -15,7 +14,6 @@ env:
 
 jobs:
   run_all_tests_single_gpu:
-    if: github.event.pull_request.draft == true
     runs-on:
       group: aws-g4dn-2xlarge
     env:
@@ -64,7 +62,6 @@ jobs:
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
   run_all_tests_multi_gpu:
-    if: github.event.pull_request.draft == false
     runs-on:
       group: aws-g4dn-2xlarge
     env:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ precommit:
 	doc-builder style trl tests docs/source --max_len 119
 
 slow_tests:
-	pytest -m "slow" tests/slow/test_grpo_slow.py::TestGRPOTrainerSlow::test_training_with_liger_grpo_loss_and_peft_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
+	pytest -m "slow" tests/ $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
 
 test_examples:
 	touch temp_results_sft_tests.txt


### PR DESCRIPTION
Fix CI slow test: https://github.com/huggingface/trl/actions/runs/18399649932/job/52425772805
> ValueError: Unknown loss type: dapo
```python
FAILED tests/slow/test_grpo_slow.py::TestGRPOTrainerSlow::test_training_with_liger_grpo_loss_and_peft_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 - ValueError: Unknown loss type: dapo
FAILED tests/slow/test_grpo_slow.py::TestGRPOTrainerSlow::test_training_with_liger_grpo_loss_and_peft_1_trl_internal_testing_tiny_MistralForCausalLM_0_2 - ValueError: Unknown loss type: dapo
```

Follow-up to:
- #4173