### PR TITLE
Remove xfail for ZeRO 2 and 3 + SFT + PEFT test

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -17,6 +17,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import torch
 import transformers
 from packaging.version import Version
 
@@ -150,7 +151,26 @@ class TestDistributed(TrlTestCase):
 
     @pytest.mark.parametrize(
         "config",
-        ["ddp", "zero2", "zero3", "fsdp2"],
+        [
+            "ddp",
+            pytest.param(
+                "zero2",
+                marks=pytest.mark.xfail(
+                    condition=Version("2.10") <= Version(torch.__version__)
+                    and Version(transformers.__version__) < Version("5.1.0"),
+                    reason="ZeRO 2 + PEFT was failing before transformers 5.1.0 on torch 2.10; see #4884",
+                ),
+            ),
+            pytest.param(
+                "zero3",
+                marks=pytest.mark.xfail(
+                    condition=Version("2.10") <= Version(torch.__version__)
+                    and Version(transformers.__version__) < Version("5.1.0"),
+                    reason="ZeRO 3 + PEFT was failing before transformers 5.1.0 on torch 2.10; see #4884",
+                ),
+            ),
+            "fsdp2",
+        ],
     )
     def test_sft_peft(self, config, get_config_path):
         # fmt: off


### PR DESCRIPTION
https://github.com/huggingface/trl/issues/4884 is now solved, the fix was released in transformers 5.1.0, these test have been xpassing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that just tightens `xfail` conditions based on dependency versions. Main risk is potential CI flakiness if the environment version detection differs from expected.
> 
> **Overview**
> Updates the distributed `test_sft_peft` parametrization to **stop xfail-ing ZeRO-2/ZeRO-3 runs on torch >= 2.10 once `transformers` is >= 5.1.0**, reflecting the upstream fix.
> 
> The `xfail` is now conditional on *both* torch >= 2.10 and `transformers` < 5.1.0, with updated reason messages to match the new version gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e0b8c52c5ca5d230999cfbe895811de0615214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->