### PR TITLE
Fix vLLM error for tools usage not supported when running GRPO training

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -412,8 +412,9 @@ class GRPOTrainer(BaseTrainer):
                     "Using tools with GRPOTrainer requires the jmespath library for response parsing. Please install "
                     "it with `pip install jmespath` to use this feature."
                 )
-        self.tools = tools or []
-        self._tool_dict = {tool.__name__: tool for tool in self.tools}
+        self.tools = tools
+        if self.tools:
+            self._tool_dict = {tool.__name__: tool for tool in self.tools}
         # At the time of initial implementation, most tokenizers do not have built-in support for response schemas.
         # While waiting for broader adoption, we provide this utility function to manually set the response schema for
         # known chat templates.
@@ -1292,7 +1293,7 @@ class GRPOTrainer(BaseTrainer):
                                     messages=ordered_set_of_prompts,
                                     **sampling_params,
                                     chat_template_kwargs=self.chat_template_kwargs,
-                                    tools=self.tools if self.tools else None,
+                                    tools=self.tools,
                                     chat_template=self.chat_template,
                                 )
                             else:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

When using GRPO training with vLLM powered generation in server mode, even if tools are not specified (i.e. equal to `None` at GRPO init) the processing at line https://github.com/huggingface/trl/blob/ad02d98cb048b8676de2c01fa08873d7dad07d6b/trl/trainer/grpo_trainer.py#L415 
causes a vLLM-side failure on line https://github.com/huggingface/trl/blob/ad02d98cb048b8676de2c01fa08873d7dad07d6b/trl/trainer/grpo_trainer.py#L1291

because `tools` parameter is not `None`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.