### PR TITLE
Remove no longer applicable warning once BCO was moved to experimental

### DIFF
--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import random
 import textwrap
-import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
@@ -366,14 +365,6 @@ class BCOTrainer(BaseTrainer):
         embedding_func: Callable | None = None,
         embedding_tokenizer: PreTrainedTokenizerBase | None = None,
     ):
-        if not os.environ.get("TRL_EXPERIMENTAL_SILENCE"):
-            warnings.warn(
-                "This trainer will soon be moved to trl.experimental and is a candidate for removal. If you rely on "
-                "it and want it to remain, please share your comments here: "
-                "https://github.com/huggingface/trl/issues/4223. Silence this warning by setting environment variable "
-                "TRL_EXPERIMENTAL_SILENCE=1.",
-                stacklevel=2,
-            )
         if embedding_func is not None and not (is_sklearn_available() and is_joblib_available()):
             raise ImportError(
                 "BCOTrainer with UDM requires the scikit-learn and joblib libraries. Please install it with `pip install scikit-learn joblib`."


### PR DESCRIPTION
Remove no longer applicable warning once BCO was moved to experimental.

This PR removes the warning message about the BCO trainer's experimental status and potential removal: the warning is no longer applicable because the trainer was already moved to experimental.