### PR TITLE
Fix extra EOS appended in DPO preprocessing for conversational data

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -707,6 +707,9 @@ class DPOTrainer(BaseTrainer):
                 Whether to add special tokens to the sequences. Typically used for encoder-decoder models. If `True`,
                 the prompt sequence will have a bos token prepended and an eos token appended. In any case, the
                 completion sequences will have an eos token appended.
+            is_chat (`bool`):
+                Whether the data is conversational. If `True`, the completion sequences will not have an eos token
+                appended.
 
         Returns:
             `dict[str, list[int]]`:


### PR DESCRIPTION
This PR fixes a bug in DPO data preparation where the preprocessing step appending an EOS token for conversational data, but it shouldn't

#### Repro

```python
from trl import DPOTrainer
from datasets import load_dataset

dataset = load_dataset("trl-internal-testing/zen", "conversational_preference", split="train")

trainer = DPOTrainer(
    model="Qwen/Qwen3-0.6B",
    train_dataset=dataset,
)

print(repr(trainer.processing_class.decode(trainer.train_dataset["chosen_input_ids"][0])))
# Before: "<think>\n\n</think>\n\nBeautiful.<|im_end|>\n<|im_end|>"
# After:  "<think>\n\n</think>\n\nBeautiful.<|im_end|>"
```

This was found when working on #3906.

Note that the solution is probably not perfectly clean nor tested, but that's fine in my opinion, it's just to have a correct DPO to compare against in #3906
