### PR TITLE
Support triggering CI via push to ci-* branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - ci-*
   pull_request:
     paths:
       # Run only when relevant files are modified


### PR DESCRIPTION
Support triggering CI via push to `ci-*` branches.

This PR updates the GitHub Actions workflow configuration to support triggering tests on additional branches for debugging purposes. Now, tests will run not only on pushes to the `main` branch but also on any branches starting with `ci-`.

Workflow configuration update:

* Modified the `branches` list in `.github/workflows/tests.yml` to include both `main` and any branch matching the pattern `ci-*`, ensuring tests are triggered for CI-related branches.