### PR TITLE
Move DPODataCollatorWithPadding to `experimental.utils` 

### DIFF
--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -55,7 +55,6 @@ from ...import_utils import is_joblib_available
 from ...models.utils import create_reference_model, prepare_deepspeed
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
-    DPODataCollatorWithPadding,
     RunningMoments,
     disable_dropout_in_model,
     log_table_to_comet_experiment,
@@ -63,6 +62,7 @@ from ...trainer.utils import (
     peft_module_casting_to_bf16,
     selective_log_softmax,
 )
+from ..utils import DPODataCollatorWithPadding
 from .bco_config import BCOConfig
 
 
@@ -303,8 +303,8 @@ class BCOTrainer(BaseTrainer):
             reuse the fine-tuned model.
         data_collator ([`~transformers.DataCollator`], *optional*):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         model_init (`Callable[[], transformers.PreTrainedModel]`):
             The model initializer to use for training. If None is specified, the default model initializer will be
             used.

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -48,7 +48,6 @@ from transformers.utils import is_peft_available, is_torch_fx_proxy
 from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
-    DPODataCollatorWithPadding,
     add_bos_token_if_needed,
     add_eos_token_if_needed,
     disable_dropout_in_model,
@@ -57,6 +56,7 @@ from ...trainer.utils import (
     peft_module_casting_to_bf16,
     selective_log_softmax,
 )
+from ..utils import DPODataCollatorWithPadding
 from .cpo_config import CPOConfig
 
 
@@ -82,8 +82,8 @@ class CPOTrainer(BaseTrainer):
             The CPO config arguments to use for training.
         data_collator ([`~transformers.DataCollator`]):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         train_dataset ([`~datasets.Dataset`]):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -53,13 +53,13 @@ from ...import_utils import is_liger_kernel_available
 from ...models.utils import create_reference_model, prepare_deepspeed
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
-    DPODataCollatorWithPadding,
     disable_dropout_in_model,
     log_table_to_comet_experiment,
     pad_to_length,
     peft_module_casting_to_bf16,
     selective_log_softmax,
 )
+from ..utils import DPODataCollatorWithPadding
 from .kto_config import KTOConfig
 
 
@@ -298,8 +298,8 @@ class KTOTrainer(BaseTrainer):
             reuse the fine-tuned model.
         data_collator ([`~transformers.DataCollator`], *optional*):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         model_init (`Callable[[], transformers.PreTrainedModel]`):
             The model initializer to use for training. If None is specified, the default model initializer will be
             used.

--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -68,8 +68,8 @@ class NashMDTrainer(OnlineDPOTrainer):
             The NashMD config arguments to use for training.
         data_collator ([`~transformers.DataCollator`]):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         train_dataset ([`~datasets.Dataset`]):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -65,7 +65,6 @@ from ...models.utils import (
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
     SIMPLE_CHAT_TEMPLATE,
-    DPODataCollatorWithPadding,
     disable_dropout_in_model,
     empty_cache,
     ensure_master_addr_port,
@@ -74,6 +73,7 @@ from ...trainer.utils import (
     truncate_right,
 )
 from ..judges import BasePairwiseJudge
+from ..utils import DPODataCollatorWithPadding
 from .online_dpo_config import OnlineDPOConfig
 
 
@@ -136,8 +136,8 @@ class OnlineDPOTrainer(BaseTrainer):
             The online DPO config arguments to use for training.
         data_collator ([`~transformers.DataCollator`]):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`]):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`] or `dict[str, Dataset | IterableDataset]`):

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -49,7 +49,6 @@ from transformers.utils import is_peft_available, is_torch_fx_proxy
 from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
-    DPODataCollatorWithPadding,
     add_bos_token_if_needed,
     add_eos_token_if_needed,
     disable_dropout_in_model,
@@ -58,6 +57,7 @@ from ...trainer.utils import (
     peft_module_casting_to_bf16,
     selective_log_softmax,
 )
+from ..utils import DPODataCollatorWithPadding
 from .orpo_config import ORPOConfig
 
 
@@ -86,8 +86,8 @@ class ORPOTrainer(BaseTrainer):
             The ORPO config arguments to use for training.
         data_collator ([`~transformers.DataCollator`]):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         train_dataset ([`~datasets.Dataset`]):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):

--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -1,0 +1,107 @@
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains utility classes and functions that are used across more than one experimental trainer or feature.
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch.nn.utils.rnn import pad_sequence
+
+from ..trainer.utils import pad
+
+
+@dataclass
+class DPODataCollatorWithPadding:
+    r"""
+    DPO DataCollator class that pads the tokenized inputs to the maximum length of the batch.
+
+    Args:
+        pad_token_id (`int` defaults to 0):
+            The tokenizer's pad_token_id.
+        label_pad_token_id (`int`, defaults to -100):
+            The label used for masking.
+        is_encoder_decoder (`bool` or `None`, `optional`, defaults to `None`):
+            Whether you model has an encoder_decoder architecture.
+    """
+
+    pad_token_id: int = 0
+    label_pad_token_id: int = -100
+    is_encoder_decoder: bool | None = False
+
+    def __call__(self, features: list[dict[str, Any]]) -> dict[str, Any]:
+        # first, pad everything to the same length
+        padded_batch = {}
+        for k in features[0].keys():
+            if k.endswith(("_input_ids", "_attention_mask", "_labels", "_pixel_values")):
+                if self.is_encoder_decoder:
+                    to_pad = [torch.LongTensor(ex[k]) for ex in features]
+
+                    if (k.startswith("prompt")) and (k.endswith("input_ids")):
+                        if self.pad_token_id is None:
+                            raise ValueError(
+                                "Padding is enabled, but the tokenizer is not configured with a padding token."
+                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
+                                " before calling the trainer."
+                            )
+                        padding_value = self.pad_token_id
+                    elif k.endswith("_attention_mask"):
+                        padding_value = 0
+                    elif k.startswith(("chosen", "rejected", "completion")) or ("decoder" in k):
+                        padding_value = self.label_pad_token_id
+                    else:
+                        raise ValueError(f"Unexpected key in batch '{k}'")
+                    padded_batch[k] = pad_sequence(to_pad, batch_first=True, padding_value=padding_value)
+                else:
+                    # Set padding value based on the key
+                    if k.endswith("_input_ids"):
+                        if self.pad_token_id is None:
+                            raise ValueError(
+                                "Padding is enabled, but the tokenizer is not configured with a padding token."
+                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
+                                " before calling the trainer."
+                            )
+                        padding_value = self.pad_token_id
+                    elif k.endswith("_labels"):
+                        padding_value = self.label_pad_token_id
+                    elif k.endswith("_attention_mask"):
+                        padding_value = 0
+                    elif k.endswith("_pixel_values"):
+                        padding_value = 0  # TODO: check if this is correct
+                    else:
+                        raise ValueError(f"Unexpected key in batch '{k}'")
+
+                    # Set padding side based on the key
+                    if k in ["prompt_input_ids", "prompt_attention_mask"]:
+                        padding_side = "left"
+                    else:
+                        padding_side = "right"
+
+                    # Set the dtype
+                    if k.endswith("_pixel_values"):
+                        dtype = torch.float32  # will be downcasted if necessary by the Trainer
+                    else:
+                        dtype = torch.int64
+
+                    # Convert to tensor and pad
+                    to_pad = [torch.tensor(ex[k], dtype=dtype) for ex in features]
+                    padded_batch[k] = pad(to_pad, padding_value=padding_value, padding_side=padding_side)
+            elif k.endswith("_logps"):
+                # the cached reference model logprobs
+                padded_batch[k] = torch.tensor([ex[k] for ex in features])
+            else:
+                padded_batch[k] = [ex[k] for ex in features]
+
+        return padded_batch

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -73,8 +73,8 @@ class XPOTrainer(OnlineDPOTrainer):
             The XPO config arguments to use for training.
         data_collator ([`~transformers.DataCollator`]):
             The data collator to use for training. If None is specified, the default data collator
-            ([`DPODataCollatorWithPadding`]) will be used which will pad the sequences to the maximum length of the
-            sequences in the batch, given a dataset of paired sequences.
+            ([`experimental.utils.DPODataCollatorWithPadding`]) will be used which will pad the sequences to the
+            maximum length of the sequences in the batch, given a dataset of paired sequences.
         train_dataset ([`~datasets.Dataset`]):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -33,7 +33,6 @@ import transformers
 from accelerate import Accelerator, PartialState, logging
 from accelerate.state import AcceleratorState
 from huggingface_hub import ModelCard, ModelCardData
-from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import Sampler
 from transformers import (
     AutoConfig,
@@ -314,90 +313,6 @@ def pad(
         output[i][slices] = t
 
     return output
-
-
-@dataclass
-class DPODataCollatorWithPadding:
-    r"""
-    DPO DataCollator class that pads the tokenized inputs to the maximum length of the batch.
-
-    Args:
-        pad_token_id (`int` defaults to 0):
-            The tokenizer's pad_token_id.
-        label_pad_token_id (`int`, defaults to -100):
-            The label used for masking.
-        is_encoder_decoder (`bool` or `None`, `optional`, defaults to `None`):
-            Whether you model has an encoder_decoder architecture.
-    """
-
-    pad_token_id: int = 0
-    label_pad_token_id: int = -100
-    is_encoder_decoder: bool | None = False
-
-    def __call__(self, features: list[dict[str, Any]]) -> dict[str, Any]:
-        # first, pad everything to the same length
-        padded_batch = {}
-        for k in features[0].keys():
-            if k.endswith(("_input_ids", "_attention_mask", "_labels", "_pixel_values")):
-                if self.is_encoder_decoder:
-                    to_pad = [torch.LongTensor(ex[k]) for ex in features]
-
-                    if (k.startswith("prompt")) and (k.endswith("input_ids")):
-                        if self.pad_token_id is None:
-                            raise ValueError(
-                                "Padding is enabled, but the tokenizer is not configured with a padding token."
-                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
-                                " before calling the trainer."
-                            )
-                        padding_value = self.pad_token_id
-                    elif k.endswith("_attention_mask"):
-                        padding_value = 0
-                    elif k.startswith(("chosen", "rejected", "completion")) or ("decoder" in k):
-                        padding_value = self.label_pad_token_id
-                    else:
-                        raise ValueError(f"Unexpected key in batch '{k}'")
-                    padded_batch[k] = pad_sequence(to_pad, batch_first=True, padding_value=padding_value)
-                else:
-                    # Set padding value based on the key
-                    if k.endswith("_input_ids"):
-                        if self.pad_token_id is None:
-                            raise ValueError(
-                                "Padding is enabled, but the tokenizer is not configured with a padding token."
-                                " Explicitly set `tokenizer.pad_token` (e.g. `tokenizer.pad_token = tokenizer.eos_token`)"
-                                " before calling the trainer."
-                            )
-                        padding_value = self.pad_token_id
-                    elif k.endswith("_labels"):
-                        padding_value = self.label_pad_token_id
-                    elif k.endswith("_attention_mask"):
-                        padding_value = 0
-                    elif k.endswith("_pixel_values"):
-                        padding_value = 0  # TODO: check if this is correct
-                    else:
-                        raise ValueError(f"Unexpected key in batch '{k}'")
-
-                    # Set padding side based on the key
-                    if k in ["prompt_input_ids", "prompt_attention_mask"]:
-                        padding_side = "left"
-                    else:
-                        padding_side = "right"
-
-                    # Set the dtype
-                    if k.endswith("_pixel_values"):
-                        dtype = torch.float32  # will be downcasted if necessary by the Trainer
-                    else:
-                        dtype = torch.int64
-
-                    # Convert to tensor and pad
-                    to_pad = [torch.tensor(ex[k], dtype=dtype) for ex in features]
-                    padded_batch[k] = pad(to_pad, padding_value=padding_value, padding_side=padding_side)
-            elif k.endswith("_logps"):
-                # the cached reference model logprobs
-                padded_batch[k] = torch.tensor([ex[k] for ex in features])
-            else:
-                padded_batch[k] = [ex[k] for ex in features]
-
-        return padded_batch
 
 
 @dataclass


### PR DESCRIPTION
The PR adds a new `trl.experimental.utils`:

Some utils are only used in experimental trainers/features. This new file aims to contain them all, to avoid having them in the main codebase.