### PR TITLE
Fix CI slow test AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -7,7 +7,6 @@ on:
       # Run only when python files are modified
       - "trl/**.py"
       - "examples/**.py"
-  pull_request:
 env:
   RUN_SLOW: "yes"
   IS_GITHUB_CI: "1"
@@ -15,7 +14,6 @@ env:
 
 jobs:
   run_all_tests_single_gpu:
-    if: github.event.pull_request.draft == true
     runs-on:
       group: aws-g4dn-2xlarge
     env:
@@ -64,7 +62,6 @@ jobs:
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
   run_all_tests_multi_gpu:
-    if: github.event.pull_request.draft == false
     runs-on:
       group: aws-g4dn-2xlarge
     env:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ precommit:
 	doc-builder style trl tests docs/source --max_len 119
 
 slow_tests:
-	pytest -m "slow" tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_sft_trainer_with_liger_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
+	pytest -m "slow" tests/ $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
 
 test_examples:
 	touch temp_results_sft_tests.txt


### PR DESCRIPTION
Fix CI slow test: https://github.com/huggingface/trl/actions/runs/18399649932/job/52425772805
> AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'
```pytest
FAILED tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_sft_trainer_with_liger_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2 - AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'
FAILED tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_sft_trainer_with_liger_1_trl_internal_testing_tiny_LlamaForCausalLM_3_2 - AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'
FAILED tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_sft_trainer_with_liger_2_trl_internal_testing_tiny_MistralForCausalLM_0_2 - AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'
FAILED tests/slow/test_sft_slow.py::TestSFTTrainerSlow::test_sft_trainer_with_liger_3_trl_internal_testing_tiny_MistralForCausalLM_0_2 - AttributeError: 'TestSFTTrainerSlow' object has no attribute 'addCleanup'
```

This issue was introduced after the conversion from `unittest` to `pytest` by:
- #4188