### PR TITLE
MGPO feature addition

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -123,6 +123,47 @@ $$
 
 This token-level ratio is then combined with a shared advantage  \\( \hat{A}_i \\), and the GRPO objective clips and optimizes each token independently across the sequence.
 
+### MaxEnt-Guided Policy Optimization
+
+**📜 Paper**: https://huggingface.co/papers/2511.06221
+
+MaxEnt-Guided Policy Optimization (MGPO) is a GRPO add-on that reweights advantages by each prompt group's success rate. Groups closest to maximum uncertainty (p_c ≈ p₀) receive the highest weight, steering training toward prompts at the model's capability boundary. MGPO was used in [VibeThinker-1.5B](https://huggingface.co/papers/2511.06221) and [VibeThinker-3B](https://arxiv.org/pdf/2606.16140).
+
+To reproduce the paper's setting, use this configuration:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    mgpo_reward_base=1.0,  # success threshold: reward >= this counts as correct (section 3.4)
+    mgpo_lambda=0.5,  # entropy deviation coefficient λ (section 3.4)
+    mgpo_target_success_rate=0.5,  # target group success rate p₀ for peak weight (section 3.4)
+    scale_rewards="group",  # standard GRPO group normalization
+)
+```
+
+`mgpo_reward_base` is the per-rollout success cutoff and should match your reward function's scale (for example, `1.0` for binary verifiable rewards). It is not necessarily the maximum possible reward.
+
+#### Advantage reweighting
+
+For each prompt, MGPO computes the empirical group success rate:
+
+$$
+p_c(q) = \frac{1}{G}\sum_{i=1}^{G}\mathbb{I}(r_i \geq \text{mgpo\_reward\_base})
+$$
+
+The max-entropy deviation distance and reweighting factor are:
+
+$$
+D_{\mathrm{ME}}(p_c(q)\|p_0) = p_c(q)\log\frac{p_c(q)}{p_0} + (1-p_c(q))\log\frac{1-p_c(q)}{1-p_0}
+$$
+
+$$
+w_{\mathrm{ME}}(p_c(q)) = \exp(-\lambda \cdot D_{\mathrm{ME}}(p_c(q)\|p_0))
+$$
+
+The reweighted advantage is  \\( \hat{A}'_j(q) = w_{\mathrm{ME}}(p_c(q)) \cdot \hat{A}_j(q) \\), applied after GRPO std-normalization.
+
 ### Geometric-Mean Policy Optimization
 
 **📜 Paper**: https://huggingface.co/papers/2507.20673

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -283,6 +283,40 @@ class TestGRPOTrainer(TrlTestCase):
             train_dataset=dataset,
         )
 
+    def test_mgpo_reward_base(self):
+        def compute_weights(rewards, num_generations, mgpo_reward_base, mgpo_lambda=0.5, mgpo_target_success_rate=0.5):
+            return GRPOTrainer._compute_mgpo_weights(
+                rewards,
+                num_generations,
+                mgpo_reward_base,
+                mgpo_lambda,
+                mgpo_target_success_rate,
+            )
+
+        num_generations = 2
+        rewards = torch.tensor([1.0, 0.0, 1.0, 1.0, 0.0, 0.0])
+        weights_mixed = compute_weights(rewards, num_generations, mgpo_reward_base=1.0)
+        weights_all_success = compute_weights(
+            torch.tensor([1.0, 1.0, 1.0, 1.0]), num_generations, mgpo_reward_base=1.0
+        )
+        weights_all_fail = compute_weights(
+            torch.tensor([0.0, 0.0, 0.0, 0.0]), num_generations, mgpo_reward_base=1.0
+        )
+
+        # pc=0.5 group gets peak weight (D_ME=0 -> w=1.0)
+        torch.testing.assert_close(weights_mixed[:2], torch.tensor([1.0, 1.0]))
+        assert weights_mixed[0] > weights_all_success[0]
+        assert weights_mixed[0] > weights_all_fail[0]
+
+        # mgpo_reward_base=0.0 is valid (must not be skipped by truthiness check)
+        weights_zero_base = compute_weights(
+            torch.tensor([0.0, -1.0, 1.0, 1.0]), num_generations, mgpo_reward_base=0.0
+        )
+        assert weights_zero_base.shape == (4,)
+
+        with pytest.raises(ValueError, match="mgpo_lambda"):
+            GRPOConfig(output_dir="/tmp/test", mgpo_lambda=0.0)
+
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -218,6 +218,21 @@ class GRPOConfig(_BaseConfig):
             log-probability ratios across valid tokens to produce a single ratio per sequence. The [GSPO
             paper](https://huggingface.co/papers/2507.18071) shows that sequence-level sampling often yields more
             stable training and better alignment with sequence-level rewards.
+        mgpo_reward_base (`float`, *optional*):
+            Success threshold for MaxEnt-Guided Policy Optimization (MGPO). A rollout counts as successful when its
+            reward is greater than or equal to this value. This is a configurable cutoff (not necessarily the maximum
+            reward) and should be set to match your reward function's scale—for example, `1.0` for binary verifiable
+            rewards. If `None`, MGPO reweighting is disabled and standard GRPO advantages are used. MGPO is introduced
+            in [Tiny Model, Big Logic](https://huggingface.co/papers/2511.06221).
+        mgpo_lambda (`float`, *optional*, defaults to `0.5`):
+            Entropy deviation regularization coefficient (λ) for MGPO. Must be greater than `0.0`. Controls the
+            sharpness of the advantage reweighting; larger values focus training more aggressively on prompts near the
+            target success rate. To disable MGPO, set `mgpo_reward_base=None`. See section 3.4 of the
+            [VibeThinker paper](https://huggingface.co/papers/2511.06221).
+        mgpo_target_success_rate (`float`, *optional*, defaults to `0.5`):
+            Target group success rate (p₀) for MGPO. Prompt groups whose empirical success rate is closest to this
+            value receive the highest advantage weight, following the maximum-entropy principle for binary outcomes.
+            See section 3.4 of the [VibeThinker paper](https://huggingface.co/papers/2511.06221).
         reward_weights (`list[float]`, *optional*):
             Weights for each reward function. Must match the number of reward functions. If `None`, all rewards are
             weighted equally with weight `1.0`.
@@ -726,6 +741,22 @@ class GRPOConfig(_BaseConfig):
             "sequence-level rewards."
         },
     )
+    mgpo_reward_base: float | None = field(
+        default=None,
+        metadata={
+            "help": "Success threshold for MGPO. A rollout counts as successful when reward >= this value. If `None`: no MGPO reweighting is applied."
+        },
+    )
+    mgpo_lambda: float = field(
+        default=0.5,
+        metadata={
+            "help": "Entropy deviation regularization coefficient (λ) for MGPO. Must be greater than 0.0."
+        },
+    )
+    mgpo_target_success_rate: float = field(
+        default=0.5,
+        metadata={"help": "Target group success rate (p₀) for MGPO advantage reweighting."},
+    )
     reward_weights: list[float] | None = field(
         default=None,
         metadata={
@@ -1028,6 +1059,12 @@ class GRPOConfig(_BaseConfig):
             raise ValueError(
                 "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
                 f"{self.num_generations}, which is less than the minimum required."
+            )
+
+        if self.mgpo_lambda <= 0:
+            raise ValueError(
+                f"`mgpo_lambda` must be greater than 0, got {self.mgpo_lambda}. "
+                "To disable MGPO, set `mgpo_reward_base=None` instead."
             )
 
         if self.vllm_importance_sampling_cap is not None:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -640,6 +640,9 @@ class GRPOTrainer(_BaseTrainer):
         self.router_aux_loss_coef = args.router_aux_loss_coef
         self.scale_rewards = args.scale_rewards
         self.importance_sampling_level = args.importance_sampling_level
+        self.mgpo_reward_base = args.mgpo_reward_base
+        self.mgpo_lambda = args.mgpo_lambda
+        self.mgpo_target_success_rate = args.mgpo_target_success_rate
         self.off_policy_mask_threshold = args.off_policy_mask_threshold
         if self.use_liger_kernel and self.off_policy_mask_threshold is not None:
             raise ValueError("Liger kernel does not support off-policy sequence masking yet.")
@@ -1095,6 +1098,25 @@ class GRPOTrainer(_BaseTrainer):
         # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.
         last_hidden_state = last_hidden_state[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
         return last_hidden_state
+
+    @staticmethod
+    def _compute_mgpo_weights(
+        rewards: torch.Tensor,
+        num_generations: int,
+        mgpo_reward_base: float,
+        mgpo_lambda: float,
+        mgpo_target_success_rate: float,
+    ) -> torch.Tensor:
+        """
+        Compute MGPO advantage reweighting signlas relative to group success rates.
+
+        See section 3.4 of https://huggingface.co/papers/2511.06221.
+        """
+        grouped_rewards = rewards.detach().view(-1, num_generations)
+        pc = (grouped_rewards >= mgpo_reward_base).float().mean(dim=1)
+        p0 = mgpo_target_success_rate
+        d_me = pc * torch.log(pc / p0 + 1e-8) + (1 - pc) * torch.log((1 - pc) / (1 - p0) + 1e-8)
+        return torch.exp(-mgpo_lambda * d_me).repeat_interleave(num_generations)
 
     def get_high_entropy_mask(self, entropies: torch.Tensor, mask: torch.Tensor, threshold: float) -> torch.Tensor:
         """
@@ -2316,6 +2338,16 @@ class GRPOTrainer(_BaseTrainer):
         # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
         # so zero their advantage to keep them from moving the policy.
         advantages = torch.nan_to_num(advantages, nan=0.0)
+
+        if self.mgpo_reward_base is not None:
+            w_me = self._compute_mgpo_weights(
+                rewards,
+                num_generations,
+                self.mgpo_reward_base,
+                self.mgpo_lambda,
+                self.mgpo_target_success_rate,
+            )
+            advantages = advantages * w_me
 
         # Slice to keep only the local part of the data
         process_slice = slice(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the advantage signal on the core GRPO training path when MGPO is enabled; default behavior is unchanged because MGPO is off unless `mgpo_reward_base` is set.
> 
> **Overview**
> Adds **MaxEnt-Guided Policy Optimization (MGPO)** as an optional GRPO extension: when `mgpo_reward_base` is set, advantages are multiplied by per-prompt weights derived from each generation group’s success rate (reward ≥ threshold), peaking when the empirical success rate matches `mgpo_target_success_rate`.
> 
> New `GRPOConfig` knobs are `mgpo_reward_base` (opt-in; `None` keeps standard GRPO), `mgpo_lambda`, and `mgpo_target_success_rate`, with validation that `mgpo_lambda` must be positive. `GRPOTrainer` implements `_compute_mgpo_weights` and applies it **after** existing GRPO advantage normalization.
> 
> Documentation in `paper_index.md` describes the method and example config; unit tests cover weight behavior (including `mgpo_reward_base=0.0`) and invalid `mgpo_lambda`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d8b50f06cbd63ee6343293bf1652316c94aac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->