### PR TITLE
Simplify role handling in prepare_multimodal_messages

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -76,20 +76,14 @@ def prepare_multimodal_messages(messages: list[dict[str, Any]], images: list | N
     new_messages = []
     images_included = False
     for message in messages:
-        if message["role"] == "system":
-            if isinstance(message["content"], str):  # if already prepared, the content will be a list
-                message = {**message, "content": [{"type": "text", "text": message["content"]}]}
-        elif message["role"] == "user":
+        if message["role"] == "user":
             if isinstance(message["content"], str) and not images_included:
                 image_entries = [{"type": "image"} for _ in range(len(images))]
                 message = {**message, "content": [*image_entries, {"type": "text", "text": message["content"]}]}
                 images_included = True
             elif isinstance(message["content"], str):
                 message = {**message, "content": [{"type": "text", "text": message["content"]}]}
-        elif message["role"] == "assistant":
-            if isinstance(message.get("content"), str):
-                message = {**message, "content": [{"type": "text", "text": message["content"]}]}
-        elif message["role"] == "tool":
+        elif message["role"] in {"assistant", "system", "tool"}:
             if isinstance(message.get("content"), str):
                 message = {**message, "content": [{"type": "text", "text": message["content"]}]}
         else:


### PR DESCRIPTION
Simplify role handling in `prepare_multimodal_messages`.

Follow-up to:
- #5496

This PR simplifies and consolidates the logic in the `prepare_multimodal_messages` function for handling different message roles. The main change is that the preparation of message content for the `assistant`, `system`, and `tool` roles is now handled together, reducing code duplication and improving maintainability.

### Changes

Refactoring and logic simplification:

* Consolidated the handling of `assistant`, `system`, and `tool` message roles into a single code block, reducing repeated code for preparing message content as a list of text entries.
* Removed the special-casing for the `system` role at the top of the function, as it is now handled together with the other roles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates per-role branching without changing the public API; main risk is subtle differences in how string `content` is wrapped for non-`user` roles.
> 
> **Overview**
> Simplifies `prepare_multimodal_messages` by consolidating the `system`, `assistant`, and `tool` role handling into a single branch that wraps string `content` into structured `[{"type": "text", ...}]` blocks.
> 
> Keeps the `user`-role logic for injecting image placeholders before the first user message, while reducing duplicated role-specific code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac41714fb2177f1965f64d0c3e901c8b5fc90d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->