### PR TITLE
Change tiny model dtype from float16 to bfloat16 to fix CUDA error

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -320,7 +320,8 @@ for model_id, model_class, dtype in [
     ("HuggingFaceM4/Idefics3-8B-Llama3", Idefics3ForConditionalGeneration, torch.bfloat16),
     ("HuggingFaceTB/SmolVLM2-2.2B-Instruct", SmolVLMForConditionalGeneration, torch.float32),
     ("llava-hf/llava-1.5-7b-hf", LlavaForConditionalGeneration, torch.float16),
-    ("llava-hf/llava-v1.6-mistral-7b-hf", LlavaNextForConditionalGeneration, torch.float16),
+    # Original model dtype is float16, but it triggers CUDA device side assert error (see GH-4741):
+    ("llava-hf/llava-v1.6-mistral-7b-hf", LlavaNextForConditionalGeneration, torch.bfloat16),
     ("OpenGVLab/InternVL3-8B-hf", InternVLForConditionalGeneration, torch.bfloat16),
     ("Qwen/Qwen2-VL-2B-Instruct", Qwen2VLForConditionalGeneration, torch.bfloat16),
     ("Qwen/Qwen2.5-VL-3B-Instruct", Qwen2_5_VLForConditionalGeneration, torch.bfloat16),


### PR DESCRIPTION
Change tiny model dtype from float16 to bfloat16 to fix CUDA error.

Fix #4741.

Regenerate tiny models: I have checked that CI tests pass with the Hub PR branch before merging to main
- [x] trl-internal-testing/tiny-LlavaNextForConditionalGeneration: https://huggingface.co/trl-internal-testing/tiny-LlavaNextForConditionalGeneration/discussions/3