### PR TITLE
TRL supports vLLM 0.11

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM version `0.10.2`. Please ensure you have this version installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions `0.10.2`, `0.11.0`, `0.11.1`, and `0.11.2`. Please ensure you have one of these versions installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/examples/notebooks/openenv_wordle_grpo.ipynb
+++ b/examples/notebooks/openenv_wordle_grpo.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -Uq git+https://github.com/huggingface/trl.git git+https://github.com/meta-pytorch/OpenEnv.git trackio vllm==0.10.2 bitsandbytes"
+    "!pip install -Uq git+https://github.com/huggingface/trl.git git+https://github.com/meta-pytorch/OpenEnv.git trackio vllm==0.11.2 bitsandbytes"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm==0.10.2",
+    "vllm>=0.10.2,<0.12.0",
     "fastapi",
     "pydantic",
     "requests",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -88,12 +88,14 @@ def is_uvicorn_available() -> bool:
 
 
 def is_vllm_available() -> bool:
-    if _vllm_available and version.parse(_vllm_version) != version.parse("0.10.2"):
-        warnings.warn(
-            f"TRL currently only supports vLLM version `0.10.2`. You have version {_vllm_version} installed. We "
-            "recommend to install this version to avoid compatibility issues.",
-            stacklevel=2,
-        )
+    if _vllm_available:
+        if not (version.parse("0.10.2") <= version.parse(_vllm_version) <= version.parse("0.11.2")):
+            warnings.warn(
+                "TRL currently supports vLLM versions: 0.10.2, 0.11.0, 0.11.1, 0.11.2. You have version "
+                f"{_vllm_version} installed. We recommend installing a supported version to avoid compatibility "
+                "issues.",
+                stacklevel=2,
+            )
     return _vllm_available
 
 


### PR DESCRIPTION
After a bunch of tests:
- `pytest tests/test_vllm_client_server.py` for client-server
- for colocate:
    ```python
    from datasets import load_dataset
    from trl import GRPOTrainer, GRPOConfig
    from trl.rewards import accuracy_reward

    dataset = load_dataset("trl-lib/DeepMath-103K", split="train[:100]")

    trainer = GRPOTrainer(
        model="Qwen/Qwen3-0.6B",
        reward_funcs=accuracy_reward,
        args=GRPOConfig(use_vllm=True, vllm_mode="colocate"),
        train_dataset=dataset,
    )
    trainer.train()
    ```


it seems like TRL works with vLLM 0.11.x


> [!WARNING]
> vLLM 0.12.0 was released a few days ago, and it is NOT compatible with TRL. We will have to modify TRL to support this version