### PR TITLE
docs: add RapidFire AI integration section to SFT Trainer

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -229,6 +229,10 @@ trainer.train()
 
 Liger Kernel is a collection of Triton kernels for LLM training that boosts multi-GPU throughput by 20%, cuts memory use by 60% (enabling up to 4× longer context), and works seamlessly with tools like FlashAttention, PyTorch FSDP, and DeepSpeed. For more information, see [Liger Kernel Integration](liger_kernel_integration).
 
+### Rapid Experimentation for SFT
+
+RapidFire AI is an open-source experimentation engine that sits on top of TRL and lets you launch multiple SFT configurations at once, even on a single GPU. Instead of trying configurations sequentially, RapidFire lets you **see all their learning curves earlier, stop underperforming runs, and clone promising ones with new settings in flight** without restarting. For more information, see [RapidFire AI Integration](rapidfire_integration).
+
 ### Train with Unsloth
 
 Unsloth is an open‑source framework for fine‑tuning and reinforcement learning that trains LLMs (like Llama, Mistral, Gemma, DeepSeek, and more) up to 2× faster with up to 70% less VRAM, while providing a streamlined, Hugging Face–compatible workflow for training, evaluation, and deployment. For more information, see [Unsloth Integration](unsloth_integration).


### PR DESCRIPTION
## Summary

This PR adds a new section to the SFT Trainer documentation that introduces RapidFire AI integration.

## Changes

- Added a new '### Rapid Experimentation for SFT' section to \docs/source/sft_trainer.md\ above the 'Train with Unsloth' section
- The section describes RapidFire AI as an open-source experimentation engine that enables launching multiple SFT configurations concurrently
- Links to the existing \apidfire_integration.md\ documentation page

## Why this change?

RapidFire AI provides a valuable capability for TRL users who want to:
- Launch multiple SFT configurations at once, even on a single GPU
- See learning curves earlier across all experiments
- Stop underperforming runs dynamically
- Clone promising runs with new settings without restarting

This addition follows the pattern of other integration sections (Liger Kernel, Unsloth) in the SFT Trainer documentation.