### PR TITLE
Fix type hint in `openenv/utils.py`: fallback for no vLLM installed case

### DIFF
--- a/trl/experimental/openenv/utils.py
+++ b/trl/experimental/openenv/utils.py
@@ -24,11 +24,6 @@ from ...import_utils import is_vllm_available
 if is_vllm_available():
     from vllm import SamplingParams
     from vllm.sampling_params import StructuredOutputsParams
-else:
-    # To make sure _build_colocate_sampling_params's return type is defined.
-    # If vllm doesn't exist, this line (-> SamplingParams:) throws error otherwise
-    SamplingParams = None
-    StructuredOutputsParams = None
 
 
 def _build_colocate_sampling_params(
@@ -36,7 +31,7 @@ def _build_colocate_sampling_params(
     overrides: dict[str, Any] | None = None,
     *,
     logprobs: bool = True,
-) -> SamplingParams:
+) -> "SamplingParams":
     if trainer.structured_outputs_regex:
         structured_outputs = StructuredOutputsParams(regex=trainer.structured_outputs_regex)
     else:


### PR DESCRIPTION
# What does this PR do?
When vllm is not installed, the imports fail, and the said type is not defined. We want to handle it safely.

Fixes # (issue)


## Before submitting
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.