### PR TITLE
Filter expected setup_chat_format deprecation warning in CI

### DIFF
--- a/tests/test_dataset_formatting.py
+++ b/tests/test_dataset_formatting.py
@@ -118,6 +118,7 @@ class TestDatasetFormatting(TrlTestCase):
         assert formatting_func is None
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestSetupChatFormat(TrlTestCase):
     def setup_method(self):
         self.tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")


### PR DESCRIPTION
Filter expected setup_chat_format deprecation warning from CI summary:
```python
tests/test_dataset_formatting.py::TestSetupChatFormat::test_setup_chat_format
tests/test_dataset_formatting.py::TestSetupChatFormat::test_example_with_setup_model
  /__w/trl/trl/trl/models/utils.py:116: FutureWarning: The `setup_chat_format` function is deprecated and will be removed in version 0.26.0. Please use `clone_chat_template` instead.
    warnings.warn(
```