### PR TITLE
[CI] Disallow installation of transformers 5.1.0 due to compatibility issues with DeepSpeed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -296,6 +296,8 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install ".[dev]"
+          # transformers 5.1.0 is broken with DeepSpeed; PR open: https://github.com/huggingface/transformers/pull/43780
+          uv pip install "transformers!=5.1.0"
 
       - name: Run distributed smoke tests
         run: |


### PR DESCRIPTION
To keep the CI green with distributed tests. Can be reverted when https://github.com/huggingface/transformers/pull/43780 is merged and released