### PR TITLE
[codex] Add Qwen2.5-family parse coverage

### DIFF
--- a/docs/source/chat_template_utils.md
+++ b/docs/source/chat_template_utils.md
@@ -6,6 +6,14 @@ For an overview of the chat templates bundled with TRL and the rationale behind 
 
 [[autodoc]] clone_chat_template
 
+## add_response_schema
+
+[[autodoc]] add_response_schema
+
+## supports_tool_calling
+
+[[autodoc]] supports_tool_calling
+
 ## is_chat_template_prefix_preserving
 
 [[autodoc]] chat_template_utils.is_chat_template_prefix_preserving

--- a/docs/source/chat_template_utils.md
+++ b/docs/source/chat_template_utils.md
@@ -8,11 +8,15 @@ For an overview of the chat templates bundled with TRL and the rationale behind 
 
 ## add_response_schema
 
-[[autodoc]] add_response_schema
+[[autodoc]] chat_template_utils.add_response_schema
 
 ## supports_tool_calling
 
-[[autodoc]] supports_tool_calling
+[[autodoc]] chat_template_utils.supports_tool_calling
+
+## parse_response
+
+[[autodoc]] chat_template_utils.parse_response
 
 ## is_chat_template_prefix_preserving
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -127,6 +127,7 @@ class TestAddResponseSchema:
             pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
+            pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
             pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         ],
     )
@@ -150,6 +151,8 @@ class TestAddResponseSchema:
     @pytest.mark.parametrize(
         "processor_name",
         [
+            pytest.param("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", id="qwen2_vl"),
+            pytest.param("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", id="qwen2.5_vl"),
             pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
             pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration", id="qwen35"),
         ],
@@ -202,6 +205,8 @@ class TestSupportsToolCalling:
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
             pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
+            pytest.param("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", id="qwen2_vl"),
+            pytest.param("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", id="qwen2.5_vl"),
             pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM", id="qwen3"),
             pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3moe"),
             pytest.param(
@@ -699,6 +704,9 @@ class TestParseResponse:
             "trl-internal-testing/tiny-GptOssForCausalLM",
             "trl-internal-testing/tiny-LlamaForCausalLM-3.1",
             "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
+            "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration",
         ):
             pytest.skip("This tokenizer doesn't support inline reasoning_content.")

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -205,8 +205,6 @@ class TestSupportsToolCalling:
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
             pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
-            pytest.param("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", id="qwen2_vl"),
-            pytest.param("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", id="qwen2.5_vl"),
             pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM", id="qwen3"),
             pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3moe"),
             pytest.param(
@@ -644,6 +642,9 @@ class TestGetTrainingChatTemplate:
         pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
+        pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
+        pytest.param("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", id="qwen2_vl"),
+        pytest.param("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", id="qwen2.5_vl"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
         pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration", id="qwen35"),

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -331,6 +331,19 @@ qwen3_5_chat_template_4b_and_above = (_CHAT_TEMPLATES_DIR / "qwen3_5_4b_and_abov
 
 ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizer, ProcessorMixin)
 
+_qwen_xml_tool_template_markers = (
+    "You may call one or more functions to assist with the user query.",
+    "For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:",
+    '<tool_call>\n{"name": "',
+    '"arguments": ',
+    "<tool_response>",
+)
+
+def _has_qwen_xml_tool_markers(chat_template: str | None) -> bool:
+    """Return whether the template contains the Qwen XML tool-calling markers."""
+    if chat_template is None:
+        return False
+    return all(marker in chat_template for marker in _qwen_xml_tool_template_markers)
 
 def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
     r"""
@@ -378,7 +391,9 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
         tokenizer.response_schema = gptoss_schema
     elif chat_template in [llama3_1_chat_template, llama3_2_chat_template]:
         tokenizer.response_schema = llama3_schema
-    elif chat_template in [qwen3_chat_template, qwen3_vl_chat_template]:
+    elif chat_template in [qwen2_5_chat_template, qwen3_chat_template, qwen3_vl_chat_template]:
+        tokenizer.response_schema = qwen3_schema
+    elif _has_qwen_xml_tool_markers(chat_template):
         tokenizer.response_schema = qwen3_schema
     elif chat_template in [qwen3_5_chat_template_2b_and_below, qwen3_5_chat_template_4b_and_above]:
         tokenizer.response_schema = qwen3_5_schema

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -339,11 +339,13 @@ _qwen_xml_tool_template_markers = (
     "<tool_response>",
 )
 
+
 def _has_qwen_xml_tool_markers(chat_template: str | None) -> bool:
     """Return whether the template contains the Qwen XML tool-calling markers."""
     if chat_template is None:
         return False
     return all(marker in chat_template for marker in _qwen_xml_tool_template_markers)
+
 
 def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
     r"""
@@ -391,12 +393,14 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
         tokenizer.response_schema = gptoss_schema
     elif chat_template in [llama3_1_chat_template, llama3_2_chat_template]:
         tokenizer.response_schema = llama3_schema
-    elif chat_template in [qwen2_5_chat_template, qwen3_chat_template, qwen3_vl_chat_template]:
+    elif chat_template == qwen2_5_chat_template:
         tokenizer.response_schema = qwen3_schema
-    elif _has_qwen_xml_tool_markers(chat_template):
+    elif chat_template in [qwen3_chat_template, qwen3_vl_chat_template]:
         tokenizer.response_schema = qwen3_schema
     elif chat_template in [qwen3_5_chat_template_2b_and_below, qwen3_5_chat_template_4b_and_above]:
         tokenizer.response_schema = qwen3_5_schema
+    elif _has_qwen_xml_tool_markers(chat_template):
+        tokenizer.response_schema = qwen3_schema
     else:
         raise ValueError(
             "Unrecognized chat template, failed to add response schema. Please manually set the response schema on "


### PR DESCRIPTION
## Summary
- add real `TestParseResponse` coverage for the Qwen2.5 family
- keep `add_response_schema()` on exact-template dispatch before the XML-marker fallback
- document the new helpers with module-qualified autodoc entries and add `parse_response`

## Validation
- `uv run --extra test --extra vlm --with jmespath python -m pytest tests/test_chat_template_utils.py -k "AddResponseSchema or ParseResponse"`
- `uv run --extra test --extra vlm --with jmespath python -m pytest tests/test_chat_template_utils.py -k "SupportsToolCalling"`
- `uv run --extra quality pre-commit run --all-files`
- `uv run --extra quality doc-builder style trl tests docs/source --max_len 119`
- `git diff --check`

## Notes
- `make precommit` is currently blocked in this worktree because `scripts/add_copyrights.py` exits non-zero when tracked Python files are already deleted locally.