### PR TITLE
Fix VLLMClient.chat sending tools=[] instead of tools=None when no tools are configured

### DIFF
--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -385,6 +385,8 @@ class VLLMClient:
 
         if isinstance(tools, list) and len(tools) > 0:
             tools = [get_json_schema(tool) if callable(tool) else tool for tool in tools]
+        else:
+            tools = None  # normalise empty list to None so the server does not activate tool-use mode
 
         response = self.session.post(
             url,


### PR DESCRIPTION
## Summary

`GRPOTrainer` initialises `self.tools = tools or []` so that it is always a list. When no tools are provided the value is `[]` (empty list). This is forwarded through `VLLMGeneration` → `VLLMClient.chat` as-is.

Inside `VLLMClient.chat` the schema-conversion guard correctly skips processing:

```python
if isinstance(tools, list) and len(tools) > 0:
    tools = [get_json_schema(tool) ...]
# tools is still [] here
```

But `tools=[]` is then included in the JSON payload sent to the vLLM server, which passes it directly to `llm.chat(tools=[])`.  Passing an *empty list* instead of `None` can activate tool-use mode with no tools defined, causing unexpected generation or errors (e.g. `TypeError` from models that validate the tools schema).

## Fix

Add an `else: tools = None` branch to normalise an empty list to `None` before it is serialised:

```python
if isinstance(tools, list) and len(tools) > 0:
    tools = [get_json_schema(tool) if callable(tool) else tool for tool in tools]
else:
    tools = None  # normalise empty list to None so the server does not activate tool-use mode
```

Fixes #5154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized request-payload change in `VLLMClient.chat`; primary risk is a behavior change for callers that previously (incorrectly) relied on `tools=[]` reaching the server.
> 
> **Overview**
> Prevents `VLLMClient.chat` from serializing `tools=[]` by converting any non-populated tools list to `None` before the `/chat/` request is sent.
> 
> This avoids accidentally activating vLLM tool-calling mode when no tools are configured, reducing spurious tool-mode errors and unexpected generations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c13e4e9fe9fbc9d3368441c0028c3ba9d37c89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->