### PR TITLE
Fix CI TRLExperimentalWarning in regular tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples tests trl
 ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
 
 test:
-	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)' tests/
+	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)' tests
 
 precommit:
 	python scripts/add_copyrights.py
@@ -16,4 +16,4 @@ slow_tests:
 	pytest -m "slow" tests/ $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
 
 test_experimental:
-	pytest -k "experimental" -n auto -s -v
+	pytest -n auto -s -v tests/experimental

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,6 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "low_priority: marks tests as low priority (deselect with '-m \"not low_priority\"')"
 ]
-addopts = [
-    "-k", "not experimental",
+norecursedirs = [
+    "tests/experimental",
 ]


### PR DESCRIPTION
Fix CI TRLExperimentalWarning in regular tests, by skipping pytest collection of experimental tests when running regular tests:
- Replace k-addopts with norecursedirs, to tell pytest to skip collection under the `tests/experimental` directory

Fix #5006.

This PR improves how experimental tests are handled.

**Test Execution Command Updates:**

* Updated the `test_experimental` target in the `Makefile` to run all tests in the `tests/experimental` directory instead of using a keyword filter, ensuring only experimental tests are executed.

**Pytest Configuration Adjustments:**

* Removed the `addopts` filter that excluded experimental tests by keyword and instead added `norecursedirs` to explicitly exclude the `tests/experimental` directory from regular test runs, making test selection more robust and clear.