### PR TITLE
Check prefix preservation at the token level

### DIFF
--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -419,6 +419,13 @@ def is_chat_template_prefix_preserving(tokenizer: PreTrainedTokenizer) -> bool:
         {"role": "tool", "name": "dummy", "content": "dummy"},
     ]
 
+    if isinstance(tokenizer, ProcessorMixin):
+        from PIL import Image
+
+        dummy_image = Image.new("RGB", (8, 8))
+        messages1 = prepare_multimodal_messages(messages1, images=[dummy_image])
+        messages2 = prepare_multimodal_messages(messages2, images=[dummy_image])
+
     try:
         ids1 = tokenizer.apply_chat_template(messages1, tokenize=True, return_dict=False)
         ids2 = tokenizer.apply_chat_template(messages2, tokenize=True, return_dict=False, add_generation_prompt=True)

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -420,18 +420,18 @@ def is_chat_template_prefix_preserving(tokenizer: PreTrainedTokenizer) -> bool:
     ]
 
     try:
-        text1 = tokenizer.apply_chat_template(messages1, tokenize=False)
-        text2 = tokenizer.apply_chat_template(messages2, tokenize=False, add_generation_prompt=True)
+        ids1 = tokenizer.apply_chat_template(messages1, tokenize=True, return_dict=False)
+        ids2 = tokenizer.apply_chat_template(messages2, tokenize=True, return_dict=False, add_generation_prompt=True)
     except TypeError:
         # Best-effort fallback for templates that reject dict args (e.g. DeepSeek-V3). This is a chat template
         # bug (see transformers#45419), and the training chat template fixes it to avoid blocking users.
         dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": "{}"}}]
         messages1[1]["tool_calls"] = dummy_tool_calls
         messages2[1]["tool_calls"] = dummy_tool_calls
-        text1 = tokenizer.apply_chat_template(messages1, tokenize=False)
-        text2 = tokenizer.apply_chat_template(messages2, tokenize=False, add_generation_prompt=True)
+        ids1 = tokenizer.apply_chat_template(messages1, tokenize=True, return_dict=False)
+        ids2 = tokenizer.apply_chat_template(messages2, tokenize=True, return_dict=False, add_generation_prompt=True)
 
-    return text2.startswith(text1)
+    return ids2[: len(ids1)] == ids1
 
 
 deepseekv3_training_chat_template = (_CHAT_TEMPLATES_DIR / "deepseekv3_training.jinja").read_text()


### PR DESCRIPTION
`is_chat_template_prefix_preserving` previously compared the rendered chat template as strings (`tokenize=False`). But `_get_tool_suffix_ids`, the consumer that relies on this property, slices token ids, not text. Two templates that share a string prefix can still diverge at the token level if the final character of the prefix merges with the following character under BPE.

This PR switches the check to `tokenize=True, return_dict=False` and compares the resulting id lists directly, so the test matches what the trainer actually does.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the prefix-preservation check to compare tokenized outputs (and adds a VLM/processor path), which can alter which chat templates are considered training-compatible and affect GRPO tool-suffix extraction.
> 
> **Overview**
> `is_chat_template_prefix_preserving` now checks prefix preservation at the **token-id level** by calling `apply_chat_template(..., tokenize=True, return_dict=False)` and comparing ID prefixes, instead of comparing rendered strings.
> 
> It also adds handling for `ProcessorMixin` (VLM) processors by converting the dummy conversation to multimodal format with a placeholder image before tokenization, keeping the check aligned with how `_get_tool_suffix_ids` slices token IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a076c4a46a4cb061b78c079dbc7f7546fe2360af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->