### PR TITLE
Don't load ref_model when precompute_ref_log_probs in DPO/KTO

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -671,9 +671,10 @@ class KTOTrainer(_BaseTrainer):
 
         # Reference model
         if ref_model is None:
-            if is_peft_model(self.model):
+            if is_peft_model(self.model) or args.precompute_ref_log_probs:
                 # If PEFT is used, the reference model is not needed since the adapter can be disabled to revert to the
-                # initial model.
+                # initial model. If precompute_ref_log_probs is True, the reference model does not need to be kept in
+                # memory during training.
                 self.ref_model = None
             else:
                 ref_model_init_kwargs = args.model_init_kwargs or {}

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -779,7 +779,7 @@ class DPOTrainer(_BaseTrainer):
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
 
         if args.sync_ref_model:
-            if self.ref_model is None:
+            if is_peft_model(self.model):
                 raise NotImplementedError(
                     "You passed `sync_ref_model=True` while using a PEFT model, which is currently not supported. "
                     "With PEFT, DPOTrainer does not keep a separate reference model in memory; instead, it recovers "

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -742,9 +742,10 @@ class DPOTrainer(_BaseTrainer):
 
         # Reference model
         if ref_model is None:
-            if is_peft_model(self.model):
+            if is_peft_model(self.model) or args.precompute_ref_log_probs:
                 # If PEFT is used, the reference model is not needed since the adapter can be disabled to revert to the
-                # initial model.
+                # initial model. If precompute_ref_log_probs is True, the reference model does not need to be kept in
+                # memory during training.
                 self.ref_model = None
             else:
                 ref_model_init_kwargs = args.model_init_kwargs or {}
@@ -1030,9 +1031,12 @@ class DPOTrainer(_BaseTrainer):
         model_kwargs["use_cache"] = False
 
         with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
-            if is_peft_model(self.model) and self.ref_model is None:
-                model = self.accelerator.unwrap_model(self.model)
-                with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+            if self.ref_model is None:
+                if is_peft_model(self.model):
+                    model = self.accelerator.unwrap_model(self.model)
+                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+                        ref_outputs = self.model(**model_kwargs)
+                else:
                     ref_outputs = self.model(**model_kwargs)
             else:
                 ref_outputs = self.ref_model(**model_kwargs)


### PR DESCRIPTION
Don't load ref_model when `precompute_ref_log_probs=True` in DPO/KTO.

This PR updates the logic for handling reference models in both the KTO and DPO trainers to better support scenarios where reference log probabilities are precomputed. The changes ensure that the reference model is not unnecessarily kept in memory, improving efficiency and compatibility.

Note that this was already the case for KTO before merging [#5534](https://github.com/huggingface/trl/pull/5534). This PR:
- Restores this behavior for KTO
- Aligns DPO with KTO

Follow-up to:
- https://github.com/huggingface/trl/pull/5534/changes#r3074073279

### Motivation

When `precompute_ref_log_probs=True` and no explicit `ref_model` is provided, the reference model does not need to stay in memory during training: its only role is to produce the reference log probabilities that get precomputed and stored in the dataset up front. Loading a full copy of the model for training defeats the memory savings the flag is intended to provide.

### Solution

**KTO**: restores behavior that was dropped in the ref model initialization refactor in #5534. The old code explicitly set `self.ref_model = None` when `precompute_ref_log_probs=True`; the refactored init removed that condition to align with DPO, causing a full model copy to always be loaded for non-PEFT models.

**DPO**: extends the same optimization. Previously DPO always loaded a ref model copy for non-PEFT models regardless of `precompute_ref_log_probs`, then kept it in memory unused for the entire training run. `compute_ref_log_probs` (called only during precomputation at init) is updated to handle `self.ref_model is None` for non-PEFT by using `self.model` directly: valid because precomputation runs before any training step, so the model is still at its initial (reference) state.

In both trainers, when `ref_model` is explicitly provided by the user, it is used as-is regardless of `precompute_ref_log_probs`.

### Changes

**Reference model handling:**

* In both `kto_trainer.py` and `dpo_trainer.py`, the logic for setting `self.ref_model` now disables the reference model if either a PEFT model is used or if `args.precompute_ref_log_probs` is set, reflecting that the reference model is not needed in these cases.

**Reference log probability computation:**

* In `dpo_trainer.py`, the `compute_ref_log_probs` method is updated to handle cases where `self.ref_model` is `None`. It now checks if the main model is a PEFT model and uses the correct adapter context, or simply uses the main model if not. This ensures correct computation of reference log probabilities when the reference model is absent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reference-model initialization and log-prob computation paths in `DPOTrainer`/`KTOTrainer`, which can affect training correctness and memory usage when `precompute_ref_log_probs=True`. Risk is moderate because behavior changes occur in core training setup but are narrowly gated by config flags.
> 
> **Overview**
> Avoids keeping a separate `ref_model` in memory when `precompute_ref_log_probs=True` in both `KTOTrainer` and `DPOTrainer`, aligning behavior with the intent of precomputing and storing reference log-probs upfront.
> 
> Updates `DPOTrainer.compute_ref_log_probs` to support `self.ref_model is None` by computing reference log-probs from `self.model` (and using the PEFT `ref` adapter context when applicable), and tightens `sync_ref_model` validation to explicitly reject the PEFT case rather than the broader “no ref model” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35293d120addbb7c314484efd58a1bb747ff26d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->