### PR TITLE
Align KTO with DPO: Support dict eval_dataset

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -265,7 +265,7 @@ class KTOTrainer(_BaseTrainer):
             Configuration for this trainer. If `None`, a default configuration is used.
         train_dataset ([`~datasets.Dataset`]):
             The dataset to use for training.
-        eval_dataset ([`~datasets.Dataset`]):
+        eval_dataset ([`~datasets.Dataset`] or `dict[str, Dataset]`):
             The dataset to use for evaluation.
         processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`], *optional*):
             Processing class used to process the data. The padding side must be set to "left". If `None`, the
@@ -501,7 +501,13 @@ class KTOTrainer(_BaseTrainer):
         # Dataset
         train_dataset = self._prepare_dataset(train_dataset, processing_class, args, "train")
         if eval_dataset is not None:
-            eval_dataset = self._prepare_dataset(eval_dataset, processing_class, args, "eval")
+            if isinstance(eval_dataset, dict):
+                eval_dataset = {
+                    key: self._prepare_dataset(dataset, processing_class, args, key)
+                    for key, dataset in eval_dataset.items()
+                }
+            else:
+                eval_dataset = self._prepare_dataset(eval_dataset, processing_class, args, "eval")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream


### PR DESCRIPTION
Align KTO with DPO: Support dict `eval_dataset`.

This PR enhances the flexibility of the `KTOTrainer` class by allowing the `eval_dataset` parameter to accept either a single dataset or a dictionary of datasets. This change is reflected in both the documentation and the dataset preparation logic.

Part of:
- #4786

### Changes

**Support for multiple evaluation datasets:**

* Updated the docstring for the `KTOTrainer` class to indicate that `eval_dataset` can now be either a single `Dataset` or a `dict[str, Dataset]`, making the expected input more flexible and clear.
* Modified the dataset preparation logic so that if `eval_dataset` is a dictionary, each dataset in the dictionary is prepared individually; otherwise, the single dataset is prepared as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to evaluation dataset preparation; training flow is unchanged, with main risk limited to unexpected eval split naming/processing differences.
> 
> **Overview**
> Adds support in `KTOTrainer` for passing `eval_dataset` as a `dict[str, Dataset]` (in addition to a single `Dataset`), matching other trainers’ behavior.
> 
> Updates the init-time dataset preparation so each named eval split is processed via `_prepare_dataset` using its dict key (instead of a single hardcoded `"eval"`), and adjusts the docstring/type hints accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1299bf240c9569a5f51265bb7cfc1d6a73b96572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->