### PR TITLE
Align KTO with DPO: Align add_model_tags

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -682,9 +682,8 @@ class KTOTrainer(_BaseTrainer):
         # self.model_accepts_loss_kwargs to False to enable scaling.
         self.model_accepts_loss_kwargs = False
 
-        # Add tags for models that have been loaded with the correct transformers version
-        if hasattr(self.model, "add_model_tags"):
-            self.model.add_model_tags(self._tag_names)
+        # Add tags to the model
+        self.model.add_model_tags(self._tag_names)
 
         if not hasattr(self, "accelerator"):
             raise AttributeError(


### PR DESCRIPTION
Align KTO with DPO: Align `add_model_tags`.

Part of:
- #4786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `hasattr(..., "add_model_tags")` guard and now calls `self.model.add_model_tags(...)` unconditionally, which could break with older/unsupported `transformers` model classes that don’t implement this method.
> 
> **Overview**
> Ensures `KTOTrainer` always tags the training model via `self.model.add_model_tags(self._tag_names)`, removing the previous conditional check.
> 
> This aligns KTO’s behavior with other trainers but changes compatibility expectations: models lacking `add_model_tags` will now raise at init instead of silently skipping tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981d28f1f48e6522bdb22cab4e39e5766df48f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->