### PR TITLE
Clean up model update group on worker exit

### DIFF
--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -275,7 +275,6 @@ class AsyncRolloutWorker:
         self.model_update_group.group.store = None
         self.model_update_group.group.socket = None
         self.model_update_group = None
-        self.model_update_group = False
 
     def pause(self) -> None:
         t0 = time.time()


### PR DESCRIPTION
Destroy the model update group when the async rollout worker shuts down to prevent errors during process termination.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lifecycle change that only runs during worker teardown, but it touches NCCL weight-transfer resources and could mask underlying shutdown issues if misused.
> 
> **Overview**
> Prevents shutdown-time errors in `AsyncRolloutWorker` by explicitly tearing down the vLLM/NCCL `model_update_group` when the worker thread exits.
> 
> Adds `_destroy_model_update_group()` and invokes it in `_run()`'s `finally` block to null out the underlying `store`/`socket` references and clear `model_update_group`, with a guard for cases where weight transfer was never initialized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cc0c5e79c52508ab55306610d06a963931a7327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->