### PR TITLE
Update tests to not pass `eval_strategy`

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -14,9 +14,7 @@
 
 import pytest
 import torch
-import transformers
 from datasets import load_dataset
-from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, GenerationConfig
 from transformers.utils import is_peft_available
 
@@ -89,11 +87,6 @@ class TestNashMDTrainer(TrlTestCase):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_nash_md_trainer_training(self, config_name):
         training_args = NashMDConfig(
@@ -103,7 +96,6 @@ class TestNashMDTrainer(TrlTestCase):
             remove_unused_columns=False,
             gradient_accumulation_steps=1,
             learning_rate=9e-1,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -115,7 +107,6 @@ class TestNashMDTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
         )
 
         trainer.train()
@@ -123,11 +114,6 @@ class TestNashMDTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -136,7 +122,6 @@ class TestNashMDTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -147,7 +132,6 @@ class TestNashMDTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             peft_config=lora_config,
         )
 
@@ -156,11 +140,6 @@ class TestNashMDTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft_and_ref_model(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -169,7 +148,6 @@ class TestNashMDTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -181,7 +159,6 @@ class TestNashMDTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             peft_config=lora_config,
         )
 
@@ -221,11 +198,6 @@ class TestNashMDTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     @require_llm_blender
     def test_nash_md_trainer_judge_training(self, config_name):
@@ -236,7 +208,6 @@ class TestNashMDTrainer(TrlTestCase):
             remove_unused_columns=False,
             gradient_accumulation_steps=1,
             learning_rate=9e-1,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -249,7 +220,6 @@ class TestNashMDTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
         )
 
         trainer.train()

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import pytest
-import transformers
 from datasets import Dataset, features, load_dataset
-from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
 
@@ -54,11 +52,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         self.reward_tokenizer = AutoTokenizer.from_pretrained(self.reward_model_id)
         self.reward_tokenizer.pad_token = self.reward_tokenizer.eos_token
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_training(self, config_name):
         training_args = OnlineDPOConfig(
@@ -66,7 +59,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -76,7 +68,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
         )
@@ -85,18 +76,12 @@ class TestOnlineDPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     def test_training_model_str(self):
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -106,7 +91,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
         )
@@ -115,18 +99,12 @@ class TestOnlineDPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     def test_training_with_ref_model(self):
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -137,7 +115,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
         )
@@ -167,11 +144,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
                 reward_processing_classes=self.reward_tokenizer,
             )
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -180,7 +152,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -190,7 +161,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
             peft_config=lora_config,
@@ -201,11 +171,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft_and_ref_model(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -214,7 +179,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -225,7 +189,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
             peft_config=lora_config,
@@ -236,11 +199,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     @require_llm_blender
     def test_training_with_judge(self, config_name):
@@ -249,7 +207,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -259,7 +216,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             judge=RandomPairwiseJudge(),
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
         )
         trainer.train()
@@ -435,22 +391,14 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert trainer.generation_config.max_new_tokens == 64
         assert not trainer.generation_config.do_sample  # From generation_kwargs
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     @require_torch_accelerator
     def test_training_with_transformers_paged(self, config_name):
-        if Version(transformers.__version__) < Version("4.57.0"):
-            pytest.xfail("Bug in transformers solved in GH#40692, released in 4.57.0.")
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
             use_transformers_paged=True,
         )
@@ -461,7 +409,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=self.reward_model,
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
             reward_processing_classes=self.reward_tokenizer,
         )
@@ -470,11 +417,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_training_with_reward_funcs(self, config_name):
         def simple_reward_func(prompts, completions, completion_ids, **kwargs):
@@ -485,7 +427,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             reward_weights=[0.7, 0.3],
             report_to="none",
         )
@@ -496,7 +437,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
             reward_funcs=[simple_reward_func, simple_reward_func],
             args=training_args,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
         )
         trainer.train()

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import pytest
-import transformers
 from datasets import load_dataset
-from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available
 
@@ -39,11 +37,6 @@ class TestXPOTrainer(TrlTestCase):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_xpo_trainer_training(self, config_name):
         training_args = XPOConfig(
@@ -53,7 +46,6 @@ class TestXPOTrainer(TrlTestCase):
             remove_unused_columns=False,
             gradient_accumulation_steps=1,
             learning_rate=9e-1,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -65,7 +57,6 @@ class TestXPOTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
         )
 
         trainer.train()
@@ -73,11 +64,6 @@ class TestXPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -86,7 +72,6 @@ class TestXPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -97,7 +82,6 @@ class TestXPOTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             peft_config=lora_config,
         )
 
@@ -106,11 +90,6 @@ class TestXPOTrainer(TrlTestCase):
         # Check if training loss is available
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @require_peft
     def test_training_with_peft_and_ref_model(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
@@ -119,7 +98,6 @@ class TestXPOTrainer(TrlTestCase):
             per_device_train_batch_size=2,
             max_steps=3,
             learning_rate=5.0e-7,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -131,7 +109,6 @@ class TestXPOTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
             peft_config=lora_config,
         )
 
@@ -169,11 +146,6 @@ class TestXPOTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
-    @pytest.mark.xfail(
-        Version(transformers.__version__) >= Version("5.4.0"),
-        reason="Issue with transformers >= 5.4.0: Must specify exactly one of input_ids or inputs_embeds (see #5421)",
-        strict=True,
-    )
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     @require_llm_blender
     def test_xpo_trainer_judge_training(self, config_name):
@@ -184,7 +156,6 @@ class TestXPOTrainer(TrlTestCase):
             remove_unused_columns=False,
             gradient_accumulation_steps=1,
             learning_rate=9e-1,
-            eval_strategy="steps",
             report_to="none",
         )
         dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
@@ -197,7 +168,6 @@ class TestXPOTrainer(TrlTestCase):
             args=training_args,
             processing_class=self.tokenizer,
             train_dataset=dummy_dataset["train"],
-            eval_dataset=dummy_dataset["test"],
         )
 
         trainer.train()


### PR DESCRIPTION
# What does this PR do?

This PR fixes https://github.com/huggingface/trl/issues/5421. We shouldn't set and pass an eval `dataset` + `eval_strategy` if we don't actually want to eval. In transformes now, we will eval on the last step in any case if `eval_strategy="step"`. This is to mirror the fact that when  save_strategy="steps", we will still save the model at the end of training. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adjusts test configuration; main risk is reduced evaluation coverage in these trainer smoke tests and any unintended reliance on eval-time code paths.
> 
> **Overview**
> Updates experimental trainer tests to avoid triggering evaluation when they’re intended as training-only smoke tests.
> 
> Removes `eval_strategy="steps"` and the corresponding `eval_dataset` arguments across `NashMDTrainer`, `OnlineDPOTrainer`, and `XPOTrainer` tests, and drops the transformers-version `xfail` guards (including a paged-transformers version check) that were working around evaluation-at-end behavior in newer `transformers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43824814e07620f040a9a82f2ff63cfed8c1abc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->