### PR TITLE
fix bug when sft calc outputs.token_accuracy

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1198,6 +1198,15 @@ class SFTTrainer(BaseTrainer):
             if hasattr(outputs, "token_accuracy") and outputs.token_accuracy is not None:
                 token_accuracy = self.accelerator.gather_for_metrics(outputs.token_accuracy).mean().item()
                 self._metrics[mode]["mean_token_accuracy"].append(token_accuracy)
+            else:
+                warnings.warn(
+                    "liger-kernel did not return token_accuracy when requested. "
+                    "The mean_token_accuracy metric will not be logged. "
+                    "This may indicate an outdated liger-kernel version. "
+                    "Consider upgrading to the latest version. "
+                    "If the issue persists after upgrading, please report it to the liger-kernel repository.",
+                    stacklevel=2
+                )
         else:
             # Compute accuracy from logits using argmax (traditional method)
             with torch.no_grad():


### PR DESCRIPTION
When I run cmd line:
`accelerate launch --config_file config.yaml examples/scripts/sft_gemma3.py`
It will return error:
```
[rank0]: main()
[rank0]: File "/root/trl/examples/scripts/sft_gemma3.py", line 70, in main
[rank0]: trainer.train()
[rank0]: File "/opt/venv/lib/python3.12/site-packages/transformers/trainer.py", line 2325, in train
[rank0]: return inner_training_loop(
[rank0]: ^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/opt/venv/lib/python3.12/site-packages/transformers/trainer.py", line 2674, in _inner_training_loop [rank0]: tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/root/trl/trl/trainer/sft_trainer.py", line 1251, in training_step
[rank0]: return super().training_step(*args, **kwargs)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [rank0]: File "/opt/venv/lib/python3.12/site-packages/transformers/trainer.py", line 4020, in training_step [rank0]: loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [rank0]: File "/root/trl/trl/trainer/sft_trainer.py", line 1198, in compute_loss [rank0]: token_accuracy = self.accelerator.gather_for_metrics(outputs.token_accuracy).mean().item()
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [rank0]: File "/opt/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 3110, in gather_for_metrics [rank0]: data = gather_object(input_data)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^ [rank0]: File "/opt/venv/lib/python3.12/site-packages/accelerate/utils/operations.py", line 459, in gather_object [rank0]: return _gpu_gather_object(object)
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: File "/opt/venv/lib/python3.12/site-packages/accelerate/utils/operations.py", line 442, in _gpu_gather_object
[rank0]: return [x for y in output_objects for x in y]
[rank0]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: 'NoneType' object is not iterable
```
This PR tries to fix it.