### PR TITLE
Refactor CLI [11/N]: Refactor scripts/vllm_serve with delayed imports

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -24,60 +24,6 @@ from itertools import chain
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 
-import torch
-import torch.distributed.distributed_c10d as c10d
-from packaging.version import Version
-from transformers import is_torch_xpu_available, is_vision_available
-
-from trl import TrlParser
-from trl.generation.vllm_generation import extract_logprobs
-from trl.import_utils import (
-    is_fastapi_available,
-    is_pydantic_available,
-    is_uvicorn_available,
-    is_vllm_ascend_available,
-    is_vllm_available,
-)
-
-
-if is_fastapi_available():
-    from fastapi import FastAPI
-
-
-if is_pydantic_available():
-    from pydantic import BaseModel
-
-
-if is_uvicorn_available():
-    import uvicorn
-
-
-if is_vision_available():
-    from PIL import Image
-
-
-if is_vllm_available():
-    import vllm
-    from vllm import LLM, SamplingParams
-    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
-    from vllm.distributed.parallel_state import get_world_group
-    from vllm.distributed.utils import StatelessProcessGroup
-
-    if Version(vllm.__version__) <= Version("0.11.0"):
-        from vllm.utils import get_open_port
-    else:
-        from vllm.utils.network_utils import get_open_port
-
-    if Version(vllm.__version__) <= Version("0.10.2"):
-        from vllm.sampling_params import GuidedDecodingParams
-    else:
-        from vllm.sampling_params import StructuredOutputsParams
-
-    if is_vllm_ascend_available():
-        from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator
-
-
-logger = logging.getLogger(__name__)
 
 # We use CUDA with multiprocessing, so we must use the 'spawn' start method. Otherwise, we will get the following
 # error: RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use
@@ -117,6 +63,18 @@ class WeightSyncWorkerExtension:
                 UUID of the device of client main process. Used to assert that devices are different from vllm workers
                 devices.
         """
+        import torch
+        import torch.distributed.distributed_c10d as c10d
+        from transformers import is_torch_xpu_available
+        from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+        from vllm.distributed.parallel_state import get_world_group
+        from vllm.distributed.utils import StatelessProcessGroup
+
+        from trl.import_utils import is_vllm_ascend_available
+
+        if is_vllm_ascend_available():
+            from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator
+
         if self.communicator is not None:
             raise RuntimeError("Weight update group already initialized. Call close_communicator first.")
 
@@ -166,6 +124,9 @@ class WeightSyncWorkerExtension:
             shape (`Sequence[int]`):
                 Shape of the weight tensor.
         """
+        import torch
+        from transformers import is_torch_xpu_available
+
         if self.communicator is None:
             raise RuntimeError("Communicator not initialized. Call `init_communicator` first.")
 
@@ -349,6 +310,8 @@ class ScriptArguments:
 def llm_worker(
     script_args: ScriptArguments, data_parallel_rank: int, master_port: int, connection: Connection
 ) -> None:
+    from vllm import LLM
+
     # Set required environment variables for DP to work with vLLM
     os.environ["VLLM_DP_RANK"] = str(data_parallel_rank)
     os.environ["VLLM_DP_RANK_LOCAL"] = str(data_parallel_rank)
@@ -419,6 +382,17 @@ def chunk_list(lst: list, n: int) -> list[list]:
 
 
 def main(script_args: ScriptArguments):
+    from packaging.version import Version
+    from transformers import is_vision_available
+
+    from trl.generation.vllm_generation import extract_logprobs
+    from trl.import_utils import (
+        is_fastapi_available,
+        is_pydantic_available,
+        is_uvicorn_available,
+        is_vllm_available,
+    )
+
     if not is_fastapi_available():
         raise ImportError(
             "FastAPI is required to run the vLLM serve script. Please install it using `pip install fastapi`."
@@ -436,6 +410,27 @@ def main(script_args: ScriptArguments):
 
     if not is_vllm_available():
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
+
+    import uvicorn
+    import vllm
+    from fastapi import FastAPI
+    from pydantic import BaseModel
+    from vllm import SamplingParams
+
+    if Version(vllm.__version__) <= Version("0.11.0"):
+        from vllm.utils import get_open_port
+    else:
+        from vllm.utils.network_utils import get_open_port
+
+    if Version(vllm.__version__) <= Version("0.10.2"):
+        from vllm.sampling_params import GuidedDecodingParams
+    else:
+        from vllm.sampling_params import StructuredOutputsParams
+
+    if is_vision_available():
+        from PIL import Image
+
+    logger = logging.getLogger(__name__)
 
     # Spawn dp workers, and setup pipes for communication
     master_port = get_open_port()
@@ -920,6 +915,8 @@ def main(script_args: ScriptArguments):
 
 
 def make_parser(subparsers: argparse._SubParsersAction | None = None):
+    from trl import TrlParser
+
     if subparsers is not None:
         parser = subparsers.add_parser("vllm-serve", help="Run the vLLM serve script", dataclass_types=ScriptArguments)
     else:


### PR DESCRIPTION
Refactor scripts/vllm_serve with delayed imports.

This PR refactors the import logic in `trl/scripts/vllm_serve.py` to defer many imports until they are needed inside functions, rather than importing them at the top of the file. This change improves the script's startup performance and reduces unnecessary dependencies when certain features are not used. The main structure and functionality of the script remain unchanged.

**Refactoring imports for efficiency and conditional dependency loading:**

* Moved imports for `torch`, `transformers`, `vllm`, and related distributed communication modules inside their respective functions (`init_communicator`, `update_named_param`, `llm_worker`, and `main`) to ensure they are only loaded when necessary.
* Deferred imports for FastAPI, Pydantic, Uvicorn, PIL, and version-dependent vLLM utilities into the `main` function, reducing top-level dependencies and allowing for more flexible execution environments. 
* Moved the import of `TrlParser` inside the `make_parser` function for more targeted usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no intended behavioral changes; main risk is missing/incorrect deferred imports causing runtime errors when specific endpoints or hardware backends are exercised.
> 
> **Overview**
> Refactors `trl/scripts/vllm_serve.py` to **delay imports of heavy and optional dependencies** (e.g., `torch`, `vllm`, distributed comms, `fastapi`/`pydantic`/`uvicorn`, PIL) into `main()`, `llm_worker()`, and `WeightSyncWorkerExtension` methods.
> 
> This keeps the serving behavior the same while making the module cheaper to import and allowing environments without these extras to load the CLI wiring until the command is actually executed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7329ef430cf2fa8c45efb4e41d6c605c372acf8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->