### PR TITLE
fix tokenize bug for ppo_tldr example

### DIFF
--- a/examples/scripts/ppo/ppo_tldr.py
+++ b/examples/scripts/ppo/ppo_tldr.py
@@ -141,11 +141,12 @@ if __name__ == "__main__":
         """pre-tokenize the dataset before training; only collate during training"""
 
         def tokenize(element):
-            input_ids = tokenizer.apply_chat_template(
-                element["messages"][:1],
+            # Extract the prompt from the first message (user message)
+            prompt_text = element["messages"][0]["content"]
+            input_ids = tokenizer(
+                prompt_text,
                 padding=False,
-                add_generation_prompt=True,
-            )
+            )["input_ids"]
             return {"input_ids": input_ids, "lengths": len(input_ids)}
 
         return dataset.map(


### PR DESCRIPTION
When I run the example following README part:
```
python examples/scripts/ppo/ppo_tldr.py \
    --dataset_name trl-internal-testing/tldr-preference-sft-trl-style \
    --dataset_test_split validation \
    --learning_rate 3e-6 \
    --output_dir pythia-1b-deduped-tldr-preference-sft-trl-style-ppo \
    --per_device_train_batch_size 1 \
    --gradient_accumulation_steps 64 \
    --total_episodes 30000 \
    --model_name_or_path EleutherAI/pythia-1b-deduped \
    --sft_model_path cleanrl/EleutherAI_pythia-1b-deduped__sft__tldr \
    --reward_model_path cleanrl/EleutherAI_pythia-1b-deduped__reward__tldr \
    --missing_eos_penalty 1.0 \
    --stop_token eos \
    --response_length 53 \
    --eval_strategy steps \
    --eval_steps 100
```
 it returns error : `ValueError: Cannot use chat template functions because tokenizer.chat_template is not set and no template argument
was passed!`. Seems the model `EleutherAI/pythia-1b-deduped` does not have its chat template. This PR solves this bug.