### PR TITLE
Sync entire prompt/completion token tensors before indexing

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1320,13 +1320,11 @@ class GRPOTrainer(_BaseTrainer):
             eos_idx[is_eos.any(dim=1)] = is_eos.int().argmax(dim=1)[is_eos.any(dim=1)]
             sequence_indices = torch.arange(is_eos.size(1), device=device).expand(is_eos.size(0), -1)
             completion_mask = (sequence_indices <= eos_idx.unsqueeze(1)).int()
-            # It's important to move the whole tensor from GPU->CPU before per-element boolean indexing + .tolist().
-            # Each p[m].tolist() on a CUDA tensor triggers a sync; this can be significant if batch size is large 
-            # or if there is a lot of contention for throughput (e.g, multiple processes)
-            p_cpu, pm_cpu = prompt_ids.cpu(), prompt_mask.bool().cpu()
-            prompt_ids = [p[m].tolist() for p, m in zip(p_cpu, pm_cpu, strict=True)]
-            c_cpu, cm_cpu = completion_ids.cpu(), completion_mask.bool().cpu()
-            completion_ids = [c[m].tolist() for c, m in zip(c_cpu, cm_cpu, strict=True)]
+            # Move tensors to CPU before per-sample to avoid many CUDA syncs/copies (costly at scale/contention).
+            prompt_ids = [p[m].tolist() for p, m in zip(prompt_ids.cpu(), prompt_mask.bool().cpu(), strict=True)]
+            completion_ids = [
+                c[m].tolist() for c, m in zip(completion_ids.cpu(), completion_mask.bool().cpu(), strict=True)
+            ]
             logprobs = None  # not used in this case
             extra_fields = {}  # No extra fields for non-rollout_func paths
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -982,8 +982,11 @@ class RLOOTrainer(_BaseTrainer):
             eos_idx[is_eos.any(dim=1)] = is_eos.int().argmax(dim=1)[is_eos.any(dim=1)]
             sequence_indices = torch.arange(is_eos.size(1), device=device).expand(is_eos.size(0), -1)
             completion_mask = (sequence_indices <= eos_idx.unsqueeze(1)).int()
-            prompt_ids = [p[m].tolist() for p, m in zip(prompt_ids, prompt_mask.bool(), strict=True)]
-            completion_ids = [c[m].tolist() for c, m in zip(completion_ids, completion_mask.bool(), strict=True)]
+            # Move tensors to CPU before per-sample to avoid many CUDA syncs/copies (costly at scale/contention).
+            prompt_ids = [p[m].tolist() for p, m in zip(prompt_ids.cpu(), prompt_mask.bool().cpu(), strict=True)]
+            completion_ids = [
+                c[m].tolist() for c, m in zip(completion_ids.cpu(), completion_mask.bool().cpu(), strict=True)
+            ]
 
         return prompt_ids, completion_ids
 


### PR DESCRIPTION
Relatively self-explanatory, details in comment.
Previously the behavior was to sync every iteration in a Python loop, causing excess CUDA syncs needlessly.

This is not a logical change, just an optimization.

Not sure how to make this change more robust than just this comment. Performance unit tests seem a little bit unstable.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [n/a?] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization that only changes where tensors are moved to CPU before Python-side indexing; primary risk is an unexpected memory/latency tradeoff from earlier host transfers.
> 
> **Overview**
> Reduces overhead in `GRPOTrainer` and `RLOOTrainer` generation by moving `prompt_ids`/`completion_ids` (and their masks) to CPU once before per-sample boolean indexing and `tolist()` conversion.
> 
> This avoids many repeated CUDA synchronizations/copies in the Python loop when extracting variable-length prompt/completion token lists, with no intended change to the resulting token sequences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 501b4a965b385b9a44669555b6c9aac5ff9c79f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->