### PR TITLE
fix(grpo): truncate tool_mask/logprobs when retokenisation shortens completion

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1485,9 +1485,17 @@ class GRPOTrainer(_BaseTrainer):
                 completion_length = len(completion_ids[idx_with_tool])
                 post_tool_length = len(post_tool_ids[idx])
                 tool_length = prompt_completion_tool_length - prompt_length - completion_length
-                tool_mask[idx_with_tool] += [0] * tool_length + [1] * post_tool_length
-                if logprobs is not None:
-                    logprobs[idx_with_tool] += [0.0] * tool_length + post_tool_logprobs[idx]
+                if tool_length >= 0:
+                    # Normal case: tool tokens (mask=0) follow the completion, then post-tool (mask=1)
+                    tool_mask[idx_with_tool] += [0] * tool_length + [1] * post_tool_length
+                    if logprobs is not None:
+                        logprobs[idx_with_tool] += [0.0] * tool_length + post_tool_logprobs[idx]
+                else:
+                    # Retokenisation produced a shorter sequence: trim the tail of tool_mask/logprobs
+                    # (tool_length is negative, so list[:tool_length] drops |tool_length| items from the end)
+                    tool_mask[idx_with_tool] = tool_mask[idx_with_tool][:tool_length] + [1] * post_tool_length
+                    if logprobs is not None:
+                        logprobs[idx_with_tool] = logprobs[idx_with_tool][:tool_length] + post_tool_logprobs[idx]
 
             # Update completion_ids with the new completions (after tool execution)
             for idx in range(len(idxs_with_tool)):


### PR DESCRIPTION
## Problem

In `GRPOTrainer._tool_call_loop`, when a tool-call round retokenises `prompt+completion+tool`, the resulting completion can be **shorter** than the previous one (`tool_length < 0`). In this case:

- `tool_mask` is only **appended** to (Python silently treats `list * negative = []`), so it grows by `post_tool_length` items.
- `completion_ids` is set to the shorter new sequence, shrinking accordingly.

The resulting length divergence causes a `RuntimeError` in `_compute_loss`:

```
RuntimeError: The size of tensor a (...) must match the size of tensor b (...) at non-singleton dimension 1
```

Reported in #5144.

## Fix

When `tool_length < 0`, trim the tail of `tool_mask` (and `logprobs` if present) by `|tool_length|` items before appending the post-tool tokens. This ensures `len(tool_mask) == len(completion_ids)` for every sample after each tool-call round.

```python
if tool_length >= 0:
    tool_mask[idx_with_tool] += [0] * tool_length + [1] * post_tool_length
    if logprobs is not None:
        logprobs[idx_with_tool] += [0.0] * tool_length + post_tool_logprobs[idx]
else:
    # list[:negative_index] trims |tool_length| items from the end
    tool_mask[idx_with_tool] = tool_mask[idx_with_tool][:tool_length] + [1] * post_tool_length
    if logprobs is not None:
        logprobs[idx_with_tool] = logprobs[idx_with_tool][:tool_length] + post_tool_logprobs[idx]
```

Fixes #5144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix in the tool-calling generation loop; main risk is an off-by-one/edge-case masking error when `tool_length` is negative.
> 
> **Overview**
> Fixes a length-mismatch bug in `GRPOTrainer._tool_call_loop` when retokenizing `prompt+completion+tool` produces a shorter sequence (`tool_length < 0`). Instead of only appending, the code now **truncates the tail of `tool_mask` (and `logprobs` when present) before adding post-tool tokens**, keeping these arrays aligned with the updated `completion_ids` and preventing downstream shape errors during loss computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b5726a4b2c7eee857eff5c90f577c22088f3664. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->