### PR TITLE
fix: check all examples for margin key in DataCollatorForPreference

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,33 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    def test_collate_with_margin_only_in_some_examples(self):
+        """Test that margins are preserved when only some examples have the key (e.g. after shuffle)."""
+        collator = DataCollatorForPreference(pad_token_id=0)
+        # First example lacks margin, second has it — simulates post-shuffle order
+        examples = [
+            {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5]},
+            {"chosen_ids": [6, 7], "rejected_ids": [8], "margin": 0.5},
+        ]
+
+        result = collator(examples)
+
+        assert "margin" in result
+        torch.testing.assert_close(result["margin"], torch.tensor([0.0, 0.5]))
+
+    def test_collate_with_margin_missing_in_later_examples(self):
+        """Test no KeyError when first example has margin but a later one does not."""
+        collator = DataCollatorForPreference(pad_token_id=0)
+        examples = [
+            {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5], "margin": 0.5},
+            {"chosen_ids": [6, 7], "rejected_ids": [8]},
+        ]
+
+        result = collator(examples)
+
+        assert "margin" in result
+        torch.testing.assert_close(result["margin"], torch.tensor([0.5, 0.0]))
+
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,8 +201,10 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
-            margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
+        if any("margin" in example for example in examples):
+            margins = torch.tensor(
+                [example.get("margin", 0.0) for example in examples], dtype=torch.float
+            )
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
 
@@ -221,7 +223,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if any("margin" in example for example in examples):
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
# What does this PR do?

Fixes the margin check in `DataCollatorForPreference.torch_call()` which only inspected `examples[0]` for the `"margin"` key. This caused two failure modes:

1. **Silent data loss**: After dataset shuffling, if the first example in a batch lacks `"margin"` but others have it, all margins are silently dropped — the margin-aware reward loss is skipped with no warning.
2. **Runtime KeyError**: If the first example has `"margin"` but a later one does not (inconsistent dataset), the list comprehension crashes.

**Fix**: Use `any()` to check all examples and `.get("margin", 0.0)` for graceful defaults.

Fixes #5539

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to collator batching logic with added tests; risk is limited to margin-handling behavior in reward training batches.
> 
> **Overview**
> Fixes `DataCollatorForPreference.torch_call()` to detect `margin` across *all* batch examples (not just `examples[0]`) and to default missing margins to `0.0`, preventing silent margin drops and `KeyError`s on inconsistent batches.
> 
> Adds two unit tests covering mixed batches where `margin` appears only in some examples (including shuffled order) to ensure `margin` is always returned with appropriate defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2d7616a4a1ddabe58f4622f4c0f1c01a34cb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->