### PR TITLE
Fix multiprocessing start method to 'spawn' for test compatibility with Python 3.12+

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1518,6 +1518,17 @@ class TestGRPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     def test_training_multiple_dataloader_workers(self):
+        # Pytest/CI often starts background threads before tests run. With Python 3.12, using the default "fork" start
+        # method in a multi-threaded process emits a DeprecationWarning and may deadlock.
+        #
+        # We force "spawn" here to make multiprocessing safe under pytest when DataLoader workers are enabled. This is
+        # test-environment–specific and not required by the training logic itself.
+        #
+        # This means the test does not cover "fork". However, "spawn" is stricter (requires full picklability and clean
+        # state) and avoids fork-after-threads issues that pytest cannot reliably test anyway. Fork-specific behavior,
+        # if needed, should be tested in a clean process outside pytest.
+        torch.multiprocessing.set_start_method("spawn", force=True)
+
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(


### PR DESCRIPTION
See comment. It suppresses the warning

```
$ pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
======================================================== test session starts =========================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.12.1, datadir-1.8.0
collected 1 item                                                                                                                     

tests/test_grpo_trainer.py .                                                                                                   [100%]

========================================================== warnings summary ==========================================================
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
tests/test_grpo_trainer.py::TestGRPOTrainer::test_training_multiple_dataloader_workers
  /fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=3836051) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 1 passed, 6 warnings in 26.41s ===================================================
```