### PR TITLE
Fix CI with min versions validation error for field 'import_name': Require kernels < 0.13.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,6 +244,7 @@ jobs:
           uv pip install accelerate==1.4.0
           uv pip install datasets==3.0.0
           uv pip install transformers==4.56.2
+          uv pip install "kernels<0.13.0"  # see GH-5528
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
Fix CI with min versions validation error for field 'import_name': Require kernels < 0.13.0.

This PR updates to the test workflow configuration by adding a version constraint for the `kernels` package to ensure compatibility.

Fix #5528.

### Changes

* Updated dependencies:
  * Added installation of `kernels` with a version constraint `<0.13.0` to address compatibility issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only dependency pin to avoid a known incompatibility; no runtime or library code changes.
> 
> **Overview**
> Updates the `tests_min_versions` GitHub Actions workflow to explicitly install `kernels<0.13.0` (per GH-5528), preventing CI failures caused by newer `kernels` versions during minimum-dependency validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593dd5e5b97f716c4fdf9f7cbac282220969ce84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->