### PR TITLE
Align KTO with DPO: Align ref_model initialization

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -337,12 +337,6 @@ class KTOTrainer(_BaseTrainer):
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")
 
-        if not isinstance(model, str) and ref_model is model:
-            raise ValueError(
-                "`model` and `ref_model` cannot be the same object. If you want `ref_model` to be the "
-                "same as `model`, you must mass a copy of it, or `None` if you use peft."
-            )
-
         # Model initialization
         if isinstance(model, str):
             model_init_kwargs = args.model_init_kwargs or {}

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from accelerate import PartialState, logging
-from accelerate.utils import tqdm
+from accelerate.utils import is_peft_model, tqdm
 from datasets import Dataset, concatenate_datasets
 from packaging.version import Version
 from torch import autocast
@@ -56,6 +56,7 @@ from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import (
     create_model_from_path,
     disable_dropout_in_model,
+    get_config_model_id,
     log_table_to_comet_experiment,
     selective_log_softmax,
 )
@@ -252,10 +253,12 @@ class KTOTrainer(_BaseTrainer):
     Args:
         model ([`~transformers.PreTrainedModel`]):
             The model to train, preferably an [`~transformers.AutoModelForSequenceClassification`].
-        ref_model ([`~transformers.PreTrainedModel`]):
-            Hugging Face transformer model with a casual language modelling head. Used for implicit reward computation
-            and loss. If no reference model is provided, the trainer will create a reference model with the same
-            architecture as the model to be optimized.
+        ref_model ([`~transformers.PreTrainedModel`], *optional*):
+            Reference model used to compute the reference log probabilities.
+
+            - If provided, this model is used directly as the reference policy.
+            - If `None`, the trainer will automatically use the initial policy corresponding to `model`, i.e. the model
+              state before KTO training starts.
         args ([`experimental.kto.KTOConfig`]):
             The arguments to use for training.
         train_dataset ([`~datasets.Dataset`]):
@@ -309,7 +312,7 @@ class KTOTrainer(_BaseTrainer):
     def __init__(
         self,
         model: PreTrainedModel | nn.Module | str = None,
-        ref_model: PreTrainedModel | nn.Module | str | None = None,
+        ref_model: PreTrainedModel | None = None,
         args: KTOConfig = None,
         train_dataset: Dataset | None = None,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
@@ -353,14 +356,11 @@ class KTOTrainer(_BaseTrainer):
                     "You passed `model_init_kwargs` to the KTOConfig, but your model is already instantiated. "
                     "The `model_init_kwargs` will be ignored."
                 )
-
-        # Reference model initialization
-        if isinstance(ref_model, str):
-            ref_model_init_kwargs = args.model_init_kwargs or {}
-            # Distributed training requires device_map=None ("auto" fails)
-            if args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
-                ref_model_init_kwargs["device_map"] = None
-            ref_model = create_model_from_path(ref_model, **ref_model_init_kwargs)
+        if ref_model is model:
+            raise ValueError(
+                "`model` and `ref_model` cannot be the same object. In most cases you should omit `ref_model` and "
+                "we'll initialize it to a copy of `model` for you."
+            )
 
         # Initialize this variable to False. This helps tracking the case when `peft_module_casting_to_bf16`
         # has been called in order to properly call autocast if needed.
@@ -678,6 +678,22 @@ class KTOTrainer(_BaseTrainer):
             optimizers=optimizers,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
+
+        # Reference model
+        if ref_model is None:
+            if is_peft_model(self.model):
+                # If PEFT is used, the reference model is not needed since the adapter can be disabled to revert to the
+                # initial model.
+                self.ref_model = None
+            else:
+                ref_model_init_kwargs = args.model_init_kwargs or {}
+                # Distributed training requires device_map=None ("auto" fails)
+                if self.args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
+                    ref_model_init_kwargs["device_map"] = None
+                ref_model_path = get_config_model_id(self.model.config)
+                self.ref_model = create_model_from_path(ref_model_path, **ref_model_init_kwargs)
+        else:
+            self.ref_model = ref_model
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -60,7 +60,7 @@ from ...trainer.utils import (
     log_table_to_comet_experiment,
     selective_log_softmax,
 )
-from ..utils import DPODataCollatorWithPadding, create_reference_model, pad_to_length, peft_module_casting_to_bf16
+from ..utils import DPODataCollatorWithPadding, pad_to_length, peft_module_casting_to_bf16
 from .kto_config import KTOConfig
 
 
@@ -439,14 +439,6 @@ class KTOTrainer(_BaseTrainer):
         self.is_peft_model = is_peft_available() and isinstance(model, PeftModel)
         self.model_adapter_name = model_adapter_name
         self.ref_adapter_name = ref_adapter_name
-
-        if ref_model:
-            self.ref_model = ref_model
-        elif self.is_peft_model or args.precompute_ref_log_probs:
-            # The `model` with adapters turned off will be used as the reference model
-            self.ref_model = None
-        else:
-            self.ref_model = create_reference_model(model)
 
         if processing_class is None:
             raise ValueError(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -464,12 +464,6 @@ class KTOTrainer(_BaseTrainer):
         else:
             self.use_dpo_data_collator = False
 
-        # Disable dropout in the model and reference model
-        if args.disable_dropout:
-            disable_dropout_in_model(model)
-            if self.ref_model is not None:
-                disable_dropout_in_model(self.ref_model)
-
         self.loss_type = args.loss_type
         self.max_length = max_length
         self.generate_during_eval = args.generate_during_eval
@@ -680,6 +674,12 @@ class KTOTrainer(_BaseTrainer):
                 self.ref_model = create_model_from_path(ref_model_path, **ref_model_init_kwargs)
         else:
             self.ref_model = ref_model
+
+        # Disable dropout in the model and reference model
+        if args.disable_dropout:
+            disable_dropout_in_model(model)
+            if self.ref_model is not None:
+                disable_dropout_in_model(self.ref_model)
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -435,7 +435,7 @@ class DPOTrainer(_BaseTrainer):
               config) with the keyword arguments in `args.model_init_kwargs`.
             - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported.
             - A [`~peft.PeftModel`] object. Only causal language models are supported.
-        ref_model (`PreTrainedModel`, *optional*):
+        ref_model ([`~transformers.PreTrainedModel`], *optional*):
             Reference model used to compute the reference log probabilities.
 
             - If provided, this model is used directly as the reference policy.


### PR DESCRIPTION
Align KTO with DPO: Align ref_model initialization.

This PR refactors how the reference model (`ref_model`) is handled in the `KTOTrainer` class, making its initialization more robust, clarifying its usage, and improving compatibility with PEFT models. The changes ensure that `ref_model` is either explicitly provided or automatically derived from the initial model state, with special handling for PEFT adapters.

Part of:
- #4786

### Changes

Reference model initialization and handling:

* The `ref_model` parameter in `KTOTrainer` is now expected to be either a `PreTrainedModel` or `None`, removing support for passing a string path directly. If `ref_model` is not provided, the trainer will automatically initialize it from the initial policy or, if using a PEFT model, set it to `None` since the adapter can be disabled to revert to the initial model.
* Added a check to prevent `model` and `ref_model` from being the same object, raising a clear error if this occurs and guiding the user to omit `ref_model` for automatic initialization.
* Updated the docstring for `ref_model` in both `KTOTrainer` and `DPOTrainer` to clarify its purpose and usage, including the new initialization logic.

Internal utilities and imports:

* Added import of `get_config_model_id` and updated imports to support the new reference model initialization logic.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `KTOTrainer` derives/loads the reference model, which can affect training dynamics and memory usage, especially for non-PEFT runs and distributed setups. While the logic mirrors `DPOTrainer`, misconfiguration could surface as runtime errors or different ref-policy behavior.
> 
> **Overview**
> Aligns `KTOTrainer` reference-policy handling with `DPOTrainer`: `ref_model` is now *optional* and, when omitted, the trainer reconstructs a reference model from `model.config` via `get_config_model_id` (or uses `None` for PEFT so adapters can be disabled to recover the initial policy).
> 
> Removes support for passing `ref_model` as a string/path and reorders setup so dropout disabling also applies to the newly-initialized reference model; also tightens validation by rejecting `ref_model is model` with updated guidance. Updates the `DPOTrainer` docstring type annotation for `ref_model` for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df5ac11599a31e08ff11416596cfafeb696fe08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->