### PR TITLE
Use FutureWarning instead of DeprecationWarning

### DIFF
--- a/trl/extras/dataset_formatting.py
+++ b/trl/extras/dataset_formatting.py
@@ -50,7 +50,7 @@ def conversations_formatting_function(
     warnings.warn(
         "`conversations_formatting_function` is deprecated and will be removed in TRL 0.27. "
         "Please use `tokenizer.apply_chat_template()` directly instead.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
 
@@ -80,7 +80,7 @@ def instructions_formatting_function(tokenizer: AutoTokenizer):
     warnings.warn(
         "`instructions_formatting_function` is deprecated and will be removed in TRL 0.27. "
         "Please use `tokenizer.apply_chat_template()` directly instead.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
 
@@ -128,7 +128,7 @@ def get_formatting_func_from_dataset(
     warnings.warn(
         "`get_formatting_func_from_dataset` is deprecated and will be removed in TRL 0.27. "
         "Please use `tokenizer.apply_chat_template()` directly instead.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
 

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -116,7 +116,7 @@ def setup_chat_format(
     warnings.warn(
         "The `setup_chat_format` function is deprecated and will be removed in version 0.26.0. Please use "
         "`clone_chat_template` instead.",
-        DeprecationWarning,
+        FutureWarning,
     )
     # check if model already had a chat template
     if tokenizer.chat_template is not None:

--- a/trl/trainer/model_config.py
+++ b/trl/trainer/model_config.py
@@ -193,7 +193,7 @@ class ModelConfig:
         if self.torch_dtype and not self.dtype:
             warnings.warn(
                 "`torch_dtype` is deprecated and will be removed in version 0.27.0, please use `dtype` instead.",
-                DeprecationWarning,
+                FutureWarning,
             )
             self.dtype = self.torch_dtype
 

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -334,7 +334,7 @@ class OnlineDPOTrainer(BaseTrainer):
                 logger.warning(
                     "The `missing_eos_penalty` parameter is deprecated when used with the deprecated `reward_model` parameter. "
                     "Please use `reward_funcs` instead of `reward_model` to continue using this feature.",
-                    DeprecationWarning,
+                    FutureWarning,
                     stacklevel=2,
                 )
             else:

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -245,7 +245,7 @@ class RewardDataCollatorWithPadding:
         warnings.warn(
             "The `RewardDataCollatorWithPadding` is deprecated and will be removed in version 0.27.0. Please use "
             "`trl.trainer.reward_trainer.DataCollatorForPreference` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         super().__init__(*args, **kwargs)
 
@@ -1273,7 +1273,7 @@ def decode_and_strip_padding(inputs: torch.Tensor, tokenizer: PreTrainedTokenize
     warnings.warn(
         "The function `decode_and_strip_padding` is deprecated and will be removed in a version 0.25.0. If you want "
         "to keep using it, please copy the code into your codebase and use it from there.",
-        DeprecationWarning,
+        FutureWarning,
     )
     decoded = tokenizer.batch_decode(inputs, skip_special_tokens=False)
     return [d.replace(tokenizer.pad_token, "") for d in decoded]


### PR DESCRIPTION
Use FutureWarning instead of DeprecationWarning.

Note that FutureWarning should be used for deprecated features when those warnings are intended for end users: FutureWarning is visible by default to users, whereas DeprecationWarning is silenced unless you run Python with -Wd. Since we want users to actually see this message (to upgrade their Python), FutureWarning is the appropriate and more effective choice.