### PR TITLE
Revert hotfix Fall back to config.text_config._name_or_path

### DIFF
--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -2026,5 +2026,4 @@ def get_config_model_id(config: PretrainedConfig) -> str:
         `str`:
             The model identifier associated with the model configuration.
     """
-    # Fall back to `config.text_config._name_or_path` if `config._name_or_path` is missing: Qwen2-VL and Qwen2.5-VL. See GH-4323
-    return getattr(config, "_name_or_path", "") or getattr(getattr(config, "text_config", None), "_name_or_path", "")
+    return getattr(config, "_name_or_path", "")


### PR DESCRIPTION
Revert hotfix:
- #4324

for issue:
- #4323

Note that the upstream issue was only present on `transformers` main branch and it has been fixed by:
- https://github.com/huggingface/transformers/pull/41808

