### PR TITLE
Fix NameError: name 'importlib' is not defined

### DIFF
--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import importlib
+import importlib.metadata
+import importlib.util
 import warnings
 from contextlib import contextmanager
 


### PR DESCRIPTION
Fix NameError: name 'importlib' is not defined:
- Add missing import

This PR adds a missing import to:
- #5129

after the merge of:
- #5128

This fixes a NameError: https://github.com/huggingface/trl/actions/runs/22217444591/job/64264358469
> NameError: name 'importlib' is not defined