### PR TITLE
Fix unpair_preference_dataset ArrowInvalid crash with extra dataset columns

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -445,7 +445,14 @@ def unpair_preference_dataset(
     {'prompt': 'The sky is', 'completion': ' blue.', 'label': True}
     ```
     """
-    return dataset.map(_unpair_row, batched=True, remove_columns=["chosen", "rejected"], num_proc=num_proc, desc=desc)
+    # Remove all original columns so that extra columns beyond ["chosen", "rejected", "prompt"]
+    # do not cause an ArrowInvalid shape mismatch after _unpair_row doubles the number of rows.
+    columns_to_remove = (
+        list(next(iter(dataset.values())).column_names)
+        if isinstance(dataset, DatasetDict)
+        else dataset.column_names
+    )
+    return dataset.map(_unpair_row, batched=True, remove_columns=columns_to_remove, num_proc=num_proc, desc=desc)
 
 
 def maybe_unpair_preference_dataset(


### PR DESCRIPTION
## Summary

`unpair_preference_dataset` calls:

```python
dataset.map(_unpair_row, batched=True, remove_columns=["chosen", "rejected"], ...)
```

`_unpair_row` doubles the number of rows (N → 2N), but only removes `"chosen"` and `"rejected"`.
Any *extra* column in the original dataset (e.g. `"source"`, `"split"`, `"metadata"`) is not removed and still has length N while the new columns (`completion`, `label`) have length 2N.  This causes:

```
ArrowInvalid: ... all arrays in a chunked array must have the same type
```
(or a shape-mismatch error, depending on the datasets version).

## Fix

Remove **all** original columns instead of only `["chosen", "rejected"]`.
`_unpair_row` emits exactly `completion`, `label`, and (when present) `prompt`; removing everything else ensures no length mismatch.

```python
# Before
return dataset.map(_unpair_row, batched=True, remove_columns=["chosen", "rejected"], ...)

# After
columns_to_remove = (
    list(next(iter(dataset.values())).column_names)
    if isinstance(dataset, DatasetDict)
    else dataset.column_names
)
return dataset.map(_unpair_row, batched=True, remove_columns=columns_to_remove, ...)
```

The `DatasetDict` branch is needed because `DatasetDict.column_names` returns a `dict`, not a `list`.

Fixes #2351

## Testing

Existing usage with the standard three columns (`prompt`, `chosen`, `rejected`) is unaffected.  Datasets with extra columns no longer crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to dataset transformation; the main behavior change is that any non-output columns are now always dropped during `unpair_preference_dataset`.
> 
> **Overview**
> Fixes an `ArrowInvalid`/shape-mismatch crash in `unpair_preference_dataset` when the input preference dataset contains extra columns beyond `chosen`/`rejected`/`prompt`.
> 
> Instead of removing only `chosen` and `rejected`, the map step now removes **all original columns** (handling both `Dataset` and `DatasetDict`) so `_unpair_row` can safely double row count without leaving mismatched-length leftovers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c6f3a15c67fc431dfcf103142d6fb7d6c49621e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->