### PR TITLE
docs: clarify PPO entropy metrics in PPO trainer docs

### DIFF
--- a/docs/source/ppo_trainer.md
+++ b/docs/source/ppo_trainer.md
@@ -38,7 +38,7 @@ The logged metrics are as follows. Here is an example [tracked run at Weights an
 
 - `eps`: Tracks the number of episodes per second.
 - `objective/kl`: The mean Kullback-Leibler (KL) divergence between the current policy and reference policy.
-- `objective/entropy`: The mean entropy of the policy, indicating the randomness of the actions chosen by the policy.
+- `objective/entropy`: The mean token-level entropy proxy on sampled rollouts, computed as `(-logprobs).sum(1).mean()` before PPO optimization.
 - `objective/non_score_reward`: The mean reward from non-score-related sources, basically `beta * kl.sum(1)`, where `beta` is the KL penalty coefficient and `kl` is the per-token KL divergence.
 - `objective/rlhf_reward`: The mean RLHF reward, which is `score - non_score_reward`.
 - `objective/scores`: The mean scores returned by the reward model / environment.
@@ -47,12 +47,17 @@ The logged metrics are as follows. Here is an example [tracked run at Weights an
 - `loss/policy_avg`: The average policy loss, indicating how well the policy is performing.
 - `loss/value_avg`: The average value loss, indicating the difference between the predicted value and the actual reward.
 - `val/clipfrac_avg`: The average fraction of value function updates that are clipped, similar to policy/clipfrac_avg but for the value function.
-- `policy/entropy_avg`: The average entropy of the policy during training, indicating how diverse the policy's actions are.
+- `policy/entropy_avg`: The average categorical entropy of the current policy during PPO optimization, computed from `logits` each minibatch and averaged across PPO epochs/minibatches.
 - `val/ratio`: The mean ratio of the current policy probability to the old policy probability, providing a measure of how much the policy has changed.
 - `val/ratio_var`: The variance of the `val/ratio`, indicating the variability in policy changes.
 - `val/num_eos_tokens`: The number of end-of-sequence (EOS) tokens generated, which can indicate the number of complete responses.
 - `lr`: lr: The current learning rate used by the optimizer.
 - `episode`: episode: The current episode count in the training process.
+
+`objective/entropy` and `policy/entropy_avg` are intentionally different signals:
+
+- `objective/entropy` is measured on the sampled behavior-policy rollouts used to build PPO advantages for the current update.
+- `policy/entropy_avg` is measured during PPO optimization on the evolving policy (after gradient steps), so it can diverge from `objective/entropy`.
 
 ## Cookbook
 


### PR DESCRIPTION
## Summary
Clarify the difference between `objective/entropy` and `policy/entropy_avg` in the PPO trainer docs.

## What changed
- Updated the `objective/entropy` description to match the rollout-time computation (`(-logprobs).sum(1).mean()`).
- Updated the `policy/entropy_avg` description to match the optimization-time entropy computed from logits.
- Added a short note explaining why these two metrics are expected to differ.

## Why
Issue #2023 points out that the two entropy metrics had very similar wording, which made interpretation difficult when debugging PPO runs.

Fixes #2023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates metric wording and adds a brief clarification note; no runtime or API behavior is modified.
> 
> **Overview**
> Clarifies the PPO trainer metric docs by rewriting the descriptions of `objective/entropy` (rollout-time proxy computed from `-logprobs`) and `policy/entropy_avg` (optimization-time categorical entropy computed from `logits`).
> 
> Adds an explicit note explaining that these metrics are measured at different phases (rollouts vs. PPO optimization) and therefore are expected to differ.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8367f1e498171825db42354ead37f96bb7a88a62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->