### PR TITLE
DataCollatorForPreference checking 'margin' in all examples

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -131,6 +131,21 @@ class TestDataCollatorForPreference(TrlTestCase):
         assert set(result.keys()) == {"input_ids", "attention_mask", "completion_mask"}
         torch.testing.assert_close(result["input_ids"], expected_input_ids)
 
+    def test_missing_reference_logps(self):
+        collator = DataCollatorForPreference(pad_token_id=0, pad_to_multiple_of=5)
+        examples = [
+            {"prompt_ids": [1], "chosen_ids": [2], "rejected_ids": [3]},
+            {"prompt_ids": [4, 5], "chosen_ids": [6, 7], "rejected_ids": [8, 9], "ref_chosen_logps": 0.2},
+            {"prompt_ids": [10, 11], "chosen_ids": [12, 13], "rejected_ids": [14, 15], "ref_rejected_logps": 0.3},
+        ]
+        result = collator(examples)
+
+        expected_ref_chosen_logps = torch.tensor([0.0, 0.2, 0.0])
+        expected_ref_rejected_logps = torch.tensor([0.0, 0.0, 0.3])
+
+        torch.testing.assert_close(result["ref_chosen_logps"], expected_ref_chosen_logps)
+        torch.testing.assert_close(result["ref_rejected_logps"], expected_ref_rejected_logps)
+
 
 class TestDataCollatorForVisionPreference(TrlTestCase):
     @pytest.mark.skipif(

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -111,7 +111,7 @@ class TestDataCollatorForPreference(TrlTestCase):
         examples = [
             {
                 "chosen_ids": [1,2,3], 
-                "rejected": [4,5]
+                "rejected_ids": [4,5]
             },
             {
                 "chosen_ids": [6,7,8],

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,30 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    def test_collate_without_margin(self):
+        collator = DataCollatorForPreference(pad_token_id=0)
+        examples = [
+            {
+                "chosen_ids": [1,2,3], 
+                "rejected": [4,5]
+            },
+            {
+                "chosen_ids": [6,7,8],
+                "rejected_ids": [9,10],
+                "margin": 0.1,
+            },
+            {
+                "chosen_ids": [11,12,13],
+                "rejected_ids": [14],
+                "margin": 0.2,
+            },
+            {
+                "chosen_ids": [15,16,17],
+                "rejected_ids": [18, 19],
+            },
+        ]
+        result = collator(examples)
+        torch.testing.assert_close(result["margin"], torch.tensor([0.0, 0.1, 0.2, 0.0]))
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -179,10 +179,13 @@ class DataCollatorForPreference(DataCollatorMixin):
         input_ids = [torch.tensor(ids) for ids in input_ids]
         attention_mask = [torch.tensor(m, dtype=torch.long) for m in attention_mask]
         completion_mask = [torch.tensor(m, dtype=torch.long) for m in completion_mask]
-        if "ref_chosen_logps" in examples[0]:
-            ref_chosen_logps = torch.tensor([example["ref_chosen_logps"] for example in examples])
-        if "ref_rejected_logps" in examples[0]:
-            ref_rejected_logps = torch.tensor([example["ref_rejected_logps"] for example in examples])
+
+        has_ref_chosen_logps = any("ref_chosen_logps" in example for example in examples)
+        if has_ref_chosen_logps:
+            ref_chosen_logps = torch.tensor([example.get("ref_chosen_logps", 0.0) for example in examples])
+        has_ref_rejected_logps = any("ref_rejected_logps" in example for example in examples)
+        if has_ref_rejected_logps:
+            ref_rejected_logps = torch.tensor([example.get("ref_rejected_logps", 0.0) for example in examples])
 
         # Pad
         output = {}
@@ -204,9 +207,9 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "ref_chosen_logps" in examples[0]:
+        if has_ref_chosen_logps:
             output["ref_chosen_logps"] = ref_chosen_logps
-        if "ref_rejected_logps" in examples[0]:
+        if has_ref_rejected_logps:
             output["ref_rejected_logps"] = ref_rejected_logps
         return output
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -204,7 +204,7 @@ class DataCollatorForPreference(DataCollatorMixin):
 
         has_margin  = any("margin" in example for example in examples)
         if has_margin:
-            margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
+            margins = torch.tensor([example.get("margin", 0.0) for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,7 +201,9 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
+
+        has_margin  = any("margin" in example for example in examples)
+        if has_margin:
             margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
@@ -221,7 +223,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if has_margin:
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
# What does this PR do?

Fixes #5539 
In trl/trainer/reward_trainer.py, DataCollatorForRewardModelingDataset.torch_call() checks for the "margin" key only on examples[0]:

if "margin" in examples[0]:
    margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)

It was fixed to use `any('margin' in example for example in examples)` to check if the examples has margin. 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. https://github.com/huggingface/trl/issues/5539
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change confined to data collation: optional fields are now detected across the whole batch and missing values default to 0.0, reducing KeyError risk for mixed-schema datasets.
> 
> **Overview**
> Fixes preference-data collation when optional fields are present only in some batch elements.
> 
> `DataCollatorForPreference` in `reward_trainer.py` now detects `margin` across all examples and fills missing margins with `0.0`; `dpo_trainer.py` does the same for `ref_chosen_logps`/`ref_rejected_logps`. New tests cover mixed batches where these optional keys are missing on some examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77e4a27fd7915e57e7ceaf09cfac7474a040c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->