### PR TITLE
Support tool call data in `is_conversational`

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -295,6 +295,7 @@ class TestPrepareMultimodalMessagesVLLM:
 
 
 class TestIsConversational(TrlTestCase):
+    # fmt: off
     conversational_examples = [
         {  # Language modeling
             "messages": [
@@ -322,6 +323,30 @@ class TestIsConversational(TrlTestCase):
             "rejected": [
                 {"role": "user", "content": "What color is the sky?"},
                 {"role": "assistant", "content": "It is green."},
+            ],
+        },
+        {  # Preference with tool calls
+            "prompt": [{"role": "user", "content": "What color is the sky?"}],
+            "chosen": [
+                {"role": "assistant", "tool_calls": [{"type": "function", "function": {"name": "get_color", "arguments": {"what": "sky"}}}]},
+                {"role": "tool", "name": "get_color", "content": "blue"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "rejected": [
+                {"role": "assistant", "tool_calls": [{"type": "function", "function": {"name": "get_color", "arguments": {"what": "tree"}}}]},
+                {"role": "tool", "name": "get_color", "content": "green"},
+                {"role": "assistant", "content": "It is green."},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "description": "Gets the color.",
+                        "name": "get_color",
+                        "parameters": {"properties": {"what": {"description": "What to get the color of.", "type": "string"}}, "required": ["what"], "type": "object"},
+                        "return": {"description": "The color.", "type": "string"},
+                    },
+                },
             ],
         },
         {  # Unpaired preference
@@ -386,6 +411,7 @@ class TestIsConversational(TrlTestCase):
             "label": True,
         },
     ]
+    # fmt: on
 
     non_conversational_examples = [
         {"prompt": "The sky is", "completion": " blue."},

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -177,7 +177,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
         if isinstance(maybe_messages, list):
             maybe_message = maybe_messages[0]
             # Each message must a list of dictionaries with keys "role" and "content"
-            if isinstance(maybe_message, dict) and "role" in maybe_message and "content" in maybe_message:
+            if isinstance(maybe_message, dict) and "role" in maybe_message:
                 return True
 
     return False


### PR DESCRIPTION
Previously, `is_conversational` required a selected message turn to include both `"role"` and `"content"`. In our preference data, the selected turn is the first message of `chosen`. When that first message is a tool call, it doesn’t have a `"content"` field (only `"role"` and `tool_call`) so `is_conversational` incorrectly returns `false`.

This PR updates the logic so tool-call message turns are treated as conversational in the preference setting, fixing the failing edge case introduced by the new test.
