### PR TITLE
[AsyncGRPO] Support async tool calls in AsyncRolloutWorker

### DIFF
--- a/docs/source/async_grpo_trainer.md
+++ b/docs/source/async_grpo_trainer.md
@@ -71,6 +71,14 @@ CUDA_VISIBLE_DEVICES=1 accelerate launch train_async_grpo.py
 
 This trainer is intentionally kept minimal and is not meant to grow into a general-purpose solution. If you need a feature that is not supported, we recommend cloning the repository and adapting the trainer to your needs directly. New features will only be considered when there is significant community demand.
 
+## Async rewards and tools
+
+As with [`GRPOTrainer`], custom reward functions can be synchronous or asynchronous. When reward functions are defined as
+`async def` coroutines, they are awaited concurrently so their latency overlaps.
+
+Tools can also be synchronous or asynchronous. When a rollout sample triggers multiple tool calls in the same round,
+asynchronous tools are awaited concurrently and their results are appended back to the conversation in tool-call order.
+
 ## AsyncGRPOConfig
 
 [[autodoc]] trl.experimental.async_grpo.AsyncGRPOConfig

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -120,3 +120,39 @@ def test_execute_tool_calls_handles_unsupported_tool_call_type():
     assert len(tool_messages) == 1
     assert tool_messages[0]["name"] == "bad_tool"
     assert "Unsupported tool call type" in tool_messages[0]["content"]
+
+
+def test_execute_tool_calls_supports_flat_tool_call_structure_without_type():
+    worker = _make_worker()
+    tool_calls = [{"name": "sync_tool", "arguments": {"value": 5}}]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={"sync_tool": sync_tool},
+            async_tool_dict={},
+        )
+    )
+
+    assert n_calls == 1
+    assert n_failures == 0
+    assert tool_messages == [{"role": "tool", "name": "sync_tool", "content": "sync:5"}]
+
+
+def test_execute_tool_calls_missing_type_does_not_raise_keyerror():
+    worker = _make_worker()
+    tool_calls = [{"name": "unknown_tool", "arguments": {}}]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={},
+            async_tool_dict={},
+        )
+    )
+
+    assert n_calls == 1
+    assert n_failures == 1
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["name"] == "unknown_tool"
+    assert "Tool unknown_tool not found." in tool_messages[0]["content"]

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -120,39 +120,3 @@ def test_execute_tool_calls_handles_unsupported_tool_call_type():
     assert len(tool_messages) == 1
     assert tool_messages[0]["name"] == "bad_tool"
     assert "Unsupported tool call type" in tool_messages[0]["content"]
-
-
-def test_execute_tool_calls_supports_flat_tool_call_structure_without_type():
-    worker = _make_worker()
-    tool_calls = [{"name": "sync_tool", "arguments": {"value": 5}}]
-
-    tool_messages, n_calls, n_failures = asyncio.run(
-        worker._execute_tool_calls(
-            tool_calls,
-            sync_tool_dict={"sync_tool": sync_tool},
-            async_tool_dict={},
-        )
-    )
-
-    assert n_calls == 1
-    assert n_failures == 0
-    assert tool_messages == [{"role": "tool", "name": "sync_tool", "content": "sync:5"}]
-
-
-def test_execute_tool_calls_missing_type_does_not_raise_keyerror():
-    worker = _make_worker()
-    tool_calls = [{"name": "unknown_tool", "arguments": {}}]
-
-    tool_messages, n_calls, n_failures = asyncio.run(
-        worker._execute_tool_calls(
-            tool_calls,
-            sync_tool_dict={},
-            async_tool_dict={},
-        )
-    )
-
-    assert n_calls == 1
-    assert n_failures == 1
-    assert len(tool_messages) == 1
-    assert tool_messages[0]["name"] == "unknown_tool"
-    assert "Tool unknown_tool not found." in tool_messages[0]["content"]

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -53,9 +53,35 @@ def test_execute_tool_calls_supports_mixed_sync_and_async_tools():
 
     assert n_calls == 2
     assert n_failures == 0
-    assert {message["name"] for message in tool_messages} == {"sync_tool", "async_tool"}
-    assert any(message["content"] == "sync:1" for message in tool_messages)
-    assert any(message["content"] == "async:2" for message in tool_messages)
+    assert tool_messages == [
+        {"role": "tool", "name": "sync_tool", "content": "sync:1"},
+        {"role": "tool", "name": "async_tool", "content": "async:2"},
+    ]
+
+
+def test_execute_tool_calls_preserves_tool_call_order_for_mixed_sync_and_async_tools():
+    worker = _make_worker()
+    tool_calls = [
+        {"type": "function", "function": {"name": "sync_tool", "arguments": {"value": 1}}},
+        {"type": "function", "function": {"name": "async_tool", "arguments": {"value": 2}}},
+        {"type": "function", "function": {"name": "sync_tool", "arguments": {"value": 3}}},
+    ]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={"sync_tool": sync_tool},
+            async_tool_dict={"async_tool": async_tool},
+        )
+    )
+
+    assert n_calls == 3
+    assert n_failures == 0
+    assert tool_messages == [
+        {"role": "tool", "name": "sync_tool", "content": "sync:1"},
+        {"role": "tool", "name": "async_tool", "content": "async:2"},
+        {"role": "tool", "name": "sync_tool", "content": "sync:3"},
+    ]
 
 
 def test_execute_tool_calls_counts_async_failures():

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -1,0 +1,96 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from trl.experimental.async_grpo.async_rollout_worker import AsyncRolloutWorker
+
+
+def sync_tool(value: int) -> str:
+    return f"sync:{value}"
+
+
+async def async_tool(value: int) -> str:
+    await asyncio.sleep(0)
+    return f"async:{value}"
+
+
+async def failing_async_tool(value: int) -> str:
+    await asyncio.sleep(0)
+    raise RuntimeError(f"boom:{value}")
+
+
+def _make_worker():
+    # Bypass __init__: these tests target tool execution semantics only.
+    return object.__new__(AsyncRolloutWorker)
+
+
+def test_execute_tool_calls_supports_mixed_sync_and_async_tools():
+    worker = _make_worker()
+    tool_calls = [
+        {"type": "function", "function": {"name": "sync_tool", "arguments": {"value": 1}}},
+        {"type": "function", "function": {"name": "async_tool", "arguments": {"value": 2}}},
+    ]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={"sync_tool": sync_tool},
+            async_tool_dict={"async_tool": async_tool},
+        )
+    )
+
+    assert n_calls == 2
+    assert n_failures == 0
+    assert {message["name"] for message in tool_messages} == {"sync_tool", "async_tool"}
+    assert any(message["content"] == "sync:1" for message in tool_messages)
+    assert any(message["content"] == "async:2" for message in tool_messages)
+
+
+def test_execute_tool_calls_counts_async_failures():
+    worker = _make_worker()
+    tool_calls = [{"type": "function", "function": {"name": "async_tool", "arguments": {"value": 3}}}]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={},
+            async_tool_dict={"async_tool": failing_async_tool},
+        )
+    )
+
+    assert n_calls == 1
+    assert n_failures == 1
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["name"] == "async_tool"
+    assert "boom:3" in tool_messages[0]["content"]
+
+
+def test_execute_tool_calls_handles_unsupported_tool_call_type():
+    worker = _make_worker()
+    tool_calls = [{"type": "not-a-function", "name": "bad_tool"}]
+
+    tool_messages, n_calls, n_failures = asyncio.run(
+        worker._execute_tool_calls(
+            tool_calls,
+            sync_tool_dict={},
+            async_tool_dict={},
+        )
+    )
+
+    assert n_calls == 1
+    assert n_failures == 1
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["name"] == "bad_tool"
+    assert "Unsupported tool call type" in tool_messages[0]["content"]

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -606,12 +606,8 @@ class AsyncRolloutWorker:
         tool_call_results: list[tuple[str, Any] | None] = [None] * len(tool_calls)
         for idx, tool_call in enumerate(tool_calls):
             n_calls += 1
-            if "type" in tool_call and tool_call["type"] != "function":
-                n_failures += 1
-                name = tool_call.get("name", "unknown")
-                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call['type']}"})
-            elif tool_call.get("type") == "function" or "function" in tool_call or "name" in tool_call:
-                function = tool_call.get("function", tool_call)
+            if tool_call["type"] == "function":
+                function = tool_call["function"]
                 name = function["name"]
                 try:
                     arguments = function.get("arguments", {})
@@ -627,8 +623,7 @@ class AsyncRolloutWorker:
             else:
                 n_failures += 1
                 name = tool_call.get("name", "unknown")
-                tool_call_type = tool_call.get("type", "missing")
-                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call_type}"})
+                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call['type']}"})
 
         if async_coros:
             coros = [coro for _, _, coro in async_coros]

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -606,8 +606,12 @@ class AsyncRolloutWorker:
         tool_call_results: list[tuple[str, Any] | None] = [None] * len(tool_calls)
         for idx, tool_call in enumerate(tool_calls):
             n_calls += 1
-            if tool_call.get("type") == "function":
-                function = tool_call["function"]
+            if "type" in tool_call and tool_call["type"] != "function":
+                n_failures += 1
+                name = tool_call.get("name", "unknown")
+                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call['type']}"})
+            elif tool_call.get("type") == "function" or "function" in tool_call or "name" in tool_call:
+                function = tool_call.get("function", tool_call)
                 name = function["name"]
                 try:
                     arguments = function.get("arguments", {})
@@ -623,7 +627,8 @@ class AsyncRolloutWorker:
             else:
                 n_failures += 1
                 name = tool_call.get("name", "unknown")
-                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call['type']}"})
+                tool_call_type = tool_call.get("type", "missing")
+                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call_type}"})
 
         if async_coros:
             coros = [coro for _, _, coro in async_coros]

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -144,11 +144,13 @@ class AsyncRolloutWorker:
 
         base_tools = tools or []
         self._sync_tool_dicts = [{} for _ in range(self.max_inflight_tasks)]
+        self._async_tool_dicts = [{} for _ in range(self.max_inflight_tasks)]
         for i in range(self.max_inflight_tasks):
             for tool in base_tools + (environment_methods[i] if self.environments is not None else []):
                 if inspect.iscoroutinefunction(tool):
-                    raise ValueError("Asynchronous tools are not supported in AsyncRolloutWorker yet.")
-                self._sync_tool_dicts[i][tool.__name__] = tool
+                    self._async_tool_dicts[i][tool.__name__] = tool
+                else:
+                    self._sync_tool_dicts[i][tool.__name__] = tool
         self.tools = base_tools + (environment_methods[0] if self.environments is not None else [])
 
         self.vllm_server_url = vllm_server_url.rstrip("/")
@@ -358,7 +360,11 @@ class AsyncRolloutWorker:
 
                     logger.info(f"[slot] assigned slot={slot} group={group_id} free_after={len(free_slots)}")
                     task = asyncio.create_task(
-                        self._generate_one(pending_groups[group_id].prompt, tool_dict=self._sync_tool_dicts[slot])
+                        self._generate_one(
+                            pending_groups[group_id].prompt,
+                            sync_tool_dict=self._sync_tool_dicts[slot],
+                            async_tool_dict=self._async_tool_dicts[slot],
+                        )
                     )
                     inflight_tasks[task] = (group_id, slot)
 
@@ -516,7 +522,7 @@ class AsyncRolloutWorker:
             group_id += 1
 
     async def _generate_one(
-        self, prompt: Messages, tool_dict: dict[str, Callable]
+        self, prompt: Messages, sync_tool_dict: dict[str, Callable], async_tool_dict: dict[str, Callable]
     ) -> tuple[list[dict[str, str]], list[int], list[float], list[int], int, int]:
         completion, completion_ids, completion_logprobs, tool_mask = [], [], [], []
         tool_call_count = 0
@@ -542,7 +548,9 @@ class AsyncRolloutWorker:
             if tool_calls is None or (max_iterations is not None and iteration_num >= max_iterations):
                 return completion, completion_ids, completion_logprobs, tool_mask, tool_call_count, tool_failure_count
 
-            tool_messages, n_calls, n_failures = self._execute_tool_calls(tool_calls, tool_dict)
+            tool_messages, n_calls, n_failures = await self._execute_tool_calls(
+                tool_calls, sync_tool_dict, async_tool_dict
+            )
             tool_call_count += n_calls
             tool_failure_count += n_failures
             completion.extend(tool_messages)
@@ -586,22 +594,49 @@ class AsyncRolloutWorker:
 
         return full_ids[len(prefix_ids) :]
 
-    def _execute_tool_calls(
-        self, tool_calls: list[dict[str, Any]], tool_dict: dict[str, Callable]
+    async def _execute_tool_calls(
+        self,
+        tool_calls: list[dict[str, Any]],
+        sync_tool_dict: dict[str, Callable],
+        async_tool_dict: dict[str, Callable],
     ) -> tuple[list[dict[str, str]], int, int]:
-        tool_messages = []
         n_calls = 0
         n_failures = 0
+        async_coros = []
+        tool_call_results = []
         for tool_call in tool_calls:
             n_calls += 1
-            function = tool_call["function"]
-            name = function["name"]
-            try:
-                arguments = function.get("arguments", {})
-                result = tool_dict[name](**arguments)
-            except Exception as error:
+            if tool_call.get("type") == "function":
+                function = tool_call["function"]
+                name = function["name"]
+                try:
+                    arguments = function.get("arguments", {})
+                    if name in sync_tool_dict:
+                        tool_call_results.append((name, sync_tool_dict[name](**arguments)))
+                    elif name in async_tool_dict:
+                        async_coros.append((name, async_tool_dict[name](**arguments)))
+                    else:
+                        raise ValueError(f"Tool {name} not found.")
+                except Exception as error:
+                    n_failures += 1
+                    tool_call_results.append((name, {"error": str(error)}))
+            else:
                 n_failures += 1
-                result = {"error": str(error)}
+                name = tool_call.get("name", "unknown")
+                tool_call_results.append((name, {"error": f"Unsupported tool call type: {tool_call['type']}"}))
+
+        if async_coros:
+            coros = [coro for _, coro in async_coros]
+            async_results = await asyncio.gather(*coros, return_exceptions=True)
+            for (name, _), result in zip(async_coros, async_results, strict=True):
+                if isinstance(result, Exception):
+                    n_failures += 1
+                    tool_call_results.append((name, {"error": str(result)}))
+                else:
+                    tool_call_results.append((name, result))
+
+        tool_messages = []
+        for name, result in tool_call_results:
             tool_messages.append({"role": "tool", "name": name, "content": str(result)})
         return tool_messages, n_calls, n_failures
 

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -603,8 +603,8 @@ class AsyncRolloutWorker:
         n_calls = 0
         n_failures = 0
         async_coros = []
-        tool_call_results = []
-        for tool_call in tool_calls:
+        tool_call_results: list[tuple[str, Any] | None] = [None] * len(tool_calls)
+        for idx, tool_call in enumerate(tool_calls):
             n_calls += 1
             if tool_call.get("type") == "function":
                 function = tool_call["function"]
@@ -612,31 +612,34 @@ class AsyncRolloutWorker:
                 try:
                     arguments = function.get("arguments", {})
                     if name in sync_tool_dict:
-                        tool_call_results.append((name, sync_tool_dict[name](**arguments)))
+                        tool_call_results[idx] = (name, sync_tool_dict[name](**arguments))
                     elif name in async_tool_dict:
-                        async_coros.append((name, async_tool_dict[name](**arguments)))
+                        async_coros.append((idx, name, async_tool_dict[name](**arguments)))
                     else:
                         raise ValueError(f"Tool {name} not found.")
                 except Exception as error:
                     n_failures += 1
-                    tool_call_results.append((name, {"error": str(error)}))
+                    tool_call_results[idx] = (name, {"error": str(error)})
             else:
                 n_failures += 1
                 name = tool_call.get("name", "unknown")
-                tool_call_results.append((name, {"error": f"Unsupported tool call type: {tool_call['type']}"}))
+                tool_call_results[idx] = (name, {"error": f"Unsupported tool call type: {tool_call['type']}"})
 
         if async_coros:
-            coros = [coro for _, coro in async_coros]
+            coros = [coro for _, _, coro in async_coros]
             async_results = await asyncio.gather(*coros, return_exceptions=True)
-            for (name, _), result in zip(async_coros, async_results, strict=True):
+            for (idx, name, _), result in zip(async_coros, async_results, strict=True):
                 if isinstance(result, Exception):
                     n_failures += 1
-                    tool_call_results.append((name, {"error": str(result)}))
+                    tool_call_results[idx] = (name, {"error": str(result)})
                 else:
-                    tool_call_results.append((name, result))
+                    tool_call_results[idx] = (name, result)
 
         tool_messages = []
-        for name, result in tool_call_results:
+        for tool_call_result in tool_call_results:
+            if tool_call_result is None:
+                raise ValueError("Unexpected missing tool call result.")
+            name, result = tool_call_result
             tool_messages.append({"role": "tool", "name": name, "content": str(result)})
         return tool_messages, n_calls, n_failures
 


### PR DESCRIPTION
  # What does this PR do?

  Adds async tool support to `trl.experimental.async_grpo.AsyncRolloutWorker`.

  This closes a feature gap with mainline `GRPOTrainer`, which already supports async tool calls. Before this change, `AsyncRolloutWorker` rejected coroutine tools
  during initialization. After this change, tools can be either synchronous or asynchronous in `AsyncGRPOTrainer`, and asynchronous tools are awaited concurrently within
  a tool-calling round.

  Scope is intentionally minimal:

  - split tools into sync and async dictionaries in `AsyncRolloutWorker`
  - execute async tools with `asyncio.gather(..., return_exceptions=True)`
  - preserve sync tool behavior
  - preserve error handling semantics by converting tool exceptions into tool error messages
  - update async GRPO docs accordingly

  Non-goals of this PR:

  - no public API change
  - no config change
  - no partial-rollout resume semantics for in-flight async tools
  - no larger agent-loop refactor

  Refs issue：#5444 (https://github.com/huggingface/trl/issues/5444)

  ## Before submitting

  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
  - [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. #5444 
  - [x] Did you make sure to update the documentation with your changes?
  - [x] Did you write any new necessary tests?

  ## AI writing disclosure

  We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in
  this PR.

  - [ ] No AI usage: the PR was written entirely by a human.
  - [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
  - [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

  ## Who can review?

  Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-execution semantics in `AsyncRolloutWorker` by introducing concurrent async tool invocation, which can affect rollout generation ordering and failure handling. While scoped to the experimental async GRPO path, concurrency/error-handling changes can surface as subtle runtime issues.
> 
> **Overview**
> Adds support for **asynchronous tool functions** during async GRPO rollouts. `AsyncRolloutWorker` now splits tools into sync vs async registries, executes async tool calls concurrently via `asyncio.gather(..., return_exceptions=True)`, and then appends tool results back to the conversation *in original tool-call order* while counting calls/failures.
> 
> Updates the Async GRPO docs to describe async tool behavior, and adds targeted tests covering mixed sync/async tools, order preservation, async failure accounting, and unsupported tool-call types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c793cfad2e1b3f7829ead03e16b4187580f8153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->