### PR TITLE
docs: Add TR-DPO paper (2404.09656) to paper index

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -722,6 +722,28 @@ training_args = DPOConfig(
 
 For the unpaired version, the user should utilize [`experimental.bco.BCOConfig`] and [`experimental.bco.BCOTrainer`].
 
+### Learn Your Reference Model for Real Good Alignment
+
+**📜 Paper**: https://huggingface.co/papers/2404.09656
+
+Trust Region DPO (TR-DPO) updates the reference policy during training, demonstrating effectiveness against DPO on the Anthropic HH and TLDR datasets, outperforming DPO by up to 19% measured by automatic evaluation with GPT-4, improving coherence, correctness, level of detail, helpfulness, and harmlessness. To reproduce the paper's setting, use this configuration:
+
+```python
+from trl import DPOConfig
+
+training_args = DPOConfig(
+    sync_ref_model=True,  # enable TR-DPO (Section 3 of the paper)
+    ref_model_mixup_alpha=0.6,  # α soft update weight (Table 1 of the paper)
+    ref_model_sync_steps=512,  # τ update frequency in steps (Table 1 of the paper)
+    beta=0.05,  # β temperature (Table 1 of the paper)
+    learning_rate=1e-6,  # learning rate (Table 2 of the paper)
+    num_train_epochs=1,  # Table 2 of the paper
+    max_length=1024,  # max tokens length (Table 2 of the paper)
+    max_grad_norm=2,  # max gradient norm (Table 2 of the paper)
+    warmup_steps=100,  # warm-up steps (Table 2 of the paper)
+)
+```
+
 ### Self-Play Preference Optimization for Language Model Alignment
 
 **📜 Paper**: https://huggingface.co/papers/2405.00675


### PR DESCRIPTION
## Summary

- Adds paper index entry for [Learn Your Reference Model for Real Good Alignment](https://huggingface.co/papers/2404.09656) (TR-DPO)
- TR-DPO dynamically updates the reference policy during training via soft updates
- Maps to `DPOConfig` with `sync_ref_model=True`, `ref_model_mixup_alpha`, and `ref_model_sync_steps`
- Method-specific hyperparameters from Table 1: α=0.6, τ=512, β=0.05
- Training config from Table 2: lr=1e-6, 1 epoch, max_length=1024, max_grad_norm=2, warmup_steps=100

## Notes

- `max_grad_norm` and `warmup_steps` are inherited from `TrainingArguments` — valid in `DPOConfig` but with different defaults (`max_grad_norm=1.0` vs paper's `2`, `warmup_steps=0` vs paper's `100`)

Ref: #4407