### PR TITLE
Fix PPO run_name parameter not taking effect

### DIFF
--- a/trl/experimental/ppo/ppo_config.py
+++ b/trl/experimental/ppo/ppo_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -35,8 +34,6 @@ class PPOConfig(TrainingArguments):
     command line.
 
     Parameters:
-        run_name (`str`, *optional*):
-            Name of the run.
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
         num_mini_batches (`int`, *optional*, defaults to `1`):
@@ -84,8 +81,6 @@ class PPOConfig(TrainingArguments):
             Mini batch size across GPUs.
         push_to_hub (`bool`, *optional*, defaults to `False`):
             Whether to push the model to the Hub after training.
-        exp_name (`str`, *optional*, defaults to `os.path.basename(__file__)[:-3]`):
-            Name of this experiment.
         reward_model_path (`str`, *optional*, defaults to `"EleutherAI/pythia-160m"`):
             Path to the reward model.
         model_adapter_name (`str`, *optional*):
@@ -152,10 +147,6 @@ class PPOConfig(TrainingArguments):
         },
     )
 
-    run_name: str | None = field(
-        default=None,
-        metadata={"help": "Name of the run."},
-    )
     dataset_num_proc: int | None = field(
         default=None,
         metadata={"help": "Number of processes to use for processing the dataset."},
@@ -246,10 +237,6 @@ class PPOConfig(TrainingArguments):
     push_to_hub: bool = field(
         default=False,
         metadata={"help": "Whether to push the model to the Hub after training."},
-    )
-    exp_name: str = field(
-        default=os.path.basename(__file__)[:-3],
-        metadata={"help": "Name of this experiment."},
     )
     reward_model_path: str = field(
         default="EleutherAI/pythia-160m",

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -27,7 +27,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 from accelerate import Accelerator, logging
-from accelerate.utils import broadcast, gather_object
+from accelerate.utils import gather_object
 from datasets import Dataset
 from torch.utils.data import DataLoader
 from transformers import (
@@ -455,9 +455,6 @@ class PPOTrainer(BaseTrainer):
         args.num_total_batches = math.ceil(
             args.total_episodes / args.batch_size
         )  # we may train for more than `total_episodes`
-        time_tensor = torch.tensor(int(time.time()), device=accelerator.device)
-        time_int = broadcast(time_tensor, 0).item()  # avoid different timestamps across processes
-        args.run_name = f"{args.exp_name}__{args.seed}__{time_int}"
         self.local_seed = args.seed + accelerator.process_index * 100003  # Prime
         if args.num_sample_generations > 0:
             self.sample_generations_freq = max(1, args.num_total_batches // args.num_sample_generations)


### PR DESCRIPTION
Fix PPO run_name parameter not taking effect.

Remove the duplicate `run_name` and the deprecated `exp_name` parameters definitions from `PPOConfig`:                                                                                                                   
- **`run_name`**: Now correctly inherited from `TrainingArguments`, which handles passing it to downstream tracking libraries                                                                            
- **`exp_name`**: Was already deprecated; this removes leftover code                                                                                                                                     
                                                                                                                                                                                                           
This aligns `PPOConfig` with other trainer configs in TRL, which don't redefine these parameters. 

Fixes #4944.