### PR TITLE
[docs] Add code example for completion_only_loss in SFT trainer docs

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -175,6 +175,21 @@ training_args = SFTConfig(assistant_only_loss=True)
 
 To train on completion only, use a [prompt-completion](dataset_formats#prompt-completion) dataset. By default, the trainer computes the loss on the completion tokens only, ignoring the prompt tokens. If you want to train on the full sequence, set `completion_only_loss=False` in the [`SFTConfig`].
 
+```python
+from trl import SFTConfig, SFTTrainer
+from datasets import load_dataset
+
+# Load a prompt-completion dataset; loss is computed on the completion only by default
+dataset = load_dataset("trl-lib/kto-mix-14k", split="train")
+
+trainer = SFTTrainer(
+    model="Qwen/Qwen2.5-0.5B-Instruct",
+    args=SFTConfig(completion_only_loss=True),  # True by default for prompt-completion datasets
+    train_dataset=dataset,
+)
+trainer.train()
+```
+
 ![train_on_completion](https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/train_on_completion.png)
 
 > [!TIP]


### PR DESCRIPTION
# What does this PR do?

The "Train on completion only" section in the SFT trainer documentation lacked a concrete code example, leaving users without a clear template for how to set up prompt-completion training with `completion_only_loss=True`. This led to confusion, as reported in issue #5324, where users did not know what dataset format to use.

This PR adds a minimal working example to the `sft_trainer.md` documentation that shows:
- How to load a prompt-completion dataset (`trl-lib/kto-mix-14k`)
- How to pass `completion_only_loss=True` to `SFTConfig`
- A comment clarifying that `True` is the default for prompt-completion datasets

Fixes #5324

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an example snippet; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a concrete Python example to the `Train on completion only` section of `sft_trainer.md`, showing how to load a prompt-completion dataset and configure `SFTConfig(completion_only_loss=True)` (noting it’s the default for prompt-completion datasets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49908912bf08028f4bc3687b37d4d27fe9eba63d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->