### PR TITLE
Update vLLM version support to 0.18.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.11.0` to `0.17.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.11.0` to `0.18.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.11.0,<=0.17.1",
+    "vllm>=0.11.0,<=0.18.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -628,9 +628,9 @@ class TestSFTTrainer(TrlTestCase):
                 tokenizer_name_or_path="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             )
         elif peft_type == "prefix_tuning":
-            if parse_version(peft.__version__) <= Version("0.18.0"):
+            if parse_version(peft.__version__) <= Version("0.17.1"):
                 pytest.xfail(
-                    "Prefix tuning with device_map='auto' is broken in peft 0.18.0 and below. See "
+                    "Prefix tuning with device_map='auto' is broken in peft 0.17.1 and below. See "
                     "https://github.com/huggingface/peft/issues/2821"
                 )
             peft_config = PrefixTuningConfig(

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -628,9 +628,9 @@ class TestSFTTrainer(TrlTestCase):
                 tokenizer_name_or_path="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             )
         elif peft_type == "prefix_tuning":
-            if parse_version(peft.__version__) <= Version("0.17.1"):
+            if parse_version(peft.__version__) <= Version("0.18.0"):
                 pytest.xfail(
-                    "Prefix tuning with device_map='auto' is broken in peft 0.17.1 and below. See "
+                    "Prefix tuning with device_map='auto' is broken in peft 0.18.0 and below. See "
                     "https://github.com/huggingface/peft/issues/2821"
                 )
             peft_config = PrefixTuningConfig(

--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -89,7 +89,7 @@ def _patch_vllm_disabled_tqdm() -> None:
 
     - Bug introduced in https://github.com/vllm-project/vllm/pull/52
     - Fixed in https://github.com/vllm-project/vllm/pull/28471 (released in v0.11.1)
-    - Since TRL currently supports vLLM v0.11.0-0.17.1, we patch it here
+    - Since TRL currently supports vLLM v0.11.0-0.18.0, we patch it here
     - This can be removed when TRL requires vLLM>=0.11.1
     """
     if _is_package_version_below("vllm", "0.11.1"):

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -105,9 +105,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.11.0") <= Version(_vllm_version) <= Version("0.17.1")):
+        if not (Version("0.11.0") <= Version(_vllm_version) <= Version("0.18.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.11.0 to 0.17.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.11.0 to 0.18.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
it seems to work:

```
$ pytest tests/test_vllm_client_server.py
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.13.11, pytest-8.4.2, pluggy-1.6.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: rerunfailures-15.1, order-1.3.0, random-order-1.2.0, asyncio-1.3.0, anyio-4.12.1, env-1.2.0, hypothesis-6.151.13, xdist-3.8.0, datadir-1.8.0, cov-7.0.0, timeout-2.4.0, rich-0.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 51 items                                                                                                                                                                 

tests/test_vllm_client_server.py ..................x..................sssssssss.....                                                                                         [100%]

=============================================================== 41 passed, 9 skipped, 1 xfailed in 583.95s (0:09:43) ===============================================================
```

nothing special from the https://github.com/vllm-project/vllm/releases/tag/v0.18.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates version bounds and user-facing warnings/docs only, with no behavioral changes beyond allowing installs up to vLLM `0.18.0`.
> 
> **Overview**
> Updates TRL’s vLLM support window to **include vLLM `0.18.0`** by raising the max version in the `trl[vllm]` optional dependency and aligning the runtime `is_vllm_available` compatibility check/warning message.
> 
> Documentation and a related compatibility patch comment are updated to reflect the new supported range (`0.11.0`–`0.18.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4e62fdb9b25963b090723f64ca13ee764108a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->