### PR TITLE
Update tokenizer apply_chat_template with return_dict=True default

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -488,13 +488,15 @@ class RewardTrainer(BaseTrainer):
                         chosen_input_ids = processing_class.apply_chat_template(
                             example["chosen"],
                             tools=example.get("tools"),
+                            return_dict=True,
                             **example.get("chat_template_kwargs", {}),
-                        )
+                        )["input_ids"]
                         rejected_input_ids = processing_class.apply_chat_template(
                             example["rejected"],
                             tools=example.get("tools"),
+                            return_dict=True,
                             **example.get("chat_template_kwargs", {}),
-                        )
+                        )["input_ids"]
                         output = {"chosen_input_ids": chosen_input_ids, "rejected_input_ids": rejected_input_ids}
                     else:
                         output = {


### PR DESCRIPTION
Pass explicitly `return_dict=True` to `apply_chat_template` and get its `input_ids` key.

This PR fixes the issue:
> RuntimeError: Could not infer dtype of dict

Fix #4447.

Note that `transformers` has recently set `return_dict=True` as the default value:
- https://github.com/huggingface/transformers/pull/41626

This PR updates the tokenization logic in the `tokenize_fn` function of `trl/trainer/reward_trainer.py` to improve compatibility with the default output format of `apply_chat_template`. Instead of assuming `return_dict=False` and directly returning the result, it now requests a dictionary and extracts only the `input_ids` field.

Tokenization logic update:

* The `apply_chat_template` method is now called with `return_dict=True`, and only the `input_ids` from the returned dictionary are used for both the `chosen` and `rejected` examples.