### PR TITLE
fix(grpo_trainer): init args before use

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -277,7 +277,9 @@ class GRPOTrainer(BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = GRPOConfig(f"{model_name}-GRPO")
+            self.args = GRPOConfig(f"{model_name}-GRPO")
+        else:
+            self.args = args
 
         # Model
         if isinstance(model, str):


### PR DESCRIPTION
# What does this PR do?
Fixes reference of `self.args` prior to initialization.

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[6], [line 19](vscode-notebook-cell:?execution_count=6&line=19)
      2 training_args = GRPOConfig(
      3     output_dir="GRPO",
      4     learning_rate=2e-5,
   (...)     15     logging_steps=1,
     16 )
     18 # Trainer
---> [19](vscode-notebook-cell:?execution_count=6&line=19) trainer = GRPOTrainer(
     20     model=model,
     21     reward_funcs=[reward_len],
     22     args=training_args,
     23     train_dataset=dataset["train"],
     24 )

File ~/projects/dotfiles/_venvs/cuda/.venv/lib/python3.13/site-packages/trl/trainer/grpo_trainer.py:348, in GRPOTrainer.__init__(self, model, reward_funcs, args, train_dataset, eval_dataset, processing_class, reward_processing_classes, callbacks, optimizers, peft_config, tools, rollout_func)
    344     model = get_peft_model(model, peft_config)
    346 # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally
    347 # handles this, but a bug currently prevents it; see https://github.com/huggingface/transformers/issues/42489
--> [348](https://vscode-remote+ssh-002dremote-002bdgx-002dspark-002dlocal.vscode-resource.vscode-cdn.net/home/carlyou/projects/notebooks/course/en/chapter13/~/projects/dotfiles/_venvs/cuda/.venv/lib/python3.13/site-packages/trl/trainer/grpo_trainer.py:348) if is_peft_available() and is_peft_model(model) and self.args.gradient_checkpointing:
    349     model.enable_input_require_grads()
    351 # When using QLoRA, the PEFT adapter weights are converted to bf16 to follow the recommendations from the
    352 # original paper (see https://huggingface.co/papers/2305.14314, paragraph 3). Normally, this can be done by
    353 # passing `autocast_adapter_dtype=False` to `get_peft_model`, but this option is not yet supported for
    354 # quantized models. See: https://github.com/huggingface/peft/issues/2889
    355 # Non-quantized models do not have the `is_loaded_in_{8,4}bit` attributes, whereas quantized models do

AttributeError: 'GRPOTrainer' object has no attribute 'args'
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.