### PR TITLE
Fix typo in xfail test reason

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -62,7 +62,7 @@ class TestDistributed(TrlTestCase):
             "ddp",
             "zero2",
             "zero3",
-            pytest.param("fsdp2", marks=pytest.mark.xfail(reason="FSDP2 DPO is currently failing, see see #4812")),
+            pytest.param("fsdp2", marks=pytest.mark.xfail(reason="FSDP2 DPO is currently failing, see #4812")),
         ],
     )
     def test_dpo(self, config, get_config_path):


### PR DESCRIPTION
Fix typo in xfail test reason:
`see see`