### PR TITLE
Fix CI issue for vlm_gemma_3n model

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1494,10 +1494,11 @@ class TestSFTTrainer(TrlTestCase):
         # Initialize the trainer
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
+            learning_rate=0.1,
             max_length=None,
             per_device_train_batch_size=1,
             gradient_checkpointing=True,
-            model_init_kwargs={"dtype": "float16"},
+            model_init_kwargs={"dtype": "bfloat16"},
             report_to="none",
         )
         trainer = SFTTrainer(model="google/gemma-3n-E2B-it", args=training_args, train_dataset=dataset)
@@ -1514,10 +1515,7 @@ class TestSFTTrainer(TrlTestCase):
         # Check the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            if "model.vision_tower" in n or "model.audio_tower" in n:
-                # The vision/audio towers are frozen during training and will not update
-                continue
-            if "model.embed_audio" in n:
+            if "model.audio_tower" in n or "model.embed_audio" in n:
                 # The audio embedding parameters are not updated because this dataset contains no audio data
                 continue
             assert not torch.allclose(param, new_param, rtol=1e-12, atol=1e-12), f"Param {n} is not updated"


### PR DESCRIPTION
When we run test case `pytest -rA tests/test_sft_trainer.py::TestSFTTrainer::test_train_vlm_gemma_3n`, it will fail both on CUDA and Intel XPU. Further investigation shows there are 2 reasons:
1. audio tower part will not update related weight during finetune
2. when using bf16 datatype, small changes for model weight will be rounded off
This PR fixes this bug.