### PR TITLE
Ensure llm-blender is importable with transformers >= v5

### DIFF
--- a/trl/experimental/judges/judges.py
+++ b/trl/experimental/judges/judges.py
@@ -58,17 +58,15 @@ def _ensure_llm_blender_importable() -> None:
     """
     Pre-import shim to work around a known `llm-blender` issue.
 
-    As of `llm-blender` v0.0.2 (see upstream issue:
-    https://github.com/yuchenlin/LLM-Blender/issues/33), importing
-    `llm_blender` may fail on `transformers` >= 5.0.0.dev0 because it
-    unconditionally accesses `transformers.utils.hub.TRANSFORMERS_CACHE`.
+    As of `llm-blender` v0.0.2 (see upstream issue: https://github.com/yuchenlin/LLM-Blender/issues/33), importing
+    `llm_blender` may fail on `transformers` >= 5.0.0.dev0 because it unconditionally accesses
+    `transformers.utils.hub.TRANSFORMERS_CACHE`.
 
-    We set this attribute to a dummy value before importing
-    `llm_blender` so that the import succeeds. This helper is intentionally
-    a no-op on older `transformers` versions.
+    We set this attribute to a dummy value before importing `llm_blender` so that the import succeeds. This helper is
+    intentionally a no-op on older `transformers` versions.
 
-    This shim can be removed once the upstream issue is fixed and the minimum
-    required `llm-blender` version includes that fix.
+    This shim can be removed once the upstream issue is fixed and the minimum required `llm-blender` version includes
+    that fix.
     """
     import transformers.utils.hub
 


### PR DESCRIPTION
This PR introduces a compatibility workaround for importing `llm_blender` when using newer versions of `transformers`. The main change is the addition of a shim to prevent import errors due to an upstream issue, ensuring smoother integration until the dependency is fixed.

Fix #4597.

Compatibility workaround for `llm-blender` import:

* Added `_ensure_llm_blender_importable()` helper to set a dummy `TRANSFORMERS_CACHE` attribute in `transformers.utils.hub` for versions >= 5.0.0.dev0, preventing import errors with `llm_blender`.
* Updated `PairRMJudge.__init__` to call the new shim before importing `llm_blender`, ensuring reliable initialization.