### PR TITLE
feat: add Llama 3 training chat template with {% generation %} markers

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -309,6 +309,7 @@ class TestIsChatTemplatePrefixPreserving:
 @pytest.mark.parametrize(
     "tokenizer_name",
     [
+        pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3", id="llama3"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForSequenceClassification", id="qwen3"),
     ],
 )

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -232,6 +232,8 @@ qwen3_5_schema = {
 
 gptoss_chat_template = (_CHAT_TEMPLATES_DIR / "gptoss.jinja").read_text()
 
+llama3_chat_template = (_CHAT_TEMPLATES_DIR / "llama3.jinja").read_text()
+
 qwen3_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3.jinja").read_text()
 
 qwen3_5_chat_template_2b_and_below = (_CHAT_TEMPLATES_DIR / "qwen3_5_2b_and_below.jinja").read_text()
@@ -365,6 +367,8 @@ def is_chat_template_prefix_preserving(tokenizer: PreTrainedTokenizer) -> bool:
     return text2.startswith(text1)
 
 
+llama3_training_chat_template = (_CHAT_TEMPLATES_DIR / "llama3_training.jinja").read_text()
+
 qwen3_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_training.jinja").read_text()
 
 
@@ -374,7 +378,7 @@ def get_training_chat_template(tokenizer: PreTrainedTokenizer) -> str | None:
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the tokenizer's template already satisfies both
-    requirements. Currently Qwen3 is supported.
+    requirements. Currently Llama 3 and Qwen3 are supported.
 
     Args:
         tokenizer (`PreTrainedTokenizer`):
@@ -423,14 +427,17 @@ def get_training_chat_template(tokenizer: PreTrainedTokenizer) -> str | None:
     if is_chat_template_prefix_preserving(tokenizer) and "{% generation %}" in tokenizer.chat_template:
         return None  # No patching needed
 
+    if tokenizer.chat_template == llama3_chat_template:
+        return llama3_training_chat_template
+
     if tokenizer.chat_template == qwen3_chat_template:
         return qwen3_training_chat_template
-    else:
-        raise ValueError(
-            "The tokenizer's chat template is not training-compatible (missing prefix-preservation or "
-            "`{% generation %}` markers) and patching is not supported for this template. "
-            "Please manually modify the tokenizer's chat template for training."
-        )
+
+    raise ValueError(
+        "The tokenizer's chat template is not training-compatible (missing prefix-preservation or "
+        "`{% generation %}` markers) and patching is not supported for this template. "
+        "Please manually modify the tokenizer's chat template for training."
+    )
 
 
 def _validate_tool_calls(tool_calls: list | None) -> None:

--- a/trl/chat_templates/llama3.jinja
+++ b/trl/chat_templates/llama3.jinja
@@ -1,0 +1,5 @@
+{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>
+
+'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>
+
+' }}{% endif %}

--- a/trl/chat_templates/llama3_training.jinja
+++ b/trl/chat_templates/llama3_training.jinja
@@ -1,0 +1,19 @@
+{#- Training variant of the Llama 3 chat template (see llama3.jinja for the original).
+    Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around assistant message output to support
+      assistant-only loss masking in SFT training.
+-#}
+{%- for message in messages %}
+    {%- if loop.index0 == 0 %}{{- bos_token }}{%- endif %}
+    {%- if message['role'] == 'assistant' %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+        {%- generation %}
+        {{- message['content'] | trim + '<|eot_id|>' }}
+        {%- endgeneration %}
+    {%- else %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n' + message['content'] | trim + '<|eot_id|>' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}


### PR DESCRIPTION
## Summary

Adds a training-compatible variant of the Llama 3 chat template with `{% generation %}` / `{% endgeneration %}` markers, enabling `return_assistant_tokens_mask=True` for assistant-only loss masking in SFT training. Contributes to #5471.

**Changes:**
- `trl/chat_templates/llama3.jinja` — original Llama 3 chat template (source of truth for the exact-match comparison in `get_training_chat_template()`)
- `trl/chat_templates/llama3_training.jinja` — training variant: same text output as original, with `{% generation %}` / `{% endgeneration %}` wrapping assistant output (`<|eot_id|>` included inside the block)
- `trl/chat_template_utils.py` — loads both templates; adds Llama 3 branch before Qwen3 in `get_training_chat_template()`; updates docstring
- `tests/test_chat_template_utils.py` — adds `trl-internal-testing/tiny-LlamaForCausalLM-3` to `TestGetTrainingChatTemplate` parametrize

**Template design:**
The training template restructures the original single-pass loop to handle the assistant role separately, so `{% generation %}` can wrap just the generated tokens (content + `<|eot_id|>`) while leaving the role header and BOS token outside. Text output is verified to be identical to the original across all test scenarios (single-turn, multi-turn, add_generation_prompt, reasoning_content, tool_calls, tools kwarg).

The Llama 3 template is already prefix-preserving (no conditional logic that changes earlier messages when new messages are appended), so the training template inherits this property without modifications.

## Test plan

- [ ] `TestGetTrainingChatTemplate[llama3]::test_new_chat_template_is_prefix_preserving` — training template is prefix-preserving
- [ ] `TestGetTrainingChatTemplate[llama3]::test_behavior_unchanged_*` — text output identical to original in all cases
- [ ] `TestGetTrainingChatTemplate[llama3]::test_assistant_masks` — assistant tokens are masked, user/BOS tokens are not
- [ ] `TestGetTrainingChatTemplate[llama3]::test_assistant_masks_multi_turn` — exactly 3 mask transitions for 2 assistant turns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how chat templates are selected/overridden for Llama 3 during training, which can affect prompt rendering and assistant-token masking if the exact-match template check diverges from upstream tokenizer templates.
> 
> **Overview**
> Adds Llama 3 support to `get_training_chat_template()` by loading `llama3.jinja` and returning a new `llama3_training.jinja` variant that wraps assistant content in `{% generation %}` / `{% endgeneration %}` for assistant-only loss masking.
> 
> Extends the existing training-template test suite to run against a Llama 3 tokenizer as well, asserting prefix preservation, unchanged rendered text across common scenarios, and correct `return_assistant_tokens_mask` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32eda8d98b42644b20f50fd6ccbbc94e4898f08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->