### PR TITLE
Fix _patch_transformers_hybrid_cache also for peft

### DIFF
--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -150,12 +150,13 @@ def _patch_vllm_cached_tokenizer() -> None:
 
 def _patch_transformers_hybrid_cache() -> None:
     """
-    Fix HybridCache import compatibility for liger_kernel<=0.6.4.
+    Fix HybridCache import for transformers v5 compatibility.
 
-    - Issue: liger_kernel imports HybridCache from transformers.cache_utils
+    - Issue: liger_kernel and peft import HybridCache from transformers.cache_utils
     - HybridCache removed in https://github.com/huggingface/transformers/pull/43168 (transformers>=5.0.0.dev0)
-    - Fixed in https://github.com/linkedin/Liger-Kernel/pull/1002 (will be released in liger_kernel>=0.6.5)
-    - This patch can be removed when TRL requires liger_kernel>=0.6.5
+    - Fixed in liger_kernel: https://github.com/linkedin/Liger-Kernel/pull/1002 (released in v0.6.5)
+    - Fixed in peft: https://github.com/huggingface/peft/pull/2735 (released in v0.18.0)
+    - This can be removed when TRL requires liger_kernel>=0.6.5 and peft>=0.18.0
     """
     if _is_package_version_below("liger_kernel", "0.6.5") or _is_package_version_below("peft", "0.18.0"):
         try:


### PR DESCRIPTION
Fix _patch_transformers_hybrid_cache also for peft:
- peft imported HybridCache from transformers.cache_utils
- it was fixed in peft v0.18.0: https://github.com/huggingface/peft/pull/2735

This PR updates the `_patch_transformers_hybrid_cache` function to improve compatibility with transformers v5 and ensure smoother integration with both `liger_kernel` and `peft` dependencies. The patch now checks for both packages' versions and updates documentation to reflect recent upstream fixes.

Dependency compatibility improvements:

* Updated the patch to check both `liger_kernel` and `peft` versions, ensuring compatibility with transformers v5 by applying the fix if either is below their respective fixed versions (`liger_kernel<0.6.5` or `peft<0.18.0`).
* Enhanced the docstring to clarify that the patch addresses compatibility for both `liger_kernel` and `peft`, and that it can be removed once both dependencies are upgraded past their fixed versions.
* Improved the warning message to reference "transformers HybridCache compatibility" instead of just "liger_kernel", making the intent clearer when an exception occurs.