### PR TITLE
perf(trl): set a timeout on vllm client HTTP calls

### DIFF
--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -181,7 +181,7 @@ class VLLMClient:
 
         while True:
             try:
-                response = requests.get(url)
+                response = requests.get(url, timeout=10.0)
             except requests.exceptions.RequestException as exc:
                 # Check if the total timeout duration has passed
                 elapsed_time = time.time() - start_time
@@ -424,7 +424,7 @@ class VLLMClient:
         """
         # Get the world size from the server
         url = f"{self.base_url}/get_world_size/"
-        response = requests.get(url)
+        response = requests.get(url, timeout=10.0)
         if response.status_code == 200:
             vllm_world_size = response.json()["world_size"]
         else:


### PR DESCRIPTION
Add a timeout to HTTP requests in trl/generation/vllm_client.py to prevent indefinite hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile trl/generation/vllm_client.py`.

Context: py-http-timeout at trl/generation/vllm_client.py:184.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a fixed timeout to two `requests.get` calls to prevent indefinite hangs, without changing request payloads or response handling logic.
> 
> **Overview**
> Adds a **10s timeout** to vLLM client HTTP health-check and world-size `GET` requests in `trl/generation/vllm_client.py`, preventing workers from hanging indefinitely when the server is unreachable or unresponsive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e76f9732bb77aa6847287c81e8ac03e630c9dd5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->