### PR TITLE
`device_map` init consistency in GRPO/RLOO/KTO

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -339,7 +339,7 @@ class KTOTrainer(BaseTrainer):
         # Model initialization
         if isinstance(model, str):
             model_init_kwargs = args.model_init_kwargs or {}
-            # Distributed training requires device_map=None ("auto" fails with DeepSpeed/FSDP)
+            # Distributed training requires device_map=None ("auto" fails)
             if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 model_init_kwargs["device_map"] = None
             model = create_model_from_path(model, **model_init_kwargs)
@@ -353,7 +353,7 @@ class KTOTrainer(BaseTrainer):
         # Reference model initialization
         if isinstance(ref_model, str):
             ref_model_init_kwargs = args.model_init_kwargs or {}
-            # Distributed training requires device_map=None
+            # Distributed training requires device_map=None ("auto" fails)
             if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 ref_model_init_kwargs["device_map"] = None
             ref_model = create_model_from_path(ref_model, **ref_model_init_kwargs)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -350,7 +350,7 @@ class GRPOTrainer(BaseTrainer):
         for i, reward_func in enumerate(reward_funcs):
             if isinstance(reward_func, str):
                 model_init_kwargs = args.model_init_kwargs or {}
-                # Special case for DeepSpeed: requires device_map=None ("auto" fails)
+                # Distributed training requires device_map=None ("auto" fails)
                 if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                     model_init_kwargs["device_map"] = None
                 reward_funcs[i] = AutoModelForSequenceClassification.from_pretrained(
@@ -562,7 +562,7 @@ class GRPOTrainer(BaseTrainer):
         else:
             # For deepspeed, fsdp or non-distributed models, create a reference model from scratch
             model_init_kwargs = args.model_init_kwargs or {}
-            # Special case for DeepSpeed: requires device_map=None ("auto" fails)
+            # Distributed training requires device_map=None ("auto" fails)
             if self.args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 model_init_kwargs["device_map"] = None
             self.ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -323,7 +323,7 @@ class RLOOTrainer(BaseTrainer):
         for i, reward_func in enumerate(reward_funcs):
             if isinstance(reward_func, str):
                 model_init_kwargs = args.model_init_kwargs or {}
-                # Special case for DeepSpeed: requires device_map=None ("auto" fails)
+                # Distributed training requires device_map=None ("auto" fails)
                 if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                     model_init_kwargs["device_map"] = None
                 reward_funcs[i] = AutoModelForSequenceClassification.from_pretrained(
@@ -456,7 +456,7 @@ class RLOOTrainer(BaseTrainer):
         else:
             # For deepspeed, fsdp or non-distributed models, create a reference model from scratch
             model_init_kwargs = args.model_init_kwargs or {}
-            # Special case for DeepSpeed: requires device_map=None ("auto" fails)
+            # Distributed training requires device_map=None ("auto" fails)
             if self.args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 model_init_kwargs["device_map"] = None
             self.ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)


### PR DESCRIPTION
When training with multi-gpu, `accelerate.prepare` requires the model `device_map` to be `None`.

This is ensured since https://github.com/huggingface/trl/pull/3950

This PR aims to add consistency when instantiating the model, by having the same condition everywhere.

/!\ Note that this PR is not fixing any bug, because the `device_map` is already modified inplace here:

https://github.com/huggingface/trl/blob/5cb03863487da1850d74f4b7602a25f3f8f27cd8/trl/trainer/grpo_trainer.py#L270-L272

and here

https://github.com/huggingface/trl/blob/5cb03863487da1850d74f4b7602a25f3f8f27cd8/trl/trainer/rloo_trainer.py#L244-L246

so technically the `if` condition is never met, but we're just adding a bit of consistency in the code.