### PR TITLE
Enable Tensor Parallelism in SFT script

### DIFF
--- a/trl/scripts/sft.py
+++ b/trl/scripts/sft.py
@@ -93,6 +93,10 @@ def main(script_args, training_args, model_args, dataset_args):
         model_kwargs["device_map"] = get_kbit_device_map()
         model_kwargs["quantization_config"] = quantization_config
 
+    # Enable tensor parallelism if configured
+    if int(os.environ.get("PARALLELISM_CONFIG_TP_SIZE", "1")) > 1:
+        model_kwargs["tp_plan"] = "auto"
+
     # Create model
     config = AutoConfig.from_pretrained(model_args.model_name_or_path)
     valid_image_text_architectures = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.values()


### PR DESCRIPTION
# What does this PR do?
Adds tp_plan="auto" to model loading in [sft.py](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py) when tp_size > 1 is configured in the accelerate parallelism config.

Currently, setting tp_size > 1 in the accelerate config creates a TP device mesh but the model is never TP-sharded — [sft.py](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py) doesn't pass tp_plan to from_pretrained(), so TP is silently ignored.

Change: 3 lines in sft.py that check PARALLELISM_CONFIG_TP_SIZE env var and inject tp_plan="auto" into model_kwargs.

Tested with Llama-3.2-1B full fine-tuning on 8 GPUs — TP sharding reduces peak memory substantially.

Note: LoRA + TP requires PEFT >= 0.18.2 (peft#3079). Full fine-tuning works with current versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model loading behavior in `trl/scripts/sft.py` when tensor parallelism is configured, which could affect distributed training startup or compatibility with specific Transformers/PEFT versions.
> 
> **Overview**
> When `PARALLELISM_CONFIG_TP_SIZE` is set to >1, the SFT script now passes `tp_plan="auto"` into `from_pretrained()` so the loaded model is tensor-parallel sharded rather than running unsharded.
> 
> This is a conditional change only during model initialization; single-device and non-TP runs keep the existing loading path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abdbdf72d1059a1f89819d96086d6c8bdc781c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->