### PR TITLE
Fix GRPOTrainer passing tools=[] to apply_chat_template when no tools are configured

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1255,7 +1255,7 @@ class GRPOTrainer(_BaseTrainer):
             if is_conversational({"prompt": prompts[0]}):
                 processor_outputs = self.processing_class.apply_chat_template(
                     conversation=prompts,
-                    tools=self.tools,
+                    tools=self.tools or None,
                     chat_template=self.chat_template,
                     add_generation_prompt=True,
                     tokenize=True,
@@ -1296,7 +1296,7 @@ class GRPOTrainer(_BaseTrainer):
             if is_conversational({"prompt": prompts[0]}):
                 generate_inputs = self.processing_class.apply_chat_template(
                     conversation=prompts,
-                    tools=self.tools,
+                    tools=self.tools or None,
                     chat_template=self.chat_template,
                     add_generation_prompt=True,
                     tokenize=True,
@@ -1415,7 +1415,7 @@ class GRPOTrainer(_BaseTrainer):
             # vLLM and transformers will error out if the input is longer than the model's max length.
             pct_ids = self.processing_class.apply_chat_template(
                 prompt_completion_tools,
-                tools=self.tools,
+                tools=self.tools or None,
                 chat_template=self.chat_template,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -1721,7 +1721,7 @@ class GRPOTrainer(_BaseTrainer):
         if images is not None:
             prompts_text = [
                 apply_chat_template(
-                    {"prompt": prompt}, self.processing_class, tools=self.tools, **self.chat_template_kwargs
+                    {"prompt": prompt}, self.processing_class, tools=self.tools or None, **self.chat_template_kwargs
                 )["prompt"]
                 for prompt in prompts
             ]


### PR DESCRIPTION
## Summary

`GRPOTrainer` initialises `self.tools = tools or []` so it is always a list.  When no tools are configured the value is `[]` (empty list).  This empty list is forwarded to `tokenizer.apply_chat_template()` at four call sites via `tools=self.tools`.

Many Jinja2 chat templates used by current models distinguish `None` from an empty list:

```jinja
{%- if tools is not none %}
  {# render tool section #}
{%- endif %}
```

Passing `tools=[]` (non-None, but empty) incorrectly triggers the tool-rendering block with no tool definitions, which produces a malformed system prompt / generation prefix.  This was observed with Qwen2.5 / Mistral tool-aware templates.

## Fix

Normalise `self.tools or None` at each `apply_chat_template` call site so that an empty tools list is treated identically to no tools at template-rendering time:

```python
# Before
tools=self.tools,

# After
tools=self.tools or None,
```

The `VLLMGeneration` constructor call (line 745) is intentionally excluded because that path's empty-list-to-None normalisation is already handled inside `VLLMClient.chat` (see companion fix in `vllm_client.py`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving for configured tools; it only changes how `apply_chat_template` is called when no tools are configured, which can affect prompt formatting for some chat templates.
> 
> **Overview**
> Fixes `GRPOTrainer` chat templating to avoid passing an empty tools list into `apply_chat_template`, which some Jinja2 templates interpret as *tools enabled* and produce malformed prompts.
> 
> All affected `apply_chat_template` call sites now pass `tools=self.tools or None` across the paged transformers path, the regular transformers generation path, the tool-call loop re-tokenization, and multimodal prompt text preparation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbb69f8a78640d1778f7ddb5410fd74ac1477134. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->