### PR TITLE
Allow minor version update of vllm

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.11.0` to `0.18.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.11.0` to `0.18.x`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.11.0,<=0.18.0",
+    "vllm>=0.11.0,<0.19.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -89,7 +89,7 @@ def _patch_vllm_disabled_tqdm() -> None:
 
     - Bug introduced in https://github.com/vllm-project/vllm/pull/52
     - Fixed in https://github.com/vllm-project/vllm/pull/28471 (released in v0.11.1)
-    - Since TRL currently supports vLLM v0.11.0-0.18.0, we patch it here
+    - Since TRL currently supports vLLM v0.11.0-0.18.x, we patch it here
     - This can be removed when TRL requires vLLM>=0.11.1
     """
     if _is_package_version_below("vllm", "0.11.1"):

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -105,9 +105,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.11.0") <= Version(_vllm_version) <= Version("0.18.0")):
+        if not (Version("0.11.0") <= Version(_vllm_version) < Version("0.19")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.11.0 to 0.18.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.11.0 to 0.18.x. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -105,7 +105,7 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.11.0") <= Version(_vllm_version) < Version("0.19")):
+        if not (Version("0.11.0") <= Version(_vllm_version) < Version("0.19.0")):
             warnings.warn(
                 f"TRL currently supports vLLM versions from 0.11.0 to 0.18.x. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",


### PR DESCRIPTION
# What does this PR do?

This PR replaces the less-than-or-equal-to sign with the less-than sign for the maximum version allowed for vllm, which in turn allows minor package bumps, especially in this case 0.18.1.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint and messaging-only changes; no functional training or serving logic is modified beyond widening the allowed vLLM patch versions.
> 
> **Overview**
> Relaxes the supported vLLM version constraint to allow patch releases in the `0.18.x` line by switching the upper bound from `<=0.18.0` to `<0.19.0` (including the `trl[vllm]` extra in `pyproject.toml`).
> 
> Updates user-facing docs and runtime warnings (`is_vllm_available` and related comments) to consistently message the supported range as `0.11.0`–`0.18.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e18d0b03022080dd08d8727c18617bfe050891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->