### PR TITLE
Fix BCOTrainer (experimental) get_batch_logps division-by-zero on all-masked rows

### DIFF
--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -1109,7 +1109,8 @@ class BCOTrainer(_BaseTrainer):
         per_token_logps = selective_log_softmax(logits, labels)
 
         if average_log_prob:
-            return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
+            denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows to avoid div-by-zero
+            return (per_token_logps * loss_mask).sum(-1) / denom
         else:
             return (per_token_logps * loss_mask).sum(-1)
 


### PR DESCRIPTION
## Summary

`BCOTrainer.get_batch_logps` computes the average log-probability as:

```python
return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
```

`loss_mask.sum(-1)` is **zero** when every token in a sequence is masked — for example when a DeepSpeed ZeRO rank receives a shard that consists entirely of padding, or when the dataset contains an example where all completion tokens are filtered out.  Dividing by zero produces `nan` logps that silently propagate into the BCO loss and gradient.

## Fix

Clamp the denominator to at least `1`:

```python
denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows
return (per_token_logps * loss_mask).sum(-1) / denom
```

A fully-masked row contributes `0` to the numerator, so the result is `0 / 1 = 0`, which is a neutral value and does not affect training.  This is consistent with the guard already applied in `GRPOTrainer` (line 2156) and `PAPOTrainer`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix in experimental training code: clamps the per-sequence token-count denominator to avoid `nan` log-probs when a row is fully masked.
> 
> **Overview**
> Fixes `BCOTrainer.get_batch_logps` to **avoid division-by-zero** when computing *average* log-probabilities for sequences where all labels are masked.
> 
> The denominator `loss_mask.sum(-1)` is now clamped to at least `1`, preventing `nan` logps from propagating into downstream BCO loss/gradients on fully-masked rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc3858f881ce278ed3a102198a5994cdfbf06be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->