### PR TITLE
Enhance PR template check to exclude reopened PRs from first-time contributor validation

### DIFF
--- a/.github/workflows/pr_template_check.yml
+++ b/.github/workflows/pr_template_check.yml
@@ -20,9 +20,13 @@ jobs:
   check-pr-template:
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-      github.event.pull_request.author_association == 'FIRST_TIMER' ||
-      github.event.pull_request.author_association == 'NONE'
+      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+       github.event.pull_request.author_association == 'FIRST_TIMER' ||
+       github.event.pull_request.author_association == 'NONE') &&
+      !(github.event.action == 'reopened' &&
+        (github.event.sender.author_association == 'MEMBER' ||
+         github.event.sender.author_association == 'OWNER' ||
+         github.event.sender.author_association == 'COLLABORATOR'))
     steps:
       - name: Check PR body follows template
         id: check


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens the GitHub Actions `if` condition for when the PR-template check job runs, with no product code changes. Main risk is unintended skipping of template enforcement on certain `reopened` events due to author_association edge cases.
> 
> **Overview**
> Adjusts the PR template check workflow so it still targets first-time contributors, but **does not run when a PR is `reopened` by a maintainer** (MEMBER/OWNER/COLLABORATOR).
> 
> This prevents the job from re-validating/auto-closing previously reopened PRs based solely on the reopen action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 360f277a9179c836b6214afe430380941e840401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->