### PR TITLE
Cast multimodal forward_kwargs to compute dtype for bf16/fp16 training

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1609,6 +1609,17 @@ class GRPOTrainer(BaseTrainer):
             prompt_inputs = self.processing_class(images=images, text=prompts_text, padding=True, return_tensors="pt")
             prompt_inputs = super()._prepare_inputs(prompt_inputs)
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
+            if self.args.bf16:
+                compute_dtype = torch.bfloat16
+            elif self.args.fp16:
+                compute_dtype = torch.float16
+            else:
+                compute_dtype = None
+            if compute_dtype is not None:
+                forward_kwargs = {
+                    k: v.to(compute_dtype) if isinstance(v, torch.Tensor) and torch.is_floating_point(v) else v
+                    for k, v in forward_kwargs.items()
+                }
         else:
             forward_kwargs = {}
 


### PR DESCRIPTION
# What does this PR do?

When training VLMs with bf16=True or fp16=True, pixel_values returned by the processor stay float32 after _prepare_inputs (dtype casting is DeepSpeed-specific).
If the vision encoder weights are bfloat16/float16, this can crash in torch.layer_norm with:
```
RuntimeError: expected scalar type BFloat16 but found Float
```
This is the next failure reported in the #4451 thread after the prompt-format TypeError.

**Note:** Fixed by casting floating-point tensors in forward_kwargs to the compute dtype when bf16=True or fp16=True. This is consistent with how the trainer already handles model dtype casting. If the model is loaded in bf16 via torch_dtype without setting the training flag, this path won't trigger, but neither does the existing model casting.


# Changes made
In the multimodal path, cast only floating-point tensors in forward_kwargs to the active compute dtype (bf16/fp16).
Leave non-floating tensors (for example image_grid_thw) unchanged.

No prompt-format behavior changes (proposed in #5064 and #5067)
No reward-function behavior changes (proposed in #5064)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@qgallouedec @kashif @albertvillanova 