### PR TITLE
Fix `supports_tool_calling` falsely accepting templates that drop assistant `tool_calls`

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -160,7 +160,8 @@ class TestSupportsToolCalling:
                 ),
             ),
             pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
-            pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3", id="llama3"),
+            pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
+            pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
             pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
             pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM", id="qwen3"),
             pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3moe"),
@@ -194,6 +195,8 @@ class TestSupportsToolCalling:
             # Silently ignores tool messages
             pytest.param("trl-internal-testing/tiny-Cohere2ForCausalLM", id="cohere2"),
             pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM", id="phi3"),
+            # Silently drops assistant tool_calls (basic Llama 3 template only reads message['content'])
+            pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3", id="llama3"),
         ],
     )
     def test_does_not_support_tool_calling(self, model_id):

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -333,9 +333,11 @@ def supports_tool_calling(processing_class) -> bool:
     """
     Check if the processing class's chat template can render a full tool-calling conversation.
 
-    This tests two things: (1) the template doesn't error when rendering a conversation with ``user → assistant (with
-    tool_calls) → tool`` roles, and (2) the tool message content actually appears in the rendered output (some
-    templates silently swallow tool messages).
+    This tests that (1) the template doesn't error when rendering a conversation with ``user → assistant (with
+    tool_calls) → tool`` roles, and (2) every part of the tool-calling exchange — the assistant's tool call name, its
+    arguments, and the tool message content — actually appears in the rendered output. Some templates silently swallow
+    `tool_calls` (e.g. the basic Llama 3 template, which only reads `message['content']`) or tool messages (e.g.
+    Cohere2, Phi3); both cases must be rejected.
 
     For VLMs (processors), the messages are converted to multimodal format via
     [`~trl.data_utils.prepare_multimodal_messages`] before rendering.
@@ -352,12 +354,21 @@ def supports_tool_calling(processing_class) -> bool:
         return False
 
     is_vlm = isinstance(processing_class, ProcessorMixin)
-    _sentinel = "TOOL_CONTENT_c4f9a8e2"
-    tool_calls = [{"type": "function", "function": {"name": "test", "arguments": {}}}]
+    # Distinct sentinels so we can tell which part of the exchange a template drops.
+    _name_sentinel = "tool_name_a8f3e2b1"
+    _arg_key_sentinel = "tool_arg_key_b9d4f5c2"
+    _arg_val_sentinel = "tool_arg_val_d6e7a9f3"
+    _content_sentinel = "tool_content_c4f9a8e2"
+    tool_calls = [
+        {
+            "type": "function",
+            "function": {"name": _name_sentinel, "arguments": {_arg_key_sentinel: _arg_val_sentinel}},
+        }
+    ]
     messages = [
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "", "tool_calls": tool_calls},
-        {"role": "tool", "name": "test", "content": _sentinel},
+        {"role": "tool", "name": _name_sentinel, "content": _content_sentinel},
     ]
     # VLMs expect content as [{"type": "text", "text": "..."}] instead of plain strings
     if is_vlm:
@@ -370,9 +381,10 @@ def supports_tool_calling(processing_class) -> bool:
         # UndefinedError (subclass): template indexes into content as a list for all roles, including tool
         #   (Idefics2, Idefics3, LlavaNext, SmolVLM)
         return False
-    # Some templates (e.g. Cohere2, Phi3) accept tool messages without error but silently ignore them.
-    # Check that the tool content actually appears in the rendered output.
-    return _sentinel in rendered
+    # All four sentinels must survive: the tool name and arguments (assistant tool_calls) AND the tool message
+    # content. Templates that silently drop either side (basic Llama 3 drops tool_calls; Cohere2/Phi3 drop tool
+    # messages) will fail this check.
+    return all(s in rendered for s in (_name_sentinel, _arg_key_sentinel, _arg_val_sentinel, _content_sentinel))
 
 
 def is_chat_template_prefix_preserving(tokenizer: PreTrainedTokenizer) -> bool:


### PR DESCRIPTION
`supports_tool_calling` only checked that a tool *message*'s content survived rendering. Templates that render tool messages correctly but silently drop the assistant's `tool_calls` (notably the basic Llama 3 template, which only reads `message['content']`) were still classified as supporting tool calling:

```python
>>> from transformers import AutoTokenizer
>>> tok = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-LlamaForCausalLM-3")
>>> tok.apply_chat_template(
...     [
...         {"role": "user", "content": "What is 3*4?"},
...         {
...             "role": "assistant",
...             "content": "",
...             "tool_calls": [{"type": "function", "function": {"name": "multiply", "arguments": {"a": 3, "b": 4}}}],
...         },
...     ],
...     tokenize=False,
... )
'<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nWhat is 3*4?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n<|eot_id|>'
```

The `multiply(a=3, b=4)` call vanished: the model has no way to emit a tool call with this template. Yet `supports_tool_calling` returned `True`.

## Fix

Plant distinct sentinels in the function name, argument key, and argument value (in addition to the existing tool-message-content sentinel) and require *all four* to survive rendering. A template now has to round-trip both halves of the exchange to be accepted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens `supports_tool_calling` detection, which may flip capability checks for some models and change downstream code paths that rely on this classification. Logic is simple but affects model/template compatibility gating.
> 
> **Overview**
> Fixes `supports_tool_calling` to **reject chat templates that silently drop assistant `tool_calls`**, not just tool-message content. The check now injects distinct sentinels for tool call name/arguments and tool response content and requires all of them to appear in the rendered prompt.
> 
> Updates tests to reflect the corrected behavior: `tiny-LlamaForCausalLM-3` is now expected to *not* support tool calling, while newer Llama 3.1/3.2 templates are added to the supported set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6a5bb685f978b74e36a0b551fe1930532c4fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->