### PR TITLE
Mark Qwen3VL tests as xfail for transformers 5.0.x

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1346,6 +1346,10 @@ class TestSFTTrainer(TrlTestCase):
                         Version(transformers.__version__) < Version("4.57.0"),
                         reason="Qwen3-VL series were introduced in transformers-4.57.0",
                     ),
+                    pytest.mark.xfail(
+                        Version("5.0.0") <= Version(transformers.__version__) < Version("5.1.0"),
+                        reason="Upstream transformers bug (transformers#43334) in 5.0.x; fixed in 5.1.0",
+                    ),
                 ],
             ),
         ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -920,6 +920,10 @@ class TestForwardMaskedLogits:
                         Version(transformers.__version__) < Version("4.57.0"),
                         reason="Qwen3-VL series were introduced in transformers-4.57.0",
                     ),
+                    pytest.mark.xfail(
+                        Version("5.0.0") <= Version(transformers.__version__) < Version("5.1.0"),
+                        reason="Upstream transformers bug (transformers#43334) in 5.0.x; fixed in 5.1.0",
+                    ),
                 ],
             ),
         ],


### PR DESCRIPTION
Mark Qwen3VL tests as xfail for transformers 5.0.x.

After having thought more carefully about the previous removal, I think the CI is more robust with this PR:
- What if we run the tests with transformers 5.0.x?
- What if we eventually set transformers-5.0.0 as the minimum required version?

Follow-up to:
- #5000

This PR adds test markers to handle a known upstream bug in the `transformers` library version 5.0.x, ensuring that affected tests are expected to fail.

Test robustness improvements:

* Added `pytest.mark.xfail` to relevant tests in `tests/test_sft_trainer.py` and `tests/test_utils.py` to account for the upstream bug in `transformers` 5.0.x, referencing issue `transformers#43334`.