### PR TITLE
feat: log raw importance ratios and fraction of truncation/masking in vLLM importance sampling correction

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -190,6 +190,10 @@ While training and evaluating, we record the following reward metrics:
 - `clip_ratio/low_min`: The minimum ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
 - `clip_ratio/high_mean`: The average ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
 - `clip_ratio/high_max`: The maximum ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
+- `sampling/frac_modified_importance_sampling_ratio`: The fraction of tokens or sequences for which the vLLM importance sampling ratio was clipped or masked due to exceeding the `vllm_importance_sampling_cap` threshold.
+- `sampling/importance_sampling_ratio/max,mean,min`: The maximum, mean, and minimum values of the vLLM importance sampling ratio after clipping or masking due to exceeding the `vllm_importance_sampling_cap` threshold.
+- `sampling/raw_importance_sampling_ratio/max,mean,min`: The maximum, mean, and minimum values of the vLLM importance sampling ratio before clipping or masking due to exceeding the `vllm_importance_sampling_cap` threshold.
+- `sampling/sampling_logp_difference/max,mean`: The maximum and mean values of the absolute difference between the log probabilities of generated tokens under the training model and the vLLM inference model.
 
 ## Customization
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1998,9 +1998,14 @@ class GRPOTrainer(_BaseTrainer):
             self._metrics[mode]["sampling/raw_importance_sampling_ratio/max"].append(
                 nanmax(self.accelerator.gather(max_raw_importance_sampling_ratio)).item()
             )
+            num_modified_is_ratios = (
+                self.accelerator.gather(torch.tensor((flat_is_ratio != raw_flat_is_ratio).sum(), device=device))
+                .sum()
+                .item()
+            )
+            num_is_ratios = self.accelerator.gather(torch.tensor(flat_is_ratio.numel(), device=device)).sum().item()
             self._metrics[mode]["sampling/frac_modified_importance_sampling_ratio"].append(
-                self.accelerator.gather(torch.ne(flat_is_ratio, raw_flat_is_ratio).float().sum()).sum().item()
-                / self.accelerator.gather(torch.tensor(flat_is_ratio.numel(), device=device)).sum().item()
+                num_modified_is_ratios / num_is_ratios if num_is_ratios > 0 else 0.0
             )
 
         output = {

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1798,7 +1798,7 @@ class GRPOTrainer(_BaseTrainer):
                 else:
                     logps_diff = per_token_logps_diff
 
-                vllm_importance_sampling_ratio = torch.exp(logps_diff)
+                raw_vllm_importance_sampling_ratio = torch.exp(logps_diff)
 
                 # vllm_importance_sampling_ratio.shape:
                 #   token_* modes:     (B, T)  (per-token ratio)
@@ -1806,11 +1806,11 @@ class GRPOTrainer(_BaseTrainer):
 
                 if self.vllm_importance_sampling_mode in ["sequence_truncate", "token_truncate"]:
                     vllm_importance_sampling_ratio = torch.clamp(
-                        vllm_importance_sampling_ratio, max=self.vllm_importance_sampling_cap
+                        raw_vllm_importance_sampling_ratio, max=self.vllm_importance_sampling_cap
                     )
                 elif self.vllm_importance_sampling_mode in ["sequence_mask", "token_mask"]:
-                    vllm_importance_sampling_ratio = vllm_importance_sampling_ratio.masked_fill(
-                        vllm_importance_sampling_ratio > self.vllm_importance_sampling_cap, value=0.0
+                    vllm_importance_sampling_ratio = raw_vllm_importance_sampling_ratio.masked_fill(
+                        raw_vllm_importance_sampling_ratio > self.vllm_importance_sampling_cap, value=0.0
                     )
                 else:
                     raise ValueError(
@@ -1954,9 +1954,12 @@ class GRPOTrainer(_BaseTrainer):
             )
             if sequence_level_is:
                 flat_is_ratio = vllm_importance_sampling_ratio.flatten()
+                raw_flat_is_ratio = raw_vllm_importance_sampling_ratio.flatten()
             else:
                 flat_is_ratio = vllm_importance_sampling_ratio[mask]
+                raw_flat_is_ratio = raw_vllm_importance_sampling_ratio[mask]
 
+            # Stats related to importance sampling ratio after masking/truncation
             min_importance_sampling_ratio = (
                 torch.min(flat_is_ratio) if flat_is_ratio.numel() > 0 else torch.tensor(0.0, device=device)
             )
@@ -1974,6 +1977,29 @@ class GRPOTrainer(_BaseTrainer):
             )
             self._metrics[mode]["sampling/importance_sampling_ratio/max"].append(
                 nanmax(self.accelerator.gather(max_importance_sampling_ratio)).item()
+            )
+
+            # Stats related to importance sampling ratio before masking/truncation
+            min_raw_importance_sampling_ratio = (
+                torch.min(raw_flat_is_ratio) if raw_flat_is_ratio.numel() > 0 else torch.tensor(0.0, device=device)
+            )
+            mean_raw_importance_sampling_ratio = (
+                torch.mean(raw_flat_is_ratio) if raw_flat_is_ratio.numel() > 0 else torch.tensor(0.0, device=device)
+            )
+            max_raw_importance_sampling_ratio = (
+                torch.max(raw_flat_is_ratio) if raw_flat_is_ratio.numel() > 0 else torch.tensor(0.0, device=device)
+            )
+            self._metrics[mode]["sampling/raw_importance_sampling_ratio/min"].append(
+                nanmin(self.accelerator.gather(min_raw_importance_sampling_ratio)).item()
+            )
+            self._metrics[mode]["sampling/raw_importance_sampling_ratio/mean"].append(
+                self.accelerator.gather(mean_raw_importance_sampling_ratio).nanmean().item()
+            )
+            self._metrics[mode]["sampling/raw_importance_sampling_ratio/max"].append(
+                nanmax(self.accelerator.gather(max_raw_importance_sampling_ratio)).item()
+            )
+            self._metrics[mode]["sampling/frac_modified_importance_sampling_ratio"].append(
+                self.accelerator.gather(torch.ne(flat_is_ratio, raw_flat_is_ratio).float().mean()).item()
             )
 
         output = {

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1999,7 +1999,8 @@ class GRPOTrainer(_BaseTrainer):
                 nanmax(self.accelerator.gather(max_raw_importance_sampling_ratio)).item()
             )
             self._metrics[mode]["sampling/frac_modified_importance_sampling_ratio"].append(
-                self.accelerator.gather(torch.ne(flat_is_ratio, raw_flat_is_ratio).float().mean()).item()
+                self.accelerator.gather(torch.ne(flat_is_ratio, raw_flat_is_ratio).float().sum()).sum().item()
+                / self.accelerator.gather(torch.tensor(flat_is_ratio.numel(), device=device)).sum().item()
             )
 
         output = {


### PR DESCRIPTION
# What does this PR do?

Resolves #5231 

This PR adds new logged metrics:
- `sampling/raw_importance_sampling_ratio/{min,max,mean}`
  - These are the same with existing `sampling/importance_sampling_ratio/{min,max,mean}` except being computed with values before truncation or masking.
- `sampling/frac_modified_importance_sampling_ratio`
  - This is the fraction of importance sampling ratio values that are either truncated or masked.


I ran the following code to verify the output:

```python
import argparse

from datasets import load_dataset
from trl import GRPOConfig, GRPOTrainer
from trl.rewards import accuracy_reward


parser = argparse.ArgumentParser()
parser.add_argument("--vllm_importance_sampling_mode", type=str, default="sequence_mask")
args = parser.parse_args()

dataset = load_dataset("trl-lib/DeepMath-103K", split="train[:5]")

args = GRPOConfig(
    output_dir=f"outputs/{args.vllm_importance_sampling_mode}",
    vllm_importance_sampling_correction=True,
    vllm_importance_sampling_mode=args.vllm_importance_sampling_mode,
    vllm_importance_sampling_cap=1.2,
    use_vllm=True,
    vllm_mode="colocate",
    max_steps=5,
    num_train_epochs=1,
    logging_steps=1,
    save_strategy="no",
    report_to="tensorboard",
)

trainer = GRPOTrainer(
    args=args,
    model="Qwen/Qwen2-0.5B-Instruct",
    reward_funcs=accuracy_reward,
    train_dataset=dataset,
)
trainer.train()
```

```
uv run --no-sync accelerate launch --num_processes 1 train_grpo_example.py --vllm_importance_sampling_mode token_truncate
uv run --no-sync accelerate launch --num_processes 1 train_grpo_example.py --vllm_importance_sampling_mode token_mask
uv run --no-sync accelerate launch --num_processes 1 train_grpo_example.py --vllm_importance_sampling_mode sequence_truncate
uv run --no-sync accelerate launch --num_processes 1 train_grpo_example.py --vllm_importance_sampling_mode sequence_mask
```

From the tensorboard records, you can see:
- The new metrics are all recorded.
- `sampling/raw_importance_sampling_ratio/max` are higher than the cap value of 1.2, while `sampling/importance_sampling_ratio/max` is upper bounded by it, which is expected as the latter are affected by truncation or masking. Masking leads to lower values than truncation, which is also expected.
- `sampling/frac_modified_importance_sampling_ratio` is higher with sequence-level IS than with token-level IS.

<img width="3612" height="2106" alt="Screenshot 2026-03-09 at 0 49 18" src="https://github.com/user-attachments/assets/07c9a42f-1624-47be-a7b9-454de64601fa" />

<img width="3600" height="2174" alt="Screenshot 2026-03-09 at 0 49 05" src="https://github.com/user-attachments/assets/ea2e08d8-e529-4bcc-af2e-6f94a5996ebe" />


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to additional metric logging around vLLM importance-sampling correction, without altering the loss or training behavior beyond minor extra tensor ops.
> 
> **Overview**
> Adds additional GRPO vLLM importance-sampling diagnostics by tracking the *raw* (pre-cap) importance sampling ratios alongside the existing capped/masked ratios.
> 
> `GRPOTrainer` now logs `sampling/raw_importance_sampling_ratio/{min,mean,max}` and `sampling/frac_modified_importance_sampling_ratio` (fraction of ratios changed by truncation/masking), and the GRPO docs are updated to list these new metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32a1746dcd83c9287e0eba2bac881dd7bc60fcb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->