### PR TITLE
Fix AttributeError: initialize vllm_client to None on all ranks in server mode

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -303,6 +303,7 @@ class VLLMGeneration:
             )
 
         if self.mode == "server":
+            self.vllm_client = None  # initialize on all ranks; only the main process will set the actual client
             if accelerator.is_main_process:
                 if self.server_base_url is not None:
                     base_url = self.server_base_url


### PR DESCRIPTION
## Summary

In `VLLMGeneration._init_vllm`, when `mode == "server"`, `self.vllm_client` is only assigned inside `if accelerator.is_main_process:`. On non-main ranks the attribute is never set, so any code path that reaches `self.vllm_client` raises:

```
AttributeError: 'VLLMGeneration' object has no attribute 'vllm_client'
```

## Fix

Add `self.vllm_client = None` immediately after `if self.mode == "server":`, before the `is_main_process` guard. The attribute now always exists on every rank; the main process overwrites it with the real `VLLMClient` instance as before.

```python
# Before
if self.mode == "server":
    if accelerator.is_main_process:
        self.vllm_client = VLLMClient(...)

# After
if self.mode == "server":
    self.vllm_client = None  # exists on all ranks
    if accelerator.is_main_process:
        self.vllm_client = VLLMClient(...)
```

Fixes #5314

## Testing

The change is a one-liner initialisation; no behavioural change for single-GPU runs or for the main process in multi-GPU runs. Existing tests for server mode continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line initialization to prevent `AttributeError` on non-main distributed ranks when `mode="server"`; main-process behavior is unchanged.
> 
> **Overview**
> Fixes a distributed server-mode bug in `VLLMGeneration._init_vllm` by always initializing `self.vllm_client` to `None` before the `accelerator.is_main_process` guard.
> 
> This prevents non-main ranks from hitting an `AttributeError` when code later references `vllm_client`, while keeping the main rank’s client setup and communicator initialization the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b92210c4fa9215f80c985458e20dc4b36cb07d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->