### PR TITLE
Silence experimental warning during docs build

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -7,6 +7,9 @@ on:
       - doc-builder*
       - v*-release
 
+env:
+  TRL_EXPERIMENTAL_SILENCE: 1
+
 jobs:
    build:
     uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -3,6 +3,9 @@ name: Build PR Documentation
 on:
   pull_request:
 
+env:
+  TRL_EXPERIMENTAL_SILENCE: 1
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Silence experimental warning during docs build.

This PR sets the `TRL_EXPERIMENTAL_SILENCE` environment variable to silence experimental warnings in the build logs for both main and pull request documentation builds.
```
Building the MDX files:   0%|          | 0/58 [00:00<?, ?it/s]
/usr/lib/python3.10/importlib/__init__.py:126: UserWarning: You are importing from 'trl.experimental'. APIs here are unstable and may change or be removed without notice. Silence this warning by setting environment variable TRL_EXPERIMENTAL_SILENCE=1.
```