### PR TITLE
Move weight management from generate() into sync_weights()

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -267,6 +267,7 @@ class VLLMGeneration:
         self.max_model_length = max_model_length
         self.max_num_seqs = max_num_seqs
         self.enable_sleep_mode = enable_sleep_mode
+        self._weights_loaded = False
         self.model_impl = model_impl
 
         # Generation configuration
@@ -440,6 +441,12 @@ class VLLMGeneration:
         if self.mode == "colocate" and self.enable_sleep_mode:
             empty_cache()  # required to avoid OOM in some cases
             self.llm.wake_up(tags=["weights"])
+            # Work around for https://github.com/vllm-project/vllm/issues/29341
+            try:
+                self.llm.collective_rpc("reload_weights")
+            except NotImplementedError:
+                # Non-CUDA vLLM backends (e.g., vllm-ascend's NPUWorkerV1), don't implement reload_weights
+                pass
 
         model = self.model
         accelerator = self.accelerator
@@ -518,6 +525,8 @@ class VLLMGeneration:
         elif self.mode == "colocate":
             self.llm.reset_prefix_cache()
 
+        self._weights_loaded = True
+
     def generate(
         self,
         prompts: list[list[int]],
@@ -565,16 +574,9 @@ class VLLMGeneration:
         repetition_penalty = self.repetition_penalty
         max_completion_length = self.max_completion_length
 
-        # Wake up colocated vLLM weights if needed (idempotent if already awake from sync_weights)
-        if self.mode == "colocate" and self.enable_sleep_mode:
-            empty_cache()  # required to avoid OOM in some cases
-            self.llm.wake_up(tags=["weights"])
-            # Work around for https://github.com/vllm-project/vllm/issues/29341
-            try:
-                self.llm.collective_rpc("reload_weights")
-            except NotImplementedError:
-                # Non-CUDA vLLM backends (e.g., vllm-ascend's NPUWorkerV1), don't implement reload_weights
-                pass
+        # Ensure vLLM weights are loaded before generating
+        if self.mode == "colocate" and self.enable_sleep_mode and not self._weights_loaded:
+            self.sync_weights()
 
         # Generate completions using vLLM: gather all prompts and use them in a single call in the main process
         if self.mode == "server":
@@ -721,5 +723,6 @@ class VLLMGeneration:
 
             if self.enable_sleep_mode:
                 self.llm.sleep(level=2)
+                self._weights_loaded = False
 
         return prompt_ids, completion_ids, logprobs, logprob_token_ids


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

generate() reloads the weights from disk via collective_rpc("reload_weights"), overwriting weights that sync_weights() just copied. This causes vLLM to always generate with base weights whenever sleep mode is enabled. I think the better practice that would have avoided this problem is to just have weights managed by one function. 

So I moved reload_weights into sync_weights() and added a flag to track weight state so generate() delegates to sync_weights() when weights are invalid after sleep. 

Fixes #5312

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case. (#5312)
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@qgallouedec Thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vLLM weight synchronization and sleep-mode lifecycle; mistakes could lead to stale/incorrect weights or extra sync overhead during generation in colocated mode.
> 
> **Overview**
> Fixes colocated vLLM sleep-mode generation using stale/base weights by **moving the `reload_weights` wake-up workaround from `generate()` into `sync_weights()`** and tracking weight validity with a new `_weights_loaded` flag.
> 
> `generate()` now calls `sync_weights()` only when sleep mode is enabled and weights are not currently loaded, and weight state is invalidated after `llm.sleep()` so the next generation re-syncs as needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e19c42f3fe74ab87e7b1c8faf2838cdcb919aff8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->