### PR TITLE
Change model dtype from bfloat16 to float32 in AsyncGRPOTrainer

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -289,7 +289,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
 
         # Model
         model_name = model
-        model = AutoModelForCausalLM.from_pretrained(model, device_map=None, dtype=torch.bfloat16)
+        model = AutoModelForCausalLM.from_pretrained(model, device_map=None, dtype=torch.float32)
 
         # Processing class
         if processing_class is None:


### PR DESCRIPTION
# What does this PR do?

not sure why, but bf16 ain't working. In the meantime, let's use fp32 

```python
"""
Minimal sanity-check for AsyncGRPOTrainer: the "Immediate EOS" test.

The model is rewarded with R(y) = -len(completion_tokens). The optimal policy
is to emit <EOS> immediately (reward = -1). Within a handful of steps the
average completion length should drop and reward_mean should climb toward -1.

Start the vLLM server:

    CUDA_VISIBLE_DEVICES=0 VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6B \
        --weight-transfer-config '{"backend":"nccl"}' \
        --logprobs-mode processed_logprobs
        --max-model-len 512

Run training:

    CUDA_VISIBLE_DEVICES=1 python train.py

!/! NOTE: depends on transformers > 5.0.0
"""

import logging
import os

from datasets import Dataset

from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer


logging.basicConfig(
    level=getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO),
    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
)

def negative_length_reward(completion_ids: list[list[int]], **kwargs) -> list[float]:
    """Reward = -len(completion). The optimal policy outputs EOS immediately (reward = -1)."""
    return [-len(ids) for ids in completion_ids]


def format_sample(sample):
    return {"prompt": [{"role": "user", "content": sample["text"]}]}


def main() -> None:
    # A trivial dataset of short prompts — content doesn't matter, the reward ignores it.
    dataset = Dataset.from_dict({"text": ["Hello", "Test prompt", "What is 1+1?", "Say something", "Hi there"] * 20})
    dataset = dataset.map(format_sample, remove_columns=dataset.column_names)

    config = AsyncGRPOConfig(
        max_staleness=1,
        per_device_train_batch_size=4,
        max_completion_length=512,
        num_generations=4,
        max_steps=400,
        logging_steps=1,
        report_to="trackio",
        log_completions=True,
        trackio_space_id="qgallouedec/trackio2",
        num_completions_to_print=3,
    )
    trainer = AsyncGRPOTrainer(
        model="Qwen/Qwen3-0.6B",
        args=config,
        train_dataset=dataset,
        reward_funcs=negative_length_reward,
    )
    trainer.train()


if __name__ == "__main__":
    main()
```

<img width="720" height="448" alt="chart-3_720" src="https://github.com/user-attachments/assets/6dd1ae60-8b92-445c-a937-4d9b3627e477" />

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c7d2f8592775893f9b4b2c3e8cd45b755033517c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->