### PR TITLE
Fix bug with GRPO trainer when tokenizer outputs token_type_ids

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1385,17 +1385,21 @@ class GRPOTrainer(BaseTrainer):
                 "truncation": True,
                 "add_special_tokens": False,
             }
+            processor_tokenizer_kwargs = {
+                "return_token_type_ids": False,
+            }
             if is_conversational({"prompt": prompts[0]}):
                 generate_inputs = self.processing_class.apply_chat_template(
                     conversation=prompts,
                     **processor_kwargs,
+                    tokenizer_kwargs=processor_tokenizer_kwargs,
                     add_generation_prompt=True,
                     tokenize=True,
                     return_dict=True,
                     **self.chat_template_kwargs,
                 )
             else:
-                generate_inputs = self.processing_class(text=prompts, **processor_kwargs)
+                generate_inputs = self.processing_class(text=prompts, **processor_kwargs, **processor_tokenizer_kwargs)
             generate_inputs = super()._prepare_inputs(generate_inputs)
 
             with (


### PR DESCRIPTION
When training with a tokenizer that has `return_token_type_ids=True` as default, we get an error from `_validate_model_kwargs` in the [transformers library](https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/generation/utils.py#L2388):

```
The following `model_kwargs` are not used by the model: ['token_type_ids'] (note: typos in the generate arguments will also show up in this list)
```

This sets `return_token_type_ids` to `False` to prevent this from happening in the GRPO trainer. `PleIAs/Baguettotron` and `PleIAs/Monad` are examples of models that I ran into this issue with.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.