### PR TITLE
fix: Pass AsyncGRPOTrainer's processing_class to AsyncRolloutWorker

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -367,6 +367,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
                     model_name=model_name,
                     dataset=train_dataset,
                     reward_funcs=reward_funcs,
+                    processing_class=processing_class,
                     tools=tools,
                     environment_factory=environment_factory,
                     num_generations=self.args.num_generations,

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -26,7 +26,7 @@ import numpy as np
 import requests
 from accelerate.logging import get_logger
 from datasets import Dataset
-from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from transformers import PreTrainedTokenizerBase
 
 from trl.chat_template_utils import (
     add_response_schema,
@@ -90,7 +90,7 @@ class AsyncRolloutWorker:
         model_name: str,
         dataset: Dataset,
         reward_funcs: list[Callable[..., list[float]]],
-        processing_class: PreTrainedTokenizerBase | None = None,
+        processing_class: PreTrainedTokenizerBase,
         tools: list[Callable] | None = None,
         environment_factory: Callable[[], object] | None = None,
         num_generations: int = 8,
@@ -166,10 +166,7 @@ class AsyncRolloutWorker:
         self.chat_template_kwargs = chat_template_kwargs or {}
         self.log_completions = log_completions
         self.num_completions_to_print = num_completions_to_print
-        if processing_class is None:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-        else:
-            self.tokenizer = processing_class
+        self.tokenizer = processing_class
         self.tokenizer = add_response_schema(self.tokenizer)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -26,7 +26,7 @@ import numpy as np
 import requests
 from accelerate.logging import get_logger
 from datasets import Dataset
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from trl.chat_template_utils import (
     add_response_schema,
@@ -90,6 +90,7 @@ class AsyncRolloutWorker:
         model_name: str,
         dataset: Dataset,
         reward_funcs: list[Callable[..., list[float]]],
+        processing_class: PreTrainedTokenizerBase | None = None,
         tools: list[Callable] | None = None,
         environment_factory: Callable[[], object] | None = None,
         num_generations: int = 8,
@@ -165,7 +166,10 @@ class AsyncRolloutWorker:
         self.chat_template_kwargs = chat_template_kwargs or {}
         self.log_completions = log_completions
         self.num_completions_to_print = num_completions_to_print
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        if processing_class is None:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        else:
+            self.tokenizer = processing_class
         self.tokenizer = add_response_schema(self.tokenizer)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.


### PR DESCRIPTION
# What does this PR do?

Fixes #5498 

`AsyncRolloutWorker` now reuses the `processing_class` in `AsyncGRPOTrainer`.

As `AsyncGRPOTrainer` already initializes `processing_class` via `AutoTokenizer.from_pretrained(model_name)`, this change preserves existing behaviors when no `processing_class` is passed, while respecting user-provided customizations when one is provided.

```diff
diff --git a/trl/experimental/async_grpo/async_rollout_worker.py b/trl/experimental/async_grpo/async_rollout_worker.py
index 4fd11312..61e51990 100644
--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -165,7 +166,10 @@ class AsyncRolloutWorker:
         self.chat_template_kwargs = chat_template_kwargs or {}
         self.log_completions = log_completions
         self.num_completions_to_print = num_completions_to_print
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        if processing_class is None:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        else:
+            self.tokenizer = processing_class
         self.tokenizer = add_response_schema(self.tokenizer)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.
```

I elected to use an if statement for compatibility purposes, specifically for custom `AsyncRolloutWorker` usages that may rely on that path.

## Before submitting


- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small wiring change that swaps `AsyncRolloutWorker` tokenization to use the already-initialized `processing_class`, affecting prompt formatting/tokenization but not core training logic.
> 
> **Overview**
> **Fixes AsyncGRPO tokenizer/processor consistency.** `AsyncGRPOTrainer` now passes its `processing_class` into `AsyncRolloutWorker`, and the worker stops constructing its own tokenizer from `model_name`.
> 
> This ensures rollout generation/scoring uses the same user-provided (or trainer-default) tokenizer configuration as training, avoiding divergence when custom tokenizers/chat templates are supplied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1f8cf55bb489683e60c45e16baf428a3611dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->