### PR TITLE
fix(grpo): suppress spurious KL gradients for zero-std reward groups

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2254,6 +2254,16 @@ class GRPOTrainer(_BaseTrainer):
                 nanmax(self.accelerator.gather(max_importance_sampling_ratio)).item()
             )
 
+        # When all completions in a reward group receive identical rewards, advantages
+        # are zero and the policy loss contributes no gradient. However, the per-token
+        # KL penalty (beta * per_token_kl in compute_loss) still fires because
+        # per_token_logps retains gradients while ref_per_token_logps is detached.
+        # Zeroing completion_mask for zero-std groups suppresses both the policy loss
+        # and the spurious KL gradient simultaneously. See issue #5588.
+        if self.beta != 0.0:
+            is_std_zero_local = is_std_zero[process_slice]  # shape: (local_completions,)
+            completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
+
         output = {
             "prompt_ids": prompt_ids,
             "prompt_mask": prompt_mask,


### PR DESCRIPTION
# What does this PR do?

Fixes a correctness bug in `GRPOTrainer` where zero-std reward groups produce spurious KL gradients when `beta > 0`.

## Root Cause

When all completions in a reward group receive identical rewards, `advantages` are zero, so the policy loss contributes no gradient — this is correct behavior. However, the per-token KL penalty term in `compute_loss`:

```python
per_token_loss = per_token_loss + self.beta * per_token_kl
```

still generates gradients through `per_token_logps` (the current model's log-probs), while `ref_per_token_logps` is detached. This results in undirected gradient updates with no reward signal to justify them — pushing the model toward the reference policy at random.

## Fix

Zero out `completion_mask` for zero-std reward groups in `_generate_and_score_completions`, just before the output dict is assembled. Since both the policy loss and the KL penalty are gated by `completion_mask` in `compute_loss`, this suppresses both simultaneously:

```python
if self.beta != 0.0:
    is_std_zero_local = is_std_zero[process_slice]  # shape: (local_completions,)
    completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
```

`is_std_zero` already has shape `(total_completions,)` in both `sum_then_normalize` and `normalize_then_sum` paths (via `repeat_interleave` and `expand_as` respectively), so `[process_slice]` correctly extracts the local rank's slice.

## Notes on RLOO

The issue title mentions RLOO, but RLOO computes KL as a reward modifier using fully-detached log-probs (`old_per_token_logps - ref_per_token_logps`), so no spurious gradients arise there. No change needed in `rloo_trainer.py`.

> **Note on the Cursor Bugbot comment:** The bot flagged entropy regularization + Liger kernel — that code was unintentionally included from a separate branch. This PR has been updated to contain only the zero-std fix (1 file, 10 lines). No entropy reg code is included.

Fixes #5588

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @lewtun — this is a correctness fix for the KL gradient issue discussed in #5588.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how training masks tokens and therefore alters optimization behavior when reward variance is zero, but the change is small and scoped to GRPO masking logic.
> 
> **Overview**
> Prevents **spurious KL-driven updates** in `GRPOTrainer` when a reward group has zero reward variance (all completions get identical rewards).
> 
> When `beta != 0`, `_generate_and_score_completions` now zeroes `completion_mask` for the local slice of zero-std groups, ensuring both the policy loss and the `beta * KL` term are simultaneously gated off for those completions (issue `#5588`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92de8f84363768aedf04eea79fbf004944ee4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->