### PR TITLE
Hotfix CI with dev dependencies: xfail test_training_vlm_and_liger

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1597,6 +1597,12 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.xfail(
+        Version(transformers.__version__).is_devrelease,  # Tests with dev dependencies
+        reason="Blocked by upstream liger-kernel bug (linkedin/Liger-Kernel#960); "
+        "fixed by linkedin/Liger-Kernel#966 but not yet released (>0.6.4 required)",
+        strict=True,
+    )
     @pytest.mark.parametrize(
         "model_id",
         [


### PR DESCRIPTION
Hotfix CI with dev dependencies: xfail `tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_vlm_and_liger[trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration]`
> AttributeError: 'Qwen2_5_VLForConditionalGeneration' object has no attribute 'language_model'

This PR marks test as expected to fail until the upstream fix in `liger-kernel` is released:
- https://github.com/linkedin/Liger-Kernel/pull/966
- https://github.com/linkedin/Liger-Kernel/issues/960

Hotfix for:
- #4601

The issue appeared in CI tests with dev dependencies after the merge of this PR in `transformers`:
- https://github.com/huggingface/transformers/pull/42156

Testing improvements:
* Added an `xfail` marker to the test parameterization for model versions, causing the test to be expected to fail when running with a development release of the `transformers` library, due to a known issue in the upstream `liger-kernel` dependency. The marker includes a clear reason and references the relevant upstream issues and required version for resolution.