### PR TITLE
Refactor vLLM generation [3/N]: Decouple profiling from trainer

### DIFF
--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -154,7 +154,7 @@ def profiling_context(trainer: Trainer, name: str) -> ProfilingContext:
     ```
     """
     context_name = f"{trainer.__class__.__name__}.{name}"
-    step = trainer.state.global_step if hasattr(trainer, "state") else None
+    step = trainer.state.global_step
 
     return ProfilingContext(
         name=context_name,


### PR DESCRIPTION
Refactor vLLM generation [3/N]: Decouple profiling from trainer.

Refactor profiling to remove the strong coupling to the trainer instance.

With this refactor, `profiling_context` now acts as a lightweight factory that builds a `ProfilingContext` instance populated with the relevant caller metadata (e.g. the trainer or other higher-level component). This object can be passed explicitly to composite attribute classes or downstream method calls, without requiring access to the full trainer. The callee can then enter the provided `ProfilingContext` as a context manager to measure and report execution duration in a uniform way, while remaining fully decoupled from the trainer implementation.

See relevant comment in:
- https://github.com/huggingface/trl/pull/4700#discussion_r2630637416

Before:
  - `profiling_context` was tightly coupled to `Trainer` class
  - Required passing entire trainer instance
  - Mixed timing and logging concerns

After:
  - Created `ProfilingContext` class that's completely decoupled from `Trainer`
  - Takes only the data it needs via constructor parameters
  - Clean separation of concerns 