### PR TITLE
Use BaseConfig post_init in experimental KTO and MiniLLM configs

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -141,8 +141,3 @@ class KTOConfig(_BaseConfig):
         default=None,
         metadata={"help": "Number of processes to use for processing the dataset."},
     )
-
-    def __post_init__(self):
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
-
-        super().__post_init__()

--- a/trl/experimental/minillm/minillm_config.py
+++ b/trl/experimental/minillm/minillm_config.py
@@ -15,8 +15,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from transformers import TrainingArguments
-
+from ...trainer.base_config import _BaseConfig
 from ...trainer.grpo_config import GRPOConfig
 
 
@@ -87,9 +86,7 @@ class MiniLLMConfig(GRPOConfig):
     def __post_init__(self):
         # We do not use the post_init of GRPOConfig because:
         # 1. num_generations can be < 2 in MiniLLMConfig. Scale_rewards must be set to "none" to avoid nan.
-        self.bf16 = not (self.fp16) if self.bf16 is None else self.bf16
-
-        TrainingArguments.__post_init__(self)
+        _BaseConfig.__post_init__(self)
 
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
         if self.num_generations == 1:


### PR DESCRIPTION
Use `_BaseConfig.__post_init__` in experimental KTO and MiniLLM configs.

This PR refactors configuration initialization logic in the experimental KTO and MiniLLM modules to ensure both configurations leverage the shared `_BaseConfig` logic. This removes redundant code.

Follow-up to:
- #5148

### Changes

**Refactoring configuration initialization:**

* Removed the custom `__post_init__` method from `KTOConfig`, eliminating manual handling of `bf16` and deferring post-initialization logic to `_BaseConfig`.
* Updated `MiniLLMConfig` to call `_BaseConfig.__post_init__` instead of manually invoking `TrainingArguments.__post_init__`, ensuring consistent configuration handling and code reuse.

**Dependency and import cleanup:**

* Removed the unused import of `TrainingArguments` and added the correct import for `_BaseConfig` in `minillm_config.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in experimental trainer configs; main impact is initialization order/default handling (notably `bf16`) now consistently flows through `_BaseConfig.__post_init__`.
> 
> **Overview**
> Aligns experimental `KTOConfig` and `MiniLLMConfig` initialization with shared `_BaseConfig` behavior.
> 
> `KTOConfig` drops its custom `__post_init__`, relying on inherited base post-init logic, and `MiniLLMConfig` switches from calling `TrainingArguments.__post_init__` (and manual `bf16` defaulting) to `_BaseConfig.__post_init__`, removing the now-unused `TrainingArguments` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932080c5f38066f72771daad510210360124120d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->