### PR TITLE
Expand the list of attention implementations compatible with packing

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -77,15 +77,6 @@ if is_liger_kernel_available():
 logger = get_logger(__name__)
 
 
-FLASH_ATTENTION_VARIANTS = {
-    "flash_attention_2",
-    "flash_attention_3",
-    "kernels-community/flash-attn2",
-    "kernels-community/flash-attn3",
-    "kernels-community/vllm-flash-attn3",
-}
-
-
 def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
     return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -824,8 +824,8 @@ class SFTTrainer(_BaseTrainer):
             if not is_padding_free_compatible_attention:
                 logger.warning(
                     "Padding-free training is enabled, but the attention implementation is not set to a variant compatible with padding-free training. "
-                    "Padding-free training flattens batches into a single sequence, and only the following implementations are known to reliably support this:\n"
-                    f"{padding_free_compatible_attention_variants_str}\n"
+                    "Padding-free training flattens batches into a single sequence, and only the following implementations are known to reliably support this:"
+                    f"\n{padding_free_compatible_attention_variants_str}\n"
                     "Using other implementations may lead to unexpected behavior. "
                     "To ensure compatibility, set `attn_implementation` in the model configuration to one of these supported options or verify that your attention mechanism can "
                     "handle flattened sequences."

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -74,13 +74,17 @@ if is_peft_available():
 logger = get_logger(__name__)
 
 
-FLASH_ATTENTION_VARIANTS = {
+PADDING_FREE_COMPATIBLE_ATTENTION_VARIANTS = [
+    "eager",
+    "sdpa",
+    "flex_attention",
     "flash_attention_2",
     "flash_attention_3",
+    "flash_attention_4",
     "kernels-community/flash-attn2",
     "kernels-community/flash-attn3",
     "kernels-community/vllm-flash-attn3",
-}
+]
 
 
 def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
@@ -803,7 +807,12 @@ class SFTTrainer(_BaseTrainer):
         # BFD packing requires padding-free mode; otherwise, the collator outputs padded attention masks, causing
         # FlashAttention to ignore position_ids and recompute them incorrectly from the padded attention mask.
         self.padding_free = args.padding_free or (args.packing and args.packing_strategy in {"bfd", "bfd_split"})
-        use_flash_attention = model.config._attn_implementation in FLASH_ATTENTION_VARIANTS
+        is_padding_free_compatible_attention = (
+            model.config._attn_implementation in PADDING_FREE_COMPATIBLE_ATTENTION_VARIANTS
+        )
+        padding_free_compatible_attention_variants_str = "\n".join(
+            f"- `{attn}`" for attn in PADDING_FREE_COMPATIBLE_ATTENTION_VARIANTS
+        )
         if self.padding_free:
             if data_collator is not None:
                 raise ValueError("Passing a custom data collator is not supported when using padding-free.")
@@ -812,14 +821,13 @@ class SFTTrainer(_BaseTrainer):
                     "You are passing `padding_free=True` with the 'wrapped' packing strategy, which is not "
                     "recommended. Please refer to the documentation to understand why this is not recommended."
                 )
-            if not use_flash_attention:
+            if not is_padding_free_compatible_attention:
                 logger.warning(
-                    "Padding-free training is enabled, but the attention implementation is not set to a supported "
-                    "flash attention variant. Padding-free training flattens batches into a single sequence, and only "
-                    "the following implementations are known to reliably support this: "
-                    f"{', '.join(sorted(FLASH_ATTENTION_VARIANTS))}. Using other implementations may lead to "
-                    "unexpected behavior. To ensure compatibility, set `attn_implementation` in the model "
-                    "configuration to one of these supported options or verify that your attention mechanism can "
+                    "Padding-free training is enabled, but the attention implementation is not set to a variant compatible with padding-free training. "
+                    "Padding-free training flattens batches into a single sequence, and only the following implementations are known to reliably support this:\n"
+                    f"{padding_free_compatible_attention_variants_str}\n"
+                    "Using other implementations may lead to unexpected behavior. "
+                    "To ensure compatibility, set `attn_implementation` in the model configuration to one of these supported options or verify that your attention mechanism can "
                     "handle flattened sequences."
                 )
 
@@ -871,11 +879,12 @@ class SFTTrainer(_BaseTrainer):
                 dataset_text_field=args.dataset_text_field,
             )
 
-        if args.packing and args.packing_strategy in {"bfd", "bfd_split"} and not use_flash_attention:
+        if args.packing and args.packing_strategy in {"bfd", "bfd_split"} and not is_padding_free_compatible_attention:
             logger.warning(
-                "You are using packing, but the attention implementation is not set to a supported flash attention "
-                "variant. Packing gathers multiple samples into a single sequence, and only the following "
-                f"implementations are known to reliably support this: {', '.join(sorted(FLASH_ATTENTION_VARIANTS))}. "
+                "You are using packing, but the attention implementation is not set to a variant compatible with packing. "
+                "Padding-free training flattens batches into a single sequence, and only the following "
+                "implementations are known to reliably support this:"
+                f"\n{padding_free_compatible_attention_variants_str}\n"
                 "Using other implementations may lead to cross-contamination between samples. To avoid this, either "
                 "disable packing by setting `packing=False`, or set `attn_implementation` in the model configuration "
                 "to one of these supported options."


### PR DESCRIPTION
# What does this PR do?

Expands the list of attention implementations compatible with packing in `SFTTrainer` to include `eager`, `sdpa`, `flex_attention`, and `flash_attention_4`, and updates the warnings accordingly.

PS: Support for the packing/padding-free case for `eager`/`sdpa`/`flex_attention` was added in  https://github.com/huggingface/transformers/pull/39194

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust which `attn_implementation` values are treated as compatible for padding-free/packing warnings and remove an unused constant in `DPOTrainer`. No training logic or data handling paths are otherwise modified.
> 
> **Overview**
> Expands `SFTTrainer`'s set of attention implementations considered compatible with *padding-free/packing* to include `eager`, `sdpa`, `flex_attention`, and `flash_attention_4`, and updates the related compatibility checks.
> 
> Reworks the warning messages emitted when `padding_free` or BFD packing is enabled with an incompatible attention implementation to show a clearer, bullet-listed set of supported variants. Also removes the unused `FLASH_ATTENTION_VARIANTS` constant from `dpo_trainer.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e073262bda6f71e9a5aef6afccb04dcf6ec94e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->