### PR TITLE
Accounting for case `num_generations_eval=1` in the calculation of the advantage 

### DIFF
--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1411,14 +1411,20 @@ class RLOOTrainer(BaseTrainer):
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
         grouped_rewards = rewards.view(-1, num_generations)
         mean_grouped_rewards = grouped_rewards.mean(dim=1)
-        std_rewards = grouped_rewards.std(dim=1)
+        if num_generations > 1:
+            std_rewards = grouped_rewards.std(dim=1)
+        else:  # this case doesn't occur during training, but could in eval when num_generations_eval=1
+            std_rewards = torch.zeros_like(mean_grouped_rewards)
         is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))
 
         # RLOO advantages computation
         grouped_sum = grouped_rewards.sum(dim=1, keepdim=True)  # (num_prompts, 1)
-        baselines = (grouped_sum - grouped_rewards) / (num_generations - 1)  # (num_prompts, num_generations)
-        baselines = baselines.view(-1)  # Flatten back to match rewards shape
-        advantages = rewards - baselines
+        if num_generations > 1:
+            baselines = (grouped_sum - grouped_rewards) / (num_generations - 1)  # (num_prompts, num_generations)
+            baselines = baselines.view(-1)  # Flatten back to match rewards shape
+            advantages = rewards - baselines
+        else:  # this case doesn't occur during training, but could in eval when num_generations_eval=1
+            advantages = torch.zeros_like(rewards)
 
         # Normalize advantages
         if self.normalize_advantages:


### PR DESCRIPTION
This PR fixes a warning that we get in the special case of `num_generations_eval=1` for both RLOO and GRPO

```
$ pytest tests/test_rloo_trainer.py::TestRLOOTrainer::test_training_with_num_generations_eval

...

tests/test_rloo_trainer.py::TestRLOOTrainer::test_training_with_num_generations_eval
  /fsx/qgallouedec/trl/trl/trainer/rloo_trainer.py:1414: UserWarning: std(): degrees of freedom is <= 0. Correction should be strictly less than the reduction factor (input numel divided by output numel). (Triggered internally at /pytorch/aten/src/ATen/native/ReduceOps.cpp:1839.)
    std_rewards = grouped_rewards.std(dim=1)
```

