### PR TITLE
FIX CI: Targeting fused parameters with LoRA

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -335,7 +335,7 @@ class TestRewardTrainer(TrlTestCase):
             model=model_id,
             args=training_args,
             train_dataset=dataset,
-            peft_config=LoraConfig(target_modules=["up_proj", "down_proj", "score"]),
+            peft_config=LoraConfig(target_modules=["gate_proj", "up_proj", "down_proj", "score"]),
         )
 
         # Save the initial parameters to compare them later


### PR DESCRIPTION
# What does this PR do?

In this test, LoRA was targeting `up_proj` but not `gate_proj`. In Transformers, these two layers are now fused. Therefore, it is no longer possible to target just one of the two. The test is now changed to target both.

It would be possible to add a workaround and set zeros for the layer that is not being targeted, but that would be a bigger task. So if we can accept targeting both, I propose to just do that.

Note that during creation of the error message alerting the user to the fact that targeting just one is not possible, there was an error in PEFT. This error is being resolved via https://github.com/huggingface/peft/pull/3127. That PR also fixes the `KeyError: 'qwen2_vl'` we see in the dev dependency CI.

Fixes subsequent issue found in https://github.com/huggingface/trl/issues/5429#issuecomment-4171495790:
> ValueError: Cannot convert PEFT target(s) up_proj without also targeting gate_proj because they are fused into gate_up_proj.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@albertvillanova 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that broadens LoRA target modules to align with upstream fused layers, with no runtime/library behavior changes.
> 
> **Overview**
> Adjusts the `RewardTrainer` MoE PEFT regression test to include `gate_proj` alongside `up_proj` in `LoraConfig(target_modules=...)`, reflecting that these projections are now fused in recent Transformers and cannot be targeted independently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2265519d26db391bc6ac209f351b339d872fe639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->