### PR TITLE
Align KTO with DPO: Add precompute_ref_batch_size

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -52,6 +52,10 @@ class KTOConfig(_BaseConfig):
             Whether to precompute the reference model log probabilities for the entire training dataset before
             training. This allows to save memory during training, as the reference model does not need to be kept in
             memory.
+        precompute_ref_batch_size (`int`, *optional*):
+            Batch size to use when precomputing reference model log probabilities. This can be set higher than the
+            training batch size to speed up preprocessing. If `None`, defaults to `per_device_train_batch_size` for
+            training and `per_device_eval_batch_size` for evaluation.
 
         > Parameters that control the training
 
@@ -120,6 +124,14 @@ class KTOConfig(_BaseConfig):
             "help": "Whether to precompute the reference model log probabilities for the entire training dataset "
             "before training. This allows to save memory during training, as the reference model does not need to be "
             "kept in memory."
+        },
+    )
+    precompute_ref_batch_size: int | None = field(
+        default=None,
+        metadata={
+            "help": "Batch size to use when precomputing reference model log probabilities. This can be set higher "
+            "than the training batch size to speed up preprocessing. If `None`, defaults to "
+            "`per_device_train_batch_size` for training and `per_device_eval_batch_size` for evaluation."
         },
     )
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -735,7 +735,7 @@ class KTOTrainer(_BaseTrainer):
             self.kto_loss_fn = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
 
         if self.precompute_ref_log_probs:
-            self.train_dataset = self._precompute_reference_log_probs(
+            self.train_dataset = self._precompute_ref_logps(
                 self.train_dataset,
                 "train",
                 self.args.precompute_ref_batch_size or self.args.per_device_train_batch_size,
@@ -743,13 +743,13 @@ class KTOTrainer(_BaseTrainer):
             if self.eval_dataset is not None:
                 if isinstance(self.eval_dataset, dict):
                     self.eval_dataset = {
-                        name: self._precompute_reference_log_probs(
+                        name: self._precompute_ref_logps(
                             dataset, name, self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
                         )
                         for name, dataset in self.eval_dataset.items()
                     }
                 else:
-                    self.eval_dataset = self._precompute_reference_log_probs(
+                    self.eval_dataset = self._precompute_ref_logps(
                         self.eval_dataset,
                         "eval",
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
@@ -769,7 +769,7 @@ class KTOTrainer(_BaseTrainer):
             if self.ref_adapter_name:
                 self.model.set_adapter(self.model_adapter_name or "default")
 
-    def _precompute_reference_log_probs(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
+    def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
         dataloader_params = {
             "batch_size": batch_size,
             "collate_fn": self.data_collator,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -736,17 +736,23 @@ class KTOTrainer(_BaseTrainer):
 
         if self.precompute_ref_log_probs:
             self.train_dataset = self._precompute_reference_log_probs(
-                self.train_dataset, "train", self.args.per_device_train_batch_size
+                self.train_dataset,
+                "train",
+                self.args.precompute_ref_batch_size or self.args.per_device_train_batch_size,
             )
             if self.eval_dataset is not None:
                 if isinstance(self.eval_dataset, dict):
                     self.eval_dataset = {
-                        name: self._precompute_reference_log_probs(dataset, name, self.args.per_device_eval_batch_size)
+                        name: self._precompute_reference_log_probs(
+                            dataset, name, self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
+                        )
                         for name, dataset in self.eval_dataset.items()
                     }
                 else:
                     self.eval_dataset = self._precompute_reference_log_probs(
-                        self.eval_dataset, "eval", self.args.per_device_eval_batch_size
+                        self.eval_dataset,
+                        "eval",
+                        self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
     @contextmanager

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -811,7 +811,6 @@ class DPOTrainer(_BaseTrainer):
                 self.args.precompute_ref_batch_size or self.args.per_device_train_batch_size,
             )
             if self.eval_dataset is not None:
-                # batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
                 if isinstance(self.eval_dataset, dict):
                     self.eval_dataset = {
                         name: self._precompute_ref_logps(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -805,17 +805,26 @@ class DPOTrainer(_BaseTrainer):
                     "Dataset or set `precompute_ref_log_probs=False`."
                 )
 
-            batch_size = self.args.precompute_ref_batch_size or self.args.per_device_train_batch_size
-            self.train_dataset = self._precompute_ref_logps(self.train_dataset, "train", batch_size)
+            self.train_dataset = self._precompute_ref_logps(
+                self.train_dataset,
+                "train",
+                self.args.precompute_ref_batch_size or self.args.per_device_train_batch_size,
+            )
             if self.eval_dataset is not None:
-                batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
+                # batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
                 if isinstance(self.eval_dataset, dict):
                     self.eval_dataset = {
-                        name: self._precompute_ref_logps(dataset, name, batch_size)
+                        name: self._precompute_ref_logps(
+                            dataset, name, self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
+                        )
                         for name, dataset in self.eval_dataset.items()
                     }
                 else:
-                    self.eval_dataset = self._precompute_ref_logps(self.eval_dataset, "eval", batch_size)
+                    self.eval_dataset = self._precompute_ref_logps(
+                        self.eval_dataset,
+                        "eval",
+                        self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
+                    )
 
     def _tokenize(
         self,


### PR DESCRIPTION
Align KTO with DPO: Add precompute_ref_batch_size

Part of:
- #4786

This PR introduces a new configuration option to control the batch size used when precomputing reference model log probabilities, and updates the relevant trainer logic to use this new option. This allows users to set a larger batch size for precomputation, potentially speeding up preprocessing and improving memory usage during training.

### Changes

**Configuration improvements:**

* Added a new `precompute_ref_batch_size` option to the `KTOConfig` class, allowing users to specify the batch size for precomputing reference model log probabilities. If not set, it defaults to the regular training or evaluation batch size.

**Trainer logic updates:**

* Updated both `KTOTrainer` and `DPOTrainer` to use the new `precompute_ref_batch_size` option when precomputing reference log probabilities for both training and evaluation datasets. This ensures the batch size for precomputation is configurable and defaults appropriately when not set.

**Code maintenance:**

* Renamed the internal method `_precompute_reference_log_probs` to `_precompute_ref_logps` in `KTOTrainer` to improve naming consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional config knob and threads it through precompute logic; main risk is altered preprocessing performance/memory characteristics if misconfigured.
> 
> **Overview**
> Adds `precompute_ref_batch_size` to `KTOConfig` to let users choose a separate batch size when precomputing reference-model log probabilities.
> 
> Updates `KTOTrainer` to use this value (falling back to train/eval batch sizes) and renames the helper from `_precompute_reference_log_probs` to `_precompute_ref_logps` for consistency; also minor formatting aligns `DPOTrainer`’s precompute calls with the same pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79732f7da971afde2303a097ec0ca87b1fb60ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->