### PR TITLE
Remove dead token attributes from experimental trainers

### DIFF
--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -358,7 +358,6 @@ class OnlineDPOTrainer(_BaseTrainer):
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
-        self.pad_token = tokenizer.pad_token
         self.pad_token_id = tokenizer.pad_token_id
         self.eos_token_id = tokenizer.eos_token_id
 

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -218,7 +218,6 @@ class SDFTTrainer(SelfDistillationMixin, _BaseTrainer):
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
-        self.pad_token = tokenizer.pad_token
         self.pad_token_id = tokenizer.pad_token_id
         self.eos_token_id = tokenizer.eos_token_id
         self.max_prompt_length = args.max_prompt_length

--- a/trl/experimental/self_distillation/base_self_distillation_trainer.py
+++ b/trl/experimental/self_distillation/base_self_distillation_trainer.py
@@ -122,6 +122,8 @@ class BaseSelfDistillationTrainer(OnlineRolloutMixin, SelfDistillationMixin, _Ba
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
+        self.pad_token_id = tokenizer.pad_token_id
+        self.eos_token_id = tokenizer.eos_token_id
         self.temperature = args.temperature
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length

--- a/trl/experimental/self_distillation/base_self_distillation_trainer.py
+++ b/trl/experimental/self_distillation/base_self_distillation_trainer.py
@@ -122,9 +122,6 @@ class BaseSelfDistillationTrainer(OnlineRolloutMixin, SelfDistillationMixin, _Ba
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
-        self.pad_token = tokenizer.pad_token
-        self.pad_token_id = tokenizer.pad_token_id
-        self.eos_token_id = tokenizer.eos_token_id
         self.temperature = args.temperature
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -158,7 +158,6 @@ class SSDTrainer(_BaseTrainer):
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
-        self.pad_token = tokenizer.pad_token
         self.pad_token_id = tokenizer.pad_token_id
         self.eos_token_id = tokenizer.eos_token_id
         self.max_prompt_length = args.max_prompt_length


### PR DESCRIPTION
Remove dead token attributes from experimental trainers.

This PR refactors the initialization logic across several experimental trainer classes by removing redundant assignments of the `pad_token` attribute. The changes ensure that only the necessary token ID attributes are set, leading to a cleaner and more consistent codebase.

Follow-up to:
- #5483

### Changes

* Removed unnecessary assignment of `self.pad_token = tokenizer.pad_token` in the `OnlineDPOTrainer`, `SDFTTrainer`, and `SSDTrainer` classes, as only the token IDs are required for downstream processing. [
* In the `BaseSelfDistillationTrainer`, removed assignments for `self.pad_token`, `self.pad_token_id`, and `self.eos_token_id`, streamlining the initialization to only include relevant attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing an unused attribute; behavior should be unchanged as padding continues to use `pad_token_id`/`eos_token_id`.
> 
> **Overview**
> Removes redundant `self.pad_token = tokenizer.pad_token` assignments from several experimental trainers (`OnlineDPOTrainer`, `SDFTTrainer`, `BaseSelfDistillationTrainer`, `SSDTrainer`), standardizing on storing only `pad_token_id`/`eos_token_id` after ensuring a pad token is set on the tokenizer.
> 
> This is a small cleanup to eliminate dead attributes and keep trainer initialization consistent without changing generation/padding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e432f213d26fbee94c72a2260768acd7cde8fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->