### PR TITLE
Fix CPOTrainer (experimental) get_batch_logps division-by-zero on all-masked rows

### DIFF
--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -739,7 +739,8 @@ class CPOTrainer(_BaseTrainer):
         per_token_logps = selective_log_softmax(logits, labels)
 
         if average_log_prob:
-            return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
+            denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows to avoid div-by-zero
+            return (per_token_logps * loss_mask).sum(-1) / denom
         else:
             return (per_token_logps * loss_mask).sum(-1)
 


### PR DESCRIPTION
## Summary

`CPOTrainer.get_batch_logps` computes the average log-probability as:

```python
return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
```

`loss_mask.sum(-1)` is **zero** when every token in a sequence is masked — for example when a DeepSpeed ZeRO rank receives a shard that consists entirely of padding, or when the dataset contains an example where all completion tokens are filtered out.  Dividing by zero produces `nan` logps that silently propagate into the CPO loss and gradient.

## Fix

Clamp the denominator to at least `1`:

```python
denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows
return (per_token_logps * loss_mask).sum(-1) / denom
```

A fully-masked row contributes `0` to the numerator, so the result is `0 / 1 = 0`, which is a neutral value and does not affect training.  This is consistent with the guard already applied in `GRPOTrainer` (line 2156) and `PAPOTrainer`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk numerical stability fix confined to `CPOTrainer.get_batch_logps`; it only changes behavior for fully masked sequences by avoiding NaNs during average log-prob computation.
> 
> **Overview**
> Fixes a division-by-zero bug in experimental `CPOTrainer.get_batch_logps` when computing *average* log-probabilities for sequences where all tokens are masked.
> 
> The denominator `loss_mask.sum(-1)` is now clamped to at least `1`, preventing `NaN` logps from propagating into the CPO loss/gradients; fully masked rows now return an average logp of `0` instead of `NaN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02d36c49a4512b98da0ed9efde1a1be84d146b32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->