### PR TITLE
Fix RewardTrainer's results not reproducible

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -288,8 +288,6 @@ class RewardTrainer(BaseTrainer):
             model_name = model_name.split("/")[-1]
             args = RewardConfig(f"{model_name}-Reward")
 
-        set_seed(args.seed)
-
         # IterableDataset requires dispatch_batches=False because Accelerate's dispatch mode may try to concatenate
         # batches from multiple processes, leading to mismatch errors.
         if isinstance(train_dataset, IterableDataset):
@@ -302,6 +300,9 @@ class RewardTrainer(BaseTrainer):
             args.accelerator_config.dispatch_batches = False
 
         # Model
+        # As AutoModelForSequenceClassification.from_pretrained() will add a random head for the model, set_seed must
+        # be done before loading the model to ensure reproducibility.
+        set_seed(args.seed)
         if isinstance(model, str):
             model_init_kwargs = args.model_init_kwargs or {}
             # Distributed training requires device_map=None ("auto" fails)


### PR DESCRIPTION
We found that the results of RewardTrainer are not reproducible, even setting the same seed under different runs. As `AutoModelForSequenceClassification.from_pretrained()` will add a random head for the model, `set_seed` must be done before loading the model.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes RewardTrainer's results not reproducible


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.