### PR TITLE
Replace deprecated AutoModelForVision2Seq with AutoModelForImageTextToText

### DIFF
--- a/tests/test_online_dpo_trainer.py
+++ b/tests/test_online_dpo_trainer.py
@@ -38,7 +38,7 @@ if is_peft_available():
 if is_vision_available():
     import numpy as np
     from PIL import Image
-    from transformers import AutoModelForVision2Seq, AutoProcessor
+    from transformers import AutoModelForImageTextToText, AutoProcessor
 
 
 class TestOnlineDPOTrainer(TrlTestCase):
@@ -510,7 +510,7 @@ class TestOnlineDPOVisionTrainer(TrlTestCase):
         dataset = Dataset.from_dict(dataset_dict)
         dataset = dataset.cast_column("images", features.Sequence(features.Image()))
 
-        model = AutoModelForVision2Seq.from_pretrained(model_id)
+        model = AutoModelForImageTextToText.from_pretrained(model_id)
         reward_model = AutoModelForSequenceClassification.from_pretrained(
             "trl-internal-testing/tiny-LlamaForCausalLM-3.2", num_labels=1
         )


### PR DESCRIPTION
Replace deprecated `AutoModelForVision2Seq` with `AutoModelForImageTextToText`.

Note that `AutoModelForVision2Seq` was deprecated in favour of `AutoModelForImageTextToText` in transformers-4.54.1 and that we require `transformers>=4.56.1` in `trl`:
- https://github.com/huggingface/transformers/pull/38900 
- https://github.com/huggingface/transformers/pull/32472

This PR fixes the FutureWarning:
> FutureWarning: The class `AutoModelForVision2Seq` is deprecated and will be removed in v5.0. Please use `AutoModelForImageTextToText` instead.