### PR TITLE
Remove chat template setup in dpo_vlm.py

### DIFF
--- a/examples/scripts/dpo_vlm.py
+++ b/examples/scripts/dpo_vlm.py
@@ -33,7 +33,7 @@ accelerate launch examples/scripts/dpo_vlm.py \
     --per_device_train_batch_size 2 \
     --gradient_accumulation_steps 32 \
     --dataset_num_proc 32 \
-    --output_dir dpo_idefics_rlaif-v \
+    --output_dir dpo_qwen_2_5_rlaif-v \
     --dtype bfloat16 \
     --gradient_checkpointing \
     --use_peft \
@@ -51,7 +51,7 @@ accelerate launch examples/scripts/dpo_vlm.py \
     --max_steps 100 \
     --gradient_accumulation_steps 32 \
     --dataset_num_proc 32 \
-    --output_dir dpo_idefics_rlaif-v \
+    --output_dir dpo_qwen_2_5_rlaif-v \
     --dtype bfloat16 \
     --gradient_checkpointing \
     --use_peft \


### PR DESCRIPTION
Setting a chat template before a DPO training doesn't really make sense. We should do it in the SFT stage.