### PR TITLE
Fix post_init warning stacklevel to 3

### DIFF
--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -422,5 +422,5 @@ class OnlineDPOConfig(TrainingArguments):
                 f"The configuration has `max_new_tokens` ({self.max_new_tokens}) >= `max_length` ({self.max_length}). "
                 "This will cause prompts to be truncated or completely removed in the forward pass. "
                 "To preserve prompts, ensure  e.g. `max_length > max_new_tokens + 512`. ",
-                stacklevel=2,
+                stacklevel=3,
             )

--- a/trl/trainer/bco_config.py
+++ b/trl/trainer/bco_config.py
@@ -30,6 +30,6 @@ class BCOConfig(_BCOConfig):
             "`from trl.experimental.bco import BCOConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/cpo_config.py
+++ b/trl/trainer/cpo_config.py
@@ -30,6 +30,6 @@ class CPOConfig(_CPOConfig):
             "`from trl.experimental.cpo import CPOConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -618,7 +618,7 @@ class DPOConfig(TrainingArguments):
                 "will be retrieved via `get_decoder`; if your model does not support this, it will no longer be "
                 "supported by the DPO trainer.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.base_model_attribute_name = "model"
@@ -628,7 +628,7 @@ class DPOConfig(TrainingArguments):
                 "`force_use_ref_model` is deprecated and will be removed in version 0.29.0. There is no need to pass "
                 "this argument anymore: if you provide a reference model, it will be used automatically.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.generate_during_eval is not None:
@@ -636,7 +636,7 @@ class DPOConfig(TrainingArguments):
                 "`generate_during_eval` is deprecated and will be removed in version 0.29.0. Please use a callback "
                 "instead. See the example at `https://gist.github.com/qgallouedec/a08da3457a3a76c5ca539d4a0b38e482`.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.generate_during_eval = False
@@ -646,7 +646,7 @@ class DPOConfig(TrainingArguments):
                 "`label_pad_token_id` is deprecated and will be removed in version 0.29.0. It will no longer be "
                 "possible to set this value.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.label_pad_token_id = -100
@@ -656,7 +656,7 @@ class DPOConfig(TrainingArguments):
                 "`max_completion_length` is deprecated and will be removed in version 0.29.0. We recommend using "
                 "`max_length` instead to control the maximum length of samples.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.max_prompt_length != -1:
@@ -664,7 +664,7 @@ class DPOConfig(TrainingArguments):
                 "`max_prompt_length` is deprecated and will be removed in version 0.29.0. We recommend filtering out"
                 "overlong prompts from your dataset before passing it to the trainer instead of using this parameter.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.max_prompt_length = 512
@@ -674,7 +674,7 @@ class DPOConfig(TrainingArguments):
                 "`model_adapter_name` is deprecated and will be removed in version 0.29.0. Only the default adapter "
                 "will be supported going forward.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.ref_adapter_name is not None:
@@ -683,7 +683,7 @@ class DPOConfig(TrainingArguments):
                 "training an adapter, you won't need this argument anymore in the next version and can rely on the "
                 "trainer. For now, it is still the only supported way to do this.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.ref_model_init_kwargs is not None:
@@ -692,7 +692,7 @@ class DPOConfig(TrainingArguments):
                 "init kwargs for the reference model, instantiate it yourself and pass it via the `ref_model` "
                 "argument.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.reference_free is not None:
@@ -700,7 +700,7 @@ class DPOConfig(TrainingArguments):
                 "`reference_free` is deprecated and will be removed in version 0.29.0. If you want a reference-free "
                 "objective, use `CPOTrainer` instead.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.reference_free = False
@@ -711,7 +711,7 @@ class DPOConfig(TrainingArguments):
                 "`'sft'` in `loss_type`; we recommend adding `'sft'` to `loss_type` and setting its weight in "
                 "`loss_weights` to `rpo_alpha`.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.tools is not None:
@@ -720,7 +720,7 @@ class DPOConfig(TrainingArguments):
                 "tools should be provided via the dataset instead but for now, `DPOConfig.tools` remains the only "
                 "supported way to pass tools.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if self.use_logits_to_keep is not None:
@@ -728,7 +728,7 @@ class DPOConfig(TrainingArguments):
                 "`use_logits_to_keep` is deprecated and will be removed in version 0.29.0. The DPO trainer will no "
                 "longer use this setting.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         else:  # keep the old default
             self.use_logits_to_keep = False

--- a/trl/trainer/gkd_config.py
+++ b/trl/trainer/gkd_config.py
@@ -30,6 +30,6 @@ class GKDConfig(_GKDConfig):
             "`from trl.experimental.gkd import GKDConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -31,6 +31,6 @@ class KTOConfig(_KTOConfig):
             "https://github.com/huggingface/trl/issues/4223. Promoting KTO to the stable API is a high-priority task. "
             "Until then, this current path (`from trl import KTOConfig`) will remain, but API changes may occur.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/nash_md_config.py
+++ b/trl/trainer/nash_md_config.py
@@ -30,6 +30,6 @@ class NashMDConfig(_NashMDConfig):
             "`from trl.experimental.nash_md import NashMDConfig`. The current import path will be removed and no "
             "longer supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/online_dpo_config.py
+++ b/trl/trainer/online_dpo_config.py
@@ -31,6 +31,6 @@ class OnlineDPOConfig(_OnlineDPOConfig):
             "no longer supported in TRL 0.29. For more information, see "
             "https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/orpo_config.py
+++ b/trl/trainer/orpo_config.py
@@ -30,6 +30,6 @@ class ORPOConfig(_ORPOConfig):
             "`from trl.experimental.orpo import ORPOConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/ppo_config.py
+++ b/trl/trainer/ppo_config.py
@@ -30,6 +30,6 @@ class PPOConfig(_PPOConfig):
             "`from trl.experimental.ppo import PPOConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/prm_config.py
+++ b/trl/trainer/prm_config.py
@@ -28,6 +28,6 @@ class PRMConfig(_PRMConfig):
             "`from trl.experimental.xco import PRMConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -649,5 +649,5 @@ class RLOOConfig(TrainingArguments):
                 "instead filter your dataset before training to ensure that prompts do not exceed your desired "
                 "length.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,
             )

--- a/trl/trainer/xpo_config.py
+++ b/trl/trainer/xpo_config.py
@@ -28,6 +28,6 @@ class XPOConfig(_XPOConfig):
             "`from trl.experimental.xco import XPOConfig`. The current import path will be removed and no longer "
             "supported in TRL 0.29. For more information, see https://github.com/huggingface/trl/issues/4223.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__post_init__()


### PR DESCRIPTION
Fix `__post_init__` warning stacklevel to 3.

This PR fixes the warning stack level for all calls in the `__post_init__` methods. The stack level is increased from 2 to 3 to improve the accuracy of warning messages, ensuring they point to the user's code rather than internal library calls. No other logic or functionality is changed.

Warning stack level adjustments across trainer configs:
* Increased `stacklevel` from 2 to 3 in all `warnings.warn` calls in all config files to improve warning tracebacks.