### PR TITLE
fix: check all examples for margin key in DataCollatorForRewardModelingDataset

### DIFF
--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,8 +201,8 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
-            margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
+        if any("margin" in example for example in examples):
+            margins = torch.tensor([example.get("margin", 0.0) for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
 


### PR DESCRIPTION
Closes #5539

## Problem

`DataCollatorForRewardModelingDataset.torch_call()` checks for the `"margin"` key only on `examples[0]`:

```python
if "margin" in examples[0]:
    margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
```

This causes two failure modes after dataset shuffling:
1. **Silent data loss** — if the first example lacks `"margin"` but others have it, margins are silently dropped
2. **Runtime `KeyError`** — if first example has `"margin"` but a later one does not, the list comprehension crashes

## Fix

```python
if any("margin" in example for example in examples):
    margins = torch.tensor([example.get("margin", 0.0) for example in examples], dtype=torch.float)
```

Uses `any()` to check all examples and `.get()` with a `0.0` default for safe access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to batch collation logic, reducing KeyErrors and avoiding silently dropping margins when batches have mixed presence of the field.
> 
> **Overview**
> Improves `DataCollatorForPreference.torch_call()` margin handling by checking *all* batch examples for a `margin` field and building the margins tensor with `example.get("margin", 0.0)` defaults. This prevents `KeyError`s and avoids silently discarding margin values when only some items in a shuffled batch include `margin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5533b98fa72031773670d0b7e7e5abd72d9cf4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->