### PR TITLE
Fix CI ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)

### DIFF
--- a/tests/experimental/test_winrate_callback.py
+++ b/tests/experimental/test_winrate_callback.py
@@ -50,10 +50,7 @@ class TrainerWithRefModel(Trainer):
             processing_class=processing_class,
         )
         # Prepare ref_model like TRL trainers do (DPOTrainer, GRPOTrainer, etc.)
-        if ref_model is not None:
-            self.ref_model = self.accelerator.prepare_model(ref_model, evaluation_mode=True)
-        else:
-            self.ref_model = None
+        self.ref_model = self.accelerator.prepare_model(ref_model, evaluation_mode=True)
 
 
 class TestWinRateCallback(TrlTestCase):


### PR DESCRIPTION
Fix CI ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?):
- Prepare ref_model in TrainerWithRefModel for TestWinRateCallback

Fix #4816.
- The bug was architectural drift: the test didn't follow the pattern that production code uses
- The ref_model was never prepared by the trainer: it's just stored as an attribute, so it stays on CPU while the main model is moved to GPU.
- Callback assumes prepared models
