### PR TITLE
(1/5) Add callback to sync weights before training begins

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -62,6 +62,23 @@ class RolloutWorkerProtocol(Protocol):
     def update_model_version(self, version: int) -> None: ...
 
 
+class _InitialWeightSyncCallback(TrainerCallback):
+    """
+    Syncs model weights to the vLLM rollout worker once, on train begin.
+
+    This fires after FSDP wrapping / ``accelerator.prepare()`` (so parameters are on GPU) but before
+    the first training step.  After the sync the rollout worker is started and this callback removes
+    itself from the trainer.
+    """
+
+    def __init__(self, trainer: "AsyncGRPOTrainer"):
+        self._trainer = trainer
+
+    def on_train_begin(self, _args, _state, _control, **_kwargs):
+        self._trainer._sync_weight()
+        self._trainer.remove_callback(type(self))
+
+
 class StepIntervalCallback(TrainerCallback):
     """
     A callback that calls a function every N optimization steps.
@@ -386,6 +403,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
             self.rollout_worker = None
 
         # Add callbacks
+        self.add_callback(_InitialWeightSyncCallback(self))
         self.add_callback(StepIntervalCallback(self._sync_weight, self.args.weight_sync_steps))
 
     def get_train_dataloader(self) -> DataLoader:
@@ -589,11 +607,6 @@ class AsyncGRPOTrainer(_BaseTrainer):
         logger.info(f"Weight sync: done. Total {weight_sync_time_s:.1f}s")
 
     def _inner_training_loop(self, *args, **kwargs):
-        # Start the rollout worker here (not in __init__) so that checkpoint loading in Trainer.train()
-        # has already restored the model weights. The sequence is: start worker thread → wait for NCCL
-        # init → sync weights to vLLM → begin generation. This ensures vLLM always uses the current
-        # policy before producing any samples (matters for resumed runs, harmless for fresh ones).
-        self._sync_weight()
         if self.accelerator.is_main_process and self.rollout_worker:
             self.rollout_worker.start()
         try:

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -76,6 +76,8 @@ class _InitialWeightSyncCallback(TrainerCallback):
 
     def on_train_begin(self, _args, _state, _control, **_kwargs):
         self._trainer._sync_weight()
+        if self._trainer.accelerator.is_main_process and self._trainer.rollout_worker:
+            self._trainer.rollout_worker.start()
         self._trainer.remove_callback(type(self))
 
 
@@ -607,8 +609,6 @@ class AsyncGRPOTrainer(_BaseTrainer):
         logger.info(f"Weight sync: done. Total {weight_sync_time_s:.1f}s")
 
     def _inner_training_loop(self, *args, **kwargs):
-        if self.accelerator.is_main_process and self.rollout_worker:
-            self.rollout_worker.start()
         try:
             return super()._inner_training_loop(*args, **kwargs)
         finally:


### PR DESCRIPTION
# What does this PR do?
- Introduces the _InitialWeightSyncCallback class to handle the first weight sync.
- Replaces the manual self._sync_weight() call inside AsyncGRPOTrainer._inner_training_loop with this dedicated callback.
- Registers the callback in the trainer's __init__.
- This ensures vLLM is guaranteed to use the current policy weights (after FSDP wrapping and moving parameters to the GPU) before producing the first batch of samples.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the training startup sequence by moving the first vLLM weight sync and rollout worker start into an `on_train_begin` callback, which could affect distributed initialization/order and rollout generation timing.
> 
> **Overview**
> Ensures the vLLM rollout worker sees the correct policy weights *before* the first training step by adding `_InitialWeightSyncCallback`, which runs a one-time `_sync_weight()` on `on_train_begin`, starts the rollout worker on the main process, and then unregisters itself.
> 
> Removes the previous manual initial sync/start logic from `AsyncGRPOTrainer._inner_training_loop`, keeping periodic weight syncing via `StepIntervalCallback` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bf921153cfc5c9b90392c7c33dd7ce7168ce680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->