### PR TITLE
Fix missing CI slow tests: ImportError: vLLM is not installed

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -134,6 +134,7 @@ class TestVLLMClientServer(TrlTestCase):
 # Same as above but using base_url to instantiate the client.
 @pytest.mark.slow
 @require_torch_multi_accelerator
+@require_vllm
 class TestVLLMClientServerBaseURL(TrlTestCase):
     model_id = "Qwen/Qwen2.5-1.5B"
 


### PR DESCRIPTION
Fix missing CI slow tests: ImportError: vLLM is not installed: https://github.com/huggingface/trl/actions/runs/18605452483/job/53053774121
- Mark missing vllm tests with require_vllm

Follow-up to:
- #4287 

Fix #4286.

