### PR TITLE
Fix CI AssertionError: assert not True

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -26,7 +26,7 @@ from ..testing_utils import TrlTestCase, require_liger_kernel, require_no_wandb,
 class TestKTOTrainer(TrlTestCase):
     def setup_method(self):
         self.model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
-        self.model = AutoModelForCausalLM.from_pretrained(self.model_id)
+        self.model = AutoModelForCausalLM.from_pretrained(self.model_id, dtype="float32")
         self.ref_model = AutoModelForCausalLM.from_pretrained(self.model_id)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token

--- a/tests/experimental/test_prm_trainer.py
+++ b/tests/experimental/test_prm_trainer.py
@@ -275,7 +275,7 @@ class TestTokenizeRow(TrlTestCase):
 class TestPRMTrainer(TrlTestCase):
     def setup_method(self):
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
-        self.model = AutoModelForTokenClassification.from_pretrained(model_id)
+        self.model = AutoModelForTokenClassification.from_pretrained(model_id, dtype="float32")
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
 
     @pytest.mark.parametrize("train_on_last_step_only", [True, False])


### PR DESCRIPTION
Fix CI AssertionError: assert not True:
- Set float32 dtype in KTO and PRM tests

Fix #4920.

Follow-up to:
- #4778