### PR TITLE
Suggest the `Json()` type for tool calling dataset format

### DIFF
--- a/docs/source/dataset_formats.md
+++ b/docs/source/dataset_formats.md
@@ -188,7 +188,7 @@ The generated schema would look like:
 A complete dataset entry for SFT might look like:
 
 ```python
-{"messages": messages, "tools": json_schema}
+{"messages": messages, "tools": [json_schema]}
 ```
 
 To get a `Dataset` you need to use the `Json()` type for tool arguments since they are arbitrary JSON objects, and not dictionaries with fixed fields and types:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is minor confusion if users rely on the previous legacy `tools` JSON-string recommendation for older `datasets` versions.
> 
> **Overview**
> Updates the tool-calling dataset documentation to treat `get_json_schema()` output as a Python dict (not a JSON string) and to store `tools` as a list of schemas (`[json_schema]`).
> 
> Adds guidance on constructing a `datasets.Dataset` by using the `Json()` feature type (or `on_mixed_types="use_json"`) for arbitrary tool-call arguments, and documents a fallback for `datasets<4.8` where `tools` should be stored via `json.dumps(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24226bf9b73a0d52b2b2f2241c2df4c4f35bdbac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->