### PR TITLE
Filter CI SWIG deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,3 +174,10 @@ markers = [
 addopts = [
     "-k", "not experimental",
 ]
+filterwarnings = [
+    # SWIG deprecations from SWIG-generated C/C++ extensions: sentencepiece
+    # Upstream issue: https://github.com/google/sentencepiece/issues/1150
+    "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
+    "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
+    "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
+]


### PR DESCRIPTION
Filter CI SWIG deprecation warnings.

Fix #5003.

This PR adds configuration to suppress specific deprecation warnings related to SWIG-generated C/C++ extensions when running tests. This helps keep test output clean by ignoring known, non-critical warnings.

Test configuration improvements:

* Added `filterwarnings` entries to `pyproject.toml` to ignore deprecation warnings about missing `__module__` attributes in SWIG-generated types, addressing noise from the `sentencepiece` dependency.