### PR TITLE
Fix raising of deprecation warning for liger_loss

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -519,7 +519,7 @@ class DPOConfig(TrainingArguments):
                     f"({loss_types})."
                 )
 
-        if self.use_liger_loss:
+        if self.use_liger_loss is not None:
             warnings.warn(
                 "The `use_liger_loss` argument is deprecated and will be removed in version 0.28.0. Please use "
                 "`use_liger_kernel` instead.",

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -705,7 +705,7 @@ class GRPOConfig(TrainingArguments):
                 f"{self.num_generations}, which is less than the minimum required."
             )
 
-        if self.use_liger_loss:
+        if self.use_liger_loss is not None:
             warnings.warn(
                 "The `use_liger_loss` argument is deprecated and will be removed in version 0.28.0. Please use "
                 "`use_liger_kernel` instead.",

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -246,7 +246,7 @@ class KTOConfig(TrainingArguments):
     def __post_init__(self):
         self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
 
-        if self.use_liger_loss:
+        if self.use_liger_loss is not None:
             warnings.warn(
                 "The `use_liger_loss` argument is deprecated and will be removed in version 0.28.0. Please use "
                 "`use_liger_kernel` instead.",


### PR DESCRIPTION
Fix raising of deprecation warning for `liger_loss`. 

Follow-up to:
* #4364

This PR fixes the rendering of the deprecation warning message in the docstring for the `use_liger_loss` parameter in the configuration classes for DPO, GRPO, and KTO trainers, and updates the handling of the deprecation warning. The main change is to ensure that deprecation warnings are triggered when `use_liger_loss` is explicitly set, rather than only when it is truthy.

Documentation updates:

* Update the docstrings for the `use_liger_loss` parameter in all three config classes to:
  * fix rendering of the deprecation message
  * remove the redundant default value of `None`
    * See related PR:
      * #4058

Deprecation handling improvements:

* Change the deprecation warning condition for `use_liger_loss` in the `__post_init__` methods of `DPOConfig`, `GRPOConfig`, and `KTOConfig` to check for `is not None` instead of truthiness. This ensures the warning is shown only when the parameter is explicitly set (either as `True` or `False`) and not only when it is set as `True`.