### PR TITLE
Simplify logic for structured outputs across vLLM versions

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -687,13 +687,11 @@ class VLLMGeneration:
                         f"Both `structured_outputs_regex` and `generation_kwargs['{structured_outputs_key}']` are set; "
                         "`structured_outputs_regex` takes precedence."
                     )
-                structured_outputs = StructuredOutputsParams(regex=self.structured_outputs_regex)
-            elif isinstance(generation_kwargs.get(structured_outputs_key), dict):
-                structured_outputs_dict = generation_kwargs.get(structured_outputs_key)
-                structured_outputs = StructuredOutputsParams(**structured_outputs_dict)
-            else:
-                structured_outputs = generation_kwargs.get(structured_outputs_key)
-            generation_kwargs[structured_outputs_key] = structured_outputs
+                generation_kwargs[structured_outputs_key] = StructuredOutputsParams(
+                    regex=self.structured_outputs_regex
+                )
+            elif isinstance(structured_outputs_kwargs := generation_kwargs.get(structured_outputs_key), dict):
+                generation_kwargs[structured_outputs_key] = StructuredOutputsParams(**structured_outputs_kwargs)
             sampling_params = SamplingParams(**generation_kwargs)
 
             if self.tensor_parallel_size > 1:


### PR DESCRIPTION
Simplify logic for structured outputs across vLLM versions.

This PR refactors the handling of structured output parameters for vLLM generation to improve compatibility across different vLLM versions and simplify the logic for setting structured output options. The main changes focus on unifying the way structured output parameters are imported and used, and on reducing code duplication related to vLLM version checks.

**vLLM structured output handling improvements:**

* Unified import and usage of `StructuredOutputsParams` and its key in `generation_kwargs` based on the vLLM version, ensuring compatibility with both pre- and post-0.10.2 versions.
* Refactored logic for setting the structured output parameter in `generation_kwargs`, removing duplicated version checks and using a single `structured_outputs_key` variable for consistency.

**Code cleanup:**

* Removed redundant imports of vLLM components and version checks from the top-level scope, moving them to where they are needed in the code.
* Updated imports to include `LLM`, `RequestOutput`, and `SamplingParams` only when vLLM is available, improving import hygiene.