### PR TITLE
Fix support for model_init_kwargs in GKD/GOLD when passed as CLI JSON string

### DIFF
--- a/trl/experimental/gkd/gkd_config.py
+++ b/trl/experimental/gkd/gkd_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.sft_config import SFTConfig
 
 
@@ -52,7 +50,7 @@ class GKDConfig(SFTConfig):
             teacher-generated output).
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["teacher_model_init_kwargs"]
+    _VALID_DICT_FIELDS = SFTConfig._VALID_DICT_FIELDS + ["teacher_model_init_kwargs"]
 
     temperature: float = field(
         default=0.9,

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.sft_config import SFTConfig
 
 
@@ -94,7 +92,7 @@ class GOLDConfig(SFTConfig):
             low, but waking the engine adds host–device transfer latency.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["teacher_model_init_kwargs"]
+    _VALID_DICT_FIELDS = SFTConfig._VALID_DICT_FIELDS + ["teacher_model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(


### PR DESCRIPTION
Fix support for model_init_kwargs when passed as CLI JSON string
- Add missing model_init_kwargs to _VALID_DICT_FIELDS

Note that `GKDConfig` and `GOLDConfig` both subclass `SFTConfig`, but they were extending the `_VALID_DICT_FIELDS` class attribute from `TrainingArguments` instead of the one from their direct parent. As a result, `model_init_kwargs` (which is defined in SFTConfig) was not included in the valid dictionary fields for these configs, causing it to be ignored when passed as a CLI JSON string.

This PR ensures that `model_init_kwargs` is properly recognized and parsed in the `GKDConfig` and `GOLDConfig` classes. The main change is to ensure that these classes reference their base class `SFTConfig` for valid dictionary fields instead of the external `TrainingArguments` class, improving consistency and maintainability.

Configuration logic improvements:

* Changed `_VALID_DICT_FIELDS` in both `GKDConfig` and `GOLDConfig` to reference `SFTConfig._VALID_DICT_FIELDS` instead of `TrainingArguments._VALID_DICT_FIELDS`, ensuring proper inheritance and avoiding unnecessary dependency on `transformers`, concretely to ensure the presence of `model_init_kwargs`.

Dependency cleanup:

* Removed unused imports of `TrainingArguments` from `trl/experimental/gkd/gkd_config.py` and `trl/experimental/gold/gold_config.py` to streamline the code and reduce external dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates config metadata used for CLI/JSON parsing and removes an unused `transformers.TrainingArguments` import, with no changes to training logic itself.
> 
> **Overview**
> Fixes `GKDConfig` and `GOLDConfig` dict/CLI JSON parsing by deriving `_VALID_DICT_FIELDS` from `SFTConfig` (their actual base class) instead of `TrainingArguments`, so `model_init_kwargs` is no longer dropped when provided via CLI.
> 
> Also removes the now-unneeded `TrainingArguments` imports from both config modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c101fb698188a4f55e9c776078f1ed48b0b79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->