### PR TITLE
[WIP] Fix OnlineDPO vLLM server completion handling

### DIFF
--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 from datasets import Dataset, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
 
+import trl.experimental.online_dpo.online_dpo_trainer as module_under_test
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
 
 from ..testing_utils import TrlTestCase, require_peft, require_torch_accelerator, require_vision, require_vllm
@@ -414,6 +418,49 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert trainer.reward_weights is not None
         assert round(abs(trainer.reward_weights[0].item() - 0.7), 5) == 0
         assert round(abs(trainer.reward_weights[1].item() - 0.3), 5) == 0
+
+
+def test_generate_vllm_server_preserves_completion_lists(monkeypatch):
+    class DummyProcessor:
+        def __call__(self, text, return_tensors, padding, padding_side, add_special_tokens):
+            return {"input_ids": torch.tensor([[101, 102, 103]])}
+
+    monkeypatch.setattr(module_under_test, "gather_object", lambda x: x)
+    monkeypatch.setattr(module_under_test, "broadcast_object_list", lambda x, from_process=0: x)
+
+    trainer = OnlineDPOTrainer.__new__(OnlineDPOTrainer)
+    trainer.accelerator = SimpleNamespace(is_main_process=True, process_index=0)
+    trainer.state = SimpleNamespace(global_step=0)
+    trainer._move_model_to_vllm = lambda: None
+    trainer._last_loaded_step = -1
+    trainer.num_generations = 2
+    trainer.repetition_penalty = 1.0
+    trainer.temperature = 1.0
+    trainer.top_p = 1.0
+    trainer.top_k = None
+    trainer.min_p = None
+    trainer.generation_config = SimpleNamespace(max_tokens=16)
+    trainer.args = SimpleNamespace(generation_kwargs={})
+    trainer.processing_class = DummyProcessor()
+    trainer.vllm_client = SimpleNamespace(
+        generate=lambda **kwargs: {
+            "completion_ids": [
+                [11, 12, 13],
+                [21, 22],
+            ]
+        }
+    )
+
+    completion_ids, prompt_ids = trainer._generate_vllm_server(["plain prompt"])
+
+    assert completion_ids == [
+        [11, 12, 13],
+        [21, 22],
+    ]
+    assert prompt_ids == [
+        [101, 102, 103],
+        [101, 102, 103],
+    ]
 
 
 @require_vision

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 from datasets import Dataset, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
 
+import trl.experimental.online_dpo.online_dpo_trainer as module_under_test
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
 
 from ..testing_utils import TrlTestCase, require_peft, require_torch_accelerator, require_vision, require_vllm
@@ -407,6 +411,49 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert trainer.reward_weights is not None
         assert round(abs(trainer.reward_weights[0].item() - 0.7), 5) == 0
         assert round(abs(trainer.reward_weights[1].item() - 0.3), 5) == 0
+
+
+def test_generate_vllm_server_preserves_completion_lists(monkeypatch):
+    class DummyProcessor:
+        def __call__(self, text, return_tensors, padding, padding_side, add_special_tokens):
+            return {"input_ids": torch.tensor([[101, 102, 103]])}
+
+    monkeypatch.setattr(module_under_test, "gather_object", lambda x: x)
+    monkeypatch.setattr(module_under_test, "broadcast_object_list", lambda x, from_process=0: x)
+
+    trainer = OnlineDPOTrainer.__new__(OnlineDPOTrainer)
+    trainer.accelerator = SimpleNamespace(is_main_process=True, process_index=0)
+    trainer.state = SimpleNamespace(global_step=0)
+    trainer._move_model_to_vllm = lambda: None
+    trainer._last_loaded_step = -1
+    trainer.num_generations = 2
+    trainer.repetition_penalty = 1.0
+    trainer.temperature = 1.0
+    trainer.top_p = 1.0
+    trainer.top_k = None
+    trainer.min_p = None
+    trainer.generation_config = SimpleNamespace(max_tokens=16)
+    trainer.args = SimpleNamespace(generation_kwargs={})
+    trainer.processing_class = DummyProcessor()
+    trainer.vllm_client = SimpleNamespace(
+        generate=lambda **kwargs: {
+            "completion_ids": [
+                [11, 12, 13],
+                [21, 22],
+            ]
+        }
+    )
+
+    completion_ids, prompt_ids = trainer._generate_vllm_server(["plain prompt"])
+
+    assert completion_ids == [
+        [11, 12, 13],
+        [21, 22],
+    ]
+    assert prompt_ids == [
+        [101, 102, 103],
+        [101, 102, 103],
+    ]
 
 
 @require_vision

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -662,8 +662,6 @@ class OnlineDPOTrainer(_BaseTrainer):
                 else None,
                 generation_kwargs=self.args.generation_kwargs,
             )["completion_ids"]
-            # Flatten: each prompt generates 2 completions
-            completion_ids = [[comp_id] for prompt_completions in completion_ids for comp_id in prompt_completions]
         else:
             completion_ids = [None] * (len(all_prompts) * 2)
 

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -676,8 +676,6 @@ class OnlineDPOTrainer(_BaseTrainer):
                 else None,
                 generation_kwargs=self.args.generation_kwargs,
             )["completion_ids"]
-            # Flatten: each prompt generates 2 completions
-            completion_ids = [[comp_id] for prompt_completions in completion_ids for comp_id in prompt_completions]
         else:
             completion_ids = [None] * (len(all_prompts) * 2)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #5514

This removes an extra flattening step in `OnlineDPOTrainer._generate_vllm_server()` when using vLLM server mode.

`trl/scripts/vllm_serve.py` already returns `completion_ids` as one `list[int]` per completion. `OnlineDPOTrainer` was flattening that result a second time, which turned multi-token completions into one-token completions before decode.

This PR removes that second flatten and adds a regression test covering the server return shape.

Validation:

- `make precommit`
- `PYTHONPATH=/tmp/trl-upstream-fix /mnt/home/john/elms-ai/.venv/bin/python -m pytest tests/experimental/test_online_dpo_trainer.py -k preserves_completion_lists`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
  https://github.com/huggingface/trl/issues/5514
- [x] Did you make sure to update the documentation with your changes?
  No documentation changes are needed for this internal bug fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with `OnlineDPOTrainer` server-mode generation or the `trl vllm-serve` response shape.
