### PR TITLE
Add example script section to experimental trainer docs

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -107,6 +107,39 @@ When using fully on-policy distillation (`lmbda=1.0`), the assistant turn can be
 {"messages": [{"role": "user", "content": "What color is the sky?"}]}
 ```
 
+## Example script
+
+Use [`trl/experimental/distillation/distillation.py`](https://github.com/huggingface/trl/blob/main/trl/experimental/distillation/distillation.py) to launch distillation training from the command line. The script supports full training, mixed on/off-policy, and LoRA via the standard `ModelConfig` flags.
+
+```bash
+# Full training (off-policy only, lmbda=0):
+python trl/experimental/distillation/distillation.py \
+    --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
+    --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
+    --dataset_name trl-lib/chatbot_arena_completions \
+    --learning_rate 2e-5 \
+    --per_device_train_batch_size 4 \
+    --gradient_accumulation_steps 8 \
+    --lmbda 0.0 \
+    --output_dir distilled-model \
+    --num_train_epochs 1
+```
+
+```bash
+# Mixed on/off-policy (lmbda=0.5):
+python trl/experimental/distillation/distillation.py \
+    --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
+    --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
+    --dataset_name trl-lib/chatbot_arena_completions \
+    --learning_rate 2e-5 \
+    --per_device_train_batch_size 4 \
+    --gradient_accumulation_steps 8 \
+    --lmbda 0.5 \
+    --beta 0.5 \
+    --output_dir distilled-model \
+    --num_train_epochs 1
+```
+
 ## DistillationTrainer
 
 [[autodoc]] experimental.distillation.DistillationTrainer

--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -160,6 +160,23 @@ P_merged("cool") = 0.1 × 0.9 = 0.09
 
 The merged distribution is unnormalized (sums to 0.81), but this is intentional and correct for ULD loss computation, which uses sorting and L1 distance.
 
+## Example script
+
+Use [`trl/experimental/gold/gold.py`](https://github.com/huggingface/trl/blob/main/trl/experimental/gold/gold.py) to launch GOLD training from the command line. The script supports full training and LoRA via the standard `ModelConfig` flags.
+
+```bash
+python trl/experimental/gold/gold.py \
+    --model_name_or_path meta-llama/Llama-3.2-1B-Instruct \
+    --teacher_model_name_or_path Qwen/Qwen2-1.5B-Instruct \
+    --dataset_name trl-lib/chatbot_arena_completions \
+    --learning_rate 2e-5 \
+    --per_device_train_batch_size 4 \
+    --gradient_accumulation_steps 8 \
+    --output_dir gold-model \
+    --num_train_epochs 1 \
+    --push_to_hub
+```
+
 ## GOLDTrainer
 
 [[autodoc]] experimental.gold.GOLDTrainer

--- a/docs/source/sdft_trainer.md
+++ b/docs/source/sdft_trainer.md
@@ -69,6 +69,29 @@ SDFT-specific hook:
 
 - `on_generation_prompts_selected`: fired when SDFT chooses the prompt source for on-policy generation. The payload includes the selected `generation_prompts` and the corresponding `generation_prompt_text`.
 
+## Example script
+
+Use [`trl/experimental/sdft/sdft.py`](https://github.com/huggingface/trl/blob/main/trl/experimental/sdft/sdft.py) to launch SDFT training from the command line. The script supports any causal LM from the Hub, custom local datasets via `--dataset_path`, and PEFT/LoRA via the standard `ModelConfig` flags.
+
+```bash
+python trl/experimental/sdft/sdft.py \
+    --model_name_or_path Qwen/Qwen3.5-0.8B \
+    --dataset_name your-org/your-dataset \
+    --output_dir outputs/sdft-qwen3.5-0.8b \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 16 \
+    --learning_rate 2e-5 \
+    --max_prompt_length 1024 \
+    --max_completion_length 512 \
+    --generate_from_teacher \
+    --sync_ref_model \
+    --ref_model_sync_steps 1 \
+    --ref_model_mixup_alpha 0.01 \
+    --eval_strategy steps \
+    --eval_steps 50 \
+    --report_to wandb
+```
+
 ## SDFTConfig
 
 [[autodoc]] experimental.sdft.SDFTConfig

--- a/docs/source/sdpo_trainer.md
+++ b/docs/source/sdpo_trainer.md
@@ -67,6 +67,35 @@ SDPO-specific hook:
 
 - `on_teacher_context_built`: fired after SDPO constructs the teacher-conditioned inputs. The payload includes `teacher_input_ids`, `teacher_attention_mask`, `completion_mask`, and `self_distillation_mask`.
 
+## Example script
+
+Use [`trl/experimental/sdpo/sdpo.py`](https://github.com/huggingface/trl/blob/main/trl/experimental/sdpo/sdpo.py) to launch SDPO training from the command line. The script supports verifiable math rewards, environment feedback via `--feedback_column`, and PEFT/LoRA via the standard `ModelConfig` flags.
+
+```bash
+python trl/experimental/sdpo/sdpo.py \
+    --model_name_or_path Qwen/Qwen2.5-Math-1.5B-Instruct \
+    --dataset_name openai/gsm8k \
+    --dataset_config main \
+    --output_dir outputs/sdpo-qwen35-2b-gsm8k \
+    --learning_rate 5e-5 \
+    --dtype bfloat16 \
+    --bf16 true \
+    --max_completion_length 128 \
+    --use_peft \
+    --lora_target_modules q_proj k_proj v_proj o_proj gate_proj up_proj down_proj \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 2 \
+    --num_generations 8 \
+    --generation_batch_size 32 \
+    --distillation_alpha 1.0 \
+    --full_logit_distillation false \
+    --sdpo_policy_loss_mode hybrid \
+    --report_to none \
+    --eval_strategy steps \
+    --eval_steps 1000 \
+    --save_strategy no
+```
+
 ## SDPOConfig
 
 [[autodoc]] experimental.sdpo.SDPOConfig


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@cmpatino @albertvillanova @qgallouedec 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change adding example CLI invocations; no runtime or API behavior is modified.
> 
> **Overview**
> Adds an **“Example script”** section to the experimental trainer docs for `DistillationTrainer`, `GOLDTrainer`, `SDFTTrainer`, and `SDPOTrainer`, linking to the corresponding `trl/experimental/*/*.py` entrypoints.
> 
> Each page now includes copy-pastable command-line examples showing typical flags (e.g., mixed on/off-policy distillation params, PEFT/LoRA options, and SDPO generation/eval settings) to help users launch training from the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2409cdd9f20170d903748c107af440808da4a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->