### PR TITLE
Fix ORPO NaN log_odds / nan grad_norm on multi-GPU DeepSpeed runs

### DIFF
--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -645,8 +645,8 @@ class ORPOTrainer(_BaseTrainer):
         """
 
         # Derived from Eqs. (4) and (7) from https://huggingface.co/papers/2403.07691 by using log identities and exp(log(P(y|x)) = P(y|x)
-        policy_chosen_logps = policy_chosen_logps.float()
-        policy_rejected_logps = policy_rejected_logps.float()
+        policy_chosen_logps = policy_chosen_logps.float().clamp(max=-1e-6)  # keep away from 0 to avoid log1mexp(-inf)
+        policy_rejected_logps = policy_rejected_logps.float().clamp(max=-1e-6)
         log_odds = (policy_chosen_logps - policy_rejected_logps) - (
             log1mexp(policy_chosen_logps) - log1mexp(policy_rejected_logps)
         )
@@ -695,7 +695,8 @@ class ORPOTrainer(_BaseTrainer):
         per_token_logps = selective_log_softmax(logits, labels)
 
         if average_log_prob:
-            return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
+            denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows (e.g. DeepSpeed padding)
+            return (per_token_logps * loss_mask).sum(-1) / denom
         else:
             return (per_token_logps * loss_mask).sum(-1)
 


### PR DESCRIPTION
## Summary

Two root causes for `nan` `log_odds_chosen` and `nan` `grad_norm` when running `ORPOTrainer` with DeepSpeed multi-GPU (reported in #3237):

### Root cause 1 — Division by zero in `get_batch_logps`

On DeepSpeed ZeRO, each rank receives a shard of the global batch.  If a shard consists entirely of padding tokens, `loss_mask.sum(-1) == 0`, and the division:

```python
return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)  # ← ZeroDivisionError / nan
```

produces `nan` log-probs, which then flow into `log_odds`.

**Fix:**
```python
denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows
return (per_token_logps * loss_mask).sum(-1) / denom
```

### Root cause 2 — `log1mexp` of near-zero log-probs

Sequence log-probabilities close to 0 (P ≈ 1) cause `log1mexp` to return `-inf`.  Subtracting two `-inf` values in:

```python
log_odds = (chosen_logps - rejected_logps) - (log1mexp(chosen_logps) - log1mexp(rejected_logps))
```

yields `nan` directly.  Under DeepSpeed BF16 this happens more often because BF16 rounds small negative values to 0.

**Fix:**
```python
policy_chosen_logps   = policy_chosen_logps.float().clamp(max=-1e-6)
policy_rejected_logps = policy_rejected_logps.float().clamp(max=-1e-6)
```

Clamping at `-1e-6` keeps `log1mexp` away from the singularity while having negligible effect on numerically normal training examples.

Fixes #3237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ORPO loss/log-probability math; while changes are small and numerically motivated, they can subtly affect training dynamics and metrics.
> 
> **Overview**
> Prevents NaNs during multi-GPU DeepSpeed ORPO training by hardening two numerical edge cases.
> 
> In `odds_ratio_loss`, clamps `policy_*_logps` slightly below 0 before calling `log1mexp` to avoid `-inf - -inf` producing `nan` when BF16 rounding yields near-zero log-probs. In `get_batch_logps`, guards the average-log-prob denominator with `clamp(min=1)` to avoid division-by-zero when a rank receives an all-padding/all-masked shard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c70c51a07aa11ca5d31b5b9f2c8ec4d5070ca3fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->