### PR TITLE
Mark test_rloo[fsdp2] as xfail for transformers 5.4.0

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -234,7 +234,14 @@ class TestDistributed(
                 ),
             ),
             pytest.param("zero3", marks=pytest.mark.xfail(reason="ZeRO 3 is currently failing, see #4899")),
-            "fsdp2",
+            pytest.param(
+                "fsdp2",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.4.0"),
+                    reason="Upstream issue: NaN weights on non-rank-0 FSDP processes (see #5386 and transformers#45050)",
+                    strict=True,
+                ),
+            ),
         ],
     )
     def test_rloo(self, config, get_config_path):


### PR DESCRIPTION
Fix CI failure for distributed test_rloo[fsdp2]:
- Mark test_rloo[fsdp2] as xfail for transformers 5.4.0

Fix #5386.

See upstream fix:
- https://github.com/huggingface/transformers/pull/45050

This PR marks the "fsdp2" configuration of the distributed test suite as an expected failure (xfail) for a specific version of the `transformers` library, providing clearer test outcomes and documentation for known upstream issues.

**Testing improvements:**

* Added a new `pytest.param` for the "fsdp2" configuration in `test_rloo`, marking it as an expected failure (`xfail`) when `transformers` version is exactly 5.4.0, with a detailed reason and strict enforcement. This documents and accounts for an upstream issue causing NaN weights on non-rank-0 FSDP processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that marks a known upstream `transformers==5.4.0` FSDP issue as an expected failure, without affecting runtime code paths.
> 
> **Overview**
> Marks the distributed `test_rloo` case for the `fsdp2` configuration as `xfail` specifically on `transformers==5.4.0`, with a documented reason and `strict=True` to prevent silent passes.
> 
> This stabilizes CI by treating the known upstream NaN-weight failure on non-rank-0 FSDP processes as an expected, version-gated test outcome.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a502f508fcfcc0ffad030a2f5cfe75e4283b382e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->