### PR TITLE
Update tests with zero3 for RLOO and GRPO as xfail only with transformers >= v5

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -235,7 +235,7 @@ class TestDistributed(TrlTestCase):
                 "zero3",
                 marks=pytest.mark.xfail(
                     Version(transformers.__version__) >= Version("5.0.0"),
-                    reason="ZeRO-3 is currently failing, see #4899",
+                    reason="ZeRO-3 fails with transformers >= 5.0.0, see #4899",
                     strict=True,
                 ),
             ),
@@ -278,7 +278,7 @@ class TestDistributed(TrlTestCase):
                 "zero3",
                 marks=pytest.mark.xfail(
                     Version(transformers.__version__) >= Version("5.0.0"),
-                    reason="ZeRO-3 is currently failing, see #4899",
+                    reason="ZeRO-3 fails with transformers >= 5.0.0, see #4899",
                     strict=True,
                 ),
             ),


### PR DESCRIPTION
Update tests with zero3 for RLOO and GRPO as xfail only with transformers >= v5.

This PR updates the test suite to more accurately handle failures related to ZeRO-3 when using newer versions of the `transformers` library. Specifically, it refines the test expectations so that tests using ZeRO-3 are only expected to fail when `transformers` version is 5.0.0 or higher.

I tested locally that the error appeared in transformers v5.0.0 after the merge of:
- https://github.com/huggingface/transformers/pull/41147

See investigation in underlying issue:
- https://github.com/huggingface/trl/issues/4899#issuecomment-4160309959


### Changes

Test suite improvements:

* Updated the `test_reward` and `test_rloo` test cases in `tests/distributed/test_distributed.py` to mark ZeRO-3 tests as expected to fail only when `transformers` version is 5.0.0 or newer, instead of unconditionally. This makes the test results more accurate and prevents false negatives on older versions. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pytest `xfail` conditions for distributed tests, affecting test expectations rather than runtime code paths.
> 
> **Overview**
> Updates distributed test parametrizations for `test_rloo` and `test_grpo` so the `zero3` configuration is marked `xfail` *only* when `transformers >= 5.0.0` (with `strict=True`), instead of always expecting failure. This reduces false failures on older `transformers` versions while retaining the known ZeRO-3 regression coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80d5dd660d2b03b34fde7fe1bf9891d5300b4e4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->