### PR TITLE
Fix PPOTrainer.save_model

### DIFF
--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -584,20 +584,18 @@ class PPOTrainer(BaseTrainer):
                 self.model.policy.set_adapter(self.model_adapter_name or "default")
 
     def save_model(self, output_dir: str | None = None, _internal_call: bool = False):
-        if not _internal_call:
-            backup_model = self.model
-            if hasattr(self.model, "policy"):
-                self.model = self.model.policy  # save only the policy for inference
-            if self.is_deepspeed_enabled:
-                backup_deepspeed = self.deepspeed
-                self.deepspeed = self.model
+        backup_model = self.model
+        if hasattr(self.model, "policy"):
+            self.model = self.model.policy  # save only the policy for inference
+        if self.is_deepspeed_enabled:
+            backup_deepspeed = self.deepspeed
+            self.deepspeed = self.model
 
         super().save_model(output_dir, _internal_call)
 
-        if not _internal_call:
-            self.model = backup_model
-            if self.is_deepspeed_enabled:
-                self.deepspeed = backup_deepspeed
+        self.model = backup_model
+        if self.is_deepspeed_enabled:
+            self.deepspeed = backup_deepspeed
 
     def train(self):
         args = self.args


### PR DESCRIPTION
Fix PPOTrainer.save_model.

This PR makes a fix to the `save_model` method in `PPOTrainer`. The change removes the conditional check for `_internal_call`, ensuring that model backup and restoration logic always runs, regardless of how the method is called.

Fix #5150, fix #3301.

Reverts a change introduced in:
- #4431