### PR TITLE
Hotfix CI: Mark tests as xfail with transformers dev for Llava models

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1030,8 +1030,22 @@ class TestDPOTrainer(TrlTestCase):
             ),
             # "trl-internal-testing/tiny-Idefics2ForConditionalGeneration",  high memory peak, skipped for now
             # "trl-internal-testing/tiny-Idefics3ForConditionalGeneration",  high memory peak, skipped for now
-            "trl-internal-testing/tiny-LlavaForConditionalGeneration",
-            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__).is_devrelease,
+                    reason="Upstream issue with transformers 5.6.0.dev0, see #5497",
+                    strict=True,
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__).is_devrelease,
+                    reason="Upstream issue with transformers 5.6.0.dev0, see #5497",
+                    strict=True,
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1639,8 +1639,22 @@ class TestSFTTrainer(TrlTestCase):
             ),
             # "trl-internal-testing/tiny-Idefics2ForConditionalGeneration",  high memory peak, skipped for now
             # "trl-internal-testing/tiny-Idefics3ForConditionalGeneration",  high memory peak, skipped for now
-            "trl-internal-testing/tiny-LlavaForConditionalGeneration",
-            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__).is_devrelease,
+                    reason="Upstream issue with transformers 5.6.0.dev0, see #5497",
+                    strict=True,
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__).is_devrelease,
+                    reason="Upstream issue with transformers 5.6.0.dev0, see #5497",
+                    strict=True,
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly


### PR DESCRIPTION
Hotfix CI: Mark tests as xfail with transformers dev for Llava models.

Hotfix for:
- #5497

Pending of a fix upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pytest expectations for CI by marking known-failing Llava/LlavaNext cases as `xfail` on `transformers` dev releases, with no production code changes.
> 
> **Overview**
> Marks the Llava and LlavaNext vision-language model cases in `test_train_vlm` for both `DPOTrainer` and `SFTTrainer` as conditional `xfail` when running against `transformers` dev releases.
> 
> This prevents CI failures from a known upstream `transformers 5.6.0.dev0` issue (see `#5497`) while keeping the tests strict for other versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc649597ce90122b86925d7ef1a97677defb055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->