### PR TITLE
Fix deprecation warning of create_reference_model

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -20,7 +20,7 @@ from transformers.utils import is_peft_available
 
 from trl.experimental.nash_md import NashMDConfig, NashMDTrainer
 from trl.experimental.nash_md.nash_md_trainer import GeometricMixtureWrapper
-from trl.models.utils import create_reference_model
+from trl.experimental.utils import create_reference_model
 
 from ..testing_utils import TrlTestCase, require_llm_blender, require_peft
 from .testing_utils import RandomPairwiseJudge


### PR DESCRIPTION
Fix deprecation warning of create_reference_model by importing it from `trl.experimental.utils`.

### Problem
Tests in `TestGeometricMixtureWrapper` are emitting a deprecation warning: https://github.com/huggingface/trl/actions/runs/22392043979/job/64816242910
> The `create_reference_model` function is now located in `trl.experimental.utils`. Please update your imports to `from trl.experimental.utils import create_reference_model`. This import path will be removed in TRL 1.0.0.

```python
  tests/experimental/test_nash_md_trainer.py::TestGeometricMixtureWrapper::test_forward
  tests/experimental/test_nash_md_trainer.py::TestGeometricMixtureWrapper::test_mixture_coefficient
  tests/experimental/test_nash_md_trainer.py::TestGeometricMixtureWrapper::test_prepare_inputs_for_generation
    /__w/trl/trl/tests/experimental/test_nash_md_trainer.py:38: FutureWarning: The `create_reference_model` function is now located in `trl.experimental.utils`. Please update your imports to `from trl.experimental.utils import create_reference_model`. This import path will be removed in TRL 1.0.0.
      self.ref_model = create_reference_model(self.model).to(self.device)
```

### Solution
Update the imports to:
```python
from trl.experimental.utils import create_reference_model
```