### PR TITLE
batch params together in weight sync and async update the weights

### DIFF
--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -511,6 +511,60 @@ class VLLMClient:
             self.communicator.broadcast(weights, src=self.rank)
             self.communicator.group.barrier()
 
+    def batch_update_named_params(self, params: list[tuple[str, torch.Tensor]], chunk_size: int | None = None):
+        """
+        Updates multiple named parameters in a single batch, reducing HTTP round-trips.
+
+        Sends parameter metadata via HTTP POST, then broadcasts each tensor via NCCL in sequence.
+        When chunk_size is set, splits params into chunks whose total element count doesn't exceed
+        the limit, avoiding large HTTP requests regardless of individual parameter sizes.
+
+        Args:
+            params: List of (name, weights_tensor) tuples.
+            chunk_size: Max total elements per HTTP call. None = all in one call. Use smaller
+                        values for large models to avoid HTTP request size limits.
+        """
+        if chunk_size is None:
+            chunks = [params]
+        else:
+            chunks = []
+            current_chunk = []
+            current_elements = 0
+            for name, weights in params:
+                n = weights.numel()
+                if current_chunk and current_elements + n > chunk_size:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_elements = 0
+                current_chunk.append((name, weights))
+                current_elements += n
+            if current_chunk:
+                chunks.append(current_chunk)
+
+        for chunk in chunks:
+            # Send metadata for this chunk
+            param_metadata = [
+                {"name": name, "dtype": str(weights.dtype), "shape": list(weights.shape)}
+                for name, weights in chunk
+            ]
+            url = f"{self.base_url}/batch_update_named_params/"
+            response = self.session.post(url, json={"params": param_metadata})
+            if response.status_code != 200:
+                raise Exception(f"Request failed: {response.status_code}, {response.text}")
+
+            # Broadcast each tensor via NCCL
+            for _name, weights in chunk:
+                if is_torch_xpu_available():
+                    self.communicator.broadcast(weights, root=self.rank)
+                else:
+                    self.communicator.broadcast(weights, src=self.rank)
+
+            # Barrier after each chunk
+            if is_torch_xpu_available():
+                self.communicator.barrier()
+            else:
+                self.communicator.group.barrier()
+
     def update_model_params(self, model: nn.Module):
         """
         Updates all parameters of the given model by calling `update_named_param` for each parameter in the model.

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -155,6 +155,10 @@ class VLLMGeneration:
         group_port (`int`, *optional*, defaults to `51216`):
             Port number for the weight update group. This is used to communicate with the vLLM server. Unless the port
             is occupied, there is no need to change it.
+        weight_sync_chunk_size (`int` or `None`, *optional*, defaults to `None`):
+            Maximum total tensor elements per HTTP request during batched weight sync to the vLLM server. `None`
+            (default) sends all parameters in a single request. Set to a smaller value (e.g. `100_000_000`) for
+            large models to avoid exceeding HTTP request size limits.
 
         > Parameters for "colocate" vLLM mode:
 
@@ -245,6 +249,7 @@ class VLLMGeneration:
         server_port: int = 8000,
         server_timeout: float = 240.0,
         group_port: int = 51216,
+        weight_sync_chunk_size: int | None = None,
         # Colocate mode configuration
         tensor_parallel_size: int = 1,
         gpu_memory_utilization: float = 0.9,
@@ -280,8 +285,9 @@ class VLLMGeneration:
         self.server_base_url = server_base_url
         self.server_host = server_host
         self.server_port = server_port
-        self.group_port = group_port
         self.server_timeout = server_timeout
+        self.group_port = group_port
+        self.weight_sync_chunk_size = weight_sync_chunk_size
 
         # Colocate mode configuration
         self.tensor_parallel_size = tensor_parallel_size
@@ -500,8 +506,20 @@ class VLLMGeneration:
                         self._sync_fsdp1_params_to_vllm(model)  # use memory-efficient post-order traversal for FSDP
                     elif fsdp_version == 2:
                         self._sync_fsdp2_params_to_vllm(model)
+                elif not zero_stage_3 and self.mode == "server" and accelerator.is_main_process:
+                    params = []
+                    for name, param in model.named_parameters():
+                        name = name.removeprefix("base_model.model.").replace(".base_layer", "")
+                        if model.prefix in name:
+                            continue
+                        if "original_module" in name:
+                            continue
+                        name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
+                        params.append((name, param.data))
+                    self.vllm_client.batch_update_named_params(params, chunk_size=self.weight_sync_chunk_size)
                 else:
                     # DeepSpeed ZeRO-3 with PEFT
+                    # ZeRO-3 gathers per-param so we can't easily batch sync them to vLLM
                     for name, param in model.named_parameters():
                         # When using PEFT, we need to recover the original parameter name
                         name = name.removeprefix("base_model.model.").replace(".base_layer", "")
@@ -530,6 +548,10 @@ class VLLMGeneration:
                     self._sync_fsdp1_params_to_vllm(model)  # use memory-efficient post-order traversal for FSDP
                 elif fsdp_version == 2:
                     self._sync_fsdp2_params_to_vllm(model)
+            elif not zero_stage_3 and self.mode == "server" and accelerator.is_main_process:
+                params = [(self._fix_param_name_to_vllm(name), param.data)
+                          for name, param in model.named_parameters()]
+                self.vllm_client.batch_update_named_params(params, chunk_size=self.weight_sync_chunk_size)
             else:
                 for name, param in model.named_parameters():
                     name = self._fix_param_name_to_vllm(name)

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import asyncio
 import base64
 import logging
 import os
@@ -184,6 +185,38 @@ class WeightSyncWorkerExtension:
 
         # Load the received weights into the model.
         self.model_runner.model.load_weights(weights=[(name, weight)])
+
+    def batch_update_named_params(self, params: list[tuple[str, str, tuple[int, ...]]]) -> None:
+        """
+        Receives and updates multiple named parameters in a single batch.
+        This avoids per-parameter HTTP round-trips. The client broadcasts each
+        parameter's tensor via NCCL in the same order as the params list.
+        Args:
+            params: List of (name, dtype, shape) tuples for each parameter.
+        """
+        if self.communicator is None:
+            raise RuntimeError("Communicator not initialized. Call `init_communicator` first.")
+
+        weights_to_load = []
+        for name, dtype_str, shape in params:
+            dtype = getattr(torch, dtype_str.split(".")[-1])
+            weight = torch.empty(shape, dtype=dtype, device=self.device)
+
+            if is_torch_xpu_available():
+                self.communicator.broadcast(weight, root=self.client_rank)
+            else:
+                self.communicator.broadcast(weight, src=self.client_rank)
+
+            weights_to_load.append((name, weight))
+
+        # Single barrier after all broadcasts
+        if is_torch_xpu_available():
+            self.communicator.barrier()
+        else:
+            self.communicator.group.barrier()
+
+        # Load all weights at once
+        self.model_runner.model.load_weights(weights=weights_to_load)
 
     def close_communicator(self) -> None:
         """
@@ -852,8 +885,9 @@ def main(script_args: ScriptArguments):
             "method": "init_communicator",
             "args": (request.host, request.port, world_size, request.client_device_uuid),
         }
-        for connection in connections:
-            connection.send({"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs})
+        msg = {"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs}
+        loop = asyncio.get_running_loop()
+        await asyncio.gather(*(loop.run_in_executor(None, conn.send, msg) for conn in connections))
 
         return {"message": "Request received, initializing communicator"}
 
@@ -880,10 +914,25 @@ def main(script_args: ScriptArguments):
         # So with collective_rpc we need to call it this way:
         # llm.collective_rpc("update_named_param", args=("name", "torch.float32", (10, 10)))
         kwargs = {"method": "update_named_param", "args": (request.name, request.dtype, tuple(request.shape))}
-        for connection in connections:
-            connection.send({"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs})
+        msg = {"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs}
+        loop = asyncio.get_running_loop()
+        await asyncio.gather(*(loop.run_in_executor(None, conn.send, msg) for conn in connections))
 
         return {"message": "Request received, updating named parameter"}
+
+    class BatchUpdateWeightsRequest(BaseModel):
+        params: list[dict]  # List of {"name": str, "dtype": str, "shape": list[int]}
+
+    @app.post("/batch_update_named_params/")
+    async def batch_update_named_params(request: BatchUpdateWeightsRequest):
+        """Batch update: sends all param metadata in one HTTP call, then NCCL broadcasts happen in sequence."""
+
+        params_list = [(p["name"], p["dtype"], tuple(p["shape"])) for p in request.params]
+        kwargs = {"method": "batch_update_named_params", "args": (params_list,)}
+        msg = {"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs}
+        loop = asyncio.get_running_loop()
+        await asyncio.gather(*(loop.run_in_executor(None, conn.send, msg) for conn in connections))
+        return {"message": f"Batch update started for {len(params_list)} parameters"}
 
     @app.post("/reset_prefix_cache/")
     async def reset_prefix_cache():

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -142,6 +142,10 @@ class GRPOConfig(_BaseConfig):
         vllm_group_port (`int`, *optional*, defaults to `51216`):
             Port number for the weight update group. This is used to communicate with the vLLM server. Unless the port
             is occupied, there is no need to change it.
+        vllm_weight_sync_chunk_size (`int` or `None`, *optional*, defaults to `None`):
+            Maximum number of total tensor elements per HTTP request during batched weight sync to the vLLM
+            server. `None` (default) sends all parameters in a single request. Set to a smaller value (e.g.
+            `500_000_000`) for large models to avoid exceeding HTTP request size limits.
 
         > Parameters that control colocated vLLM execution (only used when `vllm_mode` is `"colocate"`)
 
@@ -536,6 +540,14 @@ class GRPOConfig(_BaseConfig):
         metadata={
             "help": "Port number for the weight update group. This is used to communicate with the vLLM server. "
             "Unless the port is occupied, there is no need to change it.",
+        },
+    )
+    vllm_weight_sync_chunk_size: int | None = field(
+        default=None,
+        metadata={
+            "help": "Maximum total tensor elements per HTTP request during batched weight sync to the vLLM server. "
+            "None (default) sends all parameters in a single request. Set to a smaller value (e.g. 500_000_000) "
+            "for large models to avoid exceeding HTTP request size limits."
         },
     )
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -722,8 +722,9 @@ class GRPOTrainer(_BaseTrainer):
                 server_base_url=args.vllm_server_base_url,
                 server_host=args.vllm_server_host,
                 server_port=args.vllm_server_port,
-                group_port=args.vllm_group_port,
                 server_timeout=args.vllm_server_timeout,
+                group_port=args.vllm_group_port,
+                weight_sync_chunk_size=args.vllm_weight_sync_chunk_size,
                 # Colocate mode configuration
                 tensor_parallel_size=args.vllm_tensor_parallel_size,
                 gpu_memory_utilization=args.vllm_gpu_memory_utilization,


### PR DESCRIPTION
# What does this PR do?

Rather than firing off 100s of HTTP calls to update weights to vLLM, we can update these in batch. Also, we can async the rpc collective call so the update doesn't block the HTTP call. 

For Owen2 0.5B, this cuts the weight sync from 0.6sec to 0.15sec.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed weight-sync plumbing (HTTP + NCCL/XCCL ordering, new batching/chunking, and async worker dispatch), so subtle ordering or shape/dtype mismatches could cause sync hangs or incorrect weights despite the change being localized.
> 
> **Overview**
> Speeds up vLLM *server-mode* weight synchronization by introducing a batched update path: the client now can POST parameter metadata once (optionally chunked by total tensor elements) and then broadcast tensors sequentially, and the server loads the received weights in one `load_weights()` call.
> 
> Updates `VLLMGeneration.sync_weights()` to use this batched sync when not using ZeRO-3/FSDP gather paths, and threads a new config/arg (`weight_sync_chunk_size` / `vllm_weight_sync_chunk_size`) from `GRPOConfig` through `GRPOTrainer` into `VLLMGeneration`.
> 
> On the `trl vllm-serve` side, adds a `/batch_update_named_params/` endpoint and switches the existing `init_communicator`/`update_named_param` fan-out to workers to send over pipes concurrently via `asyncio` to avoid blocking the HTTP handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b777252b282562ba4da60f8857ceb380489c9a80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->