### PR TITLE
Run make precommit to fix docstring style

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1509,9 +1509,9 @@ class GRPOTrainer(_BaseTrainer):
     def _get_vision_token_ids(self):
         """Get vision-related special token IDs from the processor's tokenizer.
 
-        Returns a dict with keys 'vision_start', 'vision_end', 'image_pad', 'video_pad'.
-        Values are None if the token doesn't exist in the vocabulary.
-        Supports multiple VLM families (e.g. Qwen uses <|vision_start|>, Gemma uses <|image>).
+        Returns a dict with keys 'vision_start', 'vision_end', 'image_pad', 'video_pad'. Values are None if the token
+        doesn't exist in the vocabulary. Supports multiple VLM families (e.g. Qwen uses <|vision_start|>, Gemma uses
+        <|image>).
         """
         if self._vision_token_ids_cache is None:
             cache = {"vision_start": None, "vision_end": None, "image_pad": None, "video_pad": None}

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -874,8 +874,8 @@ def identity(x):
 def split_pixel_values_by_grid(batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor | list[torch.Tensor]]:
     """
     Splits `batch["pixel_values"]` into a list of tensors based on the product of each row in `batch["image_grid_thw"]`
-    and batch["num_images"] while keeping other entries unchanged.
-    For models without `image_grid_thw` (e.g. Gemma), splits by `num_images` directly.
+    and batch["num_images"] while keeping other entries unchanged. For models without `image_grid_thw` (e.g. Gemma),
+    splits by `num_images` directly.
     """
     if "pixel_values" not in batch or "num_images" not in batch:
         return batch


### PR DESCRIPTION
Run make precommit to fix docstring style.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are docstring reflow/line-wrapping only, with no behavioral or API modifications.
> 
> **Overview**
> Runs formatting to satisfy docstring style checks by reflowing long docstring lines in `GRPOTrainer._get_vision_token_ids`, `GRPOTrainer._truncate_at_image_boundary`, and `split_pixel_values_by_grid`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 889acd7ff01d5f5f5f8f3fc480b294ab30f7fbc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->