### PR TITLE
Deprecate `use_transformers_paged`

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -550,7 +550,6 @@ def test_gold_trainer_init_defaults_vllm_max_model_length_to_max_length(monkeypa
         top_p=1.0,
         seq_kd=False,
         num_generations=1,
-        use_transformers_paged=False,
         max_completion_length=16,
         top_k=0,
         log_completions=False,
@@ -666,7 +665,6 @@ def test_get_start_and_size_answers_skips_prompt_tokens():
 @pytest.mark.slow
 def test_generate_on_policy_outputs_masks_prompt(llama_tokenizer):
     trainer = GOLDTrainer.__new__(GOLDTrainer)
-    trainer.use_transformers_paged = False
     trainer.processing_class = llama_tokenizer
 
     prompt_text = "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\nHello?<|eot_id|>"
@@ -718,7 +716,6 @@ def test_generate_on_policy_outputs_masks_prompt(llama_tokenizer):
 @pytest.mark.slow
 def test_generate_on_policy_outputs_masks_prompt_smollm(smollm_tokenizer, openr1_examples):
     trainer = GOLDTrainer.__new__(GOLDTrainer)
-    trainer.use_transformers_paged = False
     trainer.processing_class = smollm_tokenizer
 
     collator = DataCollatorForChatML(tokenizer=smollm_tokenizer)

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -318,7 +318,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert config.top_k == 0
         assert config.min_p is None
         assert config.repetition_penalty == 1.0
-        assert not config.use_transformers_paged
         assert config.cache_implementation is None
         assert config.generation_kwargs is None
 
@@ -358,32 +357,6 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert trainer.generation_config.repetition_penalty == 1.2
         assert trainer.generation_config.max_new_tokens == 64
         assert not trainer.generation_config.do_sample  # From generation_kwargs
-
-    @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
-    @require_torch_accelerator
-    def test_training_with_transformers_paged(self, config_name):
-        training_args = OnlineDPOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=2,
-            max_steps=3,
-            learning_rate=5.0e-7,
-            report_to="none",
-            use_transformers_paged=True,
-        )
-        dummy_dataset = load_dataset("trl-internal-testing/zen", config_name)
-
-        trainer = OnlineDPOTrainer(
-            model=self.model,
-            reward_funcs=self.reward_model,
-            args=training_args,
-            train_dataset=dummy_dataset["train"],
-            processing_class=self.tokenizer,
-            reward_processing_classes=self.reward_tokenizer,
-        )
-        trainer.train()
-
-        # Check if training loss is available
-        assert "train_loss" in trainer.state.log_history[-1]
 
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_training_with_reward_funcs(self, config_name):

--- a/trl/experimental/dppo/dppo_config.py
+++ b/trl/experimental/dppo/dppo_config.py
@@ -113,9 +113,3 @@ class DPPOConfig(GRPOConfig):
 
         if self.off_policy_mask_threshold is not None:
             raise ValueError("off_policy_mask_threshold is not supported for DPPO")
-
-        if self.use_transformers_paged:
-            raise ValueError(
-                "DPPO requires sampled token logprobs from the generation backend. "
-                "Transformers paged (`use_transformers_paged=True`) does not support logprob extraction."
-            )

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -286,16 +286,6 @@ class GOLDConfig(SFTConfig):
         metadata={"help": "Whether to skip EOS token for teacher in ULD loss computation."},
     )
 
-    # transformers paged attention
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use the `transformers` paged implementation for generation. If set to `True`, the "
-            "`transformers` paged implementation will be used for generation instead of the default padded "
-            "implementation."
-        },
-    )
-
     # vLLM parameters
     use_vllm: bool = field(
         default=False,
@@ -413,8 +403,26 @@ class GOLDConfig(SFTConfig):
     overwrite_hub_revision: bool = field(default=False, metadata={"help": "Whether to overwrite the Hub revision."})
     push_to_hub_revision: bool = field(default=False, metadata={"help": "Whether to push to a Hub revision/branch."})
 
+    # Deprecated parameters
+    use_transformers_paged: bool = field(
+        default=False,
+        metadata={
+            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
+            "release."
+        },
+    )
+
     def __post_init__(self):
         super().__post_init__()
+
+        if self.use_transformers_paged:
+            warnings.warn(
+                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
+                "`transformers` continuous batching support in an upcoming release.",
+                FutureWarning,
+                stacklevel=3,
+            )
+
         # check lmbda and beta are in the range [0, 1]
         if self.lmbda < 0.0 or self.lmbda > 1.0:
             raise ValueError("lmbda must be in the range [0.0, 1.0].")

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -403,25 +403,8 @@ class GOLDConfig(SFTConfig):
     overwrite_hub_revision: bool = field(default=False, metadata={"help": "Whether to overwrite the Hub revision."})
     push_to_hub_revision: bool = field(default=False, metadata={"help": "Whether to push to a Hub revision/branch."})
 
-    # Deprecated parameters
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
-            "release."
-        },
-    )
-
     def __post_init__(self):
         super().__post_init__()
-
-        if self.use_transformers_paged:
-            warnings.warn(
-                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
-                "`transformers` continuous batching support in an upcoming release.",
-                FutureWarning,
-                stacklevel=3,
-            )
 
         # check lmbda and beta are in the range [0, 1]
         if self.lmbda < 0.0 or self.lmbda > 1.0:

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -39,13 +39,7 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_utils import EvalPrediction, seed_worker
-from transformers.utils import (
-    is_datasets_available,
-    is_flash_attn_2_available,
-    is_liger_kernel_available,
-    is_peft_available,
-    is_rich_available,
-)
+from transformers.utils import is_datasets_available, is_liger_kernel_available, is_peft_available, is_rich_available
 
 from ...data_utils import is_conversational, maybe_convert_to_chatml, pack_dataset
 from ...extras.profiling import profiling_decorator
@@ -882,8 +876,6 @@ class GOLDTrainer(SFTTrainer):
         self._unmatched_sum = 0.0
         self._matched_step_eq = 0.0
         self._unmatched_step_eq = 0.0
-
-        self.use_transformers_paged = args.use_transformers_paged or False
 
         self.uld_loss_fn = None
         if self.use_uld_loss:
@@ -1877,35 +1869,14 @@ class GOLDTrainer(SFTTrainer):
 
     def generate_on_policy_outputs(self, model, inputs, generation_config, pad_token_id=None):
         # Generate output with respect to the prompt only
-        if self.use_transformers_paged:
-            previous_attn = self.model.config._attn_implementation
-            if is_flash_attn_2_available():
-                model.config._attn_implementation = "paged_attention"
-            else:
-                model.config._attn_implementation = "sdpa_paged"
-            prompt_mask = inputs.get("prompt_attention_mask")
-            prompts_tensor = inputs["prompts"]
-            if prompt_mask is not None:
-                prompt_sequences = [
-                    row[mask.bool()].detach().cpu().tolist()
-                    for row, mask in zip(prompts_tensor, prompt_mask, strict=True)
-                ]
-            else:
-                prompt_sequences = [row.detach().cpu().tolist() for row in prompts_tensor]
-            generated_outputs = model.generate_batch(prompt_sequences, generation_config=generation_config)
-            model.config._attn_implementation = previous_attn
-
-            completion_ids = [output.generated_tokens for output in generated_outputs.values()]
-            generated_tokens = torch.stack([torch.tensor(ids, device=model.device) for ids in completion_ids])
-        else:
-            generated_outputs = model.generate(
-                input_ids=inputs["prompts"],
-                attention_mask=inputs.get("prompt_attention_mask", None),
-                generation_config=generation_config,
-                return_dict_in_generate=True,
-            )
-            # Get the generated token IDs
-            generated_tokens = generated_outputs.sequences
+        generated_outputs = model.generate(
+            input_ids=inputs["prompts"],
+            attention_mask=inputs.get("prompt_attention_mask", None),
+            generation_config=generation_config,
+            return_dict_in_generate=True,
+        )
+        # Get the generated token IDs
+        generated_tokens = generated_outputs.sequences
 
         batch_size = generated_tokens.size(0)
         device = generated_tokens.device
@@ -1913,18 +1884,9 @@ class GOLDTrainer(SFTTrainer):
         prompt_mask = inputs.get("prompt_attention_mask")
         pad_token_id = pad_token_id if pad_token_id is not None else self.processing_class.pad_token_id
 
-        if self.use_transformers_paged:
-            # generate_batch() returns completion-only tokens, so the entire tensor is completion.
-            prompt_lengths = torch.zeros(batch_size, dtype=torch.long, device=device)
-        else:
-            # model.generate() returns full sequences (prompt + completion), so completions start
-            # after the full padded prompt width.
-            prompt_lengths = torch.full(
-                (batch_size,),
-                inputs["prompts"].shape[1],
-                dtype=torch.long,
-                device=device,
-            )
+        # model.generate() returns full sequences (prompt + completion), so completions start
+        # after the full padded prompt width.
+        prompt_lengths = torch.full((batch_size,), inputs["prompts"].shape[1], dtype=torch.long, device=device)
 
         new_input_ids = generated_tokens
         new_attention_mask, new_labels = self._build_sequence_batch(new_input_ids, prompt_lengths, pad_token_id)

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -145,17 +145,6 @@ class OnlineDPOConfig(_BaseConfig):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the model from a
             string.
 
-        > Deprecated parameters
-
-        use_transformers_paged:
-
-            <Deprecated version="1.2.0">
-
-            Parameter `use_transformers_paged` is deprecated and will be removed in version v2.0.0. It will be
-            replaced by `transformers` continuous batching support in an upcoming release.
-
-            </Deprecated>
-
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.
@@ -372,25 +361,8 @@ class OnlineDPOConfig(_BaseConfig):
         },
     )
 
-    # Deprecated parameters
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
-            "release."
-        },
-    )
-
     def __post_init__(self):
         super().__post_init__()
-
-        if self.use_transformers_paged:
-            warnings.warn(
-                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
-                "`transformers` continuous batching support in an upcoming release.",
-                FutureWarning,
-                stacklevel=3,
-            )
 
         if hasattr(self.beta, "__len__") and len(self.beta) == 1:
             self.beta = self.beta[0]

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -76,10 +76,6 @@ class OnlineDPOConfig(_BaseConfig):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
-        use_transformers_paged (`bool`, *optional*, defaults to `False`):
-            Whether to use the `transformers` paged implementation for generation. If set to `True`, the `transformers`
-            paged implementation will be used for generation instead of the default padded implementation. This
-            parameter is only effective when `use_vllm` is set to `False`.
         cache_implementation (`str`, *optional*):
             Implementation of the cache method for faster generation when `use_vllm` is set to `False`.
         generation_kwargs (`dict[str, Any]`, *optional*):
@@ -148,6 +144,17 @@ class OnlineDPOConfig(_BaseConfig):
         model_init_kwargs (`dict[str, Any]`, *optional*):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the model from a
             string.
+
+        > Deprecated parameters
+
+        use_transformers_paged:
+
+            <Deprecated version="1.2.0">
+
+            Parameter `use_transformers_paged` is deprecated and will be removed in version v2.0.0. It will be
+            replaced by `transformers` continuous batching support in an upcoming release.
+
+            </Deprecated>
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
@@ -226,14 +233,6 @@ class OnlineDPOConfig(_BaseConfig):
             "`SamplingParams` (if using vLLM) when sampling completions. This can be used to further customize the "
             "generation behavior, such as setting `suppress_tokens`, `num_beams`, etc. If it contains keys that "
             "conflict with the other generation parameters (like `min_p`, `top_p`, etc.), they will override them."
-        },
-    )
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use the `transformers` paged implementation for generation. If set to `True`, the "
-            "`transformers` paged implementation will be used for generation instead of the default padded "
-            "implementation. This parameter is only effective when `use_vllm` is set to `False`."
         },
     )
     cache_implementation: str | None = field(
@@ -373,8 +372,25 @@ class OnlineDPOConfig(_BaseConfig):
         },
     )
 
+    # Deprecated parameters
+    use_transformers_paged: bool = field(
+        default=False,
+        metadata={
+            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
+            "release."
+        },
+    )
+
     def __post_init__(self):
         super().__post_init__()
+
+        if self.use_transformers_paged:
+            warnings.warn(
+                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
+                "`transformers` continuous batching support in an upcoming release.",
+                FutureWarning,
+                stacklevel=3,
+            )
 
         if hasattr(self.beta, "__len__") and len(self.beta) == 1:
             self.beta = self.beta[0]

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -46,7 +46,7 @@ from transformers import (
 from transformers.models.auto.modeling_auto import MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
 from transformers.trainer_utils import EvalPrediction
 from transformers.training_args import OptimizerNames
-from transformers.utils import is_flash_attn_2_available, is_peft_available, is_sagemaker_mp_enabled
+from transformers.utils import is_peft_available, is_sagemaker_mp_enabled
 
 from ...data_utils import apply_chat_template, is_conversational, maybe_apply_chat_template
 from ...extras.profiling import profiling_context
@@ -54,7 +54,7 @@ from ...generation.vllm_client import VLLMClient
 from ...import_utils import is_vllm_available
 from ...models.utils import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import disable_dropout_in_model, ensure_master_addr_port, get_config_model_id, pad
+from ...trainer.utils import disable_dropout_in_model, ensure_master_addr_port, get_config_model_id
 from ..utils import DPODataCollatorWithPadding, create_reference_model, empty_cache, prepare_peft_model, truncate_right
 from .online_dpo_config import OnlineDPOConfig
 
@@ -342,7 +342,6 @@ class OnlineDPOTrainer(_BaseTrainer):
         self.top_k = args.top_k
         self.min_p = args.min_p
         self.repetition_penalty = args.repetition_penalty
-        self.use_transformers_paged = args.use_transformers_paged
         self.vllm_mode = args.vllm_mode if args.use_vllm else None
         self.vllm_gpu_memory_utilization = args.vllm_gpu_memory_utilization
         self.vllm_tensor_parallel_size = args.vllm_tensor_parallel_size
@@ -976,76 +975,33 @@ class OnlineDPOTrainer(_BaseTrainer):
             if "image_grid_thw" in prompt_inputs:
                 vision_generation_kwargs["image_grid_thw"] = prompt_inputs["image_grid_thw"].repeat(2, 1)
 
-        if self.use_transformers_paged:
-            previous_attn = self.model_wrapped.config._attn_implementation
+        with (
+            profiling_context(self, "transformers.generate"),
+            unwrap_model_for_generation(
+                model,
+                self.accelerator,
+                gather_deepspeed3_params=self.args.ds3_gather_for_generation,
+                generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
+            ) as unwrapped_model,
+            torch.no_grad(),
+            FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
+        ):
+            # Setup cache implementation if specified
+            if self.args.cache_implementation is not None:
+                unwrapped_model.generation_config.cache_implementation = self.args.cache_implementation
 
-            if Version(transformers.__version__).release >= Version("5.0.0").release:
-                new_attn = "paged|flash_attention_2" if is_flash_attn_2_available() else "paged|sdpa"
-            else:
-                new_attn = "paged_attention" if is_flash_attn_2_available() else "sdpa_paged"
-            self.model_wrapped.config._attn_implementation = new_attn
-            with (
-                profiling_context(self, "transformers.generate_batch"),
-                unwrap_model_for_generation(
-                    model, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
-                ) as unwrapped_model,
-                torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
-            ):
-                # Cast to the appropriate dtype based on training configuration
-                if self.args.bf16:
-                    unwrapped_model.to(torch.bfloat16)
-                elif self.args.fp16:
-                    unwrapped_model.to(torch.float16)
-                with torch.inference_mode():
-                    all_outputs = unwrapped_model.generate_batch(
-                        prompt_ids.tolist(),
-                        generation_config=self.generation_config,
-                        progress_bar=False,
-                    )
-                    unwrapped_model.train()  # restore training mode, as generate_batch forces eval mode
-            completion_ids = [output.generated_tokens for output in all_outputs.values()]
-            completion_ids = [torch.tensor(ids, device=device) for ids in completion_ids]
-            completion_ids = pad(completion_ids, padding_value=self.pad_token_id, padding_side="right")
-            prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)
-            # Restore the original attention implementation, training mode
-            self.model_wrapped.config._attn_implementation = previous_attn
+            # Standard generation
+            output = unwrapped_model.generate(
+                input_ids=prompt_ids,
+                attention_mask=prompt_mask,
+                generation_config=self.generation_config,
+                **vision_generation_kwargs,
+            )
 
-            # Extract completion_ids and create completion_mask
-            prompt_length = prompt_ids.size(1)
-            completion_ids = prompt_completion_ids[:, prompt_length:]
-            completion_ids, completion_mask = truncate_right(completion_ids, eos_token_id, pad_token_id)
+        completion_ids = output[:, prompt_ids.size(1) :]
+        completion_ids, completion_mask = truncate_right(completion_ids, eos_token_id, pad_token_id)
 
-            return prompt_ids, prompt_mask, completion_ids, completion_mask
-        else:
-            # Regular generation path
-            with (
-                profiling_context(self, "transformers.generate"),
-                unwrap_model_for_generation(
-                    model,
-                    self.accelerator,
-                    gather_deepspeed3_params=self.args.ds3_gather_for_generation,
-                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
-                ) as unwrapped_model,
-                torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
-            ):
-                # Setup cache implementation if specified
-                if self.args.cache_implementation is not None:
-                    unwrapped_model.generation_config.cache_implementation = self.args.cache_implementation
-
-                # Standard generation
-                output = unwrapped_model.generate(
-                    input_ids=prompt_ids,
-                    attention_mask=prompt_mask,
-                    generation_config=self.generation_config,
-                    **vision_generation_kwargs,
-                )
-
-            completion_ids = output[:, prompt_ids.size(1) :]
-            completion_ids, completion_mask = truncate_right(completion_ids, eos_token_id, pad_token_id)
-
-            return prompt_ids, prompt_mask, completion_ids, completion_mask
+        return prompt_ids, prompt_mask, completion_ids, completion_mask
 
     def _calculate_rewards_from_functions(self, prompts, completions, completion_ids_list, **reward_kwargs):
         """

--- a/trl/experimental/self_distillation/self_distillation_config.py
+++ b/trl/experimental/self_distillation/self_distillation_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -292,25 +291,8 @@ class SelfDistillationConfig(_BaseConfig):
         },
     )
 
-    # Deprecated parameters
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
-            "release."
-        },
-    )
-
     def __post_init__(self):
         super().__post_init__()
-
-        if self.use_transformers_paged:
-            warnings.warn(
-                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
-                "`transformers` continuous batching support in an upcoming release.",
-                FutureWarning,
-                stacklevel=3,
-            )
 
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
         if self.scale_rewards not in ["group", "batch", "none"]:

--- a/trl/experimental/self_distillation/self_distillation_config.py
+++ b/trl/experimental/self_distillation/self_distillation_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -147,10 +148,6 @@ class SelfDistillationConfig(_BaseConfig):
     repetition_penalty: float = field(
         default=1.0,
         metadata={"help": "Repetition penalty used during generation."},
-    )
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={"help": "Reserved for paged generation support."},
     )
     cache_implementation: str | None = field(
         default=None,
@@ -295,8 +292,25 @@ class SelfDistillationConfig(_BaseConfig):
         },
     )
 
+    # Deprecated parameters
+    use_transformers_paged: bool = field(
+        default=False,
+        metadata={
+            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
+            "release."
+        },
+    )
+
     def __post_init__(self):
         super().__post_init__()
+
+        if self.use_transformers_paged:
+            warnings.warn(
+                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
+                "`transformers` continuous batching support in an upcoming release.",
+                FutureWarning,
+                stacklevel=3,
+            )
 
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
         if self.scale_rewards not in ["group", "batch", "none"]:

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -101,10 +102,6 @@ class GRPOConfig(_BaseConfig):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
-        use_transformers_paged (`bool`, *optional*, defaults to `False`):
-            Whether to use the `transformers` paged implementation for generation. If set to `True`, the `transformers`
-            paged implementation will be used for generation instead of the default padded implementation. This
-            parameter is only effective when `use_vllm` is set to `False`.
         cache_implementation (`str`, *optional*):
             Implementation of the cache method for faster generation when `use_vllm` is set to `False`.
 
@@ -330,6 +327,17 @@ class GRPOConfig(_BaseConfig):
             created in the currently-logged-in Hugging Face user's namespace. Note that this repository will be public
             unless you set `hub_private_repo=True` or your organization's default is to create private repositories."
 
+        > Deprecated parameters
+
+        use_transformers_paged:
+
+            <Deprecated version="1.2.0">
+
+            Parameter `use_transformers_paged` is deprecated and will be removed in version v2.0.0. It will be
+            replaced by `transformers` continuous batching support in an upcoming release.
+
+            </Deprecated>
+
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.
@@ -476,14 +484,6 @@ class GRPOConfig(_BaseConfig):
             "help": "Float that penalizes new tokens based on whether they appear in the prompt and the generated "
             "text so far. Values > 1.0 encourage the model to use new tokens, while values < 1.0 encourage the model "
             "to repeat tokens."
-        },
-    )
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use the `transformers` paged implementation for generation. If set to `True`, the "
-            "`transformers` paged implementation will be used for generation instead of the default padded "
-            "implementation. This parameter is only effective when `use_vllm` is set to `False`."
         },
     )
     cache_implementation: str | None = field(
@@ -866,8 +866,25 @@ class GRPOConfig(_BaseConfig):
         },
     )
 
+    # Deprecated parameters
+    use_transformers_paged: bool = field(
+        default=False,
+        metadata={
+            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
+            "release."
+        },
+    )
+
     def __post_init__(self):
         super().__post_init__()
+
+        if self.use_transformers_paged:
+            warnings.warn(
+                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
+                "`transformers` continuous batching support in an upcoming release.",
+                FutureWarning,
+                stacklevel=3,
+            )
 
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
 

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -96,10 +97,6 @@ class RLOOConfig(_BaseConfig):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
-        use_transformers_paged (`bool`, *optional*, defaults to `False`):
-            Whether to use the `transformers` paged implementation for generation. If set to `True`, the `transformers`
-            paged implementation will be used for generation instead of the default padded implementation. This
-            parameter is only effective when `use_vllm` is set to `False`.
         cache_implementation (`str`, *optional*):
             Implementation of the cache method for faster generation when `use_vllm` is set to `False`.
 
@@ -205,6 +202,17 @@ class RLOOConfig(_BaseConfig):
         log_unique_prompts (`bool`, *optional*, defaults to `False`):
             Whether to log unique prompts. If `True`, only unique prompts are logged. If `False`, all prompts are
             logged.
+
+        > Deprecated parameters
+
+        use_transformers_paged:
+
+            <Deprecated version="1.2.0">
+
+            Parameter `use_transformers_paged` is deprecated and will be removed in version v2.0.0. It will be
+            replaced by `transformers` continuous batching support in an upcoming release.
+
+            </Deprecated>
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
@@ -343,14 +351,6 @@ class RLOOConfig(_BaseConfig):
             "help": "Float that penalizes new tokens based on whether they appear in the prompt and the generated "
             "text so far. Values > 1.0 encourage the model to use new tokens, while values < 1.0 encourage the model "
             "to repeat tokens."
-        },
-    )
-    use_transformers_paged: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to use the `transformers` paged implementation for generation. If set to `True`, the "
-            "`transformers` paged implementation will be used for generation instead of the default padded "
-            "implementation. This parameter is only effective when `use_vllm` is set to `False`."
         },
     )
     cache_implementation: str | None = field(
@@ -544,8 +544,25 @@ class RLOOConfig(_BaseConfig):
         },
     )
 
+    # Deprecated parameters
+    use_transformers_paged: bool = field(
+        default=False,
+        metadata={
+            "help": "Deprecated. It will be replaced by `transformers` continuous batching support in an upcoming "
+            "release."
+        },
+    )
+
     def __post_init__(self):
         super().__post_init__()
+
+        if self.use_transformers_paged:
+            warnings.warn(
+                "`use_transformers_paged` is deprecated and will be removed in v2.0.0. It will be replaced by "
+                "`transformers` continuous batching support in an upcoming release.",
+                FutureWarning,
+                stacklevel=3,
+            )
 
         num_processes = self.world_size
         # The current default effective batch size


### PR DESCRIPTION
Deprecate the `use_transformers_paged` config flag. Setting it to `True` now raises a `FutureWarning`; behavior is unchanged otherwise.

Affected configs: `GRPOConfig`, `RLOOConfig`, and experimental `OnlineDPOConfig`, `GOLDConfig`, `SelfDistillationConfig`.

## Motivation

- **No usage**: the feature is not used in practice inside or outside the repo.
- **Actually worse, not faster**: the original motivation for `use_transformers_paged` was faster generation, but in a small A/B benchmark (Qwen3-0.6B, GRPO, `ultrafeedback-prompt`, `max_completion_length=256`) the paged path is ~20% *slower* than the default padded path (1428 s vs 1189 s) and consumes ~6× more peak VRAM (58.2 GiB vs 9.6 GiB). See table below.
- **Superseded soon**: `transformers` continuous batching support is landing shortly and will replace this path entirely, so maintaining the paged flag in the meantime is dead weight.
- **Maintenance cost**: the paged branch adds a third generation path in each trainer (`vLLM` / `paged` / default) that has to stay aligned across duplicated trainer code.
- **Not on par with the other generation paths**: it seems to be some inconsistency in the way the paged path handles generation resulting in higher grad norm and entropy, not sure exactly why, and if we would support this path long term we would want to investigate and fix this.

<img width="1205" height="791" alt="Screenshot 2026-04-14 at 11 29 43 AM" src="https://github.com/user-attachments/assets/142b14c3-8fd6-47f2-b586-0c3cdc352030" />

## Benchmark

```python

import argparse
import time

import torch
from datasets import load_dataset

from trl import GRPOConfig, GRPOTrainer


def reward_len(completion_ids, **kwargs):
    return [-abs(20 - len(c)) for c in completion_ids]


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--paged", type=int, default=0)
    args = parser.parse_args()

    paged = bool(args.paged)
    run_name = f"grpo-{'paged' if paged else 'nopaged'}_4"

    dataset = load_dataset("trl-lib/ultrafeedback-prompt", split="train[:64]")

    config = GRPOConfig(
        output_dir=f"/tmp/{run_name}",
        run_name=run_name,
        per_device_train_batch_size=4,
        num_generations=4,
        max_completion_length=256,
        logging_steps=1,
        report_to="trackio",
        use_transformers_paged=paged,
        chat_template_kwargs={"enable_thinking": False},
    )

    trainer = GRPOTrainer(
        model="Qwen/Qwen3-0.6B",
        args=config,
        train_dataset=dataset,
        reward_funcs=reward_len,
    )

    torch.cuda.reset_peak_memory_stats()
    t0 = time.perf_counter()
    trainer.train()
    elapsed = time.perf_counter() - t0
    peak_gb = torch.cuda.max_memory_allocated() / 1024**3

    print(f"\n===== {run_name} =====")
    print(f"elapsed:   {elapsed:.1f} s")
    print(f"peak VRAM: {peak_gb:.2f} GiB")
    print(f"samples/s: {trainer.state.log_history[-1].get('train_samples_per_second', 'n/a')}")


if __name__ == "__main__":
    main()
```

|           | No paged | Paged     |
| --------- | -------- | --------- |
| elapsed   | 1188.9 s | 1428.1 s  |
| samples/s | 0.162    | 0.134     |
| peak VRAM | 9.60 GiB | 58.17 GiB |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it deletes a previously supported generation backend/CLI flag in experimental trainers, which can break workflows that relied on paged attention despite being rarely used. Core trainers keep the flag but now emit deprecation warnings, which may affect noisy logs/tests.
> 
> **Overview**
> This PR **phases out `use_transformers_paged`** by removing the paged-attention generation branch from experimental trainers and configuration surfaces.
> 
> `GOLDTrainer.generate_on_policy_outputs` and `OnlineDPOTrainer` now always use the standard `transformers` `generate()` path when not using vLLM, and associated tests asserting paged behavior are deleted. The `use_transformers_paged` fields/docs are removed from experimental configs (`GOLDConfig`, `OnlineDPOConfig`, `SelfDistillationConfig`), and legacy validation around paged support is dropped in `DPPOConfig`.
> 
> In core configs (`GRPOConfig`, `RLOOConfig`), `use_transformers_paged` is retained but marked **deprecated**: enabling it triggers a `FutureWarning` and the docstrings explicitly note planned removal in v2.0.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909a1ec36402d6caab9b029e2910c5850f38a306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->