### PR TITLE
Add Cursor Bugbot rules from `AGENTS.md`

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,7 +1,4 @@
----
-description: Repository-specific guidelines for TRL development
-alwaysApply: true
----
+# BUGBOT.md
 
 ## Repository-specific guidance
 


### PR DESCRIPTION
Adds `.cursor/rules/agents.mdc` so Cursor users get the same repository guidelines as Claude Code / Codex agents.

Note: this duplicates `AGENTS.md`, which isn't ideal, a cleaner solution is being tracked in #5268 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Cursor-specific documentation file only; no runtime code paths or behavior change.
> 
> **Overview**
> Adds `.cursor/BUGBOT.md`, a repository guidance document for Cursor/agent tooling that spells out expectations around main vs experimental code, duplicated trainer consistency, simplicity, docstring formatting, and preferred paper links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bb83697c3a8e7235e5e2db18d5b79342f9ee79d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->