### PR TITLE
Remove outdated liger-kernel compatibility checks and warnings in tests and SFTTrainer

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -37,7 +37,6 @@ from transformers.testing_utils import backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
-from trl.import_utils import is_liger_kernel_available
 from trl.trainer.utils import get_kbit_device_map
 
 from .testing_utils import (
@@ -1911,12 +1910,6 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.0.0") and not is_liger_kernel_available(min_version="0.6.5"),
-        reason="Blocked by upstream liger-kernel bug (linkedin/Liger-Kernel#960); "
-        "fixed by linkedin/Liger-Kernel#966 but not yet released (>0.6.4 required)",
-        strict=True,
-    )
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -170,15 +170,12 @@ def _patch_transformers_hybrid_cache() -> None:
     """
     Fix HybridCache import for transformers v5 compatibility.
 
-    - Issue: liger_kernel and peft import HybridCache from transformers.cache_utils
+    - Issue: peft import HybridCache from transformers.cache_utils
     - HybridCache removed in https://github.com/huggingface/transformers/pull/43168 (transformers>=5.0.0)
-    - Fixed in liger_kernel: https://github.com/linkedin/Liger-Kernel/pull/1002 (released in v0.6.5)
     - Fixed in peft: https://github.com/huggingface/peft/pull/2735 (released in v0.18.0)
-    - This can be removed when TRL requires liger_kernel>=0.6.5 and peft>=0.18.0
+    - This can be removed when TRL requires peft>=0.18.0
     """
-    if _is_package_version_at_least("transformers", "5.0.0") and (
-        _is_package_version_below("liger_kernel", "0.6.5") or _is_package_version_below("peft", "0.18.0")
-    ):
+    if _is_package_version_at_least("transformers", "5.0.0") and _is_package_version_below("peft", "0.18.0"):
         try:
             import transformers.cache_utils
             from transformers.utils.import_utils import _LazyModule

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1245,13 +1245,9 @@ class SFTTrainer(BaseTrainer):
                 token_accuracy = self.accelerator.gather_for_metrics(outputs.token_accuracy).mean().item()
                 self._metrics[mode]["mean_token_accuracy"].append(token_accuracy)
             else:
-                # liger-kernel<=0.6.4 can omit token_accuracy even when requested; fixed for Gemma3 in
-                # https://github.com/linkedin/Liger-Kernel/pull/1010
                 warnings.warn(
                     "liger-kernel did not return token_accuracy when requested. The mean_token_accuracy metric will "
-                    "not be logged. This may indicate an outdated liger-kernel version. Consider upgrading to the "
-                    "latest version. If the issue persists after upgrading, please report it to the liger-kernel "
-                    "repository.",
+                    "not be logged. This is unexpected; please report it to the liger-kernel repository.",
                     stacklevel=2,
                 )
         else:


### PR DESCRIPTION


#5031 bumped liger to 0.7.0 but didn't removed the backward compatibility checks for older version. This PR addresses it.