### PR TITLE
fix: skip ref adapter when peft config uses target_parameters

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -672,6 +672,60 @@ class TestDPOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.allclose(param, new_param), f"Parameter {n} has not changed"
 
+    @require_peft
+    def test_train_peft_model_with_target_parameters(self):
+        """Test that DPOTrainer initializes correctly when the PEFT model uses `target_parameters`.
+
+        When `target_parameters` is set (e.g. for fused MoE expert layers), PEFT does not support creating
+        a second adapter. The trainer should skip creating the "ref" adapter and fall back to disabling
+        adapters entirely for reference logprobs. Regression test for
+        https://github.com/huggingface/trl/issues/5222
+        """
+        # Get the MoE base model
+        model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+
+        # Get the base model parameter names
+        base_param_names = [f"base_model.model.{n}" for n, _ in model.named_parameters()]
+
+        # Turn the model into a peft model with target_parameters
+        lora_config = LoraConfig(target_parameters=["mlp.experts.down_proj", "mlp.experts.gate_up_proj"])
+        model = get_peft_model(model, lora_config)
+
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        # Initialize the trainer — this should NOT raise even though target_parameters is set
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            report_to="none",
+        )
+        trainer = DPOTrainer(model=model, args=training_args, train_dataset=dataset)
+
+        # Verify that the "ref" adapter was NOT created
+        unwrapped = trainer.accelerator.unwrap_model(trainer.model)
+        assert "ref" not in unwrapped.peft_config, (
+            "The 'ref' adapter should not be created when target_parameters is set"
+        )
+
+        # Save the initial parameters to compare them later
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        # Train the model
+        trainer.train()
+
+        # Check that the training loss is not None
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check the peft params have changed and the base model params have not changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n in base_param_names:
+                torch.testing.assert_close(param, new_param), f"Parameter {n} has changed"
+            elif "base_layer" not in n:
+                assert not torch.allclose(param, new_param), f"Parameter {n} has not changed"
+
     # In practice, this test is the same as `test_train_dense_with_peft_config_lora`, since gradient checkpointing is
     # enabled by default in `DPOTrainer`. We keep it as a regression guard: if the default ever changes, we still
     # explicitly test PEFT + gradient checkpointing, which has caused issues in the past.

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -545,12 +545,24 @@ class DPOTrainer(_BaseTrainer):
         if is_peft_available() and is_peft_model(model) and ref_model is None:
             # If the model is a PEFT model with a pretrained adapter, we need to create a "ref" adapter that is a copy
             # of the "default" adapter, so that we can use it as the reference model during DPO training.
-            model.add_adapter("ref", model.peft_config["default"])
-            for name, param in model.named_parameters():
-                if ".default." in name:
-                    ref_name = name.replace(".default.", ".ref.")
-                    ref_param = model.get_parameter(ref_name)
-                    ref_param.data.copy_(param.data)
+            default_peft_config = model.peft_config["default"]
+            if getattr(default_peft_config, "target_parameters", None):
+                # When `target_parameters` is set (e.g. for fused MoE expert layers), PEFT does not support
+                # creating a second adapter. Skip creating the "ref" adapter; the fallback path in
+                # `concatenated_forward` will disable adapters entirely, which gives correct base-model
+                # reference logprobs since LoRA weights are initialized to zero.
+                logger.warning(
+                    "The default PEFT config uses `target_parameters`, which does not support multiple "
+                    "adapters. Skipping creation of the 'ref' adapter; the base model (adapters disabled) "
+                    "will be used for reference logprobs instead."
+                )
+            else:
+                model.add_adapter("ref", default_peft_config)
+                for name, param in model.named_parameters():
+                    if ".default." in name:
+                        ref_name = name.replace(".default.", ".ref.")
+                        ref_param = model.get_parameter(ref_name)
+                        ref_param.data.copy_(param.data)
 
         # Create PEFT model
         if peft_config is not None:


### PR DESCRIPTION
## Summary

Fixes #5222

`DPOTrainer.__init__()` calls `model.add_adapter("ref", model.peft_config["default"])` to create a frozen copy of the default adapter for computing reference logprobs. When the LoRA config uses `target_parameters` (required for fused MoE expert layers in Transformers 5.x), PEFT raises an error because it does not support creating a second adapter with `target_parameters`.

**Root cause:** `target_parameters` uses a fundamentally different injection mechanism in PEFT (parameter-level rather than module-level), which doesn't support multiple named adapters on the same parameter.

**Fix:** When `model.peft_config["default"]` has `target_parameters` set, skip the `add_adapter("ref", ...)` call and log a warning instead.

**Why this is safe:** The fallback path already exists and is tested. In `concatenated_forward`, the code does:
```python
with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
    ref_outputs = self.model(**model_kwargs)
```
When `"ref"` is not in `peft_config`, `use_adapter(model, adapter_name=None)` disables all adapters, yielding base model logprobs. This is correct for newly initialized LoRA weights (which start at zero, so `base_model == base_model + LoRA(0)`).

## Changes

- **`trl/trainer/dpo_trainer.py`**: Added a check for `target_parameters` in the default peft config before attempting to create the "ref" adapter. When present, logs a warning and skips adapter creation.
- **`tests/test_dpo_trainer.py`**: Added `test_train_peft_model_with_target_parameters` that creates a PeftModel with `target_parameters` on a MoE model, verifies DPOTrainer initializes without error, confirms no "ref" adapter is created, and trains successfully.

## Test plan

- [ ] New test `test_train_peft_model_with_target_parameters` passes — creates a PeftModel with `target_parameters`, initializes DPOTrainer, asserts "ref" adapter is absent, and completes a training run
- [ ] Existing `test_train_peft_model` still passes — standard LoRA without `target_parameters` still creates the "ref" adapter as before
- [ ] Existing `test_train_moe_with_peft_config` still passes — new adapter creation path (via `peft_config` arg) is unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DPOTrainer’s PEFT reference-logprob path for a specific adapter configuration; incorrect handling could affect reference logprobs or training stability for PEFT models using `target_parameters`. Scope is small and guarded by a new regression test.
> 
> **Overview**
> Fixes `DPOTrainer` initialization for PEFT LoRA configs that use `target_parameters` by **skipping creation of the frozen `ref` adapter** (PEFT doesn’t support multiple adapters in this mode) and logging a warning; reference logprobs fall back to running with adapters disabled.
> 
> Adds a regression test that builds a PEFT MoE model with `target_parameters`, asserts no `ref` adapter is created, and verifies training still updates only adapter params while leaving base params unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a6aa743779a49b6bbbac32f9b4549302a9103fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->