### PR TITLE
Ensure it functions correctly when token_accuracy is None

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1195,7 +1195,8 @@ class SFTTrainer(BaseTrainer):
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
         if self.args.use_liger_kernel:
-            token_accuracy = self.accelerator.gather_for_metrics(outputs.token_accuracy).mean().item()
+            token_accuracy = outputs.token_accuracy or 0.0
+            token_accuracy = self.accelerator.gather_for_metrics(token_accuracy).mean().item()
             self._metrics[mode]["mean_token_accuracy"].append(token_accuracy)
         else:
             # Compute accuracy from logits using argmax (traditional method)


### PR DESCRIPTION
# What does this PR do?

During training or evaluation, token_accuracy is sometimes output as None in the Liger-Kernel, 
causing the entire learning process to terminate. 
To prevent this situation, we modified the code to return 0.0 when None is passed, ensuring calculations proceed normally.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.