### PR TITLE
Fix GRPO log() NaN propagation from sparse reward functions

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -15,6 +15,7 @@
 import asyncio
 import atexit
 import copy
+import math
 import importlib.resources as pkg_resources
 import inspect
 import os
@@ -2284,7 +2285,10 @@ class GRPOTrainer(_BaseTrainer):
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"
-        metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}  # average the metrics
+        metrics = {  # average the metrics, skipping NaN values from sparse reward functions
+            key: (lambda v: sum(v) / len(v) if v else float("nan"))([x for x in val if not math.isnan(x)])
+            for key, val in self._metrics[mode].items()
+        }
 
         # This method can be called both in training and evaluation. When called in evaluation, the keys in `logs`
         # start with "eval_". We need to add the prefix "eval_" to the keys in `metrics` to match the format.


### PR DESCRIPTION
## Summary

`GRPOTrainer.log()` computes per-key metric averages with:

```python
metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}
```

`sum(val) / len(val)` returns `nan` as soon as *any* element of `val` is `nan`.  With sparse reward functions that return `None` for samples where no reward applies (e.g. tool-use rewards that skip non-tool outputs), the corresponding tensor mean becomes `nan`, which is stored in `_metrics` and then poisons every logged metric — making the training run appear completely broken even when most rewards are valid.

## Fix

Filter `nan` values out before averaging.  If *all* values for a key are `nan` the metric remains `nan` (preserving visibility into truly broken reward functions):

```python
metrics = {
    key: (lambda v: sum(v) / len(v) if v else float("nan"))([x for x in val if not math.isnan(x)])
    for key, val in self._metrics[mode].items()
}
```

Fixes #4501

## Testing

The change only affects the metric reporting path; no model outputs, gradients, or loss computations are modified.  Existing unit tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to `GRPOTrainer.log()` metric aggregation and only affects reporting; training/loss computation is unchanged.
> 
> **Overview**
> Prevents sparse reward functions that emit `NaN` (e.g., from `None` rewards) from poisoning all logged GRPO metrics by filtering out `NaN` values before averaging in `GRPOTrainer.log()`.
> 
> Adds a `math` import and leaves metrics as `NaN` only when *all* collected values for a key are `NaN`, preserving visibility into truly invalid metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9398153356dc22e03d5f330123bd63ebbed28614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->