### PR TITLE
Add `log_multimodal` param to GRPOConfig and RLOOConfig to control image logging

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2959,6 +2959,31 @@ class TestGRPOTrainerVLM(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_train_vlm_log_multimodal_false(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+            log_completions=True,
+            log_multimodal=False,
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        assert len(trainer._logs["images"]) == 0
+
     @pytest.mark.xfail(
         condition=Version(transformers.__version__) < Version("5.2.0"),
         reason="Qwen3.5 models were introduced in transformers-5.2.0",

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1834,3 +1834,28 @@ class TestRLOOTrainerVLM(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_vlm_log_multimodal_false(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+            log_completions=True,
+            log_multimodal=False,
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        assert len(trainer._logs["images"]) == 0

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -340,7 +340,7 @@ class GRPOConfig(_BaseConfig):
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
         log_multimodal (`bool`, *optional*, defaults to `True`):
-            Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
+            Whether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
             log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -339,7 +339,7 @@ class GRPOConfig(_BaseConfig):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
-        log_multimodal ('bool', *optional*, defaults to `True`):
+        log_multimodal (`bool`, *optional*, defaults to `True`):
             Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
             log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -339,6 +339,9 @@ class GRPOConfig(_BaseConfig):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
+        log_multimodal ('bool', *optional*, defaults to `True`):
+            Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
+            log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.
         log_unique_prompts (`bool`, *optional*, defaults to `False`):
@@ -902,6 +905,13 @@ class GRPOConfig(_BaseConfig):
         metadata={
             "help": "Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is "
             "installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`."
+        },
+    )
+    log_multimodal: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to log multimodal content (images, videos, etc.) together with completions. Disable this "
+            "to reduce log size when using high-resolution multimodal data."
         },
     )
     num_completions_to_print: int | None = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -834,6 +834,7 @@ class GRPOTrainer(_BaseTrainer):
         self._total_train_tokens = 0
         self._current_train_step_time = 0.0
         self.log_completions = args.log_completions
+        self.log_multimodal = args.log_multimodal
         self.log_unique_prompts = args.log_unique_prompts
         self.num_completions_to_print = args.num_completions_to_print
         # Keep logs sized to the generation batch to record only outputs from the latest model update.
@@ -2400,7 +2401,7 @@ class GRPOTrainer(_BaseTrainer):
             self._metrics[mode][name].append(global_mean)
         self._pending_metrics.clear()
 
-        if images is not None:
+        if images is not None and self.log_multimodal:
             self._logs["images"].extend(gather_object(images))
 
         if self.use_vllm and self.vllm_importance_sampling_correction:

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -213,7 +213,7 @@ class RLOOConfig(_BaseConfig):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
-        log_multimodal ('bool', *optional*, defaults to `True`):
+        log_multimodal (`bool`, *optional*, defaults to `True`):
             Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
             log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -214,7 +214,7 @@ class RLOOConfig(_BaseConfig):
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
         log_multimodal (`bool`, *optional*, defaults to `True`):
-            Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
+            Whether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
             log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -213,6 +213,9 @@ class RLOOConfig(_BaseConfig):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
             `trackio`.
+        log_multimodal ('bool', *optional*, defaults to `True`):
+            Wether to log multimodal content (images, videos, etc.) together with completions. Disable this to reduce
+            log size when using high-resolution multimodal data.
         num_completions_to_print (`int`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.
         log_unique_prompts (`bool`, *optional*, defaults to `False`):
@@ -565,6 +568,13 @@ class RLOOConfig(_BaseConfig):
         metadata={
             "help": "Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is "
             "installed, it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`."
+        },
+    )
+    log_multimodal: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to log multimodal content (images, videos, etc.) together with completions. Disable this "
+            "to reduce log size when using high-resolution multimodal data."
         },
     )
     num_completions_to_print: int | None = field(

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -549,6 +549,7 @@ class RLOOTrainer(_BaseTrainer):
         self._total_train_tokens = 0
         self._current_train_step_time = 0.0
         self.log_completions = args.log_completions
+        self.log_multimodal = args.log_multimodal
         self.log_unique_prompts = args.log_unique_prompts
         self.num_completions_to_print = args.num_completions_to_print
         # Keep logs sized to the generation batch to record only outputs from the latest model update.
@@ -1475,7 +1476,7 @@ class RLOOTrainer(_BaseTrainer):
             self._metrics[mode][name].append(global_mean)
         self._pending_metrics.clear()
 
-        if images is not None:
+        if images is not None and self.log_multimodal:
             self._logs["images"].extend(gather_object(images))
 
         output = {


### PR DESCRIPTION
# What does this PR do?

This PR introduces a `log_multimodal` option to GRPOConfig and RLOOConfig, which controls whether multimodal data is logged alongside completions.

When multiple high-resolution images are used during training, the log can quickly grow in size. While viewing images together with completions is very useful for debugging, disabling this feature for longer training runs can significantly reduce (cloud) storage usage.

The log_multimodal option defaults to True, preserving the current behavior.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] (autodoc) Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only opt-out with default True preserves existing behavior; no changes to training, rewards, or generation.
> 
> **Overview**
> Adds **`log_multimodal`** to `GRPOConfig` and `RLOOConfig` (default **`True`**) so you can turn off storing images (and other multimodal payloads) in completion logs while still using **`log_completions`**.
> 
> `GRPOTrainer` and `RLOOTrainer` only append to **`_logs["images"]`** when **`log_multimodal`** is enabled, which is meant to shrink wandb/Hub log size for VLM runs with heavy image data.
> 
> VLM tests cover **`log_multimodal=False`** and assert the images buffer stays empty after training.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a7fe25d56fba445444101b71a09bc4a97cb79f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->