### PR TITLE
Refactor KTO [2/N]: Improve config validation in KTOConfig

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -41,7 +41,6 @@ from transformers import (
     ProcessorMixin,
     TrainerCallback,
     TrainingArguments,
-    is_comet_available,
     is_wandb_available,
 )
 from transformers.trainer_utils import EvalLoopOutput, has_length
@@ -454,12 +453,6 @@ class KTOTrainer(BaseTrainer):
                     output.requires_grad_(True)
 
                 model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
-
-        if args.generate_during_eval and not (is_wandb_available() or is_comet_available()):
-            raise ValueError(
-                "`generate_during_eval=True` requires Weights and Biases or Comet to be installed."
-                " Please install `wandb` or `comet-ml` to resolve."
-            )
 
         if model is not None:
             self.is_encoder_decoder = model.config.is_encoder_decoder


### PR DESCRIPTION
Refactor KTO [2/N]: Improve config validation in KTOConfig.

This PR moves validation logic from `KTOTrainer.__init__()` to `KTOConfig.__post_init__()` for earlier error detection, better user experience, and cleaner separation of concerns.
- Principle: Fail-fast with clear, actionable error messages

Part of:
- #4786

## Problem

**Before**:
  - Validation scattered between config and trainer
  - Errors discovered late (during trainer initialization)
  - Invalid configs could be created and passed around
  - generate_during_eval validated in trainer
  - No validation for loss_type, truncation_mode, beta, weights
  - No validation for max_length relationships

**After**:
  - All validation centralized in `KTOConfig.__post_init__()`
  - Errors discovered immediately at config creation
  - Invalid configs cannot be created
  - Clear, actionable error messages with guidance
  - Comprehensive validation for all critical parameters
