### PR TITLE
Fix SFT loss type rewards being overwritten in dpo_loss()

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1277,8 +1277,9 @@ class DPOTrainer(BaseTrainer):
                 "'apo_down', 'sft']"
             )
 
-        chosen_rewards = self.beta * (chosen_logps.to(device) - ref_chosen_logps.to(device)).detach()
-        rejected_rewards = self.beta * (rejected_logps.to(device) - ref_rejected_logps.to(device)).detach()
+        if loss_type != "sft":
+            chosen_rewards = self.beta * (chosen_logps.to(device) - ref_chosen_logps.to(device)).detach()
+            rejected_rewards = self.beta * (rejected_logps.to(device) - ref_rejected_logps.to(device)).detach()
 
         return losses, chosen_rewards, rejected_rewards
 


### PR DESCRIPTION
## Summary

- In `dpo_loss()`, the `sft` loss branch correctly sets `chosen_rewards` and `rejected_rewards` to zeros (since SFT has no preference rewards), but the unconditional reward computation at the end of the method overwrites these with standard DPO implicit rewards
- This causes inflated reward metrics when using SFT as part of a multi-loss configuration (e.g., MPO with `["sigmoid", "bco_pair", "sft"]`), because the SFT component contributes DPO-style rewards instead of the intended zeros
- The fix guards the reward computation so it only runs for non-SFT loss types, preserving the correct zero rewards for SFT

## Test plan

- [ ] Existing `test_train_with_multiple_loss_types` test continues to pass
- [ ] Run MPO training with `loss_type=["sigmoid", "sft"]` and verify reward metrics are no longer inflated by the SFT component
- [ ] Verify single loss type training (e.g., `loss_type="sigmoid"`) is unaffected