### PR TITLE
Align KTO with DPO: Make conditional prompt extraction and unpairing in _prepare_dataset

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -42,7 +42,11 @@ from transformers import (
 from transformers.trainer_utils import EvalLoopOutput, has_length
 from transformers.utils import is_peft_available
 
-from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt, maybe_unpair_preference_dataset
+from ...data_utils import (
+    extract_prompt,
+    maybe_apply_chat_template,
+    unpair_preference_dataset,
+)
 from ...import_utils import is_liger_kernel_available
 from ...models.utils import prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
@@ -611,20 +615,26 @@ class KTOTrainer(_BaseTrainer):
         args: KTOConfig | None,
         dataset_name: str,
     ) -> Dataset:
-        tokenizer = getattr(processing_class, "tokenizer", processing_class)
+        # Build the kwargs for the `map` function
+        map_kwargs = {}
+        if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
+            map_kwargs["num_proc"] = args.dataset_num_proc
+
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255
         with PartialState().main_process_first():
             # Extract the prompt if needed
-            dataset = dataset.map(
-                maybe_extract_prompt,
-                num_proc=args.dataset_num_proc,
-                desc=f"Extracting prompt from {dataset_name} dataset",
-            )
+            first_example = next(iter(dataset))
+            if "prompt" not in first_example:
+                map_kwargs["desc"] = f"Extracting prompt from {dataset_name} dataset"
+                dataset = dataset.map(extract_prompt, **map_kwargs)
+
             # Unpair the dataset if needed
-            dataset = maybe_unpair_preference_dataset(
-                dataset, args.dataset_num_proc, desc=f"Unpairing {dataset_name} dataset"
-            )
+            first_example = next(iter(dataset))
+            if "chosen" in first_example and "rejected" in first_example:
+                map_kwargs["desc"] = f"Unpairing {dataset_name} dataset"
+                dataset = unpair_preference_dataset(dataset, **map_kwargs)
+
             # Apply the chat template if needed
             dataset = dataset.map(
                 maybe_apply_chat_template,
@@ -633,7 +643,8 @@ class KTOTrainer(_BaseTrainer):
                 desc=f"Applying chat template to {dataset_name} dataset",
             )
 
-            # Tokenize and prepare the training datasets
+            tokenizer = getattr(processing_class, "tokenizer", processing_class)
+            # Tokenize dataset
             dataset = dataset.map(
                 _tokenize,
                 batched=True,
@@ -641,7 +652,7 @@ class KTOTrainer(_BaseTrainer):
                 num_proc=args.dataset_num_proc,
                 desc=f"Tokenizing {dataset_name} dataset",
             )
-
+            # Process dataset
             dataset = dataset.map(
                 _process_tokens,
                 fn_kwargs={

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -616,9 +616,7 @@ class KTOTrainer(_BaseTrainer):
         dataset_name: str,
     ) -> Dataset:
         # Build the kwargs for the `map` function
-        map_kwargs = {}
-        if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
-            map_kwargs["num_proc"] = args.dataset_num_proc
+        map_kwargs = {"num_proc": args.dataset_num_proc}
 
         # Compute that only on the main process for faster data processing.
         # see: https://github.com/huggingface/trl/pull/1255


### PR DESCRIPTION
Align KTO with DPO: Make conditional prompt extraction and unpairing in _prepare_dataset

This PR refactors parts of the `_prepare_dataset` method in `KTOTrainer` to improve dataset preprocessing logic and efficiency. The changes make the prompt extraction and unpairing steps conditional based on dataset contents, streamline imports, and clarify the mapping process for better maintainability.

Part of:
- #4786

### Changes

**Dataset preprocessing improvements:**

* The `maybe_extract_prompt` and `maybe_unpair_preference_dataset` logic is replaced with explicit checks for the presence of `"prompt"`, `"chosen"`, and `"rejected"` fields in dataset examples, ensuring these steps are only applied when necessary.
* The dataset mapping arguments (`num_proc` and `desc`) are now constructed dynamically and only included when appropriate, improving compatibility with different dataset types.

**Code maintainability and clarity:**

* Imports from `data_utils` are now explicit and only the required functions are imported, reducing ambiguity and potential import errors.
* The order of dataset processing steps is clarified: prompt extraction, unpairing, chat template application, tokenization, and token processing are now clearly separated and applied in sequence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KTO dataset preprocessing flow by making prompt extraction and unpairing conditional on detected columns, which can alter how some datasets are transformed before tokenization. Risk is moderate because incorrect column detection or iterable dataset behavior could skip/duplicate preprocessing and affect training data shapes.
> 
> **Overview**
> Refactors `KTOTrainer._prepare_dataset` to **conditionally** run prompt extraction and preference unpairing by inspecting the first dataset example (skip `extract_prompt` if `prompt` already exists; skip `unpair_preference_dataset` unless `chosen`/`rejected` are present).
> 
> Cleans up `data_utils` imports to use explicit `extract_prompt`/`unpair_preference_dataset` and centralizes `dataset.map` kwargs (`num_proc` + per-step `desc`) for these preprocessing steps before chat templating, tokenization, and token processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342b3a1200281726c033c33d5b36615dca794dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->