### PR TITLE
Support processor in maybe_apply_chat_template

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -718,7 +718,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )
@@ -748,7 +748,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )
@@ -781,7 +781,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )
@@ -819,7 +819,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )
@@ -859,7 +859,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )
@@ -908,7 +908,7 @@ class TestApplyChatTemplateHarmony(TrlTestCase):
         }
         output = apply_chat_template(
             messages,
-            tokenizer=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
+            processing_class=AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptOssForCausalLM"),
             reasoning_effort="low",
             model_identity="You are HuggingGPT.",
         )

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -333,7 +333,7 @@ def apply_chat_template(
 
 def maybe_apply_chat_template(
     example: dict[str, list[dict[str, str]]],
-    tokenizer: PreTrainedTokenizerBase | ProcessorMixin,
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
     tools: list[dict | Callable] | None = None,
     **template_kwargs: Any,
 ) -> dict[str, str]:
@@ -356,7 +356,7 @@ def maybe_apply_chat_template(
             messages, where each message is a dictionary with keys `"role"` and `"content"`. Additionally, the example
             may contain a `"chat_template_kwargs"` key, which is a dictionary of additional keyword arguments to pass
             to the chat template renderer.
-        tokenizer ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
             Tokenizer to apply the chat template with.
         tools (`list[dict | Callable]`, *optional*):
             A list of tools (callable functions) that will be accessible to the model. If the template does not support
@@ -390,7 +390,7 @@ def maybe_apply_chat_template(
     ```
     """
     if is_conversational(example):
-        return apply_chat_template(example, tokenizer, tools, **template_kwargs)
+        return apply_chat_template(example, processing_class, tools, **template_kwargs)
     else:
         return example
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -199,7 +199,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
 
 def apply_chat_template(
     example: dict[str, list[dict[str, str]]],
-    tokenizer: PreTrainedTokenizerBase | ProcessorMixin,
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
     tools: list[dict | Callable] | None = None,
     **template_kwargs,
 ) -> dict[str, str]:
@@ -224,7 +224,7 @@ def apply_chat_template(
 
     # Apply the chat template to the whole conversation
     if "messages" in example:
-        messages = tokenizer.apply_chat_template(
+        messages = processing_class.apply_chat_template(
             example["messages"],
             tools=tools,
             tokenize=False,
@@ -243,7 +243,7 @@ def apply_chat_template(
             continue_final_message = True
         else:
             raise ValueError(f"Invalid role in the last message: {last_role}")
-        prompt = tokenizer.apply_chat_template(
+        prompt = processing_class.apply_chat_template(
             example["prompt"],
             tools=tools,
             continue_final_message=continue_final_message,
@@ -256,7 +256,7 @@ def apply_chat_template(
     # Apply the chat template to the entire prompt + completion
     if "prompt" in example:  # explicit prompt and prompt-completion case
         if "chosen" in example:
-            prompt_chosen = tokenizer.apply_chat_template(
+            prompt_chosen = processing_class.apply_chat_template(
                 example["prompt"] + example["chosen"],
                 tools=tools,
                 tokenize=False,
@@ -270,7 +270,7 @@ def apply_chat_template(
 
             chosen = prompt_chosen[len(prompt) :]
         if "rejected" in example and "prompt" in example:  # explicit prompt
-            prompt_rejected = tokenizer.apply_chat_template(
+            prompt_rejected = processing_class.apply_chat_template(
                 example["prompt"] + example["rejected"],
                 tools=tools,
                 tokenize=False,
@@ -283,7 +283,7 @@ def apply_chat_template(
             )
             rejected = prompt_rejected[len(prompt) :]
         if "completion" in example:
-            prompt_completion = tokenizer.apply_chat_template(
+            prompt_completion = processing_class.apply_chat_template(
                 example["prompt"] + example["completion"],
                 tools=tools,
                 tokenize=False,
@@ -297,7 +297,7 @@ def apply_chat_template(
             completion = prompt_completion[len(prompt) :]
     else:  # implicit prompt case
         if "chosen" in example:
-            chosen = tokenizer.apply_chat_template(
+            chosen = processing_class.apply_chat_template(
                 example["chosen"],
                 tools=tools,
                 tokenize=False,
@@ -305,7 +305,7 @@ def apply_chat_template(
                 **template_kwargs,
             )
         if "rejected" in example:
-            rejected = tokenizer.apply_chat_template(
+            rejected = processing_class.apply_chat_template(
                 example["rejected"],
                 tools=tools,
                 tokenize=False,

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -333,7 +333,7 @@ def apply_chat_template(
 
 def maybe_apply_chat_template(
     example: dict[str, list[dict[str, str]]],
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: PreTrainedTokenizerBase | ProcessorMixin,
     tools: list[dict | Callable] | None = None,
     **template_kwargs: Any,
 ) -> dict[str, str]:
@@ -356,7 +356,7 @@ def maybe_apply_chat_template(
             messages, where each message is a dictionary with keys `"role"` and `"content"`. Additionally, the example
             may contain a `"chat_template_kwargs"` key, which is a dictionary of additional keyword arguments to pass
             to the chat template renderer.
-        tokenizer ([`~transformers.PreTrainedTokenizerBase`]):
+        tokenizer ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
             Tokenizer to apply the chat template with.
         tools (`list[dict | Callable]`, *optional*):
             A list of tools (callable functions) that will be accessible to the model. If the template does not support

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -645,7 +645,9 @@ class BCOTrainer(_BaseTrainer):
             )
             # Apply the chat template if needed
             train_dataset = train_dataset.map(
-                maybe_apply_chat_template, fn_kwargs={"tokenizer": processing_class}, num_proc=args.dataset_num_proc
+                maybe_apply_chat_template,
+                fn_kwargs={"processing_class": processing_class},
+                num_proc=args.dataset_num_proc,
             )
             if eval_dataset is not None:
                 # Extract the prompt if needed
@@ -658,7 +660,7 @@ class BCOTrainer(_BaseTrainer):
                 )
                 eval_dataset = eval_dataset.map(
                     maybe_apply_chat_template,
-                    fn_kwargs={"tokenizer": processing_class},
+                    fn_kwargs={"processing_class": processing_class},
                     num_proc=args.dataset_num_proc,
                 )
 

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -334,13 +334,15 @@ class CPOTrainer(_BaseTrainer):
             # Extract the prompt if needed, and apply the chat template if needed
             train_dataset = train_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
             train_dataset = train_dataset.map(
-                maybe_apply_chat_template, fn_kwargs={"tokenizer": processing_class}, num_proc=args.dataset_num_proc
+                maybe_apply_chat_template,
+                fn_kwargs={"processing_class": processing_class},
+                num_proc=args.dataset_num_proc,
             )
             if eval_dataset is not None:
                 eval_dataset = eval_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
                 eval_dataset = eval_dataset.map(
                     maybe_apply_chat_template,
-                    fn_kwargs={"tokenizer": processing_class},
+                    fn_kwargs={"processing_class": processing_class},
                     num_proc=args.dataset_num_proc,
                 )
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -501,7 +501,7 @@ class KTOTrainer(_BaseTrainer):
             # Apply the chat template if needed
             train_dataset = train_dataset.map(
                 maybe_apply_chat_template,
-                fn_kwargs={"tokenizer": processing_class},
+                fn_kwargs={"processing_class": processing_class},
                 num_proc=args.dataset_num_proc,
                 desc="Applying chat template to train dataset",
             )
@@ -514,7 +514,7 @@ class KTOTrainer(_BaseTrainer):
                 )
                 eval_dataset = eval_dataset.map(
                     maybe_apply_chat_template,
-                    fn_kwargs={"tokenizer": processing_class},
+                    fn_kwargs={"processing_class": processing_class},
                     num_proc=args.dataset_num_proc,
                     desc="Applying chat template to eval dataset",
                 )

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -322,14 +322,16 @@ class ORPOTrainer(_BaseTrainer):
             # Extract the prompt if needed, and apply the chat template if needed
             train_dataset = train_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
             train_dataset = train_dataset.map(
-                maybe_apply_chat_template, fn_kwargs={"tokenizer": processing_class}, num_proc=args.dataset_num_proc
+                maybe_apply_chat_template,
+                fn_kwargs={"processing_class": processing_class},
+                num_proc=args.dataset_num_proc,
             )
             train_dataset = train_dataset.map(self.tokenize_row, num_proc=args.dataset_num_proc)
             if eval_dataset is not None:
                 eval_dataset = eval_dataset.map(maybe_extract_prompt, num_proc=args.dataset_num_proc)
                 eval_dataset = eval_dataset.map(
                     maybe_apply_chat_template,
-                    fn_kwargs={"tokenizer": processing_class},
+                    fn_kwargs={"processing_class": processing_class},
                     num_proc=args.dataset_num_proc,
                 )
                 eval_dataset = eval_dataset.map(self.tokenize_row, num_proc=args.dataset_num_proc)


### PR DESCRIPTION
Support processor in `maybe_apply_chat_template`.

This PR updates the `apply_chat_template` and `maybe_apply_chat_template` functions and their usage in tests to use a new argument name, `processing_class`, instead of `tokenizer`. This change clarifies that either a tokenizer or a processor can be passed, improving code clarity and flexibility.

Follow-up to:
- #5489

### Changes

**API changes:**

* Renamed the `tokenizer` argument to `processing_class` in the `apply_chat_template` and `maybe_apply_chat_template` functions, and updated all internal references and docstrings accordingly. This allows passing either a `PreTrainedTokenizerBase` or a `ProcessorMixin` for chat template application.

**Test updates:**

* Updated all test cases in `tests/test_data_utils.py` to use the new `processing_class` argument name when calling `apply_chat_template`.

**Internal consistency:**

* Replaced all internal references to `tokenizer` with `processing_class` within the affected functions to ensure consistent usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a parameter rename and type broadening around chat-template rendering; risk is limited to downstream callers that still pass `tokenizer=` by name.
> 
> **Overview**
> Renames the `apply_chat_template` and `maybe_apply_chat_template` public APIs to take `processing_class` (a `PreTrainedTokenizerBase` *or* `ProcessorMixin`) instead of `tokenizer`, and updates all internal calls to use the new parameter name.
> 
> Updates dataset preprocessing in experimental trainers (`bco`, `cpo`, `kto`, `orpo`) to pass `processing_class` via `fn_kwargs`, and adjusts harmony-related tests to call `apply_chat_template` with `processing_class`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1fe0f8c3efee999946376333c13644f47d3285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->