### PR TITLE
Fix import latency [1/N]: Extract _LazyModule to dedicated module

### DIFF
--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -17,7 +17,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
 from . import _compat
-from .import_utils import _LazyModule
+from ._lazy_module import _LazyModule
 
 
 try:

--- a/trl/_lazy_module.py
+++ b/trl/_lazy_module.py
@@ -1,0 +1,79 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+from itertools import chain
+from types import ModuleType
+from typing import Any
+
+
+class _LazyModule(ModuleType):
+    """
+    Module class that surfaces all objects but only performs associated imports when the objects are requested.
+    """
+
+    # Very heavily inspired by optuna.integration._IntegrationModule
+    # https://github.com/optuna/optuna/blob/master/optuna/integration/__init__.py
+    def __init__(self, name, module_file, import_structure, module_spec=None, extra_objects=None):
+        super().__init__(name)
+        self._modules = set(import_structure.keys())
+        self._class_to_module = {}
+        for key, values in import_structure.items():
+            for value in values:
+                self._class_to_module[value] = key
+        # Needed for autocompletion in an IDE
+        self.__all__ = list(import_structure.keys()) + list(chain(*import_structure.values()))
+        self.__file__ = module_file
+        self.__spec__ = module_spec
+        self.__path__ = [os.path.dirname(module_file)]
+        self._objects = {} if extra_objects is None else extra_objects
+        self._name = name
+        self._import_structure = import_structure
+
+    # Needed for autocompletion in an IDE
+    def __dir__(self):
+        result = super().__dir__()
+        # The elements of self.__all__ that are submodules may or may not be in the dir already, depending on whether
+        # they have been accessed or not. So we only add the elements of self.__all__ that are not already in the dir.
+        for attr in self.__all__:
+            if attr not in result:
+                result.append(attr)
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._objects:
+            return self._objects[name]
+        if name in self._modules:
+            value = self._get_module(name)
+        elif name in self._class_to_module.keys():
+            module = self._get_module(self._class_to_module[name])
+            value = getattr(module, name)
+        else:
+            raise AttributeError(f"module {self.__name__} has no attribute {name}")
+
+        setattr(self, name, value)
+        return value
+
+    def _get_module(self, module_name: str):
+        try:
+            return importlib.import_module("." + module_name, self.__name__)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to import {self.__name__}.{module_name} because of the following error (look up to see its"
+                f" traceback):\n{e}"
+            ) from e
+
+    def __reduce__(self):
+        return (self.__class__, (self._name, self.__file__, self._import_structure))

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
-import os
 import warnings
 from contextlib import contextmanager
-from itertools import chain
-from types import ModuleType
-from typing import Any
 
 from packaging.version import Version
 from transformers.utils.import_utils import _is_package_available
@@ -112,63 +107,3 @@ def suppress_warning(category):
 
 def suppress_experimental_warning():
     return suppress_warning(TRLExperimentalWarning)
-
-
-class _LazyModule(ModuleType):
-    """
-    Module class that surfaces all objects but only performs associated imports when the objects are requested.
-    """
-
-    # Very heavily inspired by optuna.integration._IntegrationModule
-    # https://github.com/optuna/optuna/blob/master/optuna/integration/__init__.py
-    def __init__(self, name, module_file, import_structure, module_spec=None, extra_objects=None):
-        super().__init__(name)
-        self._modules = set(import_structure.keys())
-        self._class_to_module = {}
-        for key, values in import_structure.items():
-            for value in values:
-                self._class_to_module[value] = key
-        # Needed for autocompletion in an IDE
-        self.__all__ = list(import_structure.keys()) + list(chain(*import_structure.values()))
-        self.__file__ = module_file
-        self.__spec__ = module_spec
-        self.__path__ = [os.path.dirname(module_file)]
-        self._objects = {} if extra_objects is None else extra_objects
-        self._name = name
-        self._import_structure = import_structure
-
-    # Needed for autocompletion in an IDE
-    def __dir__(self):
-        result = super().__dir__()
-        # The elements of self.__all__ that are submodules may or may not be in the dir already, depending on whether
-        # they have been accessed or not. So we only add the elements of self.__all__ that are not already in the dir.
-        for attr in self.__all__:
-            if attr not in result:
-                result.append(attr)
-        return result
-
-    def __getattr__(self, name: str) -> Any:
-        if name in self._objects:
-            return self._objects[name]
-        if name in self._modules:
-            value = self._get_module(name)
-        elif name in self._class_to_module.keys():
-            module = self._get_module(self._class_to_module[name])
-            value = getattr(module, name)
-        else:
-            raise AttributeError(f"module {self.__name__} has no attribute {name}")
-
-        setattr(self, name, value)
-        return value
-
-    def _get_module(self, module_name: str):
-        try:
-            return importlib.import_module("." + module_name, self.__name__)
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to import {self.__name__}.{module_name} because of the following error (look up to see its"
-                f" traceback):\n{e}"
-            ) from e
-
-    def __reduce__(self):
-        return (self.__class__, (self._name, self.__file__, self._import_structure))

--- a/trl/models/__init__.py
+++ b/trl/models/__init__.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING
 
-from ..import_utils import _LazyModule
+from .._lazy_module import _LazyModule
 
 
 _import_structure = {

--- a/trl/rewards/__init__.py
+++ b/trl/rewards/__init__.py
@@ -15,7 +15,7 @@
 import sys
 from typing import TYPE_CHECKING
 
-from ..import_utils import _LazyModule
+from .._lazy_module import _LazyModule
 
 
 _import_structure = {

--- a/trl/scripts/__init__.py
+++ b/trl/scripts/__init__.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING
 
-from ..import_utils import _LazyModule
+from .._lazy_module import _LazyModule
 
 
 _import_structure = {

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING
 
-from ..import_utils import _LazyModule
+from .._lazy_module import _LazyModule
 
 
 _import_structure = {


### PR DESCRIPTION
Extract _LazyModule to dedicated module.

This is the 1st PR to fix the TRL import latency I am working on:
- #5130

This PR refactors the handling of the `_LazyModule` class by moving its implementation from `import_utils.py` to a new dedicated file, `_lazy_module.py`. This change improves code organization and separation of concerns. All imports of `_LazyModule` across the codebase are updated to reflect this new location, and the now-redundant code is removed from `import_utils.py`.

### Context

TRL has a _LazyModule class in trl/import_utils.py that enables lazy loading of submodules. However, import_utils.py also contains the _is_package_available function borrowed from transformers, which was introduced by:
- #2064

This is the root cause of some seconds import latency regression (import trl eagerly loads all of transformers).

### Solution

This PR extracts _LazyModule into its own dedicated file (trl/_lazy_module.py) with zero external dependencies. This is a pure refactor with no behavior change.

### Motivation

Moving _LazyModule out of import_utils.py is a clean, reviewable refactor on its own. It also removes the responsibility mismatch: _LazyModule (module loading machinery) had no business living alongside package availability checks.