### PR TITLE
Fix CI slow test OSError: You are trying to access a gated repo

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1477,6 +1477,7 @@ class TestSFTTrainer(TrlTestCase):
     # To ensure coverage, we run tests on the full model but mark them as slow to exclude from default runs.
     @pytest.mark.slow
     @require_vision
+    @pytest.mark.skip(reason="Model google/gemma-3n-E2B-it is gated and requires HF token")
     def test_train_vlm_gemma_3n(self):
         # Get the dataset
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")


### PR DESCRIPTION
Fix CI slow test OSError: You are trying to access a gated repo:
- Skip test requiring HF token to access gated repo

* Changes:
  * Add `@pytest.mark.skip` to the `test_train_vlm_gemma_3n` test, with a reason indicating the model is gated and requires a Hugging Face token.

Fix #4282.