### PR TITLE
feat(rewards): add conditioned_reward based on GDPO

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trl.rewards import accuracy_reward, get_soft_overlong_punishment, reasoning_accuracy_reward, think_format_reward
+import asyncio
+
+from trl.rewards import (
+    conditioned_reward,
+    accuracy_reward,
+    get_soft_overlong_punishment,
+    reasoning_accuracy_reward,
+    think_format_reward,
+)
 
 from .testing_utils import TrlTestCase, require_math_latex
 
@@ -190,3 +198,156 @@ class TestReasoningAccuracyReward:
         ]
         rewards = reasoning_accuracy_reward(completions, solutions)
         assert rewards[0] is None
+
+
+
+class TestConditionedReward(TrlTestCase):
+    def test_sync_rewards(self):
+        def primary(prompts, completions, **kwargs):
+            return [1.0, 0.4, 0.8, None]
+
+        def secondary(prompts, completions, **kwargs):
+            return [2.0, 2.0, 2.0, 2.0]
+
+        conditioned = conditioned_reward(primary, secondary)
+        results = conditioned([], [])
+
+        # Expected:
+        # 1.0 >= 1.0 -> 2.0 (Changed default to 1.0)
+        # 0.4 < 1.0 -> 0.0
+        # 0.8 < 1.0 -> 0.0
+        # None -> None
+        assert results == [2.0, 0.0, 0.0, None]
+
+    def test_async_rewards(self):
+        async def primary(prompts, completions, **kwargs):
+            return [1.0, 0.4]
+
+        async def secondary(prompts, completions, **kwargs):
+            return [2.0, 2.0]
+
+        conditioned = conditioned_reward(primary, secondary)
+
+        # Using asyncio.run to execute the async wrapper
+        results = asyncio.run(conditioned([], []))
+        assert results == [2.0, 0.0]
+
+    def test_mixed_async_sync_rewards(self):
+        # Case 1: Primary async, Secondary sync
+        async def primary(prompts, completions, **kwargs):
+            return [1.0]
+
+        def secondary(prompts, completions, **kwargs):
+            return [5.0]
+
+        conditioned = conditioned_reward(primary, secondary)
+        results = asyncio.run(conditioned([], []))
+        assert results == [5.0]
+
+        # Case 2: Primary sync, Secondary async
+        def primary_sync(prompts, completions, **kwargs):
+            return [0.1]
+
+        async def secondary_async(prompts, completions, **kwargs):
+            return [5.0]
+
+        conditioned_2 = conditioned_reward(primary_sync, secondary_async)
+        results_2 = asyncio.run(conditioned_2([], []))
+        assert results_2 == [0.0]
+
+    def test_kwargs_passing(self):
+        def primary(prompts, completions, **kwargs):
+            return kwargs.get("scores")
+
+        def secondary(prompts, completions, **kwargs):
+            return [10.0] * len(prompts)  # return dummy
+
+        conditioned = conditioned_reward(primary, secondary, condition=5.0)
+        # Passing scores via kwargs
+        results = conditioned([1], [1], scores=[6.0])  # 6.0 >= 5.0 -> 10.0
+        assert results == [10.0]
+
+    def test_tensor_rewards(self):
+        import torch
+
+        def primary(prompts, completions, **kwargs):
+            # Tensor with some values above threshold (1.0), some below
+            return torch.tensor([1.2, 0.4, 1.0, 0.2])
+
+        def secondary(prompts, completions, **kwargs):
+            return torch.tensor([2.0, 3.0, 4.0, 5.0])
+
+        conditioned = conditioned_reward(primary, secondary)
+        results = conditioned([], [])
+
+        # Expected:
+        # 1.2 >= 1.0 -> 2.0
+        # 0.4 < 1.0 -> 0.0
+        # 1.0 >= 1.0 -> 4.0
+        # 0.2 < 1.0 -> 0.0
+        expected = torch.tensor([2.0, 0.0, 4.0, 0.0])
+        assert torch.equal(results, expected)
+
+    def test_mixed_type_rewards(self):
+        import torch
+
+        # Case 1: Primary Tensor, Secondary List
+        def primary_tensor(prompts, completions, **kwargs):
+            return torch.tensor([1.2, 0.4, None])  # None will convert to nan
+
+        def secondary_list(prompts, completions, **kwargs):
+            return [2.0, 3.0, 4.0]
+
+        conditioned = conditioned_reward(primary_tensor, secondary_list)
+        # Construct inputs that result in the tensor above (mocked anyway)
+        # Note: creating tensor with None usually fails or needs float('nan').
+        # But here valid torch.tensor([0.8, 0.4, float('nan')]) is assumed from a reward func returning tensor.
+        # Let's mock properly:
+        def primary_tensor_mock(prompts, completions, **kwargs):
+            return torch.tensor([1.2, 0.4, float("nan")])
+
+        conditioned = conditioned_reward(primary_tensor_mock, secondary_list)
+        results = conditioned([], [])
+
+        # Expected:
+        # 1.2 >= 1.0 -> 2.0
+        # 0.4 < 1.0 -> 0.0
+        # nan -> nan
+        expected = torch.tensor([2.0, 0.0, float("nan")])
+        # Compare with nan handling
+        assert torch.allclose(results, expected, equal_nan=True)
+
+        # Case 2: Primary List, Secondary Tensor
+        def primary_list(prompts, completions, **kwargs):
+            return [1.2, 0.4, None]
+
+        def secondary_tensor(prompts, completions, **kwargs):
+            return torch.tensor([2.0, 3.0, 4.0])
+
+        conditioned_2 = conditioned_reward(primary_list, secondary_tensor)
+        results_2 = conditioned_2([], [])
+        assert torch.allclose(results_2, expected, equal_nan=True)
+
+    def test_conditioned_reward_context_caching(self):
+        # Mock primary to track calls
+        call_count = {"primary": 0}
+
+        def primary(prompts, completions, **kwargs):
+            call_count["primary"] += 1
+            return [1.2, 0.4]
+
+        def secondary(prompts, completions, **kwargs):
+            return [2.0, 2.0]
+
+        conditioned = conditioned_reward(primary, secondary)
+
+        # 1. Call WITH context - should NOT call primary
+        context = {"primary": [1.2, 0.4]}
+        results = conditioned([], [], context=context)
+        assert results == [2.0, 0.0]
+        assert call_count["primary"] == 0
+
+        # 2. Call WITHOUT context - SHOULD call primary
+        results = conditioned([], [])
+        assert results == [2.0, 0.0]
+        assert call_count["primary"] == 1

--- a/trl/rewards/__init__.py
+++ b/trl/rewards/__init__.py
@@ -22,6 +22,7 @@ _import_structure = {
     "accuracy_rewards": ["accuracy_reward", "reasoning_accuracy_reward"],
     "format_rewards": ["think_format_reward"],
     "other_rewards": ["get_soft_overlong_punishment"],
+    "utils": ["conditioned_reward"],
 }
 
 
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
     from .accuracy_rewards import accuracy_reward, reasoning_accuracy_reward
     from .format_rewards import think_format_reward
     from .other_rewards import get_soft_overlong_punishment
+    from .utils import conditioned_reward
 
 
 else:

--- a/trl/rewards/utils.py
+++ b/trl/rewards/utils.py
@@ -1,0 +1,139 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from typing import Any, Callable, List, Optional, Union
+
+import torch
+
+
+def conditioned_reward(
+    primary_reward_func: Callable,
+    secondary_reward_func: Callable,
+    condition: float = 1.0,
+    primary_reward_name: Optional[str] = None,
+) -> Callable:
+    """
+    Creates a conditioned reward function that only applies the secondary reward if the primary reward meets a threshold.
+
+    This utility enforces a hierarchy where secondary rewards are only granted if a primary reward threshold is met.
+    This corresponds to the Eq. 8 of the GDPO paper (https://huggingface.co/papers/2601.05242).
+
+    Args:
+        primary_reward_func (`Callable`):
+            The primary reward function that determines if the condition is met.
+        secondary_reward_func (`Callable`):
+            The secondary reward function to be applied if the condition is met.
+        condition (`float`, *optional*, defaults to 1.0):
+            The threshold value for the primary reward to enable the secondary reward.
+        primary_reward_name (`str`, *optional*):
+            The name of the primary reward function. Used to query the context for cached results.
+            If None, it defaults to `primary_reward_func.__name__`.
+
+    Returns:
+        `Callable`:
+            A new reward function that wraps the primary and secondary rewards.
+            If either input function is asynchronous, the returned function will be asynchronous.
+    """
+    if primary_reward_name is None:
+        primary_reward_name = getattr(primary_reward_func, "__name__", None)
+
+    is_async = inspect.iscoroutinefunction(primary_reward_func) or inspect.iscoroutinefunction(secondary_reward_func)
+
+    def _convert_to_tensor(data, device):
+        if isinstance(data, torch.Tensor):
+            return data.to(device)
+        return torch.tensor([x if x is not None else float("nan") for x in data], device=device, dtype=torch.float32)
+
+    def _process_rewards(primary_rewards, secondary_rewards):
+        # Check for tensors or mixed interactions
+        if isinstance(primary_rewards, torch.Tensor) or isinstance(secondary_rewards, torch.Tensor):
+            # Resolve device: prefer primary if tensor, else secondary
+            device = (
+                primary_rewards.device
+                if isinstance(primary_rewards, torch.Tensor)
+                else secondary_rewards.device
+            )
+
+            primary_tensor = _convert_to_tensor(primary_rewards, device)
+            secondary_tensor = _convert_to_tensor(secondary_rewards, device)
+
+            # Logic:
+            # 1. If primary is NaN (was None), result is NaN
+            # 2. If primary >= condition, result is secondary
+            # 3. Else, result is 0.0
+
+            # Start with 0.0
+            results = torch.zeros_like(primary_tensor)
+
+            # Apply secondary where condition is met
+            mask_cond = primary_tensor >= condition
+            results = torch.where(mask_cond, secondary_tensor, results)
+
+            # Propagate NaNs (Nones)
+            mask_nan = torch.isnan(primary_tensor)
+            results = torch.where(mask_nan, float("nan"), results)
+
+            return results
+
+        final_rewards = []
+        for r_p, r_s in zip(primary_rewards, secondary_rewards):
+            if r_p is None:
+                final_rewards.append(None)
+            elif r_p >= condition:
+                final_rewards.append(r_s)
+            else:
+                final_rewards.append(0.0)
+        return final_rewards
+
+    if is_async:
+
+        async def conditioned_reward_func(prompts, completions, **kwargs) -> Union[List[Optional[float]], torch.Tensor]:
+            # Try to get primary reward from Context (Avoid Redundancy)
+            context = kwargs.get("context")
+            primary_rewards = None
+            if context is not None and primary_reward_name in context:
+                primary_rewards = context[primary_reward_name]
+
+            # Execute primary reward if not found in context
+            if primary_rewards is None:
+                if inspect.iscoroutinefunction(primary_reward_func):
+                    primary_rewards = await primary_reward_func(prompts, completions, **kwargs)
+                else:
+                    primary_rewards = primary_reward_func(prompts, completions, **kwargs)
+
+            # Execute secondary reward
+            if inspect.iscoroutinefunction(secondary_reward_func):
+                secondary_rewards = await secondary_reward_func(prompts, completions, **kwargs)
+            else:
+                secondary_rewards = secondary_reward_func(prompts, completions, **kwargs)
+
+            return _process_rewards(primary_rewards, secondary_rewards)
+
+    else:
+
+        def conditioned_reward_func(prompts, completions, **kwargs) -> Union[List[Optional[float]], torch.Tensor]:
+            # Try to get primary reward from Context (Avoid Redundancy)
+            context = kwargs.get("context")
+            primary_rewards = None
+            if context is not None and primary_reward_name in context:
+                primary_rewards = context[primary_reward_name]
+
+            if primary_rewards is None:
+                primary_rewards = primary_reward_func(prompts, completions, **kwargs)
+            secondary_rewards = secondary_reward_func(prompts, completions, **kwargs)
+
+            return _process_rewards(primary_rewards, secondary_rewards)
+
+    return conditioned_reward_func


### PR DESCRIPTION
# What does this PR do?
Fixes #4853 

This PR introduces the conditioned_reward utility, a hierarchical reward wrapper designed to mitigate "Reward Hacking" in multi-objective Reinforcement Learning. This implementation follows the strategy proposed in the [GDPO paper](https://huggingface.co/papers/2601.05242), specifically Equation 8.

## Changes

- trl/rewards/utils.py: Created the conditioned_reward higher-order function.
- trl/trainer/grpo_trainer.py: Modified _calculate_rewards to initialize and populate a context dictionary for shared batch computation. This allows conditioned_reward to retrieve previously calculated results from the same batch, avoiding redundant and expensive re-executions of the primary reward function.
- trl/rewards/__init__.py: Exported the new utility.
- tests/test_rewards.py: Added comprehensive unit tests covering sync/async logic, tensor vectorization, and context caching.
- docs/source/paper_index.md: Added a section on GDPO reward conditioning with usage examples.