### PR TITLE
[GRPO] In-place temperature scaling operation

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1075,7 +1075,7 @@ class GRPOTrainer(_BaseTrainer):
             logits = logits[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
             # Divide logits by sampling temperature.
             # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
-            logits = logits / self.temperature
+            logits.div_(self.temperature)
             completion_ids = input_ids_batch[:, -logits_to_keep:]
             logps = selective_log_softmax(logits, completion_ids)  # compute logprobs
             all_logps.append(logps)


### PR DESCRIPTION
# What does this PR do?

Use in-place operator for logits to save memory. Even for small models like qwen2 0.5B, bsz=8, and completion_len of 256, the logits tensor is ~5GB, and duplicating this for the temperature scaling was using another 5GB un-necessarily.
<img width="482" height="335" alt="Screenshot 2026-03-10 at 12 00 28 AM" src="https://github.com/user-attachments/assets/4603c2cf-c564-414a-bf6b-974c167beab5" />

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior should be numerically identical but changes tensor mutation semantics; main risk is unexpected aliasing if `logits` were reused elsewhere (it is not in this path).
> 
> **Overview**
> Updates `GRPOTrainer._get_per_token_logps_and_entropies` to apply temperature scaling via in-place `logits.div_(self.temperature)` instead of `logits / self.temperature`, reducing peak memory during logprob/entropy computation for large `(B, T, V)` logits tensors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2e8aed7249592acc900bcf50e2f8e1c05a985df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->