### PR TITLE
fix: check all examples for 'margin' in DataCollatorForPreference

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,31 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    def test_collate_without_margin(self):
+        collator = DataCollatorForPreference(pad_token_id=0)
+        examples = [
+            {
+                "chosen_ids": [1,2,3], 
+                "rejected_ids": [4,5]
+            },
+            {
+                "chosen_ids": [6,7,8],
+                "rejected_ids": [9,10],
+                "margin": 0.1,
+            },
+            {
+                "chosen_ids": [11,12,13],
+                "rejected_ids": [14],
+                "margin": 0.2,
+            },
+            {
+                "chosen_ids": [15,16,17],
+                "rejected_ids": [18, 19],
+            },
+        ]
+        result = collator(examples)
+        torch.testing.assert_close(result["margin"], torch.tensor([0.0, 0.1, 0.2, 0.0]))
+
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,8 +201,9 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
-            margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
+        if any("margin" in example for example in examples):
+            margins = torch.tensor([example["margin"] if "margin" in example else 0.0 for example in examples], dtype=torch.float)
+
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
 
@@ -221,7 +222,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if any("margin" in example for example in examples):
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
# What does this PR do?

Fixes #5539 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. https://github.com/huggingface/trl/issues/5539
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to data collation logic with added test coverage; primary risk is minor behavior change for mixed-margin batches.
> 
> **Overview**
> Fixes `DataCollatorForPreference` to detect `margin` across *all* examples in a batch (instead of only `examples[0]`) and to fill missing per-example margins with `0.0` when any margins are present.
> 
> Adds a regression test ensuring mixed batches (some examples with `margin`, some without) produce a `margin` tensor aligned with the batch and defaulted for missing entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3069ceb8df88b367147f0deb3ac382354bd2620d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->