### PR TITLE
Refactor CLI [14/N] : Remove TrainingArguments import from core trainers

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from .base_config import _BaseConfig
 
 
@@ -129,7 +127,7 @@ class DPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from .base_config import _BaseConfig
 
 
@@ -324,7 +322,7 @@ class GRPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from .base_config import _BaseConfig
 
 
@@ -82,7 +80,7 @@ class RewardConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-4` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from .base_config import _BaseConfig
 
 
@@ -216,7 +214,7 @@ class RLOOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from .base_config import _BaseConfig
 
 
@@ -112,7 +110,7 @@ class SFTConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `2e-5` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(


### PR DESCRIPTION
Remove TrainingArguments import from core trainers.

This PR is part of a refactoring to reduce the CLI latency.

This PR refactors multiple trainer configuration files to remove direct dependencies on `transformers.TrainingArguments` and instead rely on the project's own `_BaseConfig` for managing valid dictionary fields. This change improves modularity and reduces external coupling across the configuration classes.

See upstream issue:
- https://github.com/huggingface/transformers/issues/44273

Dependency refactoring:

* Removed import of `TrainingArguments` from `transformers` in all trainer config files (`dpo_config.py`, `grpo_config.py`, `reward_config.py`, `rloo_config.py`, `sft_config.py`) to eliminate unnecessary dependency.
* Changed `_VALID_DICT_FIELDS` initialization in all trainer config classes to use `_BaseConfig._VALID_DICT_FIELDS` instead of `TrainingArguments._VALID_DICT_FIELDS`, ensuring consistency and independence from external library internals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes where `_VALID_DICT_FIELDS` is sourced for several config dataclasses; behavior should remain equivalent because `_BaseConfig` inherits `TrainingArguments`, but any divergence in `_BaseConfig._VALID_DICT_FIELDS` could affect CLI argument parsing/serialization.
> 
> **Overview**
> Reduces direct `transformers` coupling in trainer config modules by removing `TrainingArguments` imports from `DPOConfig`, `GRPOConfig`, `RewardConfig`, `RLOOConfig`, and `SFTConfig`.
> 
> Each config now builds `_VALID_DICT_FIELDS` from `_BaseConfig._VALID_DICT_FIELDS` (plus `model_init_kwargs`) instead of `TrainingArguments._VALID_DICT_FIELDS`, centralizing config/CLI field validation behind TRL’s base config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b59a7039bedc811bcc70d4f48f72ec96c35ce9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->