### PR TITLE
Replace accelerate logging with stdlib in CLI

### DIFF
--- a/trl/cli.py
+++ b/trl/cli.py
@@ -17,7 +17,6 @@ import logging
 import os
 import sys
 
-import torch
 from accelerate.commands.launch import launch_command, launch_command_parser
 
 from .scripts.dpo import make_parser as make_dpo_parser
@@ -144,17 +143,6 @@ def main():
 
     elif args.command == "vllm-serve":
         (script_args,) = parser.parse_args_and_config()
-
-        # Known issue: Using DeepSpeed with tensor_parallel_size=1 and data_parallel_size>1 may cause a crash when
-        # launched via the CLI. Suggest running the module directly.
-        # More information: https://github.com/vllm-project/vllm/issues/17079
-        if script_args.tensor_parallel_size == 1 and script_args.data_parallel_size > 1 and torch.cuda.is_available():
-            logger.warning(
-                "Detected configuration: tensor_parallel_size=1 and data_parallel_size>1. This setup is known to "
-                "cause a crash when using the `trl vllm-serve` CLI entry point. As a workaround, please run the "
-                "server using the module path instead: `python -m trl.scripts.vllm_serve`",
-            )
-
         vllm_serve_main(script_args)
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes a bug with `trl vllm-serve` and data parallel > 1 where the logger from `accelerate` needs to be called after an `Accelerator()` is instantiated:

```
INFO 11-12 13:23:47 [__init__.py:216] Automatically detected platform cuda.
Traceback (most recent call last):
  File "/fsx/lewis/git/hf/trl/trl-env/bin/trl", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/fsx/lewis/git/hf/trl/trl/cli.py", line 152, in main
    logger.warning(
  File "/admin/home/lewis/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1855, in warning
    self.log(WARNING, msg, *args, **kwargs)
  File "/fsx/lewis/git/hf/trl/trl-env/lib/python3.11/site-packages/accelerate/logging.py", line 53, in log
    raise RuntimeError(
RuntimeError: You must initialize the accelerate state by calling either `PartialState()` or `Accelerator()` before using the logging utility.
```

To repro:

```sh
trl vllm-serve --model Qwen/Qwen3-4B-Thinking-2507 --data_parallel_size 8
```

The fix is to use the `stdlib` logger since we only need it for 1 warning. I've also removed the warning about DP > 1 & TP = 1 since this no longer appears to be an issue in my tests: https://github.com/vllm-project/vllm/issues/17079


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.