### PR TITLE
Fix CI FutureWarning: ref_model_init_kwargs is deprecated

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -824,10 +824,12 @@ class TestDPOTrainer(TrlTestCase):
             model_init_kwargs={"dtype": "float16"},
             report_to="none",
         )
+        # Instantiating the reference model explicitly and pass it via ref_model
+        ref_model = AutoModelForCausalLM.from_pretrained(self.model_id, dtype="float16")
 
         trainer = DPOTrainer(
             model=self.model_id,
-            ref_model=self.model_id,
+            ref_model=ref_model,
             processing_class=self.tokenizer,
             args=training_args,
             train_dataset=dummy_dataset["train"],


### PR DESCRIPTION
Fix CI FutureWarning: ref_model_init_kwargs is deprecated:
- Stop using deprecated `ref_model_init_kwargs` in tests

Fix #5008.

Follow-up to:
- #4969

### Rationale
- Our test suite should exercise the current supported public API, so we need to update the tests to the new usage.
- This keeps CI noise-free and ensures we’re testing what users should do now.