### PR TITLE
[docs] Add LLaMA 3 / Qwen 2.5 entries to `chat_templates/README`

### DIFF
--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -25,6 +25,14 @@ Original GLM-4-MoE chat template.
 
 Original GPT-OSS chat template.
 
+### `llama3.jinja`
+
+Original Llama 3 chat template.
+
+### `qwen2_5.jinja`
+
+Original Qwen2.5 chat template.
+
 ### `qwen3.jinja`
 
 Original Qwen3 chat template.
@@ -79,6 +87,20 @@ Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so
 ### `gptoss_training.jinja`
 
 Patched GPT-OSS template. Diff vs `gptoss.jinja`:
+
+Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that
+`return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `llama3_training.jinja`
+
+Patched Llama 3 template. Diff vs `llama3.jinja`:
+
+Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that
+`return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `qwen2_5_training.jinja`
+
+Patched Qwen2.5 template. Diff vs `qwen2_5.jinja`:
 
 Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that
 `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.


### PR DESCRIPTION
We forgot to document it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update in `trl/chat_templates/README.md` with no runtime or training logic changes.
> 
> **Overview**
> Adds missing README entries for the original `llama3.jinja` and `qwen2_5.jinja` templates.
> 
> Extends the training-templates section to document the corresponding `llama3_training.jinja` and `qwen2_5_training.jinja` patches, noting the `{% generation %}` / `{% endgeneration %}` wrapping required for correct assistant-only loss masking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254494209dde48c9d84e27436861667fdacf629d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->