### PR TITLE
docs: add Multi-Node Training subsection (#4384)

### DIFF
--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -374,7 +374,7 @@ This command automatically:
 
 ## Multi-Node Training
 
-When a single machine doesn't have enough GPUs, TRL can scale training across multiple machines (nodes) using [🤗 Accelerate](https://huggingface.co/docs/accelerate/usage_guides/distributed_inference).
+When a single machine doesn't have enough GPUs, TRL can scale training across multiple machines (nodes) using [🤗 Accelerate](https://huggingface.co/docs/accelerate/basic_tutorials/launch#multi-node-training).
 
 ### Accelerate Configuration
 Create an `accelerate` config file (e.g., `multi_node.yaml`) for multi-node training. Key fields:
@@ -418,7 +418,7 @@ For clusters using SLURM job scheduler, create a job script (e.g., `slurm_job.sh
 #SBATCH --gpus-per-node=8
 #SBATCH --job-name=trl_multi
 
-srun accelerate launch --config_file multi_node.yaml --machine_rank $SLURM_NODEID train.py
+srun accelerate launch --config_file multi_node.yaml train.py
 ```
 
 Then submit the job:
@@ -426,7 +426,7 @@ Then submit the job:
 sbatch slurm_job.sh
 ```
 
-SLURM automatically distributes the training across all requested nodes and GPUs. The `$SLURM_NODEID` variable is automatically replaced with each node's rank (0, 1, etc.).
+SLURM automatically distributes the training across all requested nodes and GPUs, and `srun` configures the necessary environment variables for multi-node communication.
 
 **Key SLURM directives:**
 - `--nodes=2`: Request 2 compute nodes


### PR DESCRIPTION
# What does this PR do?

This PR adds a comprehensive Multi-Node Training subsection to the TRL distributed training documentation #4384 . It provides users with practical guidance on scaling training across multiple machines using 🤗 Accelerate, covering both manual setup and HPC cluster environments.


Fixes: N/A

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.