### PR TITLE
Align KTO with DPO: Align _prepare_dataset

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -624,6 +624,7 @@ class KTOTrainer(_BaseTrainer):
         args: KTOConfig | None,
         dataset_name: str,
     ) -> Dataset:
+        tokenizer = getattr(processing_class, "tokenizer", processing_class)
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255
         with PartialState().main_process_first():
@@ -649,7 +650,7 @@ class KTOTrainer(_BaseTrainer):
             dataset = dataset.map(
                 _tokenize,
                 batched=True,
-                fn_kwargs={"tokenizer": processing_class},
+                fn_kwargs={"tokenizer": tokenizer},
                 num_proc=args.dataset_num_proc,
                 desc=f"Tokenizing {dataset_name} dataset",
             )
@@ -658,7 +659,7 @@ class KTOTrainer(_BaseTrainer):
                 _process_tokens,
                 fn_kwargs={
                     "prefix": "",
-                    "tokenizer": processing_class,
+                    "tokenizer": tokenizer,
                     "max_length": self.max_length,
                 },
                 num_proc=args.dataset_num_proc,
@@ -681,7 +682,7 @@ class KTOTrainer(_BaseTrainer):
                     _process_tokens,
                     fn_kwargs={
                         "prefix": "KL_",
-                        "tokenizer": processing_class,
+                        "tokenizer": tokenizer,
                         "max_length": self.max_length,
                     },
                     num_proc=args.dataset_num_proc,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -469,6 +469,10 @@ class KTOTrainer(_BaseTrainer):
         self.calculate_KL = True
         if self.loss_type in ["apo_zero_unpaired"]:
             self.calculate_KL = False
+        if self.calculate_KL and args.per_device_train_batch_size <= 1:
+            raise ValueError(
+                "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
+            )
 
         # metric
         self._stored_metrics = defaultdict(lambda: defaultdict(list))
@@ -487,150 +491,10 @@ class KTOTrainer(_BaseTrainer):
                 "loss.",
             )
 
-        # Compute that only on the main process for faster data processing.
-        # see: https://github.com/huggingface/trl/pull/1255
-        with PartialState().main_process_first():
-            # Extract the prompt if needed
-            train_dataset = train_dataset.map(
-                maybe_extract_prompt, num_proc=args.dataset_num_proc, desc="Extracting prompt from train dataset"
-            )
-            # Unpair the dataset if needed
-            train_dataset = maybe_unpair_preference_dataset(
-                train_dataset, args.dataset_num_proc, desc="Unpairing train dataset"
-            )
-            # Apply the chat template if needed
-            train_dataset = train_dataset.map(
-                maybe_apply_chat_template,
-                fn_kwargs={"processing_class": processing_class},
-                num_proc=args.dataset_num_proc,
-                desc="Applying chat template to train dataset",
-            )
-            if eval_dataset is not None:
-                eval_dataset = eval_dataset.map(
-                    maybe_extract_prompt, num_proc=args.dataset_num_proc, desc="Extracting prompt from eval dataset"
-                )
-                eval_dataset = maybe_unpair_preference_dataset(
-                    eval_dataset, args.dataset_num_proc, desc="Unpairing eval dataset"
-                )
-                eval_dataset = eval_dataset.map(
-                    maybe_apply_chat_template,
-                    fn_kwargs={"processing_class": processing_class},
-                    num_proc=args.dataset_num_proc,
-                    desc="Applying chat template to eval dataset",
-                )
-
-            # Tokenize and prepare the training datasets
-            train_dataset = train_dataset.map(
-                _tokenize,
-                batched=True,
-                fn_kwargs={"tokenizer": self.processing_class},
-                num_proc=args.dataset_num_proc,
-                desc="Tokenizing train dataset",
-            )
-
-            fn_kwargs = {
-                "prefix": "",
-                "tokenizer": self.processing_class,
-                "max_length": self.max_length,
-            }
-
-            train_dataset = train_dataset.map(
-                _process_tokens,
-                fn_kwargs=fn_kwargs,
-                num_proc=args.dataset_num_proc,
-                desc="Processing tokenized train dataset",
-            )
-
-            # Tokenize and prepare the eval datasets
-            if eval_dataset is not None:
-                eval_dataset = eval_dataset.map(
-                    _tokenize,
-                    fn_kwargs={"tokenizer": self.processing_class},
-                    batched=True,
-                    num_proc=args.dataset_num_proc,
-                    desc="Tokenizing eval dataset",
-                )
-
-                eval_dataset = eval_dataset.map(
-                    _process_tokens,
-                    fn_kwargs=fn_kwargs,
-                    num_proc=args.dataset_num_proc,
-                    desc="Processing tokenized eval dataset",
-                )
-
-            # Get KL datasets if needed
-            if self.calculate_KL:
-                if args.per_device_train_batch_size <= 1:
-                    raise ValueError(
-                        "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
-                    )
-
-                # create pairs for estimating the KL term by flipping the matched pairs in each batch of size total_batch_size
-                # i.e., (x_1, y_1), ..., (x_n, y_n) --> (x_1, y_n), ..., (x_n, y_1) = (x'_1, y'_1), ..., (x'_n, y'_n)
-                train_kl_dataset = train_dataset.map(
-                    _get_kl_dataset,
-                    batched=True,
-                    batch_size=args.per_device_train_batch_size,
-                    num_proc=args.dataset_num_proc,
-                    desc="Extracting KL train dataset",
-                )
-
-                fn_kwargs["prefix"] = "KL_"
-                train_kl_dataset = train_kl_dataset.map(
-                    _process_tokens,
-                    fn_kwargs=fn_kwargs,
-                    num_proc=args.dataset_num_proc,
-                    remove_columns=[c for c in train_kl_dataset.column_names if c in train_dataset.column_names],
-                    desc="Processing tokenized train KL dataset",
-                )
-
-                # merge the datasets
-                train_dataset = concatenate_datasets([train_dataset, train_kl_dataset], axis=1)
-
-                if eval_dataset is not None:
-                    # Get KL dataset
-                    eval_kl_dataset = eval_dataset.map(
-                        _get_kl_dataset,
-                        batched=True,
-                        batch_size=args.per_device_train_batch_size,
-                        num_proc=args.dataset_num_proc,
-                        desc="Extracting eval KL dataset",
-                    )
-
-                    eval_kl_dataset = eval_kl_dataset.map(
-                        _process_tokens,
-                        fn_kwargs=fn_kwargs,
-                        num_proc=args.dataset_num_proc,
-                        remove_columns=[c for c in eval_kl_dataset.column_names if c in eval_dataset.column_names],
-                        desc="Processing tokenized eval KL dataset",
-                    )
-
-                    # merge the datasets
-                    eval_dataset = concatenate_datasets([eval_dataset, eval_kl_dataset], axis=1)
-
-            # calculate dataset desirability balance
-            num_desirable = max(sum(train_dataset["label"]), 1)
-            num_undesirable = max(len(train_dataset["label"]) - num_desirable, 1)  # "label" is binary
-
-            if num_desirable != num_undesirable:
-                # The lower and upper bounds come from Eq. (8) of https://huggingface.co/papers/2402.01306
-                des_weight_lower_bound = round((num_undesirable * self.undesirable_weight / num_desirable) * 1, 2)
-                des_weight_upper_bound = round((num_undesirable * self.undesirable_weight / num_desirable) * 1.33, 2)
-                und_weight_lower_bound = round((num_desirable * self.desirable_weight / num_undesirable) / 1.33, 2)
-                und_weight_upper_bound = round((num_desirable * self.desirable_weight / num_undesirable) / 1, 2)
-
-                des_weight_in_range = des_weight_lower_bound <= self.desirable_weight <= des_weight_upper_bound
-                und_weight_in_range = und_weight_lower_bound <= self.undesirable_weight <= und_weight_upper_bound
-
-                if not (des_weight_in_range or und_weight_in_range):
-                    logger.warning(
-                        "You have different amounts of desirable/positive and undesirable/negative examples but the "
-                        "weights on the desirable and undesirable losses don't seem to be in an ideal range. Based "
-                        f"on your data, we recommend EITHER "
-                        f"desirable_weight in [{des_weight_lower_bound}, {des_weight_upper_bound}] or "
-                        f"undesirable_weight in [{und_weight_lower_bound}, {und_weight_upper_bound}] (but NOT BOTH). "
-                        "See the documentation on how to optimally set these weights.",
-                    )
+        # Dataset
+        train_dataset = self._prepare_dataset(train_dataset, processing_class, args, "train")
+        if eval_dataset is not None:
+            eval_dataset = self._prepare_dataset(eval_dataset, processing_class, args, "eval")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream
@@ -752,6 +616,109 @@ class KTOTrainer(_BaseTrainer):
                         "eval",
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
+
+    def _prepare_dataset(
+        self,
+        dataset: Dataset,
+        processing_class: PreTrainedTokenizerBase | BaseImageProcessor | FeatureExtractionMixin | ProcessorMixin,
+        args: KTOConfig | None,
+        dataset_name: str,
+    ) -> Dataset:
+        # Compute that only on the main process for faster data processing.
+        # see: https://github.com/huggingface/trl/pull/1255
+        with PartialState().main_process_first():
+            # Extract the prompt if needed
+            dataset = dataset.map(
+                maybe_extract_prompt,
+                num_proc=args.dataset_num_proc,
+                desc=f"Extracting prompt from {dataset_name} dataset",
+            )
+            # Unpair the dataset if needed
+            dataset = maybe_unpair_preference_dataset(
+                dataset, args.dataset_num_proc, desc=f"Unpairing {dataset_name} dataset"
+            )
+            # Apply the chat template if needed
+            dataset = dataset.map(
+                maybe_apply_chat_template,
+                fn_kwargs={"processing_class": processing_class},
+                num_proc=args.dataset_num_proc,
+                desc=f"Applying chat template to {dataset_name} dataset",
+            )
+
+            # Tokenize and prepare the training datasets
+            dataset = dataset.map(
+                _tokenize,
+                batched=True,
+                fn_kwargs={"tokenizer": processing_class},
+                num_proc=args.dataset_num_proc,
+                desc=f"Tokenizing {dataset_name} dataset",
+            )
+
+            dataset = dataset.map(
+                _process_tokens,
+                fn_kwargs={
+                    "prefix": "",
+                    "tokenizer": processing_class,
+                    "max_length": self.max_length,
+                },
+                num_proc=args.dataset_num_proc,
+                desc=f"Processing tokenized {dataset_name} dataset",
+            )
+
+            # Get KL datasets if needed
+            if self.calculate_KL:
+                # create pairs for estimating the KL term by flipping the matched pairs in each batch of size total_batch_size
+                # i.e., (x_1, y_1), ..., (x_n, y_n) --> (x_1, y_n), ..., (x_n, y_1) = (x'_1, y'_1), ..., (x'_n, y'_n)
+                kl_dataset = dataset.map(
+                    _get_kl_dataset,
+                    batched=True,
+                    batch_size=args.per_device_train_batch_size,
+                    num_proc=args.dataset_num_proc,
+                    desc=f"Extracting KL {dataset_name} dataset",
+                )
+
+                kl_dataset = kl_dataset.map(
+                    _process_tokens,
+                    fn_kwargs={
+                        "prefix": "KL_",
+                        "tokenizer": processing_class,
+                        "max_length": self.max_length,
+                    },
+                    num_proc=args.dataset_num_proc,
+                    remove_columns=[c for c in kl_dataset.column_names if c in dataset.column_names],
+                    desc=f"Processing tokenized {dataset_name} KL dataset",
+                )
+
+                # merge the datasets
+                dataset = concatenate_datasets([dataset, kl_dataset], axis=1)
+
+            # calculate dataset desirability balance
+            if dataset_name == "train":
+                num_desirable = max(sum(dataset["label"]), 1)
+                num_undesirable = max(len(dataset["label"]) - num_desirable, 1)  # "label" is binary
+
+                if num_desirable != num_undesirable:
+                    # The lower and upper bounds come from Eq. (8) of https://huggingface.co/papers/2402.01306
+                    des_weight_lower_bound = round((num_undesirable * self.undesirable_weight / num_desirable) * 1, 2)
+                    des_weight_upper_bound = round(
+                        (num_undesirable * self.undesirable_weight / num_desirable) * 1.33, 2
+                    )
+                    und_weight_lower_bound = round((num_desirable * self.desirable_weight / num_undesirable) / 1.33, 2)
+                    und_weight_upper_bound = round((num_desirable * self.desirable_weight / num_undesirable) / 1, 2)
+
+                    des_weight_in_range = des_weight_lower_bound <= self.desirable_weight <= des_weight_upper_bound
+                    und_weight_in_range = und_weight_lower_bound <= self.undesirable_weight <= und_weight_upper_bound
+
+                    if not (des_weight_in_range or und_weight_in_range):
+                        logger.warning(
+                            "You have different amounts of desirable/positive and undesirable/negative examples but the "
+                            "weights on the desirable and undesirable losses don't seem to be in an ideal range. Based "
+                            f"on your data, we recommend EITHER "
+                            f"desirable_weight in [{des_weight_lower_bound}, {des_weight_upper_bound}] or "
+                            f"undesirable_weight in [{und_weight_lower_bound}, {und_weight_upper_bound}] (but NOT BOTH). "
+                            "See the documentation on how to optimally set these weights.",
+                        )
+        return dataset
 
     @contextmanager
     def null_ref_context(self):


### PR DESCRIPTION
Align KTO with DPO: Align `_prepare_dataset`.

This PR refactors the dataset preparation logic in the `KTOTrainer` class to improve code maintainability and reduce duplication. The main changes involve extracting repeated dataset processing steps into a new helper method, centralizing KL dataset handling, and enforcing batch size requirements for KL calculation.

Part of:
- #4786

### Changes

**Refactoring and code organization:**

* Extracted all dataset preparation logic (prompt extraction, unpairing, chat template application, tokenization, KL dataset creation, and desirability balance checks) into a new `_prepare_dataset` method in `trl/experimental/kto/kto_trainer.py`, reducing code duplication and improving maintainability.
* Updated the main training and evaluation dataset setup to use the new `_prepare_dataset` method, simplifying the main training loop and ensuring consistent dataset processing for both train and eval datasets.

**Validation and error handling:**

* Added an explicit check to raise a `ValueError` if `per_device_train_batch_size` is less than or equal to 1 when KL calculation is enabled, ensuring correct KL term computation and preventing silent errors during training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches KTO training data preprocessing and KL dataset construction, which can change training/eval inputs and fail fast for previously accepted configs (batch size <= 1). The changes are mostly refactor, but impact a core training path.
> 
> **Overview**
> Moves duplicated dataset preprocessing in `KTOTrainer` into a new `_prepare_dataset()` helper, and updates init to run both train and eval datasets through this single path (prompt extraction, unpairing, chat templating, tokenization, optional KL dataset creation/merge).
> 
> Adds an early `ValueError` when KL is enabled but `per_device_train_batch_size <= 1`, preventing miscomputed KL/implied-reward behavior; desirability balance warnings are now scoped to the training dataset only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10c4f202544d91075d0df0e054d7ffdc761e9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->