### PR TITLE
Align KTO with DPO: Align tokenization

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -15,11 +15,11 @@
 import multiprocess
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
-from trl.experimental.kto.kto_trainer import _get_kl_dataset, _process_tokens, _tokenize
+from trl.experimental.kto.kto_trainer import _get_kl_dataset, _process_tokens
 
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
 
@@ -117,60 +117,67 @@ class TestKTOTrainer(TrlTestCase):
         )
 
         dummy_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference")
+        train_dataset = dummy_dataset["train"]
 
         trainer = KTOTrainer(
             model=self.model,
             ref_model=self.ref_model,
             args=training_args,
             processing_class=self.tokenizer,
-            train_dataset=dummy_dataset["train"],
+            train_dataset=train_dataset,
             eval_dataset=dummy_dataset["test"],
         )
 
-        train_dataset = dummy_dataset["train"]
-        tokenized_dataset = train_dataset.map(
-            _tokenize,
-            fn_kwargs={"tokenizer": trainer.processing_class},
-            batched=True,
-            batch_size=2,
+        # Verify the tokenization step via trainer.train_dataset (aligned with DPO test style).
+        # prompt_input_ids must start with the tokenized prompt text.
+        prompt_ids = self.tokenizer(train_dataset["prompt"][0])["input_ids"]
+        assert trainer.train_dataset[0]["prompt_input_ids"][: len(prompt_ids)] == prompt_ids
+        assert all(m == 1 for m in trainer.train_dataset[0]["prompt_attention_mask"])
+        # completion_input_ids = (BOS +) prompt + answer + EOS
+        assert trainer.train_dataset[0]["completion_input_ids"][-1] == self.tokenizer.eos_token_id
+        # completion_labels: -100 for the prompt part, actual token IDs for the answer+EOS part
+        n_prompt = len(trainer.train_dataset[0]["prompt_input_ids"])
+        assert trainer.train_dataset[0]["completion_labels"][:n_prompt] == [-100] * n_prompt
+        assert (
+            trainer.train_dataset[0]["completion_labels"][n_prompt:]
+            == trainer.train_dataset[0]["completion_input_ids"][n_prompt:]
         )
-        assert tokenized_dataset["prompt"][:] == train_dataset["prompt"][:]
-        assert tokenized_dataset["completion"][:] == train_dataset["completion"][:]
-        assert tokenized_dataset["label"][:] == train_dataset["label"][:]
-        assert tokenized_dataset["prompt_input_ids"][0] == [46518, 374, 2664, 1091]
-        assert tokenized_dataset["prompt_attention_mask"][0] == [1, 1, 1, 1]
-        assert tokenized_dataset["answer_input_ids"][0] == [27261, 13]
-        assert tokenized_dataset["answer_attention_mask"][0] == [1, 1]
 
-        # Test corruption of (prompt, completion) pairs for KL dataset
+        # Test corruption of (prompt, completion) pairs for KL dataset.
+        # _get_kl_dataset shifts answer_input_ids by one within each batch; prompt_input_ids are unchanged.
         for batch_size in [2, 3]:
-            tokenized_kl_dataset = tokenized_dataset.map(_get_kl_dataset, batched=True, batch_size=batch_size)
+            kl_dataset = trainer.train_dataset.map(_get_kl_dataset, batched=True, batch_size=batch_size)
 
             # Verify that the "answer_input_ids" have been modified, meaning the new "answer_input_ids" differ
             # from the original ones. However, when the length of the dataset modulo batch_size equals 1,
             # the last batch remains unaltered. This is a rare scenario that does not impact the training
             # process, so we exclude it from testing by iterating only up to len - 1.
-            for i in range(len(tokenized_kl_dataset["answer_input_ids"]) - 1):
-                assert tokenized_dataset["prompt_input_ids"][i] == tokenized_kl_dataset["prompt_input_ids"][i]
-                assert (
-                    tokenized_dataset["prompt_attention_mask"][i] == tokenized_kl_dataset["prompt_attention_mask"][i]
-                )
-                assert tokenized_dataset["answer_input_ids"][i] != tokenized_kl_dataset["answer_input_ids"][i]
+            for i in range(len(kl_dataset["answer_input_ids"]) - 1):
+                assert trainer.train_dataset["prompt_input_ids"][i] == kl_dataset["prompt_input_ids"][i]
+                assert trainer.train_dataset["prompt_attention_mask"][i] == kl_dataset["prompt_attention_mask"][i]
+                assert trainer.train_dataset["answer_input_ids"][i] != kl_dataset["answer_input_ids"][i]
 
-        fn_kwargs = {
-            "prefix": "",
-            "tokenizer": trainer.processing_class,
-            "max_length": trainer.max_length,
+        # Test _process_tokens directly with a synthetic tokenized dataset (exercises num_proc and prefix).
+        raw = {
+            "prompt_input_ids": [[100, 200, 300], [400, 500]],
+            "prompt_attention_mask": [[1, 1, 1], [1, 1]],
+            "answer_input_ids": [[600, 700], [800, 900, 1000]],
+            "answer_attention_mask": [[1, 1], [1, 1, 1]],
+            "label": [True, False],
         }
-        processed_dataset = tokenized_dataset.map(_process_tokens, fn_kwargs=fn_kwargs, num_proc=2)
-        assert processed_dataset["prompt"][:] == train_dataset["prompt"][:]
-        assert processed_dataset["completion"][:] == train_dataset["completion"][:]
-        assert processed_dataset["label"][:] == train_dataset["label"][:]
-        assert processed_dataset["prompt_input_ids"][0] == [46518, 374, 2664, 1091]
-        assert processed_dataset["prompt_attention_mask"][0] == [1, 1, 1, 1]
-        assert processed_dataset["completion_input_ids"][0] == [46518, 374, 2664, 1091, 27261, 13, 151645]
-        assert processed_dataset["completion_attention_mask"][0] == [1, 1, 1, 1, 1, 1, 1]
-        assert processed_dataset["completion_labels"][0] == [-100, -100, -100, -100, 27261, 13, 151645]
+        fn_kwargs = {"prefix": "", "tokenizer": self.tokenizer, "max_length": trainer.max_length}
+        processed_dataset = Dataset.from_dict(raw).map(_process_tokens, fn_kwargs=fn_kwargs, num_proc=2)
+        for i in range(len(processed_dataset)):
+            assert processed_dataset[i]["label"] == raw["label"][i]
+            # completion_input_ids ends with EOS
+            assert processed_dataset[i]["completion_input_ids"][-1] == self.tokenizer.eos_token_id
+            # completion_labels: -100 for prompt, answer+EOS token IDs for the rest
+            n_prompt = len(processed_dataset[i]["prompt_input_ids"])
+            assert processed_dataset[i]["completion_labels"][:n_prompt] == [-100] * n_prompt
+            assert (
+                processed_dataset[i]["completion_labels"][n_prompt:]
+                == processed_dataset[i]["completion_input_ids"][n_prompt:]
+            )
 
     def test_kto_trainer_without_providing_ref_model(self):
         training_args = KTOConfig(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -97,25 +97,7 @@ def _process_tokens(example: dict[str, Any], model: "PreTrainedModel" = None, **
     We also create the labels for the completion responses, which are of length equal to the sum of the length of the
     prompt and the completion response, with `-100` for the prompt tokens.
     """
-    prompt = example["prompt"]
-    completion = example["completion"]
-
-    batch = {
-        f"{kwargs['prefix']}prompt": prompt,
-        f"{kwargs['prefix']}completion": completion,
-        f"{kwargs['prefix']}label": example["label"],
-    }
-
-    # Check issues below for more details
-    #  1. https://github.com/huggingface/trl/issues/907
-    #  2. https://github.com/EleutherAI/lm-evaluation-harness/pull/531#issuecomment-1595586257
-    #  3. https://github.com/LianjiaTech/BELLE/issues/337
-
-    if not isinstance(prompt, str):
-        raise ValueError(f"prompt should be an str but got {type(prompt)}")
-
-    if not isinstance(completion, str):
-        raise ValueError(f"completion should be an str but got {type(completion)}")
+    batch = {f"{kwargs['prefix']}label": example["label"]}
 
     # keys of format prompt_* refers to just the prompt and answer_* refers to just the answer
     all_tokens = {

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -44,6 +44,7 @@ from transformers.utils import is_peft_available
 
 from ...data_utils import (
     extract_prompt,
+    is_conversational,
     maybe_apply_chat_template,
     unpair_preference_dataset,
 )
@@ -670,14 +671,39 @@ class KTOTrainer(_BaseTrainer):
             )
 
             tokenizer = getattr(processing_class, "tokenizer", processing_class)
+
             # Tokenize dataset
-            dataset = dataset.map(
-                _tokenize,
-                batched=True,
-                fn_kwargs={"tokenizer": tokenizer},
-                num_proc=args.dataset_num_proc,
-                desc=f"Tokenizing {dataset_name} dataset",
-            )
+            def tokenize_fn(example, processing_class):
+                if is_conversational(example):
+                    prompt_ids = self._tokenize(processing_class, example["prompt"], add_generation_prompt=True)[
+                        "input_ids"
+                    ]
+                    prompt_completion_ids = self._tokenize(
+                        processing_class, example["prompt"] + example["completion"]
+                    )["input_ids"]
+                else:
+                    prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_completion_ids = self._tokenize(
+                        processing_class, example["prompt"] + example["completion"]
+                    )["input_ids"]
+
+                if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
+                    logger.warning(
+                        "Mismatch between tokenized prompt and the start of tokenized prompt+completion. "
+                        "This may be due to unexpected tokenizer behavior, whitespace issues, or special "
+                        "token handling. Verify that the tokenizer is processing text consistently."
+                    )
+
+                return {
+                    "prompt_input_ids": prompt_ids,
+                    "prompt_attention_mask": [1] * len(prompt_ids),
+                    "answer_input_ids": prompt_completion_ids[len(prompt_ids) :],
+                    "answer_attention_mask": [1] * (len(prompt_completion_ids) - len(prompt_ids)),
+                }
+
+            map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
+            dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)
+
             # Process dataset
             dataset = dataset.map(
                 _process_tokens,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -70,7 +69,7 @@ if is_peft_available():
 
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedModel, PreTrainedTokenizer
+    from transformers import PreTrainedModel
 
 
 logger = logging.get_logger(__name__)
@@ -87,66 +86,6 @@ def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
     batch["answer_input_ids"] = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
     batch["answer_attention_mask"] = [batch["answer_attention_mask"][-1]] + batch["answer_attention_mask"][:-1]
     return batch
-
-
-def _tokenize(
-    batch: dict[str, list[Any]],
-    tokenizer: "PreTrainedTokenizer",
-) -> dict[str, list[Any]]:
-    """Tokenize a batch from a KTO specific dataset."""
-    prompt_tokenized = tokenizer(batch["prompt"], add_special_tokens=False)
-    prompt_input_ids = prompt_tokenized["input_ids"]
-    prompt_attention_mask = prompt_tokenized["attention_mask"]
-    prompt_and_completion = [
-        prompt + completion for prompt, completion in zip(batch["prompt"], batch["completion"], strict=True)
-    ]
-    full_tokenized = tokenizer(prompt_and_completion, add_special_tokens=False)
-    full_input_ids = full_tokenized["input_ids"]
-    full_attention_mask = full_tokenized["attention_mask"]
-
-    answer_input_ids = [f[len(p) :] for f, p in zip(full_input_ids, prompt_input_ids, strict=True)]
-    answer_attention_mask = [f[len(p) :] for f, p in zip(full_attention_mask, prompt_attention_mask, strict=True)]
-
-    # Concat tokens to form `enc(a) + enc(a + b)[len(enc(a)):]`
-    full_concat_input_ids = [np.concatenate([p, a]) for p, a in zip(prompt_input_ids, answer_input_ids, strict=True)]
-    # Prepare input tokens for token by token comparison
-    full_input_ids = [np.array(f) for f in full_input_ids]
-    for full, concat in zip(full_input_ids, full_concat_input_ids, strict=True):
-        if len(full) != len(concat):
-            raise ValueError(
-                "The elements in 'full_input_ids' and 'full_concat_input_ids' must have the same pairwise length."
-            )
-
-    # On some tokenizers, like Llama-2 tokenizer, there are occasions where tokens
-    # can be merged together when tokenizing prompt+answer. This could result
-    # on the last token from the prompt being different when tokenized on its own
-    # vs when done as prompt+answer.
-    response_token_ids_start_idx = [len(p) for p in prompt_input_ids]
-
-    # If tokenized prompt is different than both prompt+answer, then it means the
-    # last token has changed due to merging.
-    for idx, (p, f, r) in enumerate(zip(prompt_input_ids, full_input_ids, response_token_ids_start_idx, strict=True)):
-        if not np.array_equal(p, f[:r]):
-            response_token_ids_start_idx[idx] -= 1
-
-    prompt_input_ids = [f[:r] for f, r in zip(full_input_ids, response_token_ids_start_idx, strict=True)]
-    prompt_attention_mask = [f[:r] for f, r in zip(full_attention_mask, response_token_ids_start_idx, strict=True)]
-
-    for p, m in zip(prompt_input_ids, prompt_attention_mask, strict=True):
-        if len(p) != len(m):
-            raise ValueError("Prompt input ids and attention mask should have the same length.")
-
-    answer_input_ids = [f[r:] for f, r in zip(full_input_ids, response_token_ids_start_idx, strict=True)]
-    answer_attention_mask = [f[r:] for f, r in zip(full_attention_mask, response_token_ids_start_idx, strict=True)]
-
-    output = dict(
-        prompt_input_ids=prompt_input_ids,
-        prompt_attention_mask=prompt_attention_mask,
-        answer_input_ids=answer_input_ids,
-        answer_attention_mask=answer_attention_mask,
-    )
-
-    return output
 
 
 def _process_tokens(example: dict[str, Any], model: "PreTrainedModel" = None, **kwargs) -> dict:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -608,6 +608,34 @@ class KTOTrainer(_BaseTrainer):
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
+    def _tokenize(
+        self,
+        processing_class: PreTrainedTokenizerBase | ProcessorMixin,
+        input: str | list,
+        **kwargs,
+    ) -> dict[str, list]:
+        """Tokenize a single example for dataset preprocessing.
+
+        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+        non-conversational input (str).
+
+        Args:
+            processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+                The tokenizer or processor to use.
+            input (`str` or `list`):
+                A string for non-conversational input, or a list of message dicts for conversational input.
+            **kwargs:
+                Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
+
+        Returns:
+            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+        """
+        if isinstance(input, list):  # conversational: list of message dicts
+            result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
+        else:  # non-conversational: plain text string
+            result = processing_class(text=input)
+        return result
+
     def _prepare_dataset(
         self,
         dataset: Dataset,


### PR DESCRIPTION
Align KTO with DPO: Align tokenization.

This PR refactors the tokenization logic in `KTOTrainer` to improve clarity, modularity, and support for conversational data. The main changes include removing the old `_tokenize` function, introducing a new instance method `_tokenize` that handles both conversational and non-conversational inputs, and updating dataset preparation to use this new logic. Additionally, the pull request simplifies and clarifies the token processing pipeline.

Part of:
- #4786

### Changes

**Tokenization Refactor and Conversational Data Support:**

* Removed the original `_tokenize` function, which was previously responsible for tokenizing batches, and replaced it with a new instance method `_tokenize` that can handle both plain text and conversational (chat) inputs, improving modularity and clarity. 
* Updated dataset preparation in `_prepare_dataset` to use the new `_tokenize` method and added support for conversational data via the `is_conversational` utility, ensuring correct tokenization for both chat and non-chat datasets. 

**Code Cleanup and Simplification:**

* Removed unused imports such as `numpy` and the type import for `PreTrainedTokenizer`, streamlining dependencies.
* Simplified the `_process_tokens` function by removing redundant checks and batch construction, focusing it on label processing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how training/eval datasets are tokenized (including chat-style inputs), which can subtly affect prompt/answer boundaries and thus loss computation; tests were updated to cover the new behavior but tokenizer edge cases may still surface.
> 
> **Overview**
> Refactors `KTOTrainer` dataset preprocessing to use a new instance `_tokenize` method and a per-example `tokenize_fn`, adding explicit handling for conversational inputs via `is_conversational`/`apply_chat_template` and emitting a warning when prompt vs prompt+completion tokenization mismatches.
> 
> Removes the old batch `_tokenize` implementation (and its `numpy` dependency) and simplifies `_process_tokens` to operate purely on pre-tokenized fields while preserving the `label`.
> 
> Updates `test_tokenize_and_process_tokens` to validate tokenization through `trainer.train_dataset` (rather than calling `_tokenize` directly), adds KL corruption checks against the prepared dataset, and adds a synthetic `Dataset.from_dict` case to exercise `_process_tokens` with `num_proc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8780ca17ae373478ca3368fb05da076b6175f656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->