### PR TITLE
Fix typo in docstring for teacher_model_init_kwargs

### DIFF
--- a/trl/experimental/gkd/gkd_config.py
+++ b/trl/experimental/gkd/gkd_config.py
@@ -42,7 +42,7 @@ class GKDConfig(SFTConfig):
         teacher_model_name_or_path (`str`, *optional*):
             Model name or path of the teacher model. If `None`, the teacher model will be the same as the model being
             trained.
-        teacher_model_init_kwargs (`dict[str, Any]]`, *optional*):
+        teacher_model_init_kwargs (`dict[str, Any]`, *optional*):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the teacher model
             from a string.
         disable_dropout (`bool`, *optional*, defaults to `True`):

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -42,7 +42,7 @@ class GOLDConfig(SFTConfig):
         teacher_model_name_or_path (`str` or `None`, *optional*, defaults to `None`):
             Model name or path of the teacher model. If `None`, the teacher model will be the same as the model being
             trained.
-        teacher_model_init_kwargs (`dict[str, Any]]` or `None`, *optional*, defaults to `None`):
+        teacher_model_init_kwargs (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the teacher model
             from a string.
         teacher_tokenizer_name_or_path (`str` or `None`, *optional*, defaults to `None`):

--- a/trl/experimental/minillm/minillm_config.py
+++ b/trl/experimental/minillm/minillm_config.py
@@ -29,7 +29,7 @@ class MiniLLMConfig(GRPOConfig):
     arguments, please refer to the [`~transformers.TrainingArguments`] and [`GRPOConfig`] documentation.
 
     Args:
-        teacher_model_init_kwargs (`dict[str, Any]]`, *optional*):
+        teacher_model_init_kwargs (`dict[str, Any]`, *optional*):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the teacher model
             from a string.
         disable_dropout (`bool`, *optional*, defaults to `True`):


### PR DESCRIPTION
Fix typo in docstring for `teacher_model_init_kwargs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes correcting a malformed type annotation; no runtime logic or defaults are modified.
> 
> **Overview**
> Fixes a typo in the parameter docstrings for `teacher_model_init_kwargs` across `GKDConfig`, `GOLDConfig`, and `MiniLLMConfig`, correcting `dict[str, Any]]` to `dict[str, Any]` (and the corresponding `... or None` form in `GOLDConfig`).
> 
> No functional code or configuration behavior changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5207160e7cbbe79e85d841f521448e4d0b43435. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->