### PR TITLE
Update GRPO example to use Qwen2.5 instead of Qwen2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ from trl.rewards import accuracy_reward
 dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
 
 trainer = GRPOTrainer(
-    model="Qwen/Qwen2-0.5B-Instruct",
+    model="Qwen/Qwen2.5-0.5B-Instruct",
     reward_funcs=accuracy_reward,
     train_dataset=dataset,
 )


### PR DESCRIPTION
Updated the GRPO example in README to use `Qwen/Qwen2.5-0.5B-Instruct` instead of the older `Qwen/Qwen2-0.5B-Instruct`.

This makes the GRPO example consistent with all other examples in the README which already use Qwen2.5.