### PR TITLE
Require transformers<5 with PairRMJudge

### DIFF
--- a/trl/experimental/judges/judges.py
+++ b/trl/experimental/judges/judges.py
@@ -227,6 +227,12 @@ class PairRMJudge(BasePairwiseJudge):
     def __init__(self):
         if not is_llm_blender_available():
             raise ValueError("llm-blender is not installed. Please install it with `pip install llm-blender`.")
+        import transformers
+
+        if Version(transformers.__version__) >= Version("5.0.0"):
+            raise RuntimeError(
+                "llm-blender currently supports transformers < 5.0.0. Please install a compatible version: `pip install 'transformers<5.0.0'`. Check the issue tracker for updates: https://github.com/huggingface/trl/issues/4918"
+            )
         _ensure_llm_blender_importable()
         import llm_blender
 


### PR DESCRIPTION
Require transformers<5 with PairRMJudge.

This PR adds a compatibility check for the `transformers` library in the `PairRMJudge` class. Now, if the installed `transformers` version is 5.0.0 or higher, an explicit error is raised to inform users that only versions below 5.0.0 are supported.

Follow-up to:
- #4918