### PR TITLE
Fix import latency [2/N]: Implement native _is_package_available

### DIFF
--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -23,7 +23,8 @@ Each patch should be removed when minimum version requirements eliminate the nee
 import warnings
 
 from packaging.version import Version
-from transformers.utils.import_utils import _is_package_available
+
+from .import_utils import _is_package_available
 
 
 def _is_package_version_below(package_name: str, version_threshold: str) -> bool:

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -21,10 +21,42 @@ from types import ModuleType
 from typing import Any
 
 from packaging.version import Version
-from transformers.utils.import_utils import _is_package_available
 
 
 LIGER_KERNEL_MIN_VERSION = "0.7.0"
+PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
+
+
+# From transformers: https://github.com/huggingface/transformers/blob/556312cd45a5e619c41b0f8adf680eab0d334324/src/transformers/utils/import_utils.py#L48-L77
+def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[bool, str] | bool:
+    """Check if `pkg_name` exist, and optionally try to get its version"""
+    spec = importlib.util.find_spec(pkg_name)
+    package_exists = spec is not None
+    package_version = "N/A"
+    if package_exists and return_version:
+        try:
+            # importlib.metadata works with the distribution package, which may be different from the import
+            # name (e.g. `PIL` is the import name, but `pillow` is the distribution name)
+            distributions = PACKAGE_DISTRIBUTION_MAPPING[pkg_name]
+            # Per PEP 503, underscores and hyphens are equivalent in package names.
+            # Prefer the distribution that matches the (normalized) package name.
+            normalized_pkg_name = pkg_name.replace("_", "-")
+            if normalized_pkg_name in distributions:
+                distribution_name = normalized_pkg_name
+            elif pkg_name in distributions:
+                distribution_name = pkg_name
+            else:
+                distribution_name = distributions[0]
+            package_version = importlib.metadata.version(distribution_name)
+        except (importlib.metadata.PackageNotFoundError, KeyError):
+            # If we cannot find the metadata (because of editable install for example), try to import directly.
+            # Note that this branch will almost never be run, so we do not import packages for nothing here
+            package = importlib.import_module(pkg_name)
+            package_version = getattr(package, "__version__", "N/A")
+    if return_version:
+        return package_exists, package_version
+    else:
+        return package_exists
 
 
 def is_deepspeed_available() -> bool:


### PR DESCRIPTION
Implement native `_is_package_available`.

This is the 2nd PR to fix the TRL import latency I am working on:
- #5130

This PR updates the way the `_is_package_available` utility function is imported and implemented in the codebase. The main change is that the function is now defined locally in `trl/import_utils.py` instead of being imported from the `transformers` library, and all internal imports have been updated accordingly.

See upstream issue:
- https://github.com/huggingface/transformers/issues/44273

### Context

Both `trl/import_utils.py` and `trl/_compat.py` import `_is_package_available` from `transformers` at the top level, which was introduced by:
- #2064

Both files are eagerly loaded when import trl runs, triggering a full transformers load (~3s).

### Solution

Replace `transformers..utils.import_utils._is_package_available` with local implementation of `_is_package_available`.

After the fix (#5128 and #5129), the import latency passed from `~3s`  to `<0.5s`:
```python
import time, sys

t = time.time(); import trl
print(f"import trl: {time.time() - t:.2f}s")   # <0.5s
print("transformers" in sys.modules)           # False
```

Key changes:

**Refactoring of package availability utility:**

* Moved the `_is_package_available` function from being imported from `transformers.utils.import_utils` to a local implementation in `trl/import_utils.py`, ensuring the codebase no longer depends on the external implementation.
* Updated the import statement in `trl/_compat.py` to use the local `_is_package_available` from `.import_utils` instead of the one from `transformers.utils.import_utils`.

**Enhancements to local implementation:**

* The new `_is_package_available` function is copied from the `transformers` library and includes logic to check for a package's existence and optionally retrieve its version, handling edge cases such as distribution name differences and editable installs.