### PR TITLE
Accept mm_token_type_ids in GRPO/RLOO _get_per_token_logps_and_entropies

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1027,6 +1027,7 @@ class GRPOTrainer(BaseTrainer):
         pixel_attention_mask=None,
         image_sizes=None,
         token_type_ids=None,
+        mm_token_type_ids=None,
     ) -> dict[str, torch.Tensor | None]:
         """Compute log-probs and (optionally) entropies for each token."""
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
@@ -1056,6 +1057,8 @@ class GRPOTrainer(BaseTrainer):
                 model_inputs["image_sizes"] = image_sizes[start : start + batch_size]
             if token_type_ids is not None:
                 model_inputs["token_type_ids"] = token_type_ids[start : start + batch_size]
+            if mm_token_type_ids is not None:
+                model_inputs["mm_token_type_ids"] = mm_token_type_ids[start : start + batch_size]
 
             # Only add logits_to_keep if the model supports it
             if "logits_to_keep" in self.model_kwarg_keys:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -696,6 +696,7 @@ class RLOOTrainer(BaseTrainer):
         pixel_attention_mask=None,
         image_sizes=None,
         token_type_ids=None,
+        mm_token_type_ids=None,
     ) -> dict[str, torch.Tensor | None]:
         """Compute log-probs and (optionally) entropies for each token."""
         batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
@@ -725,6 +726,8 @@ class RLOOTrainer(BaseTrainer):
                 model_inputs["image_sizes"] = image_sizes[start : start + batch_size]
             if token_type_ids is not None:
                 model_inputs["token_type_ids"] = token_type_ids[start : start + batch_size]
+            if mm_token_type_ids is not None:
+                model_inputs["mm_token_type_ids"] = mm_token_type_ids[start : start + batch_size]
 
             # Only add logits_to_keep if the model supports it
             if "logits_to_keep" in self.model_kwarg_keys:


### PR DESCRIPTION
Accept mm_token_type_ids in GRPO/RLOO _get_per_token_logps_and_entropies.

Fix #5175.

This PR updates the `_get_per_token_logps_and_entropies` method in both GRPO and RLOO trainers to support an additional input argument, `mm_token_type_ids`. This allows the trainers to handle models that require multimodal token type IDs, improving compatibility with multimodal architectures.

### Changes

**Multimodal token type ID support:**

* Added an optional `mm_token_type_ids` argument to the `_get_per_token_logps_and_entropies` method signatures in both `trl/trainer/grpo_trainer.py` and `trl/trainer/rloo_trainer.py`.
* Updated the batching logic within `_get_per_token_logps_and_entropies` to include `mm_token_type_ids` in the `model_inputs` dictionary when provided, ensuring correct slicing and passing to the model.