### PR TITLE
Align KTO with DPO: Remove generate_during_eval

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -21,7 +21,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from trl.experimental.kto import KTOConfig, KTOTrainer
 from trl.experimental.kto.kto_trainer import _get_kl_dataset, _process_tokens, _tokenize
 
-from ..testing_utils import TrlTestCase, require_liger_kernel, require_no_wandb, require_peft
+from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
 
 
 class TestKTOTrainer(TrlTestCase):
@@ -256,37 +256,6 @@ class TestKTOTrainer(TrlTestCase):
                 new_param = trainer.model.get_parameter(n)
                 if param.sum() != 0:  # ignore 0 biases
                     assert not torch.equal(param, new_param)
-
-    @require_no_wandb
-    def test_kto_trainer_generate_during_eval_no_wandb(self):
-        training_args = KTOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=2,
-            max_steps=3,
-            remove_unused_columns=False,
-            gradient_accumulation_steps=1,
-            learning_rate=9e-1,
-            eval_strategy="steps",
-            beta=0.1,
-            generate_during_eval=True,
-            report_to="none",
-        )
-
-        dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference")
-
-        with pytest.raises(
-            ValueError,
-            match="`generate_during_eval=True` requires Weights and Biases or Comet to be installed."
-            " Please install `wandb` or `comet-ml` to resolve.",
-        ):
-            KTOTrainer(
-                model=self.model,
-                ref_model=None,
-                args=training_args,
-                processing_class=self.tokenizer,
-                train_dataset=dummy_dataset["train"],
-                eval_dataset=dummy_dataset["test"],
-            )
 
     @require_liger_kernel
     def test_kto_trainer_with_liger(self):

--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -73,10 +73,6 @@ class KTOConfig(_BaseConfig):
             Desirable losses are weighed by this factor to counter unequal number of desirable and undesirable pairs.
         undesirable_weight (`float`, *optional*, defaults to `1.0`):
             Undesirable losses are weighed by this factor to counter unequal number of desirable and undesirable pairs.
-        generate_during_eval (`bool`, *optional*, defaults to `False`):
-            If `True`, generates and logs completions from both the model and the reference model to W&B or Comet
-            during evaluation.
-
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.
@@ -162,12 +158,5 @@ class KTOConfig(_BaseConfig):
         metadata={
             "help": "Undesirable losses are weighed by this factor to counter unequal number of desirable and "
             "undesirable pairs.",
-        },
-    )
-    generate_during_eval: bool = field(
-        default=False,
-        metadata={
-            "help": "If `True`, generates and logs completions from both the model and the reference model to W&B "
-            "during evaluation."
         },
     )

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1301,28 +1301,6 @@ class KTOTrainer(_BaseTrainer):
 
         return (loss.detach(), logits, labels)
 
-    def evaluation_loop(
-        self,
-        dataloader: DataLoader,
-        description: str,
-        prediction_loss_only: bool | None = None,
-        ignore_keys: list[str] | None = None,
-        metric_key_prefix: str = "eval",
-    ) -> EvalLoopOutput:
-        """
-        Overriding built-in evaluation loop to store metrics for each batch. Prediction/evaluation loop, shared by
-        `Trainer.evaluate()` and `Trainer.predict()`.
-
-        Works both with or without labels.
-        """
-
-        # Base evaluation
-        initial_output = super().evaluation_loop(
-            dataloader, description, prediction_loss_only, ignore_keys, metric_key_prefix
-        )
-
-        return initial_output
-
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         """
         Log `logs` on the various objects watching training, including stored metrics.

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -53,7 +53,7 @@ from ...trainer.utils import (
     get_config_model_id,
     selective_log_softmax,
 )
-from ..utils import DPODataCollatorWithPadding, pad_to_length, peft_module_casting_to_bf16
+from ..utils import DPODataCollatorWithPadding, peft_module_casting_to_bf16
 from .kto_config import KTOConfig
 
 
@@ -1262,54 +1262,6 @@ class KTOTrainer(_BaseTrainer):
         if dataset is None or not has_length(dataset):
             return None
         return SequentialSampler(dataset)
-
-    def generate_from_model_and_ref(self, model, batch: dict[str, torch.LongTensor]) -> tuple[str, str]:
-        """Generate samples from the model and reference model for the given batch of inputs."""
-
-        # If one uses `generate_during_eval` with peft + bf16, we need to explicitly call generate with
-        # the torch amp context manager as some hidden states are silently casted to full precision.
-        generate_context_manager = (
-            autocast(self.accelerator.device.type) if self._peft_has_been_casted_to_bf16 else nullcontext()
-        )
-
-        with generate_context_manager:
-            policy_output = model.generate(
-                input_ids=batch["prompt_input_ids"],
-                attention_mask=batch["prompt_attention_mask"],
-                max_length=self.max_length,
-                do_sample=True,
-                pad_token_id=self.processing_class.pad_token_id,
-            )
-
-            # if reference_output in batch use that otherwise use the reference model
-            if "reference_output" in batch:
-                reference_output = batch["reference_output"]
-            else:
-                if self.ref_model is None:
-                    with self.null_ref_context():
-                        reference_output = self.model.generate(
-                            input_ids=batch["prompt_input_ids"],
-                            attention_mask=batch["prompt_attention_mask"],
-                            max_length=self.max_length,
-                            do_sample=True,
-                            pad_token_id=self.processing_class.pad_token_id,
-                        )
-                else:
-                    reference_output = self.ref_model.generate(
-                        input_ids=batch["prompt_input_ids"],
-                        attention_mask=batch["prompt_attention_mask"],
-                        max_length=self.max_length,
-                        do_sample=True,
-                        pad_token_id=self.processing_class.pad_token_id,
-                    )
-
-        policy_output = pad_to_length(policy_output, self.max_length, self.processing_class.pad_token_id)
-        policy_output_decoded = self.processing_class.batch_decode(policy_output, skip_special_tokens=True)
-
-        reference_output = pad_to_length(reference_output, self.max_length, self.processing_class.pad_token_id)
-        reference_output_decoded = self.processing_class.batch_decode(reference_output, skip_special_tokens=True)
-
-        return policy_output_decoded, reference_output_decoded
 
     def prediction_step(
         self,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -13,17 +13,14 @@
 # limitations under the License.
 
 import inspect
-import random
 import textwrap
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
-from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-import pandas as pd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -42,8 +39,6 @@ from transformers import (
     PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
-    is_comet_available,
-    is_wandb_available,
 )
 from transformers.trainer_utils import EvalLoopOutput, has_length
 from transformers.utils import is_peft_available
@@ -56,7 +51,6 @@ from ...trainer.utils import (
     create_model_from_path,
     disable_dropout_in_model,
     get_config_model_id,
-    log_table_to_comet_experiment,
     selective_log_softmax,
 )
 from ..utils import DPODataCollatorWithPadding, pad_to_length, peft_module_casting_to_bf16
@@ -68,9 +62,6 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     from peft import PeftModel, get_peft_model, prepare_model_for_kbit_training
-
-if is_wandb_available():
-    import wandb
 
 
 if TYPE_CHECKING:
@@ -427,12 +418,6 @@ class KTOTrainer(_BaseTrainer):
 
                 model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
-        if args.generate_during_eval and not (is_wandb_available() or is_comet_available()):
-            raise ValueError(
-                "`generate_during_eval=True` requires Weights and Biases or Comet to be installed."
-                " Please install `wandb` or `comet-ml` to resolve."
-            )
-
         # KTO only supports causal language models, not encoder-decoder models
         if model is not None and hasattr(model.config, "is_encoder_decoder") and model.config.is_encoder_decoder:
             raise ValueError(
@@ -476,7 +461,6 @@ class KTOTrainer(_BaseTrainer):
 
         self.loss_type = args.loss_type
         self.max_length = max_length
-        self.generate_during_eval = args.generate_during_eval
         self.processing_class = processing_class
         self.precompute_ref_log_probs = args.precompute_ref_log_probs
 
@@ -1379,44 +1363,6 @@ class KTOTrainer(_BaseTrainer):
 
         Works both with or without labels.
         """
-
-        # Sample and save to game log if requested (for one batch to save time)
-        if self.generate_during_eval:
-            # Generate random indices within the range of the total number of samples
-            num_samples = len(dataloader.dataset)
-            random_indices = random.sample(range(num_samples), k=self.args.eval_batch_size)
-
-            # Use dataloader.dataset.select to get the random batch without iterating over the DataLoader
-            random_batch_dataset = dataloader.dataset.select(random_indices)
-            random_batch = self.data_collator(random_batch_dataset)
-            random_batch = self._prepare_inputs(random_batch)
-
-            target_labels = torch.tensor(random_batch["label"], dtype=torch.bool, device=self.accelerator.device)
-            target_indices = torch.where(~target_labels)[0]
-            target_batch = {
-                "prompt_input_ids": random_batch["prompt_input_ids"][target_indices],
-                "prompt_attention_mask": random_batch["prompt_attention_mask"][target_indices],
-                "prompt": itemgetter(*target_indices)(random_batch["prompt"]),
-            }
-            policy_output_decoded, ref_output_decoded = self.generate_from_model_and_ref(self.model, target_batch)
-
-            table = pd.DataFrame(
-                columns=["Prompt", "Policy", "Ref Model"],
-                data=[
-                    [prompt, pol[len(prompt) :], ref[len(prompt) :]]
-                    for prompt, pol, ref in zip(
-                        target_batch["prompt"], policy_output_decoded, ref_output_decoded, strict=True
-                    )
-                ],
-            )
-            if "wandb" in self.args.report_to:
-                wandb.log({"game_log": wandb.Table(data=table)})
-
-            if "comet_ml" in self.args.report_to:
-                log_table_to_comet_experiment(
-                    name="game_log.csv",
-                    table=table,
-                )
 
         # Base evaluation
         initial_output = super().evaluation_loop(


### PR DESCRIPTION
Align KTO with DPO: Remove `generate_during_eval`.

This PR removes the `generate_during_eval` feature from the KTO training pipeline, along with all related code, configuration, and dependencies. The change streamlines the codebase by eliminating unused or unsupported evaluation-time generation and logging functionality.

See related comment in:
- https://github.com/huggingface/trl/pull/5542#discussion_r3080409501

Part of:
- #4786

### Changes

**Configuration and Argument Removal**
* Removed the `generate_during_eval` parameter from the `KTOConfig` class and its documentation, so this option is no longer available to users. 

**Dependency and Import Cleanup**
* Eliminated imports related to Weights & Biases (`wandb`), Comet ML, pandas, and other utilities that were only needed for `generate_during_eval`.

**Trainer Logic Simplification**
* Removed all code that checked for or used `generate_during_eval`, including error handling for missing dependencies and the associated class attribute.

**Method and Evaluation Loop Removal**
* Deleted the `generate_from_model_and_ref` method and all evaluation loop logic that generated and logged completions during evaluation, including code for random sampling, table creation, and logging to external services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a user-facing `KTOConfig` argument and associated eval-time generation/logging path, which is a breaking API change for anyone relying on it. Core training logic is otherwise untouched, so runtime risk is limited to evaluation behavior and configuration parsing.
> 
> **Overview**
> **Removes the `generate_during_eval` feature from experimental KTO.** The `KTOConfig` option is deleted (docs + dataclass field), and `KTOTrainer` drops the corresponding validation, state, and the custom `evaluation_loop`/generation helpers that sampled prompts and logged policy/ref completions.
> 
> This also cleans up now-unused dependencies and imports (e.g., `wandb`/Comet availability checks, `pandas`, random sampling utilities) and removes the dedicated test that asserted an error when `generate_during_eval=True` without trackers installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52647ad471fe4609b1d6cf0415130c76defc2474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->