### PR TITLE
[docs] Add hardware requirements note to quickstart

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -6,6 +6,10 @@ TRL is a comprehensive library for post-training foundation models using techniq
 
 Get started instantly with TRL's most popular trainers. Each example uses compact models for quick experimentation.
 
+> [!TIP]
+> These examples require a GPU with at least 40 GB of VRAM (e.g., A100) to run with default settings. For GPUs with
+> 24 GB (e.g., L4, A10G) or less, see the [Out of Memory?](#out-of-memory) section below.
+
 ### Supervised Fine-Tuning
 
 ```python
@@ -103,7 +107,15 @@ trl reward --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
 
 ### Out of Memory?
 
-Reduce batch size and enable optimizations:
+The default training settings (e.g., `per_device_train_batch_size=8`, `max_length=1024`) use approximately 24 GB of VRAM. If you encounter out-of-memory errors, try the following options depending on your GPU:
+
+**For GPUs with 24 GB (e.g., L4, A10G):** CUDA memory fragmentation may cause OOM even though the peak usage fits. Set this environment variable before training:
+
+```bash
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+```
+
+**For GPUs with 16 GB or less (e.g., T4):** reduce batch size, sequence length, and use a memory-efficient optimizer:
 
 <hfoptions id="batch_size">
 <hfoption id="SFT">


### PR DESCRIPTION
# What does this PR do?

Adds a hardware requirements note to the quickstart page and improves the "Out of Memory?" troubleshooting section with memory optimization tips.

Users following the quickstart examples may unexpectedly run into OOM errors because there is no indication of the VRAM requirements. This was reported in #4968.

Fixes #4968

## Benchmark results

Benchmarked using `Qwen/Qwen2.5-0.5B` with `SFTConfig` defaults. RTX 2070 was tested locally, T4/L4/A10G/A100 were tested using [Modal](https://modal.com) serverless GPUs.

With default settings, training failed with OOM on RTX 2070 (8 GB), T4 (16 GB), L4 (24 GB), and A10G (24 GB).

The following configurations ran successfully:

| GPU | VRAM | Config | Status | Peak (nvidia-smi) |
|-----|------|--------|--------|-------------------|
| RTX 2070 | 8 GB | batch=1, max_length=256, fp16, adamw_8bit | OK | 5.3 GB |
| L4 | 24 GB | default + expandable_segments | OK | 21.3 GB |
| A10G | 24 GB | default + expandable_segments | OK | 21.3 GB |
| A100 | 40 GB | default | OK | 24.2 GB |

The benchmark script is available upon request.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior. Main risk is minor confusion if hardware guidance becomes outdated or misinterpreted.
> 
> **Overview**
> Adds a **VRAM requirement callout** to the quickstart examples, warning that default configs assume ~40GB GPUs and pointing smaller GPUs to troubleshooting.
> 
> Expands the *Out of Memory?* section with concrete guidance: notes expected VRAM use for defaults, suggests `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for 24GB GPUs to reduce fragmentation-related OOMs, and clarifies that <=16GB GPUs should reduce batch/sequence settings and use more memory-efficient options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab32a5141656bcfa3af5eb6fdb2dc9f001e8f8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->