### PR TITLE
Update RewardFunc type to use RewardCallable protocol

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -27,7 +27,7 @@ from collections.abc import Callable
 from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, Optional
 
 import datasets
 import pandas as pd
@@ -109,9 +109,19 @@ if is_trackio_available():
 
 logger = get_logger(__name__)
 
+
+class RewardCallable(Protocol):
+    def __call__(
+        self,
+        prompts: list[Any] | None = None,
+        completions: list[Any] | None = None,
+        completion_ids: list[list[int]] | None = None,
+        **kwargs: Any,
+    ) -> list[float | None]: ...
+
 # What we call a reward function is a callable that takes a list of prompts and completions and returns a list of
 # rewards. When it's a string, it's a model ID, so it's loaded as a pretrained model.
-RewardFunc = str | PreTrainedModel | Callable[[list, list], list[float]]
+RewardFunc = str | PreTrainedModel | RewardCallable
 
 # What we call a rollout function is a callable that takes prompts (list) and the trainer instance as parameters and
 # returns a dict of generation results. Those results must include "prompt_ids", "completion_ids", and "logprobs"


### PR DESCRIPTION
Refactor RewardFunc type to use RewardCallable protocol for better type safety because it matches the actual usage of the reward function in the code:
```python
output_reward_func = reward_func(
    prompts=prompts, completions=completions, completion_ids=completion_ids_list, **reward_kwargs
)
```

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case. https://github.com/huggingface/trl/issues/4939
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.