### PR TITLE
Enable zero3 init and 16-bit model saving for ds ulysses config

### DIFF
--- a/examples/accelerate_configs/alst_ulysses_4gpu.yaml
+++ b/examples/accelerate_configs/alst_ulysses_4gpu.yaml
@@ -20,8 +20,8 @@ deepspeed_config:
   seq_parallel_communication_data_type: bf16
   offload_optimizer_device: none
   offload_param_device: none
-  zero3_init_flag: false
-  zero3_save_16bit_model: false
+  zero3_init_flag: true
+  zero3_save_16bit_model: true
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'
 machine_rank: 0


### PR DESCRIPTION
Aligns deepspeed zero3 saving to be the same as the other ds configs
