### PR TITLE
Hotfix CI: Mark tests as xfail with peft dev due to KeyError: 'qwen2_vl'

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -38,7 +38,7 @@ from transformers.testing_utils import backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
-from trl.import_utils import is_liger_kernel_available
+from trl.import_utils import _is_package_available, is_liger_kernel_available
 from trl.trainer.utils import get_kbit_device_map
 
 from .testing_utils import (
@@ -57,6 +57,9 @@ from .testing_utils import (
 
 if is_peft_available():
     from peft import LoraConfig, PeftModel, get_peft_model
+
+
+_peft_available, _peft_version = _is_package_available("peft", return_version=True)
 
 
 def multiply_tool(a: int, b: int) -> int:
@@ -2074,7 +2077,14 @@ class TestGRPOTrainer(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    _peft_available and Version(_peft_version).is_devrelease,
+                    reason="Upstream issue with peft 0.18.2.dev0, see #5428",
+                    strict=True,
+                ),
+            ),
         ],
     )
     @require_vision

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -28,12 +28,16 @@ from transformers import (
 from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
+from trl.import_utils import _is_package_available
 
 from .testing_utils import TrlTestCase, require_peft, require_vision, require_vllm
 
 
 if is_peft_available():
     from peft import LoraConfig, get_peft_model
+
+
+_peft_available, _peft_version = _is_package_available("peft", return_version=True)
 
 
 class TestRLOOTrainer(TrlTestCase):
@@ -1464,7 +1468,14 @@ class TestRLOOTrainer(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    _peft_available and Version(_peft_version).is_devrelease,
+                    reason="Upstream issue with peft 0.18.2.dev0, see #5428",
+                    strict=True,
+                ),
+            ),
         ],
     )
     @require_vision


### PR DESCRIPTION
Hotfix CI: Mark tests as xfail with peft dev due to KeyError: 'qwen2_vl'.

This PR updates the test suites for `GRPOTrainer` and `RLOOTrainer` to improve compatibility checks with the `peft` package and to handle a known upstream issue with a specific development version of `peft`. The changes ensure that tests are conditionally marked as expected failures when running against problematic versions, improving the reliability and clarity of test outcomes.

Hotfix for:
- #5428 

See proposed fixing PR in `peft`:
- https://github.com/huggingface/peft/pull/3127

### Changes

Dependency and version checks:

* Introduced `_is_package_available` to both `test_grpo_trainer.py` and `test_rloo_trainer.py` to check for the presence and version of the `peft` package. 
* Added logic to retrieve `_peft_available` and `_peft_version` using `_is_package_available` in both test files.

Test robustness improvements:

* Updated parameterized tests in both `test_grpo_trainer.py` and `test_rloo_trainer.py` to use `pytest.mark.xfail` for the model `"trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration"` when running with a development release of `peft`, referencing a known upstream issue. This ensures tests fail gracefully and with clear reasoning when the issue is encountered. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-suite dependency/version detection and conditional `xfail` marking to stabilize CI against a known upstream `peft` dev-release regression.
> 
> **Overview**
> **Stabilizes CI for VLM + PEFT training tests** by detecting `peft` availability/version via `trl.import_utils._is_package_available`.
> 
> The `GRPOTrainer` and `RLOOTrainer` VLM+PEFT training parametrized tests now mark `tiny-Qwen2_5_VLForConditionalGeneration` as `xfail` when running against a `peft` *dev release* (referencing upstream issue `#5428`), so failures surface as expected rather than breaking the suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 422f48f532b68f6b53a74588f4a6280142a335c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->