### PR TITLE
Update AsyncGRPO example with GSM8K and tested hyperparameters

### DIFF
--- a/examples/scripts/async_grpo.py
+++ b/examples/scripts/async_grpo.py
@@ -12,16 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-CUDA_VISIBLE_DEVICES=1 VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-4B \
-    --weight-transfer-config '{"backend":"nccl"}' \
-    --max-model-len 9216
+# /// script
+# dependencies = [
+#     "trl",
+#     "math-verify",
+#     "latex2sympy2_extended",
+#     "trackio",
+# ]
+# ///
 
-LOG_LEVEL=DEBUG CUDA_VISIBLE_DEVICES=0 accelerate launch examples/scripts/async_grpo.py
 """
+pip install math_verify
 
-import logging
-import os
+CUDA_VISIBLE_DEVICES=1 VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6B \
+    --max-model-len 2048 \
+    --logprobs-mode processed_logprobs \
+    --weight-transfer-config '{"backend":"nccl"}'
+
+CUDA_VISIBLE_DEVICES=0 accelerate launch examples/scripts/async_grpo.py
+"""
 
 from datasets import load_dataset
 
@@ -29,34 +38,33 @@ from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
 from trl.rewards import accuracy_reward
 
 
-logging.basicConfig(
-    level=getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
-logging.getLogger("trl").setLevel(logging.DEBUG)
-
-
 def format_sample(sample):
-    return {"prompt": sample["messages"][:1], "solution": sample["answer"]}
+    return {
+        "prompt": [{"role": "user", "content": sample["question"]}],
+        "solution": sample["answer"].split("####")[-1].strip(),
+    }
 
 
 def main() -> None:
-    dataset = load_dataset("open-r1/OpenR1-Math-220k", split="train[:10000]")
+    dataset = load_dataset("openai/gsm8k", "main", split="train")
     dataset = dataset.map(format_sample, remove_columns=dataset.column_names)
 
     config = AsyncGRPOConfig(
-        output_dir="./results",
-        per_device_train_batch_size=1,
-        num_train_epochs=1,
-        max_completion_length=4096,
-        max_steps=10,
+        output_dir="async_grpo_gsm8k",
+        save_strategy="no",
+        per_device_train_batch_size=16,
+        gradient_accumulation_steps=2,
+        max_completion_length=1024,
+        chat_template_kwargs={"enable_thinking": False},
+        max_steps=200,
+        learning_rate=1e-5,
         report_to="trackio",
-        trackio_space_id=None,
-        project="async_grpo",
+        trackio_space_id="async-grpo-gsm8k",
+        project="async-grpo-gsm8k",
         log_completions=True,
     )
     trainer = AsyncGRPOTrainer(
-        model="Qwen/Qwen3-4B",
+        model="Qwen/Qwen3-0.6B",
         args=config,
         train_dataset=dataset,
         reward_funcs=accuracy_reward,


### PR DESCRIPTION
# What does this PR do?

In this PR, I propose a simplification to the AsyncGRPO example. The current one seems to be too complex for the 4B version of the Qwen3 model, leading to a reward and loss of 0. In this update, I use a smaller version of the model and without thinking activated, combined with a simpler dataset. In 200 steps (15 mins), improvements are clear 😄 

<img width="455" height="309" alt="Screenshot 2026-04-17 at 10 31 14" src="https://github.com/user-attachments/assets/f31c7c88-6ea3-4d2f-993e-f53934327b94" />

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@AmineDiro @qgallouedec 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to an example script and adjust dataset/model choices plus training/config parameters without affecting library code paths.
> 
> **Overview**
> Switches the `examples/scripts/async_grpo.py` AsyncGRPO walkthrough from OpenR1 Math + `Qwen3-4B` to GSM8K + `Qwen3-0.6B`, including new sample formatting and answer extraction.
> 
> Refreshes the runnable setup and training defaults (adds inline script deps and updated vLLM launch flags, disables saving, increases batch/accumulation, shortens completions, disables *thinking*, and sets new Trackio project/space plus learning rate and step count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8ecdbac831c59d0ce1d548e4e406cea03ee0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->