### PR TITLE
Fix CI FutureWarning: rpo_alpha is deprecated

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -986,7 +986,6 @@ class TestDPOTrainer(TrlTestCase):
         output = trainer.concatenated_forward(model, batch)
         output2 = trainer2.concatenated_forward(model, batch)
 
-        np.testing.assert_allclose(output["nll_loss"].item(), output2["nll_loss"].item(), atol=1e-5)
         np.testing.assert_allclose(
             output["mean_chosen_logits"].item(), output2["mean_chosen_logits"].item(), atol=1e-5
         )


### PR DESCRIPTION
Fix CI FutureWarning: rpo_alpha is deprecated:
- Stop using deprecated `rpo_alpha` in tests

Fix #5010.

Follow-up to:
- #4969

### Rationale
- Our test suite should exercise the current supported public API, so we need to update the tests to the new usage.
- This keeps CI noise-free and ensures we’re testing what users should do now.