### PR TITLE
refactor(async_rollout_worker): renamed tool variables to mirror `grpo_trainer.py`

### DIFF
--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -546,27 +546,28 @@ class AsyncRolloutWorker:
             tool_call_count += n_calls
             tool_failure_count += n_failures
             completion.extend(tool_messages)
-            tool_suffix_ids = self._build_messages_suffix_ids(tool_messages)
-            completion_ids.extend(tool_suffix_ids)
-            completion_logprobs.extend([0.0] * len(tool_suffix_ids))
-            tool_mask.extend([0] * len(tool_suffix_ids))
-            prompt_ids = prompt_ids + turn_ids + tool_suffix_ids
+            suffix_ids = self._get_tool_suffix_ids(tool_messages)
+            completion_ids.extend(suffix_ids)
+            completion_logprobs.extend([0.0] * len(suffix_ids))
+            tool_mask.extend([0] * len(suffix_ids))
+            prompt_ids = prompt_ids + turn_ids + suffix_ids
             iteration_num += 1
 
-    def _build_messages_suffix_ids(self, messages: list[dict[str, Any]]) -> list[int]:
-        template_messages = [
+    def _get_tool_suffix_ids(self, tool_messages: list[dict[str, Any]]) -> list[int]:
+        """Get token IDs for tool result formatting by using a minimal dummy conversation."""
+        dummy_messages = [
             {"role": "user", "content": ""},
             {"role": "assistant", "content": ""},
         ]
         prefix_ids = self.tokenizer.apply_chat_template(
-            template_messages,
+            dummy_messages,
             return_dict=False,
             tools=self.tools,
             chat_template=self.chat_template,
             **self.chat_template_kwargs,
         )
-        prefix_and_messages_ids = self.tokenizer.apply_chat_template(
-            template_messages + messages,
+        full_ids = self.tokenizer.apply_chat_template(
+            dummy_messages + tool_messages,
             return_dict=False,
             chat_template=self.chat_template,
             add_generation_prompt=True,
@@ -575,15 +576,15 @@ class AsyncRolloutWorker:
         )
 
         # Some chat templates (notably Qwen3/Qwen3.5) render "...<|im_end|>\n" after an assistant/tool block.
-        # When we compute `suffix_ids` by slicing `prefix_and_messages_ids`, we must align the slicing boundary to
+        # When we compute `suffix_ids` by slicing `full_ids`, we must align the slicing boundary to
         # EOS (not EOS + newline).
         last_eos_idx = max(i for i, tok_id in enumerate(prefix_ids) if tok_id == self.tokenizer.eos_token_id)
         prefix_ids = prefix_ids[: last_eos_idx + 1]
 
-        if prefix_and_messages_ids[: len(prefix_ids)] != prefix_ids:
+        if full_ids[: len(prefix_ids)] != prefix_ids:
             raise ValueError("Unexpected tokenization: the EOS-trimmed prefix IDs are not a prefix of the full IDs.")
 
-        return prefix_and_messages_ids[len(prefix_ids) :]
+        return full_ids[len(prefix_ids) :]
 
     def _execute_tool_calls(
         self, tool_calls: list[dict[str, Any]], tool_dict: dict[str, Callable]


### PR DESCRIPTION
# What does this PR do?

This is a small refactor following @qgallouedec  https://github.com/huggingface/trl/pull/5330#discussion_r2968451257 in my previous PR.

To harmonize `async_rollout_worker.py` with `grpo_trainer.py` tool variables:


_build_messages_suffix_ids → _get_tool_suffix_ids
messages → tool_messages
template_messages → dummy_messages
prefix_and_messages_ids → full_ids
tool_suffix_ids → suffix_ids




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor limited to tool-message suffix tokenization and variable renames; behavior should be unchanged but could affect tool-call prompting if the suffix slicing logic is accidentally altered.
> 
> **Overview**
> Refactors `AsyncRolloutWorker` tool-call handling to mirror `grpo_trainer.py` naming and structure.
> 
> Renames `_build_messages_suffix_ids` to `_get_tool_suffix_ids` and consistently renames related locals (`messages`→`tool_messages`, `template_messages`→`dummy_messages`, `prefix_and_messages_ids`→`full_ids`, `tool_suffix_ids`→`suffix_ids`) while keeping the same suffix-ID computation and call site in `_generate_one`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0da28b1f97a7ed39c637288720d9028c561cafe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->