### PR TITLE
Remove experimental imports from testing_utils

### DIFF
--- a/tests/experimental/test_judges.py
+++ b/tests/experimental/test_judges.py
@@ -12,14 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 import sys
 import time
 
 import pytest
 
-from trl.experimental.judges import AllTrueJudge, HfPairwiseJudge, PairRMJudge
+from trl.experimental.judges import AllTrueJudge, BaseBinaryJudge, HfPairwiseJudge, PairRMJudge
 
-from ..testing_utils import RandomBinaryJudge, TrlTestCase, require_llm_blender
+from ..testing_utils import TrlTestCase, require_llm_blender
+
+
+class RandomBinaryJudge(BaseBinaryJudge):
+    """
+    Random binary judge, for testing purposes.
+    """
+
+    def judge(self, prompts, completions, gold_completions=None, shuffle_order=True):
+        return [random.choice([0, 1, -1]) for _ in range(len(prompts))]
 
 
 class TestJudges(TrlTestCase):

--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -22,7 +22,8 @@ from trl.experimental.nash_md import NashMDConfig, NashMDTrainer
 from trl.experimental.nash_md.nash_md_trainer import GeometricMixtureWrapper
 from trl.models.utils import create_reference_model
 
-from ..testing_utils import RandomPairwiseJudge, TrlTestCase, require_llm_blender, require_peft
+from ..testing_utils import TrlTestCase, require_llm_blender, require_peft
+from .testing_utils import RandomPairwiseJudge
 
 
 if is_peft_available():

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -22,7 +22,6 @@ from transformers.utils import is_peft_available, is_vision_available
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
 
 from ..testing_utils import (
-    RandomPairwiseJudge,
     TrlTestCase,
     require_llm_blender,
     require_peft,
@@ -30,6 +29,7 @@ from ..testing_utils import (
     require_vision,
     require_vllm,
 )
+from .testing_utils import RandomPairwiseJudge
 
 
 if is_peft_available():

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -19,7 +19,8 @@ from transformers.utils import is_peft_available
 
 from trl.experimental.xpo import XPOConfig, XPOTrainer
 
-from ..testing_utils import RandomPairwiseJudge, TrlTestCase, require_llm_blender, require_peft
+from ..testing_utils import TrlTestCase, require_llm_blender, require_peft
+from .testing_utils import RandomPairwiseJudge
 
 
 if is_peft_available():

--- a/tests/experimental/testing_utils.py
+++ b/tests/experimental/testing_utils.py
@@ -1,0 +1,28 @@
+# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+
+from trl.experimental.judges import BasePairwiseJudge
+
+
+class RandomPairwiseJudge(BasePairwiseJudge):
+    """
+    Random pairwise judge, for testing purposes.
+    """
+
+    def judge(self, prompts, completions, shuffle_order=True, return_scores=False):
+        if not return_scores:
+            return [random.randint(0, len(completion) - 1) for completion in completions]
+        else:
+            return [random.random() for _ in range(len(prompts))]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import random
 import signal
 import warnings
 from collections.abc import Callable
@@ -31,7 +30,6 @@ from transformers.utils import (
     is_vision_available,
 )
 
-from trl.experimental.judges import BaseBinaryJudge, BasePairwiseJudge
 from trl.import_utils import (
     is_joblib_available,
     is_liger_kernel_available,
@@ -95,27 +93,6 @@ def is_ampere_or_newer(device_index=0):
 
 
 require_ampere_or_newer = pytest.mark.skipif(not is_ampere_or_newer(), reason="test requires Ampere or newer GPU")
-
-
-class RandomBinaryJudge(BaseBinaryJudge):
-    """
-    Random binary judge, for testing purposes.
-    """
-
-    def judge(self, prompts, completions, gold_completions=None, shuffle_order=True):
-        return [random.choice([0, 1, -1]) for _ in range(len(prompts))]
-
-
-class RandomPairwiseJudge(BasePairwiseJudge):
-    """
-    Random pairwise judge, for testing purposes.
-    """
-
-    def judge(self, prompts, completions, shuffle_order=True, return_scores=False):
-        if not return_scores:
-            return [random.randint(0, len(completion) - 1) for completion in completions]
-        else:
-            return [random.random() for _ in range(len(prompts))]
 
 
 class TrlTestCase:


### PR DESCRIPTION
Remove experimental imports from testing_utils.

This PR refactors the location of test utility classes used for judge testing in the experimental test suite. The main change is moving the `RandomBinaryJudge` and `RandomPairwiseJudge` classes from the shared `tests/testing_utils.py` file into the new `tests/experimental/testing_utils.py` file, and updating imports in experimental tests to reference the new location. This improves modularity and organization of test utilities, keeping experimental-specific test helpers separate from general-purpose ones.

Currently, a warning is raised in our regular CI tests because `tests/testing_utils` is importing from experimental:
```python
tests/testing_utils.py:34
  /fsx/albert/dev/trl/tests/testing_utils.py:34: TRLExperimentalWarning: You are importing from 'trl.experimental'. APIs here are unstable and may change or be removed without notice. Silence this warning by setting environment variable TRL_EXPERIMENTAL_SILENCE=1.
    from trl.experimental.judges import BaseBinaryJudge, BasePairwiseJudge
```