### PR TITLE
Replace deprecated list with tuple indexing in PPOTrainer

### DIFF
--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -563,7 +563,7 @@ class PPOTrainer(BaseTrainer):
                 rewards = non_score_reward.clone()
                 actual_start = torch.arange(rewards.size(0), device=rewards.device)
                 actual_end = torch.where(sequence_lengths_p1 < rewards.size(1), sequence_lengths_p1, sequence_lengths)
-                rewards[[actual_start, actual_end]] += scores
+                rewards[actual_start, actual_end] += scores
 
                 # 5. whiten rewards
                 if args.whiten_rewards:


### PR DESCRIPTION
Replace deprecated list with tuple indexing in PPOTrainer.

This PR fixes a PyTorch deprecation warning where list-based indexing will be removed in PyTorch 2.9:
> UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result

The fix changes from list indexing `[[actual_start, actual_end]]` to tuple indexing `[actual_start, actual_end]`, which is the recommended approach. This maintains identical behavior while ensuring forward compatibility with PyTorch 2.9+.

### Details
PyTorch is deprecating the use of list sequences for multidimensional indexing. The warning states:
```python
  tests/test_ppo_trainer.py::TestPPOTrainer::test_peft_training
  tests/test_ppo_trainer.py::TestPPOTrainer::test_basic_training
  tests/test_ppo_trainer.py::TestPPOTrainer::test_basic_training
  tests/test_ppo_trainer.py::TestPPOTrainer::test_basic_training
    /__w/trl/trl/trl/trainer/ppo_trainer.py:566: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /pytorch/torch/csrc/autograd/python_variable_indexing.cpp:306.)
      rewards[[actual_start, actual_end]] += scores
```