### PR TITLE
fix(grpo): skip gradient updates for zero-std reward groups

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2254,6 +2254,16 @@ class GRPOTrainer(_BaseTrainer):
                 nanmax(self.accelerator.gather(max_importance_sampling_ratio)).item()
             )
 
+        # When all completions in a reward group receive identical rewards, advantages
+        # are zero and the policy loss contributes no gradient. However, the per-token
+        # KL penalty (beta * per_token_kl in compute_loss) still fires because
+        # per_token_logps retains gradients while ref_per_token_logps is detached.
+        # Zeroing completion_mask for zero-std groups suppresses both the policy loss
+        # and the spurious KL gradient simultaneously. See issue #5588.
+        if self.beta != 0.0:
+            is_std_zero_local = is_std_zero[process_slice]  # shape: (local_completions,)
+            completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
+
         output = {
             "prompt_ids": prompt_ids,
             "prompt_mask": prompt_mask,


### PR DESCRIPTION
Fixes #5588.

When all completions in a group get the same reward, `advantages` are zero and the policy loss drops out — that part is correct. But if `beta > 0`, the KL term (`beta * per_token_kl`) still runs: `per_token_logps` retains gradients while `ref_per_token_logps` is detached. So you end up with real weight updates driven entirely by KL with no reward signal behind them.

The fix is to zero `completion_mask` for zero-std groups before the output dict is assembled:

```python
if self.beta != 0.0:
    is_std_zero_local = is_std_zero[process_slice]
    completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
```

Both the policy loss and KL penalty are gated by `completion_mask` in `compute_loss`, so this suppresses both at once. `is_std_zero` has shape `(total_completions,)` in both the `sum_then_normalize` and `normalize_then_sum` paths, so `[process_slice]` correctly picks the local rank's slice.

RLOO isn't affected — it computes KL from fully-detached log-probs, so no gradients flow through zero-std groups there.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training masking behavior for specific reward-group edge cases; incorrect masking could unintentionally drop learning signal or alter KL regularization dynamics when `beta != 0`.
> 
> **Overview**
> Prevents GRPO from updating weights on groups where all completions receive identical rewards by **zeroing `completion_mask` for zero-reward-std groups** when `beta != 0.0`.
> 
> This gates both the policy loss and the per-token KL penalty (which otherwise can backprop on its own) to avoid KL-only gradients in the zero-advantage case (issue `#5588`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92275c687d59164cbb842fbac1408fb7de835be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->