### PR TITLE
Remove ignored max_length parameter from PRMTrainer data collator

### DIFF
--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -141,7 +141,7 @@ class PRMTrainer(BaseTrainer):
                 raise ValueError(
                     "A processing_class must be specified when using the default DataCollatorForTokenClassification"
                 )
-            data_collator = DataCollatorForTokenClassification(processing_class, max_length=args.max_length)
+            data_collator = DataCollatorForTokenClassification(processing_class)
 
         if "input_ids" not in train_dataset.column_names:
             with PartialState().main_process_first():


### PR DESCRIPTION
Remove ignored `max_length` parameter from `PRMTrainer` data collator.

This PR fixes a UserWarning in `PRMTrainer` where `max_length` was being passed to `DataCollatorForTokenClassification` but ignored during training: https://github.com/huggingface/trl/actions/runs/18855787317/job/53803267316
> UserWarning: `max_length` is ignored when `padding`=`True` and there is no truncation strategy. To pad to max length, use `padding='max_length'`.

### Changes

Remove the `max_length` parameter from `DataCollatorForTokenClassification` initialization in `PRMTrainer`.

### Rationale

- **Truncation is already handled**: The `tokenize_row()` method already performs all necessary truncation based on `max_length`, `max_prompt_length`, and `max_completion_length`.
- **Dynamic padding is more efficient**: The data collator uses `padding=True` by default, which pads each batch to its longest sequence rather than a fixed length.
- **No functional change**: This only removes an ignored parameter that was generating warnings. Training behavior remains identical.
