### PR TITLE
Pin transformers < 5 in judges extra due to incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ deepspeed = [
 ]
 judges = [
     "openai>=1.23.2",
-    "llm-blender>=0.0.2"
+    "llm-blender>=0.0.2",
+    "transformers<5.0.0",  # see #4918
 ]
 kernels = [
     "kernels"


### PR DESCRIPTION
Pin transformers < 5 in judges extra due to incompatibility.

Follow-up to:
- #4918