### PR TITLE
[GRPO] fix: remove SAPO temperature check

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -512,11 +512,6 @@ class GRPOTrainer(BaseTrainer):
                 "Iterable datasets are not yet supported in GRPOTrainer. Please use a standard dataset instead."
             )
 
-        if args.loss_type == "sapo" and (args.sapo_temperature_neg is None or args.sapo_temperature_pos is None):
-            raise ValueError(
-                "When using `sapo` loss, both `sapo_temperature_neg` and `sapo_temperature_pos` must be set."
-            )
-
         if args.loss_type == "luspo" and args.importance_sampling_level != "sequence":
             logger.warning(
                 "When using `'luspo'` loss, `importance_sampling_level` should be set to `'sequence'` to mirror the "


### PR DESCRIPTION
`sapo_temperature_neg` and `sapo_temperature_pos` are typed as `float` with default values and don't permit `None` (type hint). 

https://github.com/huggingface/trl/blob/19c5f4460cd9b405a95fabb05322ceb98864e915/trl/trainer/grpo_config.py#L622-L637

The check is over-defensive and can be removed. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.