### PR TITLE
Hotfix CI due to generation config by setting tests as xfail

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1367,7 +1367,10 @@ class TestGRPOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+                marks=pytest.mark.xfail(reason="Blocked by upstream bug in transformers#42762", strict=True),
+            ),
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
         ],
     )
@@ -1465,7 +1468,10 @@ class TestGRPOTrainer(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                marks=pytest.mark.xfail(reason="Blocked by upstream bug in transformers#42762", strict=True),
+            ),
         ],
     )
     @require_vision

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1106,7 +1106,10 @@ class TestRLOOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+                marks=pytest.mark.xfail(reason="Blocked by upstream bug in transformers#42762", strict=True),
+            ),
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
         ],
     )
@@ -1204,7 +1207,10 @@ class TestRLOOTrainer(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                marks=pytest.mark.xfail(reason="Blocked by upstream bug in transformers#42762", strict=True),
+            ),
         ],
     )
     @require_vision


### PR DESCRIPTION
Hotfix CI due to generation config by setting tests as xfail.

This PR updates the test suites for both `GRPOTrainer` and `RLOOTrainer` to handle known upstream issues with certain model variants. The main change is marking tests involving `tiny-Qwen2_5_VLForConditionalGeneration` and `tiny-Qwen2VLForConditionalGeneration` as expected failures (`xfail`) due to a bug in the `transformers` library, ensuring that CI is green.

This PR marks test as expected to fail until `transformers` fixes the issue:
- https://github.com/huggingface/transformers/issues/42762