### PR TITLE
Hotfix CI: Update skipif for test_rloo[fsdp2] after transformers 5.5.0 release

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -242,7 +242,7 @@ class TestDistributed(TrlTestCase):
             pytest.param(
                 "fsdp2",
                 marks=pytest.mark.skipif(
-                    Version(transformers.__version__) == Version("5.4.0"),
+                    Version(transformers.__version__) >= Version("5.4.0"),
                     reason="Upstream issue: NaN weights on non-rank-0 FSDP processes (see #5386 and transformers#45050)",
                 ),
             ),


### PR DESCRIPTION
Update xfail for test_rloo[fsdp2] after transformers 5.5.0 release: https://github.com/huggingface/trl/actions/runs/23935842019/job/69811980618
> FAILED tests/distributed/test_distributed.py::TestDistributed::test_rloo[fsdp2] - AssertionError: assert 1 == 0


This PR updates a test condition in `tests/distributed/test_distributed.py` to improve compatibility with newer versions of the `transformers` library.

Hotfix for:
- #5386

Follow-up to:
- #5387 
- #5403

### Changes

Test compatibility update:

* The `pytest.mark.skipif` condition for the "fsdp2" test now skips the test for all `transformers` versions greater than or equal to `5.4.0`, instead of only skipping for exactly version `5.4.0`. This addresses an upstream issue with NaN weights on non-rank-0 FSDP processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that widens a `skipif` gate, with no runtime or library behavior impact. Main risk is reduced CI coverage for `fsdp2` on newer `transformers` versions until the upstream issue is resolved.
> 
> **Overview**
> Updates the distributed `test_rloo` parametrization so the `fsdp2` configuration is skipped for **all** `transformers` versions `>= 5.4.0` (instead of only `== 5.4.0`) due to an upstream NaN-weights issue on non-rank-0 FSDP processes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46470df64ab6e4a69050d426abf29ba6e43c1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->