### PR TITLE
Replace wrong comment about chat template with EOS

### DIFF
--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -1407,7 +1407,7 @@ class GOLDTrainer(SFTTrainer):
                 **map_kwargs,
             )
 
-            # Apply the chat template if needed and preserve original text
+            # Add EOS token if needed: non-conversational only
             first_example = next(iter(dataset))
             if not is_conversational(first_example):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -880,7 +880,7 @@ class DPOTrainer(_BaseTrainer):
                     map_kwargs["desc"] = f"Extracting prompt from {dataset_name} dataset"
                 dataset = dataset.map(extract_prompt, **map_kwargs)
 
-            # Apply the chat template if needed
+            # Add EOS token if needed: non-conversational only
             first_example = next(iter(dataset))
             if not is_conversational(first_example):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -559,7 +559,7 @@ class RewardTrainer(_BaseTrainer):
 
         with PartialState().main_process_first():
             if not is_processed:
-                # Add EOS token to the end of the sequences if needed
+                # Add EOS token if needed: non-conversational only
                 first_example = next(iter(dataset))
                 if not is_conversational(first_example):
                     if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1102,7 +1102,7 @@ class SFTTrainer(_BaseTrainer):
                         **map_kwargs,
                     )
 
-                # Apply the chat template if needed
+                # Add EOS token if needed: non-conversational only
                 first_example = next(iter(dataset))
                 if not is_conversational(first_example):
                     if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`


### PR DESCRIPTION
Replace wrong comment about applying chat template with EOS addition.

This PR updates comments in several trainer modules to clarify that the EOS (end-of-sequence) token is added only for non-conversational datasets, rather than applying a chat template. No functional code changes are introduced.

- Documentation clarification:
  * Updated comments in `trl/experimental/gold/gold_trainer.py`, `trl/trainer/dpo_trainer.py`, and `trl/trainer/sft_trainer.py` to specify that the EOS token is added only for non-conversational datasets, improving code readability and intent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in trainer dataset preprocessing; no runtime or data-handling behavior is modified.
> 
> **Overview**
> Clarifies dataset preprocessing comments across `gold_trainer`, `sft_trainer`, `dpo_trainer`, and `reward_trainer` to state that an EOS token is appended *only for non-conversational datasets*, replacing misleading references to “applying the chat template.”
> 
> No functional behavior changes; this is a documentation/readability-only update around the existing EOS-appending `map()` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc973953af2b57e1386fad5ee0b1732414ec8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->