### PR TITLE
Replace `warmup_ratio` with `warmup_steps`

### DIFF
--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -195,7 +195,7 @@ hf jobs uv run \
     --output_dir grpo-full-qwen3-0.6b \
     --learning_rate 1.0e-6 \
     --lr_scheduler_type cosine \
-    --warmup_ratio 0.0 \
+    --warmup_steps 0.0 \
     --max_grad_norm 1.0 \
     --beta 0.0 \
     --max_completion_length 4096 \
@@ -229,7 +229,7 @@ uv run "https://huggingface.co/datasets/burtenshaw/lora-without-regrets/resolve/
     --output_dir grpo-full-qwen3-0.6b \
     --learning_rate 1.0e-6 \
     --lr_scheduler_type cosine \
-    --warmup_ratio 0.0 \
+    --warmup_steps 0.0 \
     --max_grad_norm 1.0 \
     --beta 0.0 \
     --max_completion_length 4096 \

--- a/docs/source/nash_md_trainer.md
+++ b/docs/source/nash_md_trainer.md
@@ -124,7 +124,7 @@ python examples/scripts/nash_md.py \
     --dataset_name trl-lib/ultrafeedback-prompt \
     --learning_rate 5.0e-7 \
     --output_dir Qwen2.5-0.5B-NashMD-PairRM \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --push_to_hub
 ```
 

--- a/docs/source/online_dpo_trainer.md
+++ b/docs/source/online_dpo_trainer.md
@@ -126,7 +126,7 @@ python examples/scripts/dpo_online.py \
     --dataset_name trl-lib/ultrafeedback-prompt \
     --learning_rate 5.0e-7 \
     --output_dir Qwen2.5-0.5B-Online-DPO-PairRM \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --push_to_hub
 ```
 
@@ -167,7 +167,7 @@ accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml \
     --gradient_accumulation_steps 2 \
     --num_train_epochs 3 \
     --max_new_tokens 53 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --save_steps 0.1 \
     --push_to_hub
@@ -185,7 +185,7 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml
     --gradient_accumulation_steps 2 \
     --num_train_epochs 3 \
     --max_new_tokens 53 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --save_steps 0.1 \
     --push_to_hub
@@ -203,7 +203,7 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml
     --gradient_accumulation_steps 4 \
     --num_train_epochs 3 \
     --max_new_tokens 53 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --save_steps 0.1 \
     --push_to_hub

--- a/docs/source/xpo_trainer.md
+++ b/docs/source/xpo_trainer.md
@@ -126,7 +126,7 @@ python examples/scripts/xpo.py \
     --dataset_name trl-lib/ultrafeedback-prompt \
     --learning_rate 5.0e-7 \
     --output_dir Qwen2.5-0.5B-XPO-PairRM \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --push_to_hub
 ```
 

--- a/examples/scripts/bco.py
+++ b/examples/scripts/bco.py
@@ -44,7 +44,7 @@ python examples/scripts/bco.py \
     --max_length 2048 \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
-    --warmup_ratio 0.1
+    --warmup_steps 0.1
 
 # QLoRA:
 python examples/scripts/bco.py \
@@ -60,11 +60,11 @@ python examples/scripts/bco.py \
     --save_strategy no \
     --output_dir bco-aligned-model-lora \
     --logging_first_step \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --max_length 2048 \
     --max_completion_length 1024 \
     --no_remove_unused_columns \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --use_peft \
     --load_in_4bit \
     --lora_target_modules all-linear \

--- a/examples/scripts/kto.py
+++ b/examples/scripts/kto.py
@@ -35,7 +35,7 @@ python trl/scripts/kto.py \
     --gradient_accumulation_steps 1 \
     --eval_steps 500 \
     --output_dir kto-aligned-model \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --logging_first_step
 
 # QLoRA:
@@ -49,7 +49,7 @@ python trl/scripts/kto.py \
     --gradient_accumulation_steps 1 \
     --eval_steps 500 \
     --output_dir kto-aligned-model-lora \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --logging_first_step \
     --use_peft \
     --load_in_4bit \

--- a/examples/scripts/nash_md.py
+++ b/examples/scripts/nash_md.py
@@ -33,7 +33,7 @@ python examples/scripts/nash_md.py \
     --gradient_accumulation_steps 32 \
     --num_train_epochs 3 \
     --max_new_tokens 64 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --push_to_hub
 
@@ -49,7 +49,7 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml
     --gradient_accumulation_steps 32 \
     --num_train_epochs 3 \
     --max_new_tokens 64 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --push_to_hub
 """

--- a/examples/scripts/online_dpo.py
+++ b/examples/scripts/online_dpo.py
@@ -32,7 +32,7 @@ python examples/scripts/online_dpo.py \
     --output_dir pythia-1b-tldr-online-dpo \
     --per_device_train_batch_size 8 \
     --gradient_accumulation_steps 16 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0
 
 With LoRA:
@@ -44,7 +44,7 @@ python examples/scripts/online_dpo.py \
     --output_dir pythia-1b-tldr-online-dpo \
     --per_device_train_batch_size 16 \
     --gradient_accumulation_steps 8 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --use_peft
 """

--- a/examples/scripts/sft_gpt_oss.py
+++ b/examples/scripts/sft_gpt_oss.py
@@ -40,7 +40,7 @@ accelerate launch \
     --per_device_train_batch_size 2 \
     --num_train_epochs 1 \
     --logging_steps 1 \
-    --warmup_ratio 0.03 \
+    --warmup_steps 0.03 \
     --lr_scheduler_type cosine_with_min_lr \
     --lr_scheduler_kwargs '{"min_lr_rate": 0.1}' \
     --output_dir gpt-oss-20b-multilingual-reasoner \

--- a/examples/scripts/sft_video_llm.py
+++ b/examples/scripts/sft_video_llm.py
@@ -44,7 +44,7 @@ accelerate launch \
     --save_steps 300 \
     --learning_rate 8e-5 \
     --max_grad_norm 0.3 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --lr_scheduler_type cosine \
     --push_to_hub False \
     --dtype bfloat16

--- a/examples/scripts/xpo.py
+++ b/examples/scripts/xpo.py
@@ -33,7 +33,7 @@ python examples/scripts/xpo.py \
     --gradient_accumulation_steps 32 \
     --num_train_epochs 3 \
     --max_new_tokens 64 \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --missing_eos_penalty 1.0 \
     --push_to_hub
 """

--- a/trl/scripts/kto.py
+++ b/trl/scripts/kto.py
@@ -37,7 +37,7 @@ python trl/scripts/kto.py \
     --gradient_accumulation_steps 1 \
     --eval_steps 500 \
     --output_dir=kto-aligned-model \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --logging_first_step
 ```
 
@@ -54,7 +54,7 @@ python trl/scripts/kto.py \
     --gradient_accumulation_steps 1 \
     --eval_steps 500 \
     --output_dir=kto-aligned-model-lora \
-    --warmup_ratio 0.1 \
+    --warmup_steps 0.1 \
     --logging_first_step \
     --use_peft \
     --load_in_4bit \


### PR DESCRIPTION
`warmup_ratio` is deprecated and will be removed in transformers 5.2.0. We can simply replace it by `warmup_since` since when the value is below 1, it's interpreted as a ratio.