### PR TITLE
Raise warnings at 2nd stack level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,7 @@ Example:
        "The `Trainer.foo` method is deprecated and will be removed in version 0.14.0. "
        "Please use the `Trainer.bar` class instead.",
        FutureWarning,
+       stacklevel=2,
    )
    ```
 

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -371,7 +371,8 @@ class BCOTrainer(BaseTrainer):
                 "This trainer will soon be moved to trl.experimental and is a candidate for removal. If you rely on "
                 "it and want it to remain, please share your comments here: "
                 "https://github.com/huggingface/trl/issues/4223. Silence this warning by setting environment variable "
-                "TRL_EXPERIMENTAL_SILENCE=1."
+                "TRL_EXPERIMENTAL_SILENCE=1.",
+                stacklevel=2,
             )
         if embedding_func is not None and not (is_sklearn_available() and is_joblib_available()):
             raise ImportError(

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -1129,7 +1129,8 @@ class GOLDTrainer(SFTTrainer):
                         warnings.warn(
                             "Mismatch between tokenized prompt and the start of tokenized prompt+completion. "
                             "This may be due to unexpected tokenizer behavior, whitespace issues, or special "
-                            "token handling. Verify that the tokenizer is processing text consistently."
+                            "token handling. Verify that the tokenizer is processing text consistently.",
+                            stacklevel=2,
                         )
 
                     # Create a completion mask

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -392,4 +392,5 @@ class OnlineDPOConfig(TrainingArguments):
                 f"The configuration has `max_new_tokens` ({self.max_new_tokens}) >= `max_length` ({self.max_length}). "
                 "This will cause prompts to be truncated or completely removed in the forward pass. "
                 "To preserve prompts, ensure  e.g. `max_length > max_new_tokens + 512`. ",
+                stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -92,7 +92,7 @@ def is_vllm_available() -> bool:
         warnings.warn(
             f"TRL currently only supports vLLM version `0.10.2`. You have version {_vllm_version} installed. We "
             "recommend to install this version to avoid compatibility issues.",
-            UserWarning,
+            stacklevel=2,
         )
     return _vllm_available
 

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -605,6 +605,7 @@ class MergeModelCallback(_MergeModelCallback):
             "`from trl.experimental.merge_model_callback import MergeModelCallback`. The current import path will be "
             "removed and no longer supported in TRL 0.27. For more information, see "
             "https://github.com/huggingface/trl/issues/4223.",
+            stacklevel=2,
         )
 
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -365,7 +365,8 @@ class KTOTrainer(BaseTrainer):
                 "This trainer will soon be moved to trl.experimental and is a candidate for removal. If you rely on "
                 "it and want it to remain, please share your comments here: "
                 "https://github.com/huggingface/trl/issues/4223. Silence this warning by setting environment variable "
-                "TRL_EXPERIMENTAL_SILENCE=1."
+                "TRL_EXPERIMENTAL_SILENCE=1.",
+                stacklevel=2,
             )
         if type(args) is TrainingArguments:
             raise ValueError("Please use `KTOConfig` instead TrainingArguments.")

--- a/trl/trainer/model_config.py
+++ b/trl/trainer/model_config.py
@@ -197,6 +197,7 @@ class ModelConfig:
             warnings.warn(
                 "`torch_dtype` is deprecated and will be removed in version 0.27.0, please use `dtype` instead.",
                 FutureWarning,
+                stacklevel=2,
             )
             self.dtype = self.torch_dtype
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -247,7 +247,8 @@ class RLOOTrainer(BaseTrainer):
                 "This trainer will soon be moved to trl.experimental and is a candidate for removal. If you rely on "
                 "it and want it to remain, please share your comments here: "
                 "https://github.com/huggingface/trl/issues/4223. Silence this warning by setting environment variable "
-                "TRL_EXPERIMENTAL_SILENCE=1."
+                "TRL_EXPERIMENTAL_SILENCE=1.",
+                stacklevel=2,
             )
 
         # Args

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -282,6 +282,7 @@ class RewardDataCollatorWithPadding:
             "The `RewardDataCollatorWithPadding` is deprecated and will be removed in version 0.27.0. Please use "
             "`trl.trainer.reward_trainer.DataCollatorForPreference` instead.",
             FutureWarning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Raise warnings at 2nd stack level.

This PRadds the `stacklevel=2` parameter to all `warnings.warn()` calls, ensuring that warnings point to the user's code that triggered them rather than to the library internals. This change will make it easier for users to identify the source of deprecation and usage warnings.

These changes enhance the developer experience by making warning messages more actionable and user-friendly.