### PR TITLE
feat: Support log_completion for swanlab backend

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2464,7 +2464,7 @@ class GRPOTrainer(BaseTrainer):
                     rows = df_dedup.values.tolist()
                     table = logging_backend.echarts.Table()
                     table.add(headers, rows)
-                    logging_backend.log({"completions": table})
+                    logging_backend.log({mode: {"completions": table}})
                 else:
                     # wandb/trackio: support images
                     if images_raw:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -66,7 +66,7 @@ from ..data_utils import (
 )
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..extras.vllm_client import VLLMClient
-from ..import_utils import is_jmespath_available, is_liger_kernel_available, is_vllm_available
+from ..import_utils import is_jmespath_available, is_liger_kernel_available, is_vllm_available, is_swanlab_available
 from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import _ForwardRedirection, disable_gradient_checkpointing
 from .base_trainer import BaseTrainer
@@ -116,6 +116,10 @@ if is_wandb_available():
 
 if is_trackio_available():
     import trackio
+
+if is_swanlab_available():
+    import swanlab
+
 
 if is_bitsandbytes_available():
     import bitsandbytes as bnb
@@ -2433,6 +2437,8 @@ class GRPOTrainer(BaseTrainer):
                 logging_backends.append(wandb)
             if self.args.report_to and "trackio" in self.args.report_to:
                 logging_backends.append(trackio)
+            if self.args.report_to and "swanlab" in self.args.report_to:
+                logging_backends.append(swanlab)
 
             table = {
                 "step": [str(self.state.global_step)] * len(self._logs["prompt"]),
@@ -2444,24 +2450,31 @@ class GRPOTrainer(BaseTrainer):
 
             df_base = pd.DataFrame(table)
             images_raw = self._logs["images"] or []
+            # Prepare df without images first (swanlab doesn't support images)
+            if self.log_unique_prompts:
+                df_dedup = df_base.drop_duplicates(subset=["prompt"])
+            else:
+                df_dedup = df_base
 
             for logging_backend in logging_backends:
-                if images_raw:
-                    images = []
-                    for image_list in self._logs["images"]:
-                        images.append([logging_backend.Image(image) for image in image_list])
-                    df = pd.concat(
-                        [df_base, pd.Series(images, name="image")],
-                        axis=1,
-                        copy=False,
-                    )
+                # swanlab: use echarts Table without support images
+                # TODO: add image support for swanlab
+                if logging_backend is swanlab:
+                    headers = list(df_dedup.columns)
+                    rows = df_dedup.values.tolist()
+                    table = logging_backend.echarts.Table()
+                    table.add(headers, rows)
+                    logging_backend.log({"completions": table})
                 else:
-                    df = df_base
-
-                if self.log_unique_prompts:
-                    df = df.drop_duplicates(subset=["prompt"])
-
-                logging_backend.log({"completions": logging_backend.Table(dataframe=df)})
+                    # wandb/trackio: support images
+                    if images_raw:
+                        images = []
+                        for image_list in self._logs["images"]:
+                            images.append([logging_backend.Image(image) for image in image_list])
+                        df = pd.concat([df_dedup, pd.Series(images, name="image")], axis=1, copy=False)
+                    else:
+                        df = df_dedup
+                    logging_backend.log({"completions": logging_backend.Table(dataframe=df)})
 
     # Ensure the model card is saved along with the checkpoint
     def _save_checkpoint(self, model, trial):


### PR DESCRIPTION
# What does this PR do?

TRL's GRPO trainer does not support uploading completion of decode to Swanlab. This PR supports this.


## Technical notes:

- SwanLab uses `logging_backend.echarts.Table()` instead of `logging_backend.Table(dataframe=df)`
- Currently swanlab does not support image logging (unlike wandb/trackio), so images are skipped for this backend



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? (N/A - code only)
- [ ] Did you write any new necessary tests? (N/A - no new tests needed)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
