### PR TITLE
Support JSON string parsing of teacher_model_init_kwargs in MiniLLMConfig

### DIFF
--- a/trl/experimental/minillm/minillm_config.py
+++ b/trl/experimental/minillm/minillm_config.py
@@ -47,6 +47,8 @@ class MiniLLMConfig(GRPOConfig):
             Whether to apply length normalization to the rewards.
     """
 
+    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["teacher_model_init_kwargs"]
+
     teacher_model_init_kwargs: dict[str, Any] | None = field(
         default=None,
         metadata={


### PR DESCRIPTION
Support JSON string parsing of teacher_model_init_kwargs in MiniLLMConfig
- Add missing _VALID_DICT_FIELDS to MiniLLMConfig

This PR is required for:
- #5258

This PR makes change the `MiniLLMConfig` class, extending the set of valid dictionary fields to include `teacher_model_init_kwargs` for improved configuration handling. Otherwise, `TrainingArguments.__post_init__` won't parse the JSON string into a dict

* Added `teacher_model_init_kwargs` to the `_VALID_DICT_FIELDS` list in `MiniLLMConfig`, enabling its use in dictionary-based configuration workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line config metadata change limited to argument parsing/validation; low chance of behavioral impact beyond enabling the previously-ignored field.
> 
> **Overview**
> `MiniLLMConfig` now extends `TrainingArguments._VALID_DICT_FIELDS` to include `teacher_model_init_kwargs`, enabling dictionary/JSON-string configuration of teacher model init kwargs to be accepted and parsed during `TrainingArguments.__post_init__`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77013dcc8a273379697eca05249e1a5272c21588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->