### PR TITLE
Pass tools as None to `apply_chat_template` when it is an empty list

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -208,7 +208,7 @@ def apply_chat_template(
 
     For more details, see [`maybe_apply_chat_template`].
     """
-    tools = tools or None  # "or None": Llama-specific bug: it renders tool boilerplate for tools=[]
+    tools = tools or None  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
     # Check that the example has the correct keys
     supported_keys = ["prompt", "chosen", "rejected", "completion", "messages", "label"]
     example_keys = {key for key in example.keys() if key in supported_keys}

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -327,7 +327,7 @@ class AsyncRolloutWorker:
                             prompt,
                             return_dict=False,
                             add_generation_prompt=True,
-                            tools=self.tools or None,  # "or None": Llama bug: it renders tool boilerplate for tools=[]
+                            tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
                             chat_template=self.chat_template,
                             **self.chat_template_kwargs,
                         )
@@ -527,7 +527,7 @@ class AsyncRolloutWorker:
             prompt,
             return_dict=False,
             add_generation_prompt=True,
-            tools=self.tools or None,  # "or None": Llama bug: it renders tool boilerplate for tools=[]
+            tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
             chat_template=self.chat_template,
             **self.chat_template_kwargs,
         )
@@ -562,7 +562,7 @@ class AsyncRolloutWorker:
         prefix_ids = self.tokenizer.apply_chat_template(
             dummy_messages,
             return_dict=False,
-            tools=self.tools or None,  # "or None": Llama bug: it renders tool boilerplate for tools=[]
+            tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
             chat_template=self.chat_template,
             **self.chat_template_kwargs,
         )
@@ -571,7 +571,7 @@ class AsyncRolloutWorker:
             return_dict=False,
             chat_template=self.chat_template,
             add_generation_prompt=True,
-            tools=self.tools or None,  # "or None": Llama bug: it renders tool boilerplate for tools=[]
+            tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
             **self.chat_template_kwargs,
         )
 

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -251,7 +251,7 @@ class DPPOTrainer(GRPOTrainer):
             # See: https://github.com/huggingface/transformers/issues/44514
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
-                tools=self.tools or None,  # "or None": Llama-specific bug: it renders tool boilerplate for tools=[]
+                tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
                 chat_template=self.chat_template,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -491,7 +491,7 @@ class DPPOTrainer(GRPOTrainer):
             # Tokenize and filter samples whose length exceeds max allowed length
             pct_ids = self.processing_class.apply_chat_template(
                 prompt_completion_tools,
-                tools=self.tools or None,  #  "or None": Llama-specific bug: it renders tool boilerplate for tools=[]
+                tools=self.tools or None,  #  `or None`: Llama bug: it renders tool boilerplate for tools=[]
                 chat_template=self.chat_template,
                 add_generation_prompt=True,
                 tokenize=True,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1261,7 +1261,7 @@ class GRPOTrainer(_BaseTrainer):
             # See: https://github.com/huggingface/transformers/issues/44514
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
-                tools=self.tools or None,  # "or None": Llama-specific bug: it renders tool boilerplate for tools=[]
+                tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
                 chat_template=self.chat_template,
                 add_generation_prompt=True,
                 tokenize=True,


### PR DESCRIPTION
Fixes #5379


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small, consistent parameter normalization that only affects how chat templates are rendered when `tools` is an empty list.
> 
> **Overview**
> Fixes tool-calling prompt rendering by normalizing `tools=[]` to `tools=None` before calling `apply_chat_template`, working around a Llama template bug that injects unwanted tool boilerplate.
> 
> This behavior is applied consistently across dataset templating (`data_utils.apply_chat_template`) and GRPO/DPPO/Async GRPO rollout/tokenization paths so empty tool lists no longer alter the rendered prompt/ids.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c6f445b351ea787fedd3601e72b1e90d378d0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->