### PR TITLE
Expose trainer dataset type metadata

### DIFF
--- a/docs/source/dataset_formats.md
+++ b/docs/source/dataset_formats.md
@@ -422,6 +422,8 @@ Choosing the right dataset type depends on the task you are working on and the s
 | [`experimental.prm.PRMTrainer`] | [Stepwise supervision](#stepwise-supervision) |
 | [`experimental.xpo.XPOTrainer`] | [Prompt-only](#prompt-only) |
 
+The same metadata is also exposed programmatically on each trainer class through the `dataset_types` attribute. For example, `GRPOTrainer.dataset_types == ("prompt-only",)`.
+
 ## Using any dataset with TRL: preprocessing and conversion
 
 Many datasets come in formats tailored to specific tasks, which might not be directly compatible with TRL. To use such datasets with TRL, you may need to preprocess and convert them into the required format.

--- a/tests/test_trainer_metadata.py
+++ b/tests/test_trainer_metadata.py
@@ -1,0 +1,44 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib import import_module
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "expected"),
+    [
+        ("trl", "DPOTrainer", ("preference",)),
+        ("trl", "GRPOTrainer", ("prompt-only",)),
+        ("trl", "RewardTrainer", ("preference",)),
+        ("trl", "RLOOTrainer", ("prompt-only",)),
+        ("trl", "SFTTrainer", ("language-modeling", "prompt-completion")),
+        ("trl.experimental.bco", "BCOTrainer", ("unpaired-preference", "preference")),
+        ("trl.experimental.cpo", "CPOTrainer", ("preference",)),
+        ("trl.experimental.gkd", "GKDTrainer", ("prompt-completion",)),
+        ("trl.experimental.kto", "KTOTrainer", ("unpaired-preference", "preference")),
+        ("trl.experimental.nash_md", "NashMDTrainer", ("prompt-only",)),
+        ("trl.experimental.online_dpo", "OnlineDPOTrainer", ("prompt-only",)),
+        ("trl.experimental.orpo", "ORPOTrainer", ("preference",)),
+        ("trl.experimental.ppo", "PPOTrainer", ("tokenized-language-modeling",)),
+        ("trl.experimental.prm", "PRMTrainer", ("stepwise-supervision",)),
+        ("trl.experimental.xpo", "XPOTrainer", ("prompt-only",)),
+    ],
+)
+def test_trainer_dataset_types(module_name, class_name, expected):
+    module = import_module(module_name)
+    trainer_class = getattr(module, class_name)
+
+    assert trainer_class.dataset_types == expected

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -394,6 +394,7 @@ class BCOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "bco"]
     _name = "BCO"
+    dataset_types = ("unpaired-preference", "preference")
     _paper = {
         "title": "Binary Classifier Optimization for Large Language Model Alignment",
         "id": "2404.04656",

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -111,6 +111,7 @@ class CPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "cpo"]
     _name = "CPO"
+    dataset_types = ("preference",)
     _paper = {
         "title": "Contrastive Preference Optimization: Pushing the Boundaries of LLM Performance in Machine Translation",
         "id": "2401.08417",

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -92,6 +92,7 @@ class GKDTrainer(SFTTrainer):
 
     _tag_names = ["trl", "gkd"]
     _name = "GKD"
+    dataset_types = ("prompt-completion",)
     _paper = {
         "title": "On-Policy Distillation of Language Models: Learning from Self-Generated Mistakes",
         "id": "2306.13649",

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -293,6 +293,7 @@ class KTOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "kto"]
     _name = "KTO"
+    dataset_types = ("unpaired-preference", "preference")
     _paper = {
         "title": "KTO: Model Alignment as Prospect Theoretic Optimization",
         "id": "2402.01306",

--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -148,6 +148,7 @@ class NashMDTrainer(OnlineDPOTrainer):
 
     _tag_names = ["trl", "nash-md"]
     _name = "Nash-MD"
+    dataset_types = ("prompt-only",)
     _paper = {
         "title": "Nash Learning from Human Feedback",
         "id": "2312.00886",

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -153,6 +153,7 @@ class OnlineDPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "online-dpo"]
     _name = "Online DPO"
+    dataset_types = ("prompt-only",)
     _paper = {
         "title": "Direct Language Model Alignment from Online AI Feedback",
         "id": "2402.04792",

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -122,6 +122,7 @@ class ORPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "orpo"]
     _name = "ORPO"
+    dataset_types = ("preference",)
     _paper = {
         "title": "ORPO: Monolithic Preference Optimization without Reference Model",
         "id": "2403.07691",

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -341,6 +341,7 @@ class PPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "ppo"]
     _name = "PPO"
+    dataset_types = ("tokenized-language-modeling",)
     _paper = {
         "title": "Fine-Tuning Language Models from Human Preferences",
         "id": "1909.08593",

--- a/trl/experimental/prm/prm_trainer.py
+++ b/trl/experimental/prm/prm_trainer.py
@@ -134,6 +134,7 @@ class PRMTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "prm"]
     _name = "PRM"
+    dataset_types = ("stepwise-supervision",)
     _paper = {
         "title": "Solving math word problems with process-and outcome-based feedback",
         "id": "2211.14275",

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -89,6 +89,7 @@ class XPOTrainer(OnlineDPOTrainer):
 
     _tag_names = ["trl", "xpo"]
     _name = "XPO"
+    dataset_types = ("prompt-only",)
     _paper = {
         "title": "Exploratory Preference Optimization: Harnessing Implicit Q*-Approximation for Sample-Efficient RLHF",
         "id": "2405.21046",

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -28,6 +28,7 @@ class _BaseTrainer(Trainer):
     _name = "Base"
     _paper = {}
     _template_file = None
+    dataset_types: tuple[str, ...] = ()
 
     def create_model_card(
         self,

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -484,6 +484,7 @@ class DPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "dpo"]
     _name = "DPO"
+    dataset_types = ("preference",)
     _paper = {
         "title": "Direct Preference Optimization: Your Language Model is Secretly a Reward Model",
         "id": "2305.18290",

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -254,6 +254,7 @@ class GRPOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "grpo"]
     _name = "GRPO"
+    dataset_types = ("prompt-only",)
     _paper = {
         "title": "DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models",
         "id": "2402.03300",

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -317,6 +317,7 @@ class RewardTrainer(_BaseTrainer):
     _tag_names = ["trl", "reward-trainer"]
     _name = "Reward"
     _template_file = "rm_model_card.md"
+    dataset_types = ("preference",)
 
     def __init__(
         self,

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -202,6 +202,7 @@ class RLOOTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "rloo"]
     _name = "RLOO"
+    dataset_types = ("prompt-only",)
     _paper = {
         "title": "Back to Basics: Revisiting REINFORCE-Style Optimization for Learning from Human Feedback in LLMs",
         "id": "2402.14740",

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -639,6 +639,7 @@ class SFTTrainer(_BaseTrainer):
 
     _tag_names = ["trl", "sft"]
     _name = "SFT"
+    dataset_types = ("language-modeling", "prompt-completion")
 
     def __init__(
         self,


### PR DESCRIPTION
# What does this PR do?

Fixes #5511

TRL already documents the expected dataset type for each trainer, but that information is not exposed programmatically. Downstream wrappers and validation layers currently have to hardcode trainer-name checks or maintain their own registry to decide whether a trainer expects `prompt-only`, `preference`, `prompt-completion`, and so on.

This PR exposes that already-documented information as trainer metadata via a `dataset_types` class attribute.

Related context:
- #3468
- #3915
- #3919
- #4147
- #4201
- #4358

The implementation is metadata only:
- define `dataset_types` on `_BaseTrainer`
- populate it on the trainers already covered by the dataset-format table
- add a focused test covering those mappings
- add a short documentation note showing how to access the metadata programmatically

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
