### PR TITLE
Set type annotation for default configs across trainers

### DIFF
--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -402,7 +402,7 @@ class DistillationTrainer(_BaseTrainer):
         peft_config: Optional["PeftConfig"] = None,
     ):
         if args is None:
-            args = DistillationConfig(output_dir="tmp_distillation")
+            args: DistillationConfig = DistillationConfig(output_dir="tmp_distillation")
 
         # ── Student model loading ──
         model_init_kwargs = args.model_init_kwargs or {}

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -205,7 +205,7 @@ class DPPOTrainer(GRPOTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else model.config._name_or_path
             model_name = model_name.split("/")[-1]
-            args = DPPOConfig(f"{model_name}-DPPO")
+            args: DPPOConfig = DPPOConfig(f"{model_name}-DPPO")
 
         self.divergence_type = args.divergence_type
         self.divergence_topk = args.divergence_topk

--- a/trl/experimental/minillm/minillm_trainer.py
+++ b/trl/experimental/minillm/minillm_trainer.py
@@ -185,7 +185,7 @@ class MiniLLMTrainer(GRPOTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = MiniLLMConfig(f"{model_name}-MiniLLM")
+            args: MiniLLMConfig = MiniLLMConfig(f"{model_name}-MiniLLM")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream

--- a/trl/experimental/papo/papo_trainer.py
+++ b/trl/experimental/papo/papo_trainer.py
@@ -128,7 +128,7 @@ class PAPOTrainer(GRPOTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else model.config._name_or_path
             model_name = model_name.split("/")[-1]
-            args = PAPOConfig(f"{model_name}-PAPO")
+            args: PAPOConfig = PAPOConfig(f"{model_name}-PAPO")
 
         # Store PAPO-specific parameters
         self.perception_loss_weight = args.perception_loss_weight

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -517,7 +517,7 @@ class DPOTrainer(_BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = DPOConfig(f"{model_name}-DPO")
+            args: DPOConfig = DPOConfig(f"{model_name}-DPO")
 
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -287,7 +287,7 @@ class GRPOTrainer(_BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = GRPOConfig(f"{model_name}-GRPO")
+            args: GRPOConfig = GRPOConfig(f"{model_name}-GRPO")
 
         # Model
         if isinstance(model, str):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -337,7 +337,7 @@ class RewardTrainer(_BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = RewardConfig(f"{model_name}-Reward")
+            args: RewardConfig = RewardConfig(f"{model_name}-Reward")
 
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -235,7 +235,7 @@ class RLOOTrainer(_BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = RLOOConfig(f"{model_name}-RLOO")
+            args: RLOOConfig = RLOOConfig(f"{model_name}-RLOO")
 
         # Model
         if isinstance(model, str):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -661,13 +661,13 @@ class SFTTrainer(_BaseTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
-            args = SFTConfig(f"{model_name}-SFT")
+            args: SFTConfig = SFTConfig(f"{model_name}-SFT")
         elif isinstance(args, TrainingArguments) and not isinstance(args, SFTConfig):
             dict_args = args.to_dict()
             dict_args["hub_token"] = args.hub_token  # to_dict hides the hub_token
             if Version(transformers.__version__) < Version("5.0.0"):
                 dict_args.pop("push_to_hub_token")
-            args = SFTConfig(**dict_args)
+            args: SFTConfig = SFTConfig(**dict_args)
 
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")


### PR DESCRIPTION
Set type annotation for default configs across trainers.

This PR makes a consistent typing improvement across several trainer classes. Specifically, it updates the initialization of configuration objects to use explicit type annotations when assigning default config instances in the constructors. This enhances code clarity and helps with static type checking.

### Changes

**Type Annotation Improvements in Trainer Constructors:**

* Explicitly annotates the type of the `args` variable when assigning default config objects such as `SFTConfig`, `DPOConfig`, `GRPOConfig`, `RewardConfig`, `RLOOConfig`, `MiniLLMConfig`, `DPPOConfig`, `PAPOConfig`, and `DistillationConfig` in their respective trainer `__init__` methods.

* Also applies type annotations when converting from `TrainingArguments` to the respective config object in the `SFTTrainer`.

These changes improve type safety and code readability throughout the trainer initialization logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk typing-only change: adds explicit `Config` annotations when creating default `args` in trainer constructors, without altering runtime behavior.
> 
> **Overview**
> Makes trainer initialization typing more explicit by annotating `args` with the concrete `*Config` type when a default config is constructed (e.g., `SFTConfig`, `DPOConfig`, `GRPOConfig`, `RewardConfig`, `RLOOConfig`, `MiniLLMConfig`, `DPPOConfig`, `PAPOConfig`, `DistillationConfig`).
> 
> Also annotates the `SFTTrainer` path that converts a generic `TrainingArguments` instance into an `SFTConfig`, improving static type-checking consistency across trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0aef2ac7469d86982d4e568b38b465fa924f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->