### PR TITLE
Fix type of TrainingArguments.logging_steps in docs

### DIFF
--- a/trl/trainer/base_config.py
+++ b/trl/trainer/base_config.py
@@ -51,7 +51,7 @@ class BaseConfig(TrainingArguments):
     """
 
     # Override fields from TrainingArguments to set defaults preferred by all TRL trainers.
-    logging_steps: int | float = field(
+    logging_steps: float = field(
         default=10,
         metadata={
             "help": "Log every X updates steps. Should be an integer or a float in range `[0,1)`. If smaller than 1, "


### PR DESCRIPTION
Fix type of `TrainingArguments.logging_steps` in docs.

This PR makes a minor update to the `BaseConfig` class, so `logging_steps` parameter is documented to accept both integers and floats, rather than only floats.