### PR TITLE
Fix prepare_multimodal_messages not normalizing empty string content for assistant/tool roles

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -87,10 +87,10 @@ def prepare_multimodal_messages(messages: list[dict[str, Any]], images: list | N
             elif isinstance(message["content"], str):
                 message = {**message, "content": [{"type": "text", "text": message["content"]}]}
         elif message["role"] == "assistant":
-            if message.get("content") and isinstance(message["content"], str):
+            if isinstance(message.get("content"), str):
                 message = {**message, "content": [{"type": "text", "text": message["content"]}]}
         elif message["role"] == "tool":
-            if message.get("content") and isinstance(message["content"], str):
+            if isinstance(message.get("content"), str):
                 message = {**message, "content": [{"type": "text", "text": message["content"]}]}
         else:
             raise ValueError(


### PR DESCRIPTION
Fix `prepare_multimodal_messages` not normalizing empty string content for assistant/tool roles.

Several VLM processors (Idefics2, Idefics3, Llava, LlavaNext, Qwen3VL, SmolVLM) crash when `apply_chat_template` receives `"content": ""` on an assistant or tool message, but all accept `"content": [{"type": "text", "text": ""}]`. Reported by @qgallouedec in:
- https://github.com/huggingface/trl/pull/5474#discussion_r3061642294

The previous condition `message.get("content") and isinstance(...)` was falsy for empty strings, so `"content": ""` was passed through unchanged, causing crashes on those processors.

This PR fixes it by replacing `message.get("content") and isinstance(message["content"], str)` with `isinstance(message.get("content"), str)` for the "assistant" and "tool" role branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional change that only affects how `assistant`/`tool` string content (including empty strings) is wrapped into structured text blocks.
> 
> **Overview**
> Fixes `prepare_multimodal_messages` to **always wrap string `content` (including `""`)** for `assistant` and `tool` roles into `[{"type": "text", "text": ...}]`.
> 
> This prevents passing through raw empty-string content, which can crash some processors when calling `apply_chat_template`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24be02a92cb730ecb4ad519eb38563245594958e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->