### PR TITLE
Drop vLLM 0.11 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.11.0` to `0.17.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.17.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.11.0,<=0.17.1",
+    "vllm>=0.12.0,<=0.17.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -83,30 +83,6 @@ def _patch_vllm_logging() -> None:
         os.environ["VLLM_LOGGING_LEVEL"] = os.getenv("VLLM_LOGGING_LEVEL", "ERROR")
 
 
-def _patch_vllm_disabled_tqdm() -> None:
-    """
-    Fix DisabledTqdm class in vLLM.
-
-    - Bug introduced in https://github.com/vllm-project/vllm/pull/52
-    - Fixed in https://github.com/vllm-project/vllm/pull/28471 (released in v0.11.1)
-    - Since TRL currently supports vLLM v0.11.0-0.17.1, we patch it here
-    - This can be removed when TRL requires vLLM>=0.11.1
-    """
-    if _is_package_version_below("vllm", "0.11.1"):
-        try:
-            import vllm.model_executor.model_loader.weight_utils
-            from tqdm import tqdm
-
-            class DisabledTqdm(tqdm):
-                def __init__(self, *args, **kwargs):
-                    kwargs["disable"] = True
-                    super().__init__(*args, **kwargs)
-
-            vllm.model_executor.model_loader.weight_utils.DisabledTqdm = DisabledTqdm
-        except (ImportError, AttributeError) as e:
-            warnings.warn(f"Failed to patch vLLM DisabledTqdm: {e}", stacklevel=2)
-
-
 def _patch_vllm_cached_tokenizer() -> None:
     """
     Fix get_cached_tokenizer for transformers v5 compatibility.
@@ -242,7 +218,6 @@ def _patch_transformers_parallelism_config() -> None:
 
 # Apply vLLM patches
 _patch_vllm_logging()
-_patch_vllm_disabled_tqdm()
 _patch_vllm_cached_tokenizer()
 
 # Apply transformers patches

--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -83,66 +83,6 @@ def _patch_vllm_logging() -> None:
         os.environ["VLLM_LOGGING_LEVEL"] = os.getenv("VLLM_LOGGING_LEVEL", "ERROR")
 
 
-def _patch_vllm_cached_tokenizer() -> None:
-    """
-    Fix get_cached_tokenizer for transformers v5 compatibility.
-
-    - Issue: vLLM's get_cached_tokenizer accesses all_special_tokens_extended
-    - Removed in transformers: https://github.com/huggingface/transformers/pull/40936 (transformers>=5.0.0)
-    - Fixed in https://github.com/vllm-project/vllm/pull/29686 (released in v0.12.0)
-    - This can be removed when TRL requires vLLM>=0.12.0
-    """
-    if _is_package_version_at_least("transformers", "5.0.0") and _is_package_version_below("vllm", "0.12.0"):
-        try:
-            import contextlib
-            import copy
-
-            import vllm.transformers_utils.tokenizer
-
-            def get_cached_tokenizer(tokenizer):
-                cached_tokenizer = copy.copy(tokenizer)
-                tokenizer_all_special_ids = tokenizer.all_special_ids
-                tokenizer_all_special_tokens = tokenizer.all_special_tokens
-                tokenizer_vocab = tokenizer.get_vocab()
-                tokenizer_len = len(tokenizer)
-
-                max_token_id = max(tokenizer_vocab.values())
-                if hasattr(tokenizer, "vocab_size"):
-                    with contextlib.suppress(NotImplementedError):
-                        max_token_id = max(max_token_id, tokenizer.vocab_size)
-
-                class CachedTokenizer(tokenizer.__class__):  # type: ignore
-                    @property
-                    def all_special_ids(self) -> list[int]:
-                        return tokenizer_all_special_ids
-
-                    @property
-                    def all_special_tokens(self) -> list[str]:
-                        return tokenizer_all_special_tokens
-
-                    @property
-                    def max_token_id(self) -> int:
-                        return max_token_id
-
-                    def get_vocab(self) -> dict[str, int]:
-                        return tokenizer_vocab
-
-                    def __len__(self) -> int:
-                        return tokenizer_len
-
-                    def __reduce__(self):
-                        return get_cached_tokenizer, (tokenizer,)
-
-                CachedTokenizer.__name__ = f"Cached{tokenizer.__class__.__name__}"
-
-                cached_tokenizer.__class__ = CachedTokenizer
-                return cached_tokenizer
-
-            vllm.transformers_utils.tokenizer.get_cached_tokenizer = get_cached_tokenizer
-        except (ImportError, AttributeError) as e:
-            warnings.warn(f"Failed to patch vLLM cached_tokenizer: {e}", stacklevel=2)
-
-
 def _patch_transformers_hybrid_cache() -> None:
     """
     Fix HybridCache import for transformers v5 compatibility.
@@ -218,7 +158,6 @@ def _patch_transformers_parallelism_config() -> None:
 
 # Apply vLLM patches
 _patch_vllm_logging()
-_patch_vllm_cached_tokenizer()
 
 # Apply transformers patches
 _patch_transformers_hybrid_cache()

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -105,9 +105,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.11.0") <= Version(_vllm_version) <= Version("0.17.1")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.17.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.11.0 to 0.17.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.17.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -398,7 +398,6 @@ def chunk_list(lst: list, n: int) -> list[list]:
 def main(script_args: ScriptArguments):
     import asyncio
 
-    from packaging.version import Version
     from transformers import is_vision_available
 
     from trl.generation.vllm_generation import extract_logprobs
@@ -428,16 +427,11 @@ def main(script_args: ScriptArguments):
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
 
     import uvicorn
-    import vllm
     from fastapi import FastAPI
     from pydantic import BaseModel
     from vllm import SamplingParams
     from vllm.sampling_params import StructuredOutputsParams
-
-    if Version(vllm.__version__) <= Version("0.11.0"):
-        from vllm.utils import get_open_port
-    else:
-        from vllm.utils.network_utils import get_open_port
+    from vllm.utils.network_utils import get_open_port
 
     if is_vision_available():
         from PIL import Image


### PR DESCRIPTION
This PR drops the support for vLLM 0.11, which is one step toward raising the min version to vLLM 0.18 (which natively supports weight sync)

Motivations:

- 0.12.0 is 4+ months old (released Dec 3, 2025; today is 2026-04-14), plenty of time for users to upgrade. This is well past the typical "stable enough to rely on" window.
- vLLM moves fast and we were already carrying compat shims for 0.11 (`_patch_vllm_disabled_tqdm`, the `get_open_port` import fallback, and the `get_cached_tokenizer` patch for transformers v5). Dropping 0.11 lets us delete dead code instead of maintaining it.
- We still support a 6-version window (0.12.0 → 0.17.1). That's generous, not a tight pin.
- Low blast radius: anyone pinned to 0.11 can either bump vLLM (easy) or pin an older TRL. No one is stuck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the minimum supported vLLM version and removes related compatibility shims; risk is limited but users pinned to vLLM 0.11 will break and the serve script’s import path assumption could surface version-edge issues.
> 
> **Overview**
> Drops vLLM `0.11.x` support by bumping the supported/allowed range to `0.12.0`–`0.18.0` across docs, the `trl[vllm]` extra, and `is_vllm_available()` warnings.
> 
> Removes vLLM-0.11-specific compatibility code in `trl/_compat.py` (DisabledTqdm + cached tokenizer patches) and simplifies `trl vllm-serve` to always import `get_open_port` from `vllm.utils.network_utils` (no version branching).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f85b4d3c67bb5d4d4c099f56d751a62415056b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->