### PR TITLE
Fix empty-target SDPO/self-distillation batches returning a graph-disconnected zero loss

### DIFF
--- a/trl/experimental/self_distillation/self_distillation_mixin.py
+++ b/trl/experimental/self_distillation/self_distillation_mixin.py
@@ -102,11 +102,6 @@ class SelfDistillationMixin:
         else:
             response_mask = completion_mask
 
-        if response_mask.sum() == 0:
-            mode = "train" if model.training else "eval"
-            self._log_self_distillation_metric(mode, "distillation_loss", 0.0)
-            return torch.tensor(0.0, device=completion_ids.device, requires_grad=True)
-
         student_input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         student_attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
         student_model_inputs = {
@@ -204,6 +199,11 @@ class SelfDistillationMixin:
             mode,
             "distillation_loss",
             self.accelerator.gather(mean_distill_loss).mean().item(),
+        )
+        self._log_self_distillation_metric(
+            mode,
+            "empty_target_batch",
+            float(response_mask.sum().item() == 0),
         )
 
         return loss


### PR DESCRIPTION
## Summary

This PR fixes a bug in the experimental self-distillation stack where an empty self-distillation batch returns a standalone zero tensor instead of a zero loss connected to the model forward graph.

Under DeepSpeed ZeRO-2, this can cause backward/all-reduce failures (for example `IndexError: list index out of range`) when SDPO runs in `distillation_only` mode and a batch contains no valid self-distillation targets.

## Problem

In `trl.experimental.self_distillation.self_distillation_mixin.SelfDistillationMixin._compute_self_distillation_loss`, the current code does:

```python
if response_mask.sum() == 0:
    ...
    return torch.tensor(0.0, device=completion_ids.device, requires_grad=True)
```

This returns a scalar with `requires_grad=True`, but it is not connected to any model parameter.

This becomes problematic in setups such as:

- `SDPOTrainer`
- `sdpo_policy_loss_mode="distillation_only"`
- `include_environment_feedback=False`
- no successful rollouts in the current batch
- DeepSpeed ZeRO-2

In that case, the trainer still calls `backward()` on a loss that is numerically valid but graph-disconnected, and DeepSpeed gradient bucket reduction can fail.

## Why this can happen in practice

This is not a purely theoretical edge case.

In SDPO without rich feedback, the self-distillation target mask can legitimately be all zeros when:

- no rollout in the current prompt group exceeds `success_reward_threshold`, and
- no usable privileged/environment feedback is available.

So "empty target batch" is a valid training-time condition, especially early in training on hard binary-reward tasks.

## Root cause

The issue is not that the batch has no valid distillation targets.

The issue is that the current implementation handles that case by returning a standalone zero tensor, instead of keeping the zero loss connected to the student forward graph.

The original verl SDPO implementation handles this more robustly: it still runs the student/teacher forward path and lets an all-zero mask drive the final loss to zero. That means the scalar loss remains graph-connected and backward is safe even when the effective target batch is empty.

## Fix

Change the empty-target behavior so that the returned loss remains connected to the model graph, instead of early-returning a standalone zero tensor.

In other words:

- keep empty-target batches numerically zero,
- but avoid producing a graph-disconnected loss.

## Impact

This makes SDPO/self-distillation training more robust in `distillation_only` mode, especially with DeepSpeed ZeRO-2.

It also aligns the behavior more closely with the original verl implementation for empty self-distillation batches.

## Reproduction

A minimal reproduction looks like:

- `SDPOTrainer`
- `sdpo_policy_loss_mode="distillation_only"`
- `include_environment_feedback=False`
- binary-reward task
- current batch has no successful rollouts
- DeepSpeed ZeRO-2 enabled

Observed failure:

```text
[rank3]:   File ".../OPSD/sdpo_train.py", line 185, in <module>
[rank3]:     trainer.train()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/transformers/trainer.py", line 2325, in train
[rank3]:     return inner_training_loop(
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/transformers/trainer.py", line 2674, in _inner_training_loop
[rank3]:     tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/trl/experimental/self_distillation/base_self_distillation_trainer.py", line 333, in training_step
[rank3]:     output = super().training_step(model, inputs, num_items_in_batch)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/transformers/trainer.py", line 4071, in training_step
[rank3]:     self.accelerator.backward(loss, **kwargs)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/accelerate/accelerator.py", line 2732, in backward
[rank3]:     self.deepspeed_engine_wrapped.backward(loss, sync_gradients=self.sync_gradients, **kwargs)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/accelerate/utils/deepspeed.py", line 270, in backward
[rank3]:     self.engine.backward(loss, **kwargs)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/utils/nvtx.py", line 20, in wrapped_fn
[rank3]:     ret_val = func(*args, **kwargs)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/engine.py", line 2357, in backward
[rank3]:     self._backward_epilogue()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/engine.py", line 2288, in _backward_epilogue
[rank3]:     self.allreduce_gradients()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/utils/nvtx.py", line 20, in wrapped_fn
[rank3]:     ret_val = func(*args, **kwargs)
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/engine.py", line 2239, in allreduce_gradients
[rank3]:     self.optimizer.overlapping_partition_gradients_reduce_epilogue()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/zero/stage_1_and_2.py", line 947, in overlapping_partition_gradients_reduce_epilogue
[rank3]:     self.independent_gradient_partition_epilogue()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/zero/stage_1_and_2.py", line 839, in independent_gradient_partition_epilogue
[rank3]:     self.reduce_ipg_grads()
[rank3]:   File "/opt/conda/envs/opsd/lib/python3.10/site-packages/deepspeed/runtime/zero/stage_1_and_2.py", line 1478, in reduce_ipg_grads
[rank3]:     self.average_tensor(bucket.buffer[bucket.index].narrow(0, 0, bucket.elements), comm_dtype)
[rank3]: IndexError: list index out of range
```

during gradient reduction in DeepSpeed backward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes loss computation behavior in the training loop for a previously short-circuited edge case; while intended to stabilize distributed backprop, it could affect performance (extra forward) or masking assumptions in self-distillation runs.
> 
> **Overview**
> Fixes empty self-distillation batches by **removing the early return of a standalone zero tensor** in `_compute_self_distillation_loss`, ensuring the returned zero loss remains connected to the student forward pass (avoiding DeepSpeed/ZeRO backward/all-reduce failures).
> 
> Adds an `empty_target_batch` metric alongside `distillation_loss` to explicitly track when the response mask contains no supervised targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49774f53e5cc84a083c9d7db0ce35f3407dde0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->