### PR TITLE
Fix KTOTrainer (experimental) get_batch_logps division-by-zero on all-masked rows

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -929,7 +929,8 @@ class KTOTrainer(_BaseTrainer):
         per_token_logps = selective_log_softmax(logits, labels)
 
         if average_log_prob:
-            return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
+            denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows to avoid div-by-zero
+            return (per_token_logps * loss_mask).sum(-1) / denom
         else:
             return (per_token_logps * loss_mask).sum(-1)
 


### PR DESCRIPTION
## Summary

`KTOTrainer.get_batch_logps` computes the average log-probability as:

```python
return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
```

`loss_mask.sum(-1)` is **zero** when every token in a sequence is masked — for example when a DeepSpeed ZeRO rank receives a shard that consists entirely of padding, or when the dataset contains an example where all completion tokens are filtered out.  Dividing by zero produces `nan` logps that silently propagate into the KTO loss and gradient.

## Fix

Clamp the denominator to at least `1`:

```python
denom = loss_mask.sum(-1).clamp(min=1)  # guard against all-masked rows
return (per_token_logps * loss_mask).sum(-1) / denom
```

A fully-masked row contributes `0` to the numerator, so the result is `0 / 1 = 0`, which is a neutral value and does not affect training.  This is consistent with the guard already applied in `GRPOTrainer` (line 2156) and `PAPOTrainer`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small numerical-stability guard in `KTOTrainer.get_batch_logps` that only affects the edge case where all tokens are masked, preventing `nan` values from propagating into loss/gradients.
> 
> **Overview**
> Fixes a numerical edge case in experimental `KTOTrainer.get_batch_logps` when computing *average* log-probabilities.
> 
> When a sequence has all tokens masked (`labels == -100`), the code now clamps the denominator (`loss_mask.sum(-1)`) to at least `1`, preventing division-by-zero and avoiding `nan` log-probs during training.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49dec3db69c746c870cc34e33767f96b5b82d351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->