### PR TITLE
Raise FutureWarning for classes moved to experimental

### DIFF
--- a/trl/trainer/bco_config.py
+++ b/trl/trainer/bco_config.py
@@ -24,6 +24,8 @@ class BCOConfig(_BCOConfig):
         warnings.warn(
             "The `BCOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.bco import BCOConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/bco_trainer.py
+++ b/trl/trainer/bco_trainer.py
@@ -24,6 +24,8 @@ class BCOTrainer(_BCOTrainer):
         warnings.warn(
             "The `BCOTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.bco import BCOTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -271,7 +271,9 @@ class WinRateCallback(_WinRateCallback):
             "The `WinRateCallback` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.winrate_callback import WinRateCallback`. The current import path will be removed "
             "and no longer supported in TRL 0.29. For more information, see "
-            "https://github.com/huggingface/trl/issues/4223."
+            "https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -24,6 +24,8 @@ class CPOConfig(_CPOConfig):
         warnings.warn(
             "The `CPOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.cpo import CPOConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/gkd_config.py
+++ b/trl/trainer/gkd_config.py
@@ -24,6 +24,8 @@ class GKDConfig(_GKDConfig):
         warnings.warn(
             "The `GKDConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.gkd import GKDConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -24,6 +24,8 @@ class GKDTrainer(_GKDTrainer):
         warnings.warn(
             "The `GKDTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.gkd import GKDTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/judges.py
+++ b/trl/trainer/judges.py
@@ -29,7 +29,9 @@ class AllTrueJudge(_AllTrueJudge):
         warnings.warn(
             "The `AllTrueJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import AllTrueJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -39,7 +41,9 @@ class BaseBinaryJudge(_BaseBinaryJudge):
         warnings.warn(
             "The `BaseBinaryJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import BaseBinaryJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -49,7 +53,9 @@ class BaseJudge(_BaseJudge):
         warnings.warn(
             "The `BaseJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import BaseJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -59,7 +65,9 @@ class BasePairwiseJudge(_BasePairwiseJudge):
         warnings.warn(
             "The `BasePairwiseJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import BasePairwiseJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -69,7 +77,9 @@ class BaseRankJudge(_BaseRankJudge):
         warnings.warn(
             "The `BaseRankJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import BaseRankJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -79,7 +89,9 @@ class HfPairwiseJudge(_HfPairwiseJudge):
         warnings.warn(
             "The `HfPairwiseJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import HfPairwiseJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -89,7 +101,9 @@ class OpenAIPairwiseJudge(_OpenAIPairwiseJudge):
         warnings.warn(
             "The `OpenAIPairwiseJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import OpenAIPairwiseJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -99,6 +113,8 @@ class PairRMJudge(_PairRMJudge):
         warnings.warn(
             "The `PairRMJudge` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.judges import PairRMJudge`. The current import path will be removed and no "
-            "longer supported in TRL 0.29."
+            "longer supported in TRL 0.29.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/nash_md_config.py
+++ b/trl/trainer/nash_md_config.py
@@ -24,6 +24,8 @@ class NashMDConfig(_NashMDConfig):
         warnings.warn(
             "The `NashMDConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.nash_md import NashMDConfig`. The current import path will be removed and no "
-            "longer supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "longer supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/nash_md_trainer.py
+++ b/trl/trainer/nash_md_trainer.py
@@ -24,6 +24,8 @@ class NashMDTrainer(_NashMDTrainer):
         warnings.warn(
             "The `NashMDTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.nash_md import NashMDTrainer`. The current import path will be removed and no "
-            "longer supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "longer supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/online_dpo_config.py
+++ b/trl/trainer/online_dpo_config.py
@@ -25,6 +25,8 @@ class OnlineDPOConfig(_OnlineDPOConfig):
             "The `OnlineDPOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.online_dpo import OnlineDPOConfig`. The current import path will be removed and "
             "no longer supported in TRL 0.29. For more information, see "
-            "https://github.com/huggingface/trl/issues/4223."
+            "https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/online_dpo_trainer.py
+++ b/trl/trainer/online_dpo_trainer.py
@@ -25,6 +25,8 @@ class OnlineDPOTrainer(_OnlineDPOTrainer):
             "The `OnlineDPOTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.online_dpo import OnlineDPOTrainer`. The current import path will be removed and "
             "no longer supported in TRL 0.29. For more information, see "
-            "https://github.com/huggingface/trl/issues/4223."
+            "https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/orpo_config.py
+++ b/trl/trainer/orpo_config.py
@@ -24,6 +24,8 @@ class ORPOConfig(_ORPOConfig):
         warnings.warn(
             "The `ORPOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.orpo import ORPOConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/orpo_trainer.py
+++ b/trl/trainer/orpo_trainer.py
@@ -24,6 +24,8 @@ class ORPOTrainer(_ORPOTrainer):
         warnings.warn(
             "The `ORPOTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.orpo import ORPOTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -24,6 +24,8 @@ class PPOConfig(_PPOConfig):
         warnings.warn(
             "The `PPOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.ppo import PPOConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/ppo_trainer.py
+++ b/trl/trainer/ppo_trainer.py
@@ -24,6 +24,8 @@ class PPOTrainer(_PPOTrainer):
         warnings.warn(
             "The `PPOTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.ppo import PPOTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/prm_config.py
+++ b/trl/trainer/prm_config.py
@@ -22,6 +22,8 @@ class PRMConfig(_PRMConfig):
         warnings.warn(
             "The `PRMConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.xco import PRMConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/prm_trainer.py
+++ b/trl/trainer/prm_trainer.py
@@ -22,6 +22,8 @@ class PRMTrainer(_PRMTrainer):
         warnings.warn(
             "The `PRMTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.prm import PRMTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)

--- a/trl/trainer/xpo_config.py
+++ b/trl/trainer/xpo_config.py
@@ -22,6 +22,8 @@ class XPOConfig(_XPOConfig):
         warnings.warn(
             "The `XPOConfig` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.xco import XPOConfig`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__post_init__()

--- a/trl/trainer/xpo_trainer.py
+++ b/trl/trainer/xpo_trainer.py
@@ -22,6 +22,8 @@ class XPOTrainer(_XPOTrainer):
         warnings.warn(
             "The `XPOTrainer` is now located in `trl.experimental`. Please update your imports to "
             "`from trl.experimental.xpo import XPOTrainer`. The current import path will be removed and no longer "
-            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223."
+            "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Raise `FutureWarning` (instead of `UserWarning`) for classes moved to experimental.

This PR updates all deprecation warnings related to the relocation of several trainer classes and config objects in the experimental submodule. The warnings now explicitly specify the warning type as `FutureWarning` and set `stacklevel=2` to improve the clarity and visibility of the warnings for users. This ensures users are properly notified about the upcoming removal of old import paths in TRL 0.29 and are guided to update their imports accordingly.