### PR TITLE
Fix `SFTTrainer` support for single-image data

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1014,9 +1014,7 @@ class TestDPOTrainer(TrlTestCase):
     @require_vision
     def test_train_vlm(self, model_id):
         # Get the dataset
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_preference", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_preference", split="train")
 
         # Initialize the trainer
         training_args = DPOConfig(
@@ -1105,9 +1103,7 @@ class TestDPOTrainer(TrlTestCase):
     @pytest.mark.skip(reason="Model google/gemma-3n-E2B-it is gated and requires HF token")
     def test_train_vlm_gemma_3n(self):
         # Get the dataset
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_preference", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_preference", split="train")
 
         # Initialize the trainer
         training_args = DPOConfig(

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1728,9 +1728,7 @@ class TestGRPOTrainer(TrlTestCase):
     )
     @require_vision
     def test_training_vlm(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1781,9 +1779,7 @@ class TestGRPOTrainer(TrlTestCase):
     )
     @require_vision
     def test_training_vlm_beta_non_zero(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1832,9 +1828,7 @@ class TestGRPOTrainer(TrlTestCase):
     def test_training_vlm_peft(self, model_id):
         model = AutoModelForImageTextToText.from_pretrained(model_id, dtype="float32")
         base_param_names = [f"base_model.model.{n}" for n, _ in model.named_parameters()]
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1878,9 +1872,7 @@ class TestGRPOTrainer(TrlTestCase):
     )
     @require_vision
     def test_training_vlm_and_importance_sampling(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1927,9 +1919,7 @@ class TestGRPOTrainer(TrlTestCase):
     @require_vision
     @require_liger_kernel
     def test_training_vlm_and_liger(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1978,9 +1968,7 @@ class TestGRPOTrainer(TrlTestCase):
     @require_vllm
     @pytest.mark.skip(reason="We should add a mock for the vLLM server.")
     def test_training_vlm_and_vllm(self, model_id) -> None:
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1200,9 +1200,7 @@ class TestRLOOTrainer(TrlTestCase):
     )
     @require_vision
     def test_training_vlm(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1252,9 +1250,7 @@ class TestRLOOTrainer(TrlTestCase):
     )
     @require_vision
     def test_training_vlm_beta_non_zero(self, model_id):
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1303,9 +1299,7 @@ class TestRLOOTrainer(TrlTestCase):
     def test_training_vlm_peft(self, model_id):
         model = AutoModelForImageTextToText.from_pretrained(model_id, dtype="float32")
         base_param_names = [f"base_model.model.{n}" for n, _ in model.named_parameters()]
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""
@@ -1352,9 +1346,7 @@ class TestRLOOTrainer(TrlTestCase):
     @require_vllm
     @pytest.mark.skip(reason="We should add a mock for the vLLM server.")
     def test_training_vlm_and_vllm(self, model_id) -> None:
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_only", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
             """Reward function that rewards longer completions."""

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1548,9 +1548,7 @@ class TestSFTTrainer(TrlTestCase):
     @require_vision
     def test_train_vlm(self, model_id):
         # Get the dataset
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_language_modeling", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")
 
         # Initialize the trainer
         training_args = SFTConfig(
@@ -1643,9 +1641,7 @@ class TestSFTTrainer(TrlTestCase):
     @require_vision
     def test_train_vlm_prompt_completion(self, model_id):
         # Get the dataset
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_prompt_completion", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_completion", split="train")
 
         # Initialize the trainer
         training_args = SFTConfig(
@@ -1681,9 +1677,7 @@ class TestSFTTrainer(TrlTestCase):
     @pytest.mark.skip(reason="Model google/gemma-3n-E2B-it is gated and requires HF token")
     def test_train_vlm_gemma_3n(self):
         # Get the dataset
-        dataset = load_dataset(
-            "trl-internal-testing/zen-image", "conversational_language_modeling", split="train"
-        )
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")
 
         # Initialize the trainer
         training_args = SFTConfig(


### PR DESCRIPTION
In TRL, we support both an `image` column (containing a single image) and an `images` column (containing a list of images).

Before this PR, `SFTTrainer` would ignore the `image` column because it was not included in the trainer’s signature. This PR fixes that issue.

I also suggest that for the `zen-image` dataset, we use an `image` column that directly contains the image, rather than a list with a single element. The list-based format is already covered and tested by the `zen-multi-image` dataset.
