### PR TITLE
feat(grpo): add entropy regularization to GRPOTrainer

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -781,6 +781,29 @@ class GRPOConfig(_BaseConfig):
             "non-truncated completions are considered."
         },
     )
+    entropy_coef: float = field(
+        default=0.0,
+        metadata={
+            "help": "Coefficient for the entropy regularization term added to the GRPO loss "
+            "(L = L_GRPO - entropy_coef * H(pi)). Encourages exploration by penalizing low-entropy "
+            "(overconfident) distributions. Set to `0.0` to disable. Use `entropy_final_coef` and "
+            "`entropy_decay_steps` to linearly decay the coefficient over training steps."
+        },
+    )
+    entropy_final_coef: float = field(
+        default=0.0,
+        metadata={
+            "help": "Final entropy regularization coefficient after linear decay over `entropy_decay_steps` "
+            "steps. When equal to `entropy_coef`, no decay is applied. Ignored when `entropy_coef=0.0`."
+        },
+    )
+    entropy_decay_steps: int = field(
+        default=1000,
+        metadata={
+            "help": "Number of training steps to linearly decay the entropy regularization coefficient "
+            "from `entropy_coef` to `entropy_final_coef`. Ignored when `entropy_coef == entropy_final_coef`."
+        },
+    )
     max_tool_calling_iterations: int | None = field(
         default=None,
         metadata={

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -568,6 +568,9 @@ class GRPOTrainer(_BaseTrainer):
             raise ValueError("Liger kernel does not support off-policy sequence masking yet.")
         self.mask_truncated_completions = args.mask_truncated_completions
         self.top_entropy_quantile = args.top_entropy_quantile
+        self.entropy_coef = args.entropy_coef
+        self.entropy_final_coef = args.entropy_final_coef
+        self.entropy_decay_steps = args.entropy_decay_steps
         if self.use_liger_kernel and self.top_entropy_quantile < 1.0:
             raise NotImplementedError(
                 "Liger Kernels don't currently support masking token positions based on entropy."
@@ -2589,6 +2592,14 @@ class GRPOTrainer(_BaseTrainer):
 
         mean_entropy = masked_batch_mean(entropies)
         self._metrics[mode]["entropy"].append(self.accelerator.gather(mean_entropy).nanmean().item())
+
+        if self.entropy_coef != 0.0:
+            step = self.state.global_step if mode == "train" else 0
+            decay_t = min(step / max(self.entropy_decay_steps, 1), 1.0)
+            effective_coef = self.entropy_coef + (self.entropy_final_coef - self.entropy_coef) * decay_t
+            grad_accum = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            loss = loss - (effective_coef / grad_accum) * mean_entropy
+            self._metrics[mode]["entropy_coef"].append(effective_coef)
 
         if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
             # Compute the clipped probability ratios


### PR DESCRIPTION
# What does this PR do?

Adds explicit entropy regularization to the GRPO training objective to prevent entropy collapse and improve exploration during early training.

Introduces `entropy_coef`, `entropy_final_coef`, and `entropy_decay_steps` to `GRPOConfig`. When `entropy_coef > 0`, an entropy bonus is added to the loss:

```
L = L_GRPO - effective_coef * H(π)
```

The coefficient can optionally decay linearly from `entropy_coef` to `entropy_final_coef` over `entropy_decay_steps` training steps. Reuses the existing per-token entropy tensor already computed in `_get_per_token_logps_and_entropies()` — no additional forward pass overhead. Disabled by default (`entropy_coef=0.0`).

**Usage:**
```python
# Static coefficient
GRPOConfig(entropy_coef=0.01)

# With linear decay
GRPOConfig(entropy_coef=0.02, entropy_final_coef=0.0, entropy_decay_steps=1000)
```

Fixes #5584

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @lewtun @kashif — this implements the feature requested in #5584. Happy to add tests and docs if the approach looks good to you.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GRPO training objective by adding an optional entropy regularization term, which can affect training dynamics and metrics across runs. Risk is limited by defaulting the feature off (`entropy_coef=0.0`) and keeping the change localized to GRPO loss computation.
> 
> **Overview**
> **Adds entropy regularization to GRPO training (opt-in).** `GRPOConfig` now exposes `entropy_coef`, `entropy_final_coef`, and `entropy_decay_steps` to control an entropy bonus term.
> 
> **Updates `GRPOTrainer` loss computation** to subtract `effective_coef * mean_entropy` (with linear decay over `global_step` and accumulation-aware scaling) and logs the active `entropy_coef` as a metric when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4d4701aec82555173d27c54099b9c57ee12a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->