### PR TITLE
Restrict VLM padding workaround to transformers 5.3.0

### DIFF
--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -246,9 +246,10 @@ class DPPOTrainer(GRPOTrainer):
                 images.append(prompt_images if prompt_images else None)
             images = images if has_images else None
 
-            # We pass padding=True to work around a bug introduced in transformers 5.2.0 in some processors
-            # (e.g. Qwen2.5-VL) that crash on batched unpadded input. We then unpad input_ids using attention_mask.
-            # See: https://github.com/huggingface/transformers/issues/44514
+            # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
+            # batched unpadded input (transformers#44514).
+            # Fixed in transformers 5.4.0 (transformers#44563).
+            needs_padding_workaround = Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
                 tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
@@ -256,13 +257,17 @@ class DPPOTrainer(GRPOTrainer):
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,
-                padding=True,
+                **({"padding": True} if needs_padding_workaround else {}),
                 **self.chat_template_kwargs,
             )
-            prompt_ids = [
-                [tok for tok, mask in zip(ids, attention_mask, strict=True) if mask]
-                for ids, attention_mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
-            ]
+            if needs_padding_workaround:
+                # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
+                prompt_ids = [
+                    [tok for tok, m in zip(ids, mask, strict=True) if m]
+                    for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
+                ]
+            else:
+                prompt_ids = tokenized["input_ids"]
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
         else:
             prompt_ids = self.processing_class(text=prompts)["input_ids"]

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1289,9 +1289,10 @@ class GRPOTrainer(_BaseTrainer):
                 images.append(prompt_images if prompt_images else None)
             images = images if has_images else None
 
-            # We pass padding=True to work around a bug introduced in transformers 5.2.0 in some processors
-            # (e.g. Qwen2.5-VL) that crash on batched unpadded input. We then unpad input_ids using attention_mask.
-            # See: https://github.com/huggingface/transformers/issues/44514
+            # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
+            # batched unpadded input (transformers#44514).
+            # Fixed in transformers 5.4.0 (transformers#44563).
+            needs_padding_workaround = Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
                 tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
@@ -1299,14 +1300,17 @@ class GRPOTrainer(_BaseTrainer):
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,
-                padding=True,
+                **({"padding": True} if needs_padding_workaround else {}),
                 **self.chat_template_kwargs,
             )
-            # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
-            prompt_ids = [
-                [tok for tok, m in zip(ids, mask, strict=True) if m]
-                for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
-            ]
+            if needs_padding_workaround:
+                # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
+                prompt_ids = [
+                    [tok for tok, m in zip(ids, mask, strict=True) if m]
+                    for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
+                ]
+            else:
+                prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
         else:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -919,22 +919,26 @@ class RLOOTrainer(_BaseTrainer):
                 images.append(prompt_images if prompt_images else None)
             images = images if has_images else None
 
-            # We pass padding=True to work around a bug introduced in transformers 5.2.0 in some processors
-            # (e.g. Qwen2.5-VL) that crash on batched unpadded input. We then unpad input_ids using attention_mask.
-            # See: https://github.com/huggingface/transformers/issues/44514
+            # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
+            # batched unpadded input (transformers#44514).
+            # Fixed in transformers 5.4.0 (transformers#44563).
+            needs_padding_workaround = Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,
-                padding=True,
+                **({"padding": True} if needs_padding_workaround else {}),
                 **self.chat_template_kwargs,
             )
-            # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
-            prompt_ids = [
-                [tok for tok, m in zip(ids, mask, strict=True) if m]
-                for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
-            ]
+            if needs_padding_workaround:
+                # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
+                prompt_ids = [
+                    [tok for tok, m in zip(ids, mask, strict=True) if m]
+                    for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
+                ]
+            else:
+                prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
         else:


### PR DESCRIPTION
Restrict VLM padding workaround to transformers 5.3.0.

This PR updates the prompt tokenization logic in several trainer classes to handle a specific bug in the `transformers` library more robustly. The main change is to apply a padding workaround only for affected `transformers` versions (5.3.x), and to simplify the logic for handling padded and unpadded input IDs. This avoids unnecessary padding for unaffected versions and ensures compatibility with future releases.

Additionally, this PR fixes:
- #5502
- this issue arises when passing `padding=True`, but only with transformers >= 5.4.0 

Fix #5502.

### Motivation

- The bug (`Qwen2_5_VLProcessor.apply_chat_template` crashing on batched unpadded input) was introduced in transformers 5.3.0:
  - The original comment also incorrectly attributed the bug to transformers 5.2.0.
  - https://github.com/huggingface/transformers/issues/44514

- The bug was fixed in 5.4.0
  - huggingface/transformers#44563

- In `trl`, it was fixed with `padding=True` workaround in `_tokenize_prompts` (GRPO, RLOO, DPPO trainers) that was applied unconditionally to all transformers versions
  - #5239

### Solution

- Gate the workaround with `Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")`
- Pass `padding=True` only when the workaround is active; omit the argument entirely otherwise (see #5502)
- Skip the unpadding step when the workaround is not active, using `tokenized["input_ids"]` directly
- Correct the comment to reference the right version and link the fix PR

### Changes

**Bug workaround and version handling:**

* Added a conditional check for the `transformers` library version (>=5.3.0 and <5.4.0) to determine if the padding workaround should be applied, instead of always applying padding. (GRPO, RLOO, and experimental DPPO)
* Updated comments to clarify that the bug is present in `transformers` 5.3.0 and fixed in 5.4.0, with references to the relevant GitHub issues and PRs. 

**Prompt ID extraction logic:**

* Only unpads `input_ids` using the `attention_mask` when the workaround is needed; otherwise, uses the tokenized `input_ids` directly, simplifying the code path for unaffected versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches prompt tokenization in multiple trainers; version-gated padding/unpadding could change input IDs for some `transformers` versions and affect multimodal generation edge cases.
> 
> **Overview**
> Restricts the VLM `apply_chat_template` padding workaround to `transformers` versions `>=5.3.0` and `<5.4.0`, instead of always forcing `padding=True`.
> 
> When the workaround is inactive, the trainers now skip the unpadding step and use `tokenized["input_ids"]` directly; comments were updated to reference the correct upstream bug/fix (transformers#44514/#44563).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3dbe2adccdb5a7b60d7eedf77d82271fa6536b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->