### PR TITLE
Fix PPO reward placement at EOS token and missing_eos_penalty stop-token mismatch

### DIFF
--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -750,7 +750,10 @@ class PPOTrainer(_BaseTrainer):
 
                 # Response Processing 3. Filter completion. Ensure that the sample contains stop_token_id
                 # Completions not passing that filter will receive a lower score.
-                contain_eos_token = torch.any(postprocessed_responses == self.processing_class.eos_token_id, dim=-1)
+                # Use stop_token_id (which may differ from eos_token_id) so that missing_eos_penalty
+                # is applied correctly when a custom stop token is configured.
+                _stop_id = self.stop_token_id if self.stop_token_id is not None else self.processing_class.eos_token_id
+                contain_eos_token = torch.any(postprocessed_responses == _stop_id, dim=-1)
                 if self.args.missing_eos_penalty is not None:
                     scores[~contain_eos_token] -= self.args.missing_eos_penalty
                 # accelerator.print(f"{scores=}, {(contain_eos_token.sum() / len(contain_eos_token))=}")
@@ -771,7 +774,7 @@ class PPOTrainer(_BaseTrainer):
                 non_score_reward = -args.kl_coef * kl
                 rewards = non_score_reward.clone()
                 actual_start = torch.arange(rewards.size(0), device=rewards.device)
-                actual_end = torch.where(sequence_lengths_p1 < rewards.size(1), sequence_lengths_p1, sequence_lengths)
+                actual_end = sequence_lengths  # place score at EOS token, not at the following PAD token
                 rewards[actual_start, actual_end] += scores
 
                 # 5. whiten rewards


### PR DESCRIPTION
## Summary

Two related bugs in `trl/experimental/ppo/ppo_trainer.py`:

### Bug 1 — Reward placed at PAD token instead of EOS

The score is accumulated at `actual_end = sequence_lengths_p1 = sequence_lengths + 1`, which points to the **first PAD token after EOS**.  Because the PAD position is later zeroed out by the loss mask, the reward score effectively does not contribute to training.

Per prior RLHF literature (*"N+ Implementation Details of RLHF with PPO"*, Rafailov et al. *"From r to Q*"*), the score should be assigned at the **EOS token** itself.

```python
# Before — score lands on PAD
actual_end = torch.where(sequence_lengths_p1 < rewards.size(1), sequence_lengths_p1, sequence_lengths)

# After — score lands on EOS
actual_end = sequence_lengths  # place score at EOS token, not at the following PAD token
```

`sequence_lengths` is always within bounds: for max-length (unpadded) responses it already equals `response_len - 1`.

### Bug 2 — `missing_eos_penalty` never triggers with custom stop token

```python
contain_eos_token = torch.any(postprocessed_responses == self.processing_class.eos_token_id, dim=-1)
```

When a custom `stop_token_id` is configured that differs from `eos_token_id`, the truncation step replaces tokens after the stop token with PAD, but the EOS-presence check still looks for `eos_token_id`.  If the model never emits `eos_token_id` (only the custom stop token), `contain_eos_token` is always `False` and `missing_eos_penalty` is never applied.

```python
# After — use stop_token_id (falls back to eos_token_id when stop_token_id is None)
_stop_id = self.stop_token_id if self.stop_token_id is not None else self.processing_class.eos_token_id
contain_eos_token = torch.any(postprocessed_responses == _stop_id, dim=-1)
```

Fixes #3750

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PPO reward/penalty logic in `ppo_trainer.py`, which can materially affect training signals and learned behavior, especially for runs using custom stop tokens. Low implementation complexity, but high impact on model optimization dynamics.
> 
> **Overview**
> Fixes two PPO rollout-processing issues in `trl/experimental/ppo/ppo_trainer.py`.
> 
> `missing_eos_penalty` now checks for the configured `stop_token_id` (falling back to `eos_token_id`) so completions that omit the *actual* stop token are penalized correctly.
> 
> The per-sample score is now added to `rewards` at the EOS position (`sequence_lengths`) instead of the following PAD position, ensuring the scalar reward is not masked out during training.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fab5af5e453d445e2dfc6efbe0ec218456672e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->