### PR TITLE
Fix CI tests patching BaseTrainer

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -812,7 +812,7 @@ class TestSFTTrainer(TrlTestCase):
             "attention_mask": torch.tensor([[1, 1, 1, 1, 1]]),
         }
 
-        with patch("trl.trainer.sft_trainer.BaseTrainer.compute_loss", side_effect=mock_super_compute_loss):
+        with patch("transformers.Trainer.compute_loss", side_effect=mock_super_compute_loss):
             trainer.compute_loss(trainer.model, inputs)
 
         assert captured["skip_logits"] is True
@@ -846,7 +846,7 @@ class TestSFTTrainer(TrlTestCase):
             dummy_outputs = (dummy_loss, torch.randn(1, 5, trainer.model.config.vocab_size))
             return (dummy_loss, dummy_outputs)
 
-        with patch("trl.trainer.sft_trainer.BaseTrainer.compute_loss", side_effect=mock_super_compute_loss):
+        with patch("transformers.Trainer.compute_loss", side_effect=mock_super_compute_loss):
             trainer.predict(trainer.train_dataset)
 
         assert captured["skip_logits"] is False


### PR DESCRIPTION
Fix CI tests patching BaseTrainer.

Fix issue introduced by:
- #5169

This PR fixes the test mocks in SFT to patch the correct class for `compute_loss`. The patch target is changed from `trl.trainer.sft_trainer.BaseTrainer` to `transformers.Trainer`, ensuring that the tests correctly intercept calls to the method in the actual base class being used.

Test improvements:

* Fixed the patch target in two test cases to mock `compute_loss` on `transformers.Trainer` instead of `trl.trainer.sft_trainer.BaseTrainer`, ensuring compatibility with the current class hierarchy.