### PR TITLE
fix(DeepSeek OPSM): passing correct (vLLM) logprobs

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -997,66 +997,6 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    def test_compute_loss_and_off_policy_mask_with_correct_sampling_per_token_logps(self):
-        """
-        Test that _compute_loss correctly selects sampling_per_token_logps for OPSM if available or fallback to
-        old_per_token_logps otherwise.
-        """
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            off_policy_mask_threshold=0.5,
-            report_to="none",
-            bf16=False,
-            fp16=False,
-        )
-
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=training_args,
-            train_dataset=dataset,
-        )
-
-        # Mock inputs matching the structure for GRPOTrainer
-        batch_size = 2
-        seq_len = 4
-        device = trainer.accelerator.device
-        inputs = {
-            "prompt_ids": torch.zeros((batch_size, seq_len), dtype=torch.long, device=device),
-            "prompt_mask": torch.ones((batch_size, seq_len), dtype=torch.long, device=device),
-            "completion_ids": torch.zeros((batch_size, seq_len), dtype=torch.long, device=device),
-            "completion_mask": torch.ones((batch_size, seq_len), dtype=torch.long, device=device),
-            "advantages": torch.zeros((batch_size,), device=device),
-            "old_per_token_logps": torch.ones((batch_size, seq_len), device=device),
-            "sampling_per_token_logps": torch.ones((batch_size, seq_len), device=device) * 2.0,
-            "ref_per_token_logps": torch.zeros((batch_size, seq_len), device=device),
-            "num_items_in_batch": batch_size,
-        }
-
-        # Mock _get_per_token_logps_and_entropies to avoid running the model
-        per_token_logps = torch.zeros((batch_size, seq_len), device=device)
-        entropies = torch.zeros((batch_size, seq_len), device=device)
-        trainer._get_per_token_logps_and_entropies = lambda *args, **kwargs: (per_token_logps, entropies)
-
-        # Case 1: sampling_per_token_logps is present (vLLM scenario)
-        with patch.object(GRPOTrainer, "get_off_policy_mask", wraps=GRPOTrainer.get_off_policy_mask) as mock_get_mask:
-            trainer._compute_loss(trainer.model, inputs)
-
-            # Verify that get_off_policy_mask received the sampling logps (2.0)
-            _, kwargs = mock_get_mask.call_args
-            torch.testing.assert_close(kwargs["sampling_per_token_logps"], inputs["sampling_per_token_logps"])
-
-        # Case 2: sampling_per_token_logps is absent (local PyTorch scenario)
-        inputs.pop("sampling_per_token_logps")
-        with patch.object(GRPOTrainer, "get_off_policy_mask", wraps=GRPOTrainer.get_off_policy_mask) as mock_get_mask:
-            trainer._compute_loss(trainer.model, inputs)
-
-            # Verify that get_off_policy_mask fell back to old_per_token_logps (1.0)
-            _, kwargs = mock_get_mask.call_args
-            torch.testing.assert_close(kwargs["sampling_per_token_logps"], inputs["old_per_token_logps"])
-
     def test_training_with_bias_correction_kl(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2325,7 +2325,7 @@ class GRPOTrainer(BaseTrainer):
             # OPSM should use inference-time logprobs to detect both sources of off-policyness:
             # 1. Drift from gradient updates (always present)
             # 2. Drift from training-inference mismatch (when using vLLM)
-            # If using vLLM, prioritize sampling_per_token_logps as the old policy logprobs; otherwise use old_per_token_logps
+            # When using vLLM, prioritize sampling_per_token_logps, otherwise use old_per_token_logps
             sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
 
             off_policy_mask = self.get_off_policy_mask(


### PR DESCRIPTION
# What does this PR do?

Hello,  
This PR fixes a mistake I made in the DeepSeek Off-Policy Sequence Masking (OPSM) implementation https://github.com/huggingface/trl/pull/4689

&nbsp;

There are 2 sources of "off-policyness" that OPSM aims to improve:
- drift with repetitive num grad updates
- drift with hybrid training

Currently only the 1st point was covered and is relevant whether we use vLLM or not.

But the 2nd point, when using vLLM, was not covered because I was passing `old_per_token_logps` thinking they were the vLLM logprobs. Those are in fact the local pytorch model logprobs and vLLM logprobs are `sampling_per_token_logps`.

So now with the fix, when OPSM is enabled, we prioritize vLLM logprobs if available. If `None`, `old_per_token_logps` are used, so that users still benefit from OPSM for the 1st source of off-policyness (even if they don't use vLLM).

More details in the discussion with @LeonEricsson  https://github.com/huggingface/trl/pull/4689#issuecomment-3764246518

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@qgallouedec since he was on the previous PR