### PR TITLE
Remove truncation from tokenizer calls if no max_length

### DIFF
--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -145,7 +145,7 @@ def _tokenize(
     )
 
     if embedding_tokenizer is not None:
-        embedding_tokenized = embedding_tokenizer(batch["prompt"], truncation=True, add_special_tokens=False)
+        embedding_tokenized = embedding_tokenizer(batch["prompt"], add_special_tokens=False)
 
         output.update(
             {


### PR DESCRIPTION
Remove truncation from tokenizer calls if no max_length.

This PR removes the `truncation=True` argument when calling the tokenizers without `max_length` argument. This change simplifies the tokenizer calls.

Changes in:
- Experimental BCO

Follow-up to discussions in: https://github.com/huggingface/trl/pull/4964#discussion_r2765765868, https://github.com/huggingface/trl/pull/4965#discussion_r2765762964, and https://github.com/huggingface/trl/pull/4966#discussion_r2765749367.