### PR TITLE
Add uv/hf jobs support to OpenEnv scripts 

### DIFF
--- a/examples/scripts/openenv/browsergym.py
+++ b/examples/scripts/openenv/browsergym.py
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# dependencies = [
+#     "trl[vllm]",
+#     "peft",
+#     "trackio>=0.13.0",
+#     "kernels",
+#     "openenv @ git+https://github.com/meta-pytorch/OpenEnv.git",
+#     "openenv_core",
+# ]
+# ///
+
 """
 Simple script to run GRPO training with OpenEnv's BrowserGym environment and vLLM.
 
@@ -485,6 +496,8 @@ def main() -> None:
         generation_batch_size=args.num_generations,  # Must be divisible by num_generations
         max_completion_length=args.max_new_tokens,
         logging_steps=args.logging_steps,
+        report_to="trackio",
+        trackio_space_id=f"browsergym-grpo-{sanitize_name(args.model_id)}-{timestamp}",
         save_strategy="steps",
         save_steps=args.save_interval,
         save_total_limit=args.save_total_limit,

--- a/examples/scripts/openenv/browsergym_llm.py
+++ b/examples/scripts/openenv/browsergym_llm.py
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# dependencies = [
+#     "trl[vllm]",
+#     "peft",
+#     "trackio>=0.13.0",
+#     "kernels",
+#     "openenv @ git+https://github.com/meta-pytorch/OpenEnv.git",
+#     "openenv_core",
+# ]
+# ///
+
 """
 Simple script to run GRPO training with OpenEnv's BrowserGym environment and vLLM for LLMs.
 
@@ -416,6 +427,8 @@ def main() -> None:
         generation_batch_size=args.num_generations,  # Must be divisible by num_generations
         max_completion_length=args.max_new_tokens,
         logging_steps=args.logging_steps,
+        report_to="trackio",
+        trackio_space_id=f"browsergym-grpo-{sanitize_name(args.model_id)}-{timestamp}",
         save_strategy="steps",
         save_steps=args.save_interval,
         save_total_limit=args.save_total_limit,

--- a/examples/scripts/openenv/catch.py
+++ b/examples/scripts/openenv/catch.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# dependencies = [
+#     "trl[vllm]",
+#     "peft",
+#     "trackio>=0.13.0",
+#     "kernels",
+#     "openenv @ git+https://github.com/meta-pytorch/OpenEnv.git",
+#     "openenv_core",
+# ]
+# ///
+
+
 """
 Simple script to run GRPO training with OpenEnv's Catch environment (OpenSpiel) and vLLM. The reward function
 is based on the catch game where the agent tries to catch falling balls.
@@ -216,6 +228,7 @@ def main():
         vllm_server_base_url=args.vllm_server_url if args.vllm_mode == "server" else None,
         logging_steps=1,
         report_to="trackio",
+        trackio_space_id=f"{args.model.split('/')[-1]}-GRPO-Catch",
         num_train_epochs=1,
         max_completion_length=4,
         gradient_accumulation_steps=4,

--- a/examples/scripts/openenv/echo.py
+++ b/examples/scripts/openenv/echo.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# dependencies = [
+#     "trl[vllm]",
+#     "peft",
+#     "trackio>=0.13.0",
+#     "kernels",
+#     "openenv @ git+https://github.com/meta-pytorch/OpenEnv.git",
+#     "openenv_core",
+# ]
+# ///
+
+
 """
 Simple script to run GRPO training with OpenEnv's Echo environment and vLLM. The reward function encourages
 longer completions.
@@ -179,6 +191,7 @@ def main():
         vllm_server_base_url=args.vllm_server_url if args.vllm_mode == "server" else None,
         logging_steps=1,
         report_to="trackio",
+        trackio_space_id=f"{args.model.split('/')[-1]}-GRPO-Rollout",
         num_train_epochs=1,
         max_completion_length=2048,
         gradient_accumulation_steps=4,

--- a/examples/scripts/openenv/wordle.py
+++ b/examples/scripts/openenv/wordle.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# /// script
+# dependencies = [
+#     "trl[vllm]",
+#     "peft",
+#     "trackio>=0.13.0",
+#     "kernels",
+#     "openenv @ git+https://github.com/meta-pytorch/OpenEnv.git",
+#     "openenv_core",
+# ]
+# ///
+
+
 """
 Simple script to run GRPO training with OpenEnv's Wordle environment and vLLM.
 
@@ -462,6 +474,8 @@ def main() -> None:
         num_generations=args.num_generations,
         max_completion_length=args.max_new_tokens,
         logging_steps=args.logging_steps,
+        report_to="trackio",
+        trackio_space_id=f"wordle-grpo-{sanitize_name(args.model_id)}-{timestamp}",
         save_strategy="steps",
         save_steps=args.save_interval,
         save_total_limit=args.save_total_limit,


### PR DESCRIPTION
# What does this PR do?

This allows standalone training via hf jobs by running the script directly:

```bash
hf jobs uv run --flavor a100-large --secrets HF_TOKEN https://raw.githubusercontent.com/huggingface/trl/main/examples/scripts/openenv/browsergym_llm.py --vllm-mode colocate
```

I'm opening this to also get your thoughts on the following line:

```python
os.environ.setdefault("TRACKIO_SPACE_ID", "trl-trackio")
```

that we have in the rest of the scripts. `TRACKIO_SPACE_ID` is [deprecated](https://github.com/huggingface/transformers/blob/728f34c3c31cde2b6015b8368fa5c1a71eaec8a6/src/transformers/integrations/integration_utils.py#L974) in `transformers` ([PR](https://github.com/huggingface/transformers/pull/40950)).

That line could be removed from all the scripts and we could rely solely on the user input arguments instead. Let me know your thoughts.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

@qgallouedec @albertvillanova