### PR TITLE
Fix deprecation of DPOConfig.max_completion_length

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -651,13 +651,15 @@ class DPOConfig(TrainingArguments):
         else:  # keep the old default
             self.label_pad_token_id = -100
 
-        if self.max_completion_length is not None:
+        if self.max_completion_length != -1:
             warnings.warn(
                 "`max_completion_length` is deprecated and will be removed in version 0.29.0. We recommend using "
                 "`max_length` instead to control the maximum length of samples.",
                 FutureWarning,
                 stacklevel=2,
             )
+        else:  # keep the old default
+            self.max_completion_length = None
 
         if self.max_prompt_length != -1:
             warnings.warn(


### PR DESCRIPTION
Fix deprecation of DPOConfig.max_completion_length.

Follow-up to:
- #4969

This PR fixes the initialization logic for `max_completion_length` in the `DPOConfig` class: how deprecated configuration values are handled.

Configuration deprecation handling:

* Changed the check for `max_completion_length` from `is not None` to `!= -1`, ensuring that the deprecation warning is only triggered when a meaningful value is set.
* Added a fallback to reset `max_completion_length` to `None` when its value is `-1`, preserving the old default behavior.