### PR TITLE
Update GitHub Action to use specific version of github-script

### DIFF
--- a/.github/workflows/pr_template_check.yml
+++ b/.github/workflows/pr_template_check.yml
@@ -1,5 +1,7 @@
-# This workflow runs on every PR opened or edited by a first-time contributor (author_association
-# is FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, or NONE). It checks that the PR body:
+# This workflow runs when a PR is first opened by an external contributor
+# (author_association is FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, or NONE).
+# Org members with public membership are skipped (author_association = MEMBER).
+# It checks that the PR body:
 #   1. Contains a non-empty description (not just the template placeholder)
 #   2. Includes the "## Before submitting" checklist
 #   3. Has at least one checkbox checked
@@ -9,7 +11,7 @@ name: PR Template Check
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened]
 
 permissions:
   pull-requests: write
@@ -19,14 +21,10 @@ permissions:
 jobs:
   check-pr-template:
     runs-on: ubuntu-latest
-    if: |
-      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-       github.event.pull_request.author_association == 'FIRST_TIMER' ||
-       github.event.pull_request.author_association == 'NONE') &&
-      !(github.event.action == 'reopened' &&
-        (github.event.sender.author_association == 'MEMBER' ||
-         github.event.sender.author_association == 'OWNER' ||
-         github.event.sender.author_association == 'COLLABORATOR'))
+    if: >
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+      github.event.pull_request.author_association == 'FIRST_TIMER' ||
+      github.event.pull_request.author_association == 'NONE'
     steps:
       - name: Check PR body follows template
         id: check

--- a/.github/workflows/pr_template_check.yml
+++ b/.github/workflows/pr_template_check.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Check PR body follows template
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         with:


### PR DESCRIPTION
see https://github.com/huggingface/tracking-issues/issues/417

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins a GitHub Action dependency to a specific commit in a workflow, reducing supply-chain drift without changing the workflow logic.
> 
> **Overview**
> Pins the `actions/github-script` dependency in `pr_template_check.yml` from the floating `v7` tag to a specific commit SHA (still `v7`). This makes the PR template check workflow deterministic and less susceptible to upstream tag changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c212880fd08e1fdf5285aaff495a77862c3210c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->