### PR TITLE
Fix deprecation warning of fork in multi-threaded process

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocess
 import pytest
 import torch
 from datasets import load_dataset
@@ -98,6 +99,11 @@ class TestKTOTrainer(TrlTestCase):
             )
 
     def test_tokenize_and_process_tokens(self):
+        # Pytest/CI often starts background threads before tests run. Under Python 3.12+,
+        # using "fork" in a multi-threaded process emits a DeprecationWarning and may deadlock.
+        # Force "spawn" to keep this multiprocessing test safe while still exercising `num_proc=2`.
+        multiprocess.set_start_method("spawn", force=True)
+
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,


### PR DESCRIPTION
Fix deprecation warning of fork in multi-threaded process:
- Force spawn multiprocess start method in KTO test

Related to:
- #5036

### Problem
Tests for KTO `test_tokenize_and_process_tokens` are emitting a deprecation warning: https://github.com/huggingface/trl/actions/runs/22392043979/job/64816242910
> This process (pid=884) is multi-threaded, use of fork() may lead to deadlocks in the child.

```python
  tests/experimental/test_kto_trainer.py::TestKTOTrainer::test_tokenize_and_process_tokens
  tests/experimental/test_kto_trainer.py::TestKTOTrainer::test_tokenize_and_process_tokens
  tests/experimental/test_kto_trainer.py::TestKTOTrainer::test_tokenize_and_process_tokens
    /__w/trl/trl/.venv/lib/python3.13/site-packages/multiprocess/popen_fork.py:67: DeprecationWarning: This process (pid=884) is multi-threaded, use of fork() may lead to deadlocks in the child.
      self.pid = os.fork()
```

### Solution
Force "spawn" as multiprocessing start method for these tests.