### PR TITLE
Fix CI AssertionError: Parameter has not changed

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2261,7 +2261,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
             logging_strategy="no",
         )
 
-        model = AutoModelForCausalLM.from_pretrained(model_name)
+        model = AutoModelForCausalLM.from_pretrained(model_name, dtype="float32")
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         tokenizer.pad_token = tokenizer.eos_token if tokenizer.pad_token is None else tokenizer.pad_token
 


### PR DESCRIPTION
Fix CI AssertionError: Parameter has not changed:
- Set float32 dtype in test_training_with_liger_grpo_kernel

Fix #4903.

Follow-up to:
- #4778