### PR TITLE
Refactor KTO [1/N]: Modernize model initialization

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -33,7 +33,6 @@ from datasets import Dataset, concatenate_datasets
 from torch import autocast
 from torch.utils.data import DataLoader, SequentialSampler
 from transformers import (
-    AutoModelForCausalLM,
     BaseImageProcessor,
     DataCollator,
     FeatureExtractionMixin,
@@ -53,6 +52,7 @@ from ...import_utils import is_liger_kernel_available
 from ...models.utils import create_reference_model, peft_module_casting_to_bf16, prepare_deepspeed
 from ...trainer.base_trainer import BaseTrainer
 from ...trainer.utils import (
+    create_model_from_path,
     disable_dropout_in_model,
     log_table_to_comet_experiment,
     pad_to_length,
@@ -366,49 +366,33 @@ class KTOTrainer(BaseTrainer):
                 "same as `model`, you must mass a copy of it, or `None` if you use peft."
             )
 
-        if args.model_init_kwargs is None:
-            model_init_kwargs = {}
-        elif not isinstance(model, str):
-            raise ValueError("You passed model_kwargs to the KTOTrainer. But your model is already instantiated.")
-        else:
-            model_init_kwargs = args.model_init_kwargs
-            dtype = model_init_kwargs.get("dtype", "auto")
-            if dtype is not None:
-                # Convert to `torch.dtype` if an str is passed
-                if isinstance(dtype, str) and dtype != "auto":
-                    dtype = getattr(torch, dtype)
-                if dtype != "auto" and not isinstance(dtype, torch.dtype):
-                    raise ValueError(
-                        f"Invalid `dtype` passed to the KTOConfig. Expected a string with either `torch.dtype` or 'auto', but got {dtype}."
-                    )
-                model_init_kwargs["dtype"] = dtype
-            model_init_kwargs["device_map"] = model_init_kwargs.get("device_map", "auto")
-
-        if args.ref_model_init_kwargs is None:
-            ref_model_init_kwargs = {}
-        elif not isinstance(ref_model, str):
-            raise ValueError(
-                "You passed ref_model_kwargs to the KTOTrainer. But your ref_model is already instantiated."
-            )
-        else:
-            ref_model_init_kwargs = args.ref_model_init_kwargs
-            dtype = ref_model_init_kwargs.get("dtype", "auto")
-            if dtype is not None:
-                # Convert to `torch.dtype` if an str is passed
-                if isinstance(dtype, str) and dtype != "auto":
-                    dtype = getattr(torch, dtype)
-                if dtype != "auto" and not isinstance(dtype, torch.dtype):
-                    raise ValueError(
-                        f"Invalid `dtype` passed to the KTOConfig. Expected a string with either `torch.dtype` or 'auto', but got {dtype}."
-                    )
-                ref_model_init_kwargs["dtype"] = dtype
-            ref_model_init_kwargs["device_map"] = ref_model_init_kwargs.get("device_map", "auto")
-
+        # Model initialization
         if isinstance(model, str):
-            model = AutoModelForCausalLM.from_pretrained(model, **model_init_kwargs)
+            model_init_kwargs = args.model_init_kwargs or {}
+            # Distributed training requires device_map=None ("auto" fails with DeepSpeed/FSDP)
+            if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
+                model_init_kwargs["device_map"] = None
+            model = create_model_from_path(model, **model_init_kwargs)
+        else:
+            if args.model_init_kwargs is not None:
+                logger.warning(
+                    "You passed `model_init_kwargs` to the KTOConfig, but your model is already instantiated. "
+                    "The `model_init_kwargs` will be ignored."
+                )
 
+        # Reference model initialization
         if isinstance(ref_model, str):
-            ref_model = AutoModelForCausalLM.from_pretrained(ref_model, **ref_model_init_kwargs)
+            ref_model_init_kwargs = args.ref_model_init_kwargs or {}
+            # Distributed training requires device_map=None
+            if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
+                ref_model_init_kwargs["device_map"] = None
+            ref_model = create_model_from_path(ref_model, **ref_model_init_kwargs)
+        else:
+            if ref_model is not None and args.ref_model_init_kwargs is not None:
+                logger.warning(
+                    "You passed `ref_model_init_kwargs` to the KTOConfig, but your ref_model is already instantiated. "
+                    "The `ref_model_init_kwargs` will be ignored."
+                )
 
         # Initialize this variable to False. This helps tracking the case when `peft_module_casting_to_bf16`
         # has been called in order to properly call autocast if needed.


### PR DESCRIPTION
Refactor KTO [1/N]: Modernize model initialization.

This PR modernizes KTOTrainer's model initialization to align with SFTTrainer's clean and maintainable patterns. It replaces manual model loading with the `create_model_from_path()` helper function.

Part of:
- #4786

## Problem

**Before** (KTO):
  - Manual handling of `model_init_kwargs` and `ref_model_init_kwargs` (43 lines)
  - Manual dtype conversion with `getattr(torch, dtype)`
  - Manual device_map setting
  - Duplicate code for model and ref_model
  - Direct calls to `AutoModelForCausalLM.from_pretrained`
  - Hard errors instead of warnings for already-instantiated models

**After** (Aligned with SFT):
  - Clean kwargs handling with `or {}` pattern
  - Automatic dtype conversion via helper
  - DeepSpeed/MULTI_GPU device_map handling
  - Single call to `create_model_from_path` helper
  - User-friendly warnings

