### PR TITLE
Add retry strategy to vLLM Client for increased robustness

### DIFF
--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -142,7 +142,7 @@ class VLLMClient:
             status=3,  # retry a limited number of times when we receive certain HTTP error responses from the server
             status_forcelist=[500, 502, 503],  # only retry on server-side errors that are usually temporary
             backoff_factor=2,  # exponential backoff between retries (2s, 4s, 8s, ...)
-            allowed_methods=["POST", "GET"],  # allow retries for POST as well, because safe to retry in this context
+            allowed_methods=["POST", "GET"],  # allow POST as well, even though we're not sure it's safe here
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
### Motivation

  vLLM connection drops can cause training errors and interrupt long-running jobs. This PR allows users to configure retry behavior to make training more robust against transient network issues.

 ### Summary of Changes

  Added configurable HTTP retry parameters for the VLLMClient that can be configured via trainer configs (GRPOConfig, RLOOConfig, OnlineDPOConfig, GOLDConfig)

 #### New Configuration Parameters

  | Parameter                   | Default         | Description                                     |
  |-----------------------------|-----------------|-------------------------------------------------|
  | vllm_retry_total            | 5               | Total number of retries for HTTP requests       |
  | vllm_retry_backoff_factor   | 2.0             | Backoff factor for retry delays                 |
  | vllm_retry_status           | 3               | Number of retries for status codes in forcelist |
  | vllm_retry_status_forcelist | [500, 502, 503] | HTTP status codes that trigger a retry          |
  | vllm_retry_allowed_methods  | ["POST", "GET"] | HTTP methods allowed to be retried              |

<!-- Remove if not applicable -->

Fixes # (issue)


- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

@qgallouedec 