### PR TITLE
Added speculative_config to vllm-serve

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -318,11 +318,20 @@ class ScriptArguments:
             "GPUs. If not set, vLLM defaults to the multiproc backend (single-node only)."
         },
     )
+    speculative_config: str | None = field(
+        default=None,
+        metadata={
+            "help": "JSON string for vLLM speculative decoding config. "
+            'Example: \'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}\''
+        },
+    )
 
 
 def llm_worker(
     script_args: ScriptArguments, data_parallel_rank: int, master_port: int, connection: Connection
 ) -> None:
+    import json as _json
+
     from vllm import LLM
 
     # Set required environment variables for DP to work with vLLM
@@ -330,6 +339,11 @@ def llm_worker(
     os.environ["VLLM_DP_RANK_LOCAL"] = str(data_parallel_rank)
     os.environ["VLLM_DP_SIZE"] = str(script_args.data_parallel_size)
     os.environ["VLLM_DP_MASTER_PORT"] = str(master_port)
+
+    # Parse optional speculative decoding config
+    _spec_kwargs = {}
+    if script_args.speculative_config:
+        _spec_kwargs["speculative_config"] = _json.loads(script_args.speculative_config)
 
     llm = LLM(
         model=script_args.model,
@@ -350,6 +364,7 @@ def llm_worker(
         distributed_executor_backend=script_args.distributed_executor_backend,
         # Important so temperature scaling/logit tweaking affects the TIS log probs
         logprobs_mode="processed_logprobs",
+        **_spec_kwargs,
     )
 
     # Send ready signal to parent process


### PR DESCRIPTION
# What does this PR do?                                                                                                                                                                                                              
                                                                                                                                                                                                                                       
  Adds a `--speculative_config` CLI argument to `trl vllm-serve`, exposing vLLM's speculative decoding config as a JSON string. This enables drafts like Qwen3 native MTP heads or Eagle3 drafts during GRPO/RLOO generation without     
  forking the serve script.                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  ### Usage                                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  ```bash
  # Qwen3.5 native MTP (no extra draft model needed)
  trl vllm-serve --model Qwen/Qwen3.5-9B \                                                                                                                                                                                               
      --speculative_config '{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'
                                                                                                                                                                                                                                         
  # Eagle3 draft model
  trl vllm-serve --model Qwen/Qwen3-32B \                                                                                                                                                                                                
      --speculative_config '{"model": "RedHatAI/Qwen3-32B-speculator.eagle3", "method": "eagle3", "num_speculative_tokens": 3, "draft_tensor_parallel_size": 1}'
   ```                                                                                                                                                                                                                            
  ### Changes
                                                                                                                                                                                                                                         
  1. New speculative_config: str | None field on ScriptArguments.
  2. llm_worker() parses the JSON string and forwards it to LLM(speculative_config=...) when set (no-op when unset — fully backwards compatible).
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
    
 ### Who can review?                                                                                                                                                                                                                        
                  
  Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.                                                                                   
 
                                                                                                                                                                                                                                         

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes vLLM engine initialization by optionally injecting user-provided JSON, which can alter generation behavior or raise runtime errors if misconfigured/invalid JSON.
> 
> **Overview**
> Adds a new `--speculative_config` argument to `trl vllm-serve` that accepts a JSON string for vLLM speculative decoding.
> 
> When provided, the worker parses the JSON and forwards it to `vllm.LLM(..., speculative_config=...)`; when unset, startup behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c7305cbdfb52b36641de207252cf12b3924081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->