### PR TITLE
[vllm-serve] Add extra_llm_kwargs for passing additional arguments to vllm.LLM()

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -331,19 +331,7 @@ def llm_worker(
     os.environ["VLLM_DP_SIZE"] = str(script_args.data_parallel_size)
     os.environ["VLLM_DP_MASTER_PORT"] = str(master_port)
 
-    try:
-        extra_kwargs = json.loads(script_args.extra_llm_kwargs)
-    except json.JSONDecodeError as e:
-        logging.getLogger(__name__).error(
-            f'Failed to parse extra_llm_kwargs as JSON: {e}. Ignoring extra kwargs'
-        )
-        extra_kwargs = {}
-
-    if not isinstance(extra_kwargs, dict):
-        logging.getLogger(__name__).error(
-            f'extra_llm_kwargs must be a JSON object, got {type(extra_kwargs).__name__}. Ignoring extra kwargs'
-        )
-        extra_kwargs = {}
+    extra_kwargs = json.loads(script_args.extra_llm_kwargs)
 
     llm_kwargs = dict(
         model=script_args.model,


### PR DESCRIPTION
# What does this PR do?

- Add an extra `extra_llm_kwargs` argument to `trl vllm-serve` CLI for passing additional kwargs to `vllm.VLLM()` that aren't explicitly exposed as `ScriptArguments` fields.
- This enables features like `language_model_only`, `gdn_prefill_backend`, `generation_config`, etc. without requiring a new CLI arg for each one. These arguments in particular are very helpful for being able to serve Qwen 3.5 in fp8.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new JSON-parsed CLI parameter that can override core `LLM()` initialization settings, so invalid JSON or conflicting keys can cause startup failures or unexpected runtime behavior.
> 
> **Overview**
> `trl vllm-serve` now accepts `extra_llm_kwargs` (a JSON string) and merges it into the arguments used to construct `vllm.LLM()`.
> 
> This enables configuring vLLM engine options not explicitly exposed by the script, with the explicit behavior that provided keys can override existing CLI-derived `LLM()` kwargs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86228350f34f342276a4c1cce1daf9d5b104f15c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->