### PR TITLE
Fix `ref_model` docstring format in `DPOTrainer`

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -435,7 +435,7 @@ class DPOTrainer(_BaseTrainer):
               config) with the keyword arguments in `args.model_init_kwargs`.
             - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported.
             - A [`~peft.PeftModel`] object. Only causal language models are supported.
-        ref_model (`PreTrainedModel`, *optional*):
+        ref_model ([`~transformers.PreTrainedModel`], *optional*):
             Reference model used to compute the reference log probabilities.
 
             - If provided, this model is used directly as the reference policy.


### PR DESCRIPTION
## Summary
- Use proper cross-reference link syntax (`` [`~transformers.PreTrainedModel`] ``) for `ref_model` type annotation in `DPOTrainer` docstring, consistent with the `model` parameter above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only change adjusting the `ref_model` type annotation; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates the `DPOTrainer` docstring so the `ref_model` parameter uses the correct cross-reference format (`[`~transformers.PreTrainedModel`]`) consistent with the `model` parameter documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19f467df01aef89909c95b8fca0befa6adf5f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->