### PR TITLE
Fix CI FutureWarning: generate_during_eval is deprecated

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -40,7 +40,6 @@ from .testing_utils import (
     TrlTestCase,
     require_bitsandbytes,
     require_liger_kernel,
-    require_no_wandb,
     require_peft,
     require_torch_accelerator,
     require_torch_gpu_if_bnb_not_multi_backend_enabled,
@@ -559,37 +558,6 @@ class TestDPOTrainer(TrlTestCase):
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
 
-    @require_no_wandb
-    def test_dpo_trainer_generate_during_eval_no_wandb(self):
-        training_args = DPOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=2,
-            max_steps=3,
-            remove_unused_columns=False,
-            gradient_accumulation_steps=1,
-            learning_rate=9e-1,
-            eval_strategy="steps",
-            beta=0.1,
-            generate_during_eval=True,
-            report_to="none",
-        )
-
-        dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
-
-        with pytest.raises(
-            ValueError,
-            match="`generate_during_eval=True` requires Weights and Biases, MLFlow or Comet to be installed."
-            " Please install `wandb`, `mlflow` or `comet-ml` to resolve.",
-        ):
-            DPOTrainer(
-                model=self.model,
-                ref_model=None,
-                args=training_args,
-                processing_class=self.tokenizer,
-                train_dataset=dummy_dataset["train"],
-                eval_dataset=dummy_dataset["test"],
-            )
-
     @require_bitsandbytes
     @require_peft
     @require_torch_gpu_if_bnb_not_multi_backend_enabled
@@ -647,32 +615,20 @@ class TestDPOTrainer(TrlTestCase):
         trainer.save_model()
 
     @pytest.mark.parametrize(
-        "loss_type, pre_compute, gen_during_eval",
+        "loss_type, pre_compute",
         [
-            ("sigmoid", False, False),
-            ("sigmoid", False, True),
-            ("sigmoid", True, False),
-            ("sigmoid", True, True),
-            ("ipo", False, False),
-            ("ipo", False, True),
-            ("ipo", True, False),
-            ("ipo", True, True),
-            ("aot_pair", False, False),
-            ("aot_pair", False, True),
-            ("aot_pair", True, False),
-            ("aot_pair", True, True),
-            ("aot", False, False),
-            ("aot", False, True),
-            ("aot", True, False),
-            ("aot", True, True),
-            ("bco_pair", False, False),
-            ("bco_pair", False, True),
-            ("bco_pair", True, False),
-            ("bco_pair", True, True),
-            ("robust", False, False),
-            ("robust", False, True),
-            ("robust", True, False),
-            ("robust", True, True),
+            ("sigmoid", False),
+            ("sigmoid", True),
+            ("ipo", False),
+            ("ipo", True),
+            ("aot_pair", False),
+            ("aot_pair", True),
+            ("aot", False),
+            ("aot", True),
+            ("bco_pair", False),
+            ("bco_pair", True),
+            ("robust", False),
+            ("robust", True),
         ],
     )
     @require_bitsandbytes
@@ -681,7 +637,7 @@ class TestDPOTrainer(TrlTestCase):
         get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8,
         reason="Skipping because bf16 not supported on CUDA GPU with capability < 8.0",
     )
-    def test_dpo_lora_bf16_autocast(self, loss_type, pre_compute, gen_during_eval):
+    def test_dpo_lora_bf16_autocast(self, loss_type, pre_compute):
         from peft import LoraConfig
         from transformers import BitsAndBytesConfig
 
@@ -708,7 +664,6 @@ class TestDPOTrainer(TrlTestCase):
             eval_strategy="steps",
             bf16=True,
             beta=0.1,
-            generate_during_eval=gen_during_eval,
             loss_type=loss_type,
             precompute_ref_log_probs=pre_compute,
             report_to="none",
@@ -1517,7 +1472,6 @@ class TestDPOTrainerSlow(TrlTestCase):
             report_to="none",
             gradient_checkpointing=True,  # default, here for clarity
             gradient_checkpointing_kwargs=gradient_checkpointing_kwargs,
-            generate_during_eval=False,
             loss_type=loss_type,
             precompute_ref_log_probs=pre_compute_logits,
             beta=0.1,
@@ -1586,7 +1540,6 @@ class TestDPOTrainerSlow(TrlTestCase):
             gradient_checkpointing=True,  # default, here for clarity
             gradient_checkpointing_kwargs=gradient_checkpointing_kwargs,
             beta=0.1,
-            generate_during_eval=False,
             loss_type=loss_type,
             precompute_ref_log_probs=pre_compute_logits,
             max_length=self.max_length,


### PR DESCRIPTION
Fix CI FutureWarning: generate_during_eval is deprecated:
- Stop testing generate_during_eval in DPO

Fix #5016.

Follow-up to:
- #4969

### Rationale
- Our test suite should exercise the current supported public API, so we need to update the tests to the new usage.
- This keeps CI noise-free and ensures we’re testing what users should do now.