### PR TITLE
Revert "Hotfix CI with dev dependencies: xfail test_prepare_inputs_for_generation"

### DIFF
--- a/tests/test_modeling_geometric_mixture_wrapper.py
+++ b/tests/test_modeling_geometric_mixture_wrapper.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import torch
 from transformers import AutoModelForCausalLM, GenerationConfig
 


### PR DESCRIPTION
This PR reverts the addition of the `xfail` marker (now it `xpass`es) introduced by the PR:
- huggingface/trl#4372

The upstream issue has been resolved and the fix has already been merged in `transformers`:
- https://github.com/huggingface/transformers/pull/41764
- https://github.com/huggingface/transformers/commit/f30c22500b126aa42e73ee86b7db5e3d7564734b

Currently the test triggers an XPASS error, indicating that the expected failure no longer occurs: https://github.com/huggingface/trl/actions/runs/19710221467/job/56468518803
>   FAILED tests/test_modeling_geometric_mixture_wrapper.py::TestGeometricMixtureWrapper::test_prepare_inputs_for_generation - [XPASS(strict)] Blocked by upstream fix pending in huggingface/transformers#41764 (tracked in GH-4272)