### PR TITLE
Align KTO with DPO: Align ref_model preparation for distributed training

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -45,7 +45,7 @@ from transformers.utils import is_peft_available
 
 from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt, maybe_unpair_preference_dataset
 from ...import_utils import is_liger_kernel_available
-from ...models.utils import prepare_deepspeed
+from ...models.utils import prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import (
     create_model_from_path,
@@ -686,26 +686,11 @@ class KTOTrainer(_BaseTrainer):
         if hasattr(self.model, "add_model_tags"):
             self.model.add_model_tags(self._tag_names)
 
-        if not hasattr(self, "accelerator"):
-            raise AttributeError(
-                "Your `Trainer` does not have an `accelerator` object. Consider upgrading `transformers`."
-            )
-
-        # Deepspeed Zero-3 does not support precompute_ref_log_probs
-        if self.is_deepspeed_enabled:
-            if self.accelerator.state.deepspeed_plugin.zero_stage == 3 and self.precompute_ref_log_probs:
-                raise ValueError(
-                    "You cannot use `precompute_ref_log_probs=True` with Deepspeed ZeRO-3. Please set `precompute_ref_log_probs=False`."
-                )
-
-        if self.ref_model is None:
-            if not (self.is_peft_model or self.precompute_ref_log_probs):
-                raise ValueError(
-                    "No reference model and model is not a Peft model. Try setting `precompute_ref_log_probs=True`"
-                )
-        else:
+        if self.ref_model is not None:
             if self.is_deepspeed_enabled:
                 self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
+            elif self.is_fsdp_enabled:
+                self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
 


### PR DESCRIPTION
Align KTO with DPO: Align ref_model preparation for distributed training.

Part of:
- #4786

This PR introduces support for Fully Sharded Data Parallel (FSDP) in the `KTOTrainer` by updating the way reference models are prepared. It also refactors the initialization logic to improve clarity and remove unnecessary checks.

### Changes

Support for distributed training strategies:

* Added `prepare_fsdp` to the imports and updated the reference model preparation logic to use `prepare_fsdp` when FSDP is enabled, similar to how Deepspeed is handled. 

Refactoring and simplification:

* Removed redundant checks and error messages related to the presence of the `accelerator` object and Deepspeed/PEFT logic, streamlining the initialization process for the reference model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `KTOTrainer` distributed-training initialization and removes prior validation around Deepspeed ZeRO-3 and reference-model requirements, which could change failure modes and allow unsupported configurations to proceed further before erroring.
> 
> **Overview**
> `KTOTrainer` now prepares `ref_model` with `prepare_fsdp` when FSDP is enabled, mirroring the existing Deepspeed handling.
> 
> The init-time reference-model logic is simplified by removing explicit `accelerator` presence checks and some Deepspeed/PEFT/precompute validation, and only applying distributed wrapping when `ref_model` is actually present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f78b85386c71e10149fb0b2524a9e359547ec97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->