### PR TITLE
Remove TrainingArguments import from experimental trainers

### DIFF
--- a/trl/experimental/bco/bco_config.py
+++ b/trl/experimental/bco/bco_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.base_config import _BaseConfig
 
 
@@ -78,7 +76,7 @@ class BCOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `5e-7` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/experimental/cpo/cpo_config.py
+++ b/trl/experimental/cpo/cpo_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.base_config import _BaseConfig
 
 
@@ -91,7 +89,7 @@ class CPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.base_config import _BaseConfig
 
 
@@ -74,7 +72,7 @@ class KTOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -16,8 +16,6 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.base_config import _BaseConfig
 
 
@@ -161,7 +159,7 @@ class OnlineDPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `5e-7` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(

--- a/trl/experimental/orpo/orpo_config.py
+++ b/trl/experimental/orpo/orpo_config.py
@@ -15,8 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
 from ...trainer.base_config import _BaseConfig
 
 
@@ -71,7 +69,7 @@ class ORPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = TrainingArguments._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(


### PR DESCRIPTION
Remove TrainingArguments import from experimental trainers.

This PR refactors multiple experimental trainer configuration files to remove direct dependencies on `transformers.TrainingArguments` and instead rely on the project's own `_BaseConfig` for managing valid dictionary fields. This change improves modularity and reduces external coupling across the configuration classes.

Follow-up to:
- #5257

### Changes

Dependency and configuration updates:

* Removed the import of `TrainingArguments` from all experimental config files (`BCOConfig`, `CPOConfig`, `KTOConfig`, `OnlineDPOConfig`, `ORPOConfig`) to eliminate unnecessary dependency.
* Changed the assignment of `_VALID_DICT_FIELDS` in each config class to use `_BaseConfig._VALID_DICT_FIELDS` instead of `TrainingArguments._VALID_DICT_FIELDS`, ensuring consistency and reducing external dependency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how experimental configs derive `_VALID_DICT_FIELDS`; runtime impact should be limited to argument/dict field validation if `_BaseConfig._VALID_DICT_FIELDS` differs from `TrainingArguments` in a given transformers version.
> 
> **Overview**
> Removes the `TrainingArguments` import from several experimental trainer config modules (`BCOConfig`, `CPOConfig`, `KTOConfig`, `OnlineDPOConfig`, `ORPOConfig`).
> 
> Each config now sets `_VALID_DICT_FIELDS` based on `_BaseConfig._VALID_DICT_FIELDS` (plus `model_init_kwargs`) rather than `TrainingArguments._VALID_DICT_FIELDS`, reducing direct coupling to `transformers` in these experimental configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2e93cc407590f07eace280320deeeed1c205247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->