### PR TITLE
🖼️ Fix reporting images with vLLM

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1952,6 +1952,7 @@ class GRPOTrainer(BaseTrainer):
                     if images_raw:
                         # TODO: Implement once supported upstream https://github.com/gradio-app/trackio/issues/334
                         logger.info("Skipping image logging for Trackio")
+                        df = df_base
                         # images = []
                         # for image_list in self._logs["images"]:
                         #     images.append([trackio.Image(image) for image in image_list])

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1561,6 +1561,7 @@ class RLOOTrainer(BaseTrainer):
                     if images_raw:
                         # TODO: Implement once supported upstream https://github.com/gradio-app/trackio/issues/334
                         logger.info("Skipping image logging for Trackio")
+                        df = df_base
                         # images = []
                         # for image_list in self._logs["images"]:
                         #     images.append([trackio.Image(image) for image in image_list])


### PR DESCRIPTION
Before:

```python
from datasets import load_dataset
from trl import GRPOTrainer, GRPOConfig

dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")

# Dummy reward function: count the number of unique characters in the completions
def reward_num_unique_chars(completions, **kwargs):
    return [len(set(c[0]["content"])) for c in completions]

trainer = GRPOTrainer(
    model="trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
    reward_funcs=reward_num_unique_chars,
    train_dataset=dataset,
    args=GRPOConfig(
        log_completions=True,
        report_to="trackio",
        max_completion_length=32,
        num_generations=3,
        per_device_train_batch_size=3, 
    ),
)
trainer.train()
```


gives

```
Traceback (most recent call last):
  File "/fsx/qgallouedec/trl/sandbox/grpo_fp32.py", line 22, in <module>
    trainer.train()
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/transformers/trainer.py", line 2325, in train
    return inner_training_loop(
           ^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/transformers/trainer.py", line 2756, in _inner_training_loop
    self._maybe_log_save_evaluate(
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/transformers/trainer.py", line 3217, in _maybe_log_save_evaluate
    self.log(logs, start_time)
  File "/fsx/qgallouedec/trl/trl/trainer/grpo_trainer.py", line 1947, in log
    if logging_backend is wandb:
                          ^^^^^
NameError: name 'wandb' is not defined
```

bug introduced in #4359