### PR TITLE
Set upper transformers version to skip distributed test_rloo after fixed

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -244,7 +244,7 @@ class TestDistributed(TrlTestCase):
             pytest.param(
                 "fsdp2",
                 marks=pytest.mark.skipif(
-                    Version(transformers.__version__) >= Version("5.4.0"),
+                    Version("5.4.0") <= Version(transformers.__version__) < Version("5.6.0"),
                     reason="Upstream issue: NaN weights on non-rank-0 FSDP processes (see #5386 and transformers#45050)",
                 ),
             ),


### PR DESCRIPTION
Set upper transformers version in distributed test_rloo after fixed.

Revert:
- #5387

Upstream fix is merged:
- https://github.com/huggingface/transformers/pull/45050


This PR makes a targeted update to a test skip condition in `tests/distributed/test_distributed.py` to refine when a specific test is skipped based on the version of the `transformers` library.

### Changes

Test condition refinement:

* Updated the `pytest.mark.skipif` condition in `test_reward` to only skip the test for `transformers` versions between 5.4.0 (inclusive) and 5.6.0 (exclusive), instead of all versions greater than or equal to 5.4.0. This ensures the test is only skipped for the problematic version range, improving test coverage for other versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a `pytest.mark.skipif` condition in a distributed test, affecting test execution/coverage but not runtime behavior.
> 
> **Overview**
> Updates the distributed `test_rloo` parametrization so the `fsdp2` case is skipped only for `transformers` versions `>=5.4.0` and `<5.6.0`, rather than for all versions `>=5.4.0`, restoring test coverage once the upstream NaN-weights issue was fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ede672bdb3bac9bb2957633d1b541c05f6c44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->