### PR TITLE
Update tests with zero3 for RLOO and GRPO once fixed in transformers 5.5.4

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -236,8 +236,8 @@ class TestDistributed(TrlTestCase):
             pytest.param(
                 "zero3",
                 marks=pytest.mark.xfail(
-                    Version(transformers.__version__) >= Version("5.0.0"),
-                    reason="ZeRO-3 fails with transformers >= 5.0.0, see #4899",
+                    Version("5.0.0") <= Version(transformers.__version__) < Version("5.5.4"),
+                    reason="ZeRO-3 fails with transformers >= 5.0.0 and < 5.5.4 (fixed in transformers#45414), see #4899",
                     strict=True,
                 ),
             ),
@@ -279,8 +279,8 @@ class TestDistributed(TrlTestCase):
             pytest.param(
                 "zero3",
                 marks=pytest.mark.xfail(
-                    Version(transformers.__version__) >= Version("5.0.0"),
-                    reason="ZeRO-3 fails with transformers >= 5.0.0, see #4899",
+                    Version("5.0.0") <= Version(transformers.__version__) < Version("5.5.4"),
+                    reason="ZeRO-3 fails with transformers >= 5.0.0 and < 5.5.4 (fixed in transformers#45414), see #4899",
                     strict=True,
                 ),
             ),


### PR DESCRIPTION
Update tests with zero3 for RLOO and GRPO once fixed in transformers 5.5.4.

This PR updates the test conditions for ZeRO-3 integration with the `transformers` library to reflect a recent upstream fix. The tests now only expect failures for a specific range of `transformers` versions where the issue is known to occur, improving the accuracy of test expectations.

Fix #4899, after the upstream issue in `transformers`:
- https://github.com/huggingface/transformers/issues/45137

has been fixed by:
- https://github.com/huggingface/transformers/pull/45414

Follow-up to:
- #5420
- #5404
- #4898
- #4899

### Changes

Test condition updates:

* In both `test_reward` and `test_rloo` in `tests/distributed/test_distributed.py`, the `pytest.mark.xfail` condition for the "zero3" parameter is updated to only expect failures when `transformers` version is greater than or equal to 5.0.0 and less than 5.5.4, reflecting that the issue is fixed in `transformers#45414`. The reason message is also updated for clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pytest `xfail` version gating and messages in distributed tests, with no production code changes.
> 
> **Overview**
> Updates distributed tests so the `zero3` parameter is only marked `xfail` for `transformers` versions `>= 5.0.0` and `< 5.5.4`, reflecting that the upstream ZeRO-3 issue is fixed in `transformers` 5.5.4.
> 
> Also updates the associated `xfail` reason strings (and keeps `strict=True`) in `test_rloo` and `test_grpo` to document the fixed upstream PR/reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef7620e6204dafedc6e16fb5c42f619bc7a135b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->