### PR TITLE
fix: handle None eval_dataset in example code

### DIFF
--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -524,13 +524,16 @@ class PPOTrainer(BaseTrainer):
         self.model, self.optimizer, self.dataloader = accelerator.prepare(self.model, self.optimizer, self.dataloader)
         torch.manual_seed(self.local_seed)  # reset the local seed again
 
-        self.eval_dataloader = DataLoader(
-            self.eval_dataset,
-            batch_size=args.per_device_eval_batch_size,
-            collate_fn=self.data_collator,
-            drop_last=True,
-        )  # no need to shuffle eval dataset
-        self.eval_dataloader = accelerator.prepare(self.eval_dataloader)
+        if self.eval_dataset is not None:
+            self.eval_dataloader = DataLoader(
+                self.eval_dataset,
+                batch_size=args.per_device_eval_batch_size,
+                collate_fn=self.data_collator,
+                drop_last=True,
+            )  # no need to shuffle eval dataset
+            self.eval_dataloader = accelerator.prepare(self.eval_dataloader)
+        else:
+            self.eval_dataloader = iter([])  # empty list not enter for loop
 
         if self.is_deepspeed_enabled:
             self.reward_model = prepare_deepspeed(


### PR DESCRIPTION
# What does this PR do?

Prevent example scripts from crashing when `eval_dataset=None`.

Currently, passing None to `eval_dataset` in example scripts
raises an error. This PR adds a guard to skip evaluation
if `eval_dataset` is None.

This ensures that example scripts can run even if no evaluation
dataset is provided, improving robustness.

Fixes # (issue)

## Before submitting
- [x] This PR fixes a bug in example code
- [ ] Discussed via a GitHub issue (not necessary here)
- [ ] Updated documentation (not required)
- [ ] Added minimal test (optional)

## Who can review?

Anyone in the community is welcome to review this PR.
