### PR TITLE
Fix typo in GRPO description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Explore how to seamlessly integrate TRL with OpenEnv in our [dedicated documenta
 
 ## Overview
 
-TRL is a cutting-edge library designed for post-training foundation models using advanced techniques like Supervised Fine-Tuning (SFT), Group Realtive Policy Optimization (GRPO), and Direct Preference Optimization (DPO). Built on top of the [🤗 Transformers](https://github.com/huggingface/transformers) ecosystem, TRL supports a variety of model architectures and modalities, and can be scaled-up across various hardware setups.
+TRL is a cutting-edge library designed for post-training foundation models using advanced techniques like Supervised Fine-Tuning (SFT), Group Relative Policy Optimization (GRPO), and Direct Preference Optimization (DPO). Built on top of the [🤗 Transformers](https://github.com/huggingface/transformers) ecosystem, TRL supports a variety of model architectures and modalities, and can be scaled-up across various hardware setups.
 
 ## Highlights
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small typo in the README.  The phrase _“Group **Realtive** Policy Optimization (GRPO)”_ is corrected to  
_“Group Relative Policy Optimization (GRPO)”_.

## Before submitting
- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? (Not applicable for a small typo fix.)
- [x] Did you make sure to update the documentation with your changes? (README updated.)
- [ ] Did you write any new necessary tests? (Not applicable.)

## Who can review?

Anyone in the community is welcome to review this PR.