### PR TITLE
Align SFT entropy metric with the loss token set

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1287,21 +1287,28 @@ class SFTTrainer(_BaseTrainer):
         # Compute entropy
         if not self.args.use_liger_kernel:  # liger doesn't return logits
             with torch.no_grad():
-                per_token_entropy = entropy_from_logits(outputs.logits)
-                # When using Prompt Tuning, skip the virtual tokens in logits before entropy computation, since they
-                # do not correspond to actual input tokens.
+                if "shift_labels" in inputs:
+                    # When using CP or SP, labels are pre-shifted.
+                    shift_logits = outputs.logits.contiguous()
+                    shift_labels = inputs["shift_labels"]
+                else:
+                    shift_logits = outputs.logits[..., :-1, :].contiguous()
+                    shift_labels = labels[..., 1:].contiguous()
+
+                # Prompt Tuning and P-Tuning output logits for virtual tokens but Prefix-Tuning does not.
                 if (
                     self.num_virtual_tokens > 0
                     and model.peft_config[model.active_adapter].peft_type != PeftType.PREFIX_TUNING
                 ):
-                    per_token_entropy = per_token_entropy[:, self.num_virtual_tokens :]
-                if "attention_mask" in inputs:
-                    attention_mask = inputs["attention_mask"]
-                    entropy = torch.sum(per_token_entropy * attention_mask) / attention_mask.sum()
-                elif "position_ids" in inputs:
-                    entropy = torch.mean(per_token_entropy)
+                    shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
+
+                per_token_entropy = entropy_from_logits(shift_logits)
+                mask = shift_labels != -100
+                total = mask.sum()
+                if total > 0:
+                    entropy = (per_token_entropy * mask).sum() / total
                 else:
-                    raise ValueError("Expected 'attention_mask' or 'position_ids' in inputs.")
+                    entropy = per_token_entropy.new_zeros(())
                 entropy = self.accelerator.gather_for_metrics(entropy).mean().item()
             self._metrics[mode]["entropy"].append(entropy)
 


### PR DESCRIPTION
Before this PR, the default entropy metric was averaged over all non-padding tokens (weighted by `attention_mask`), while the loss is computed only over non-ignored label tokens. The two sets diverge in several common setups:

- `completion_only_loss=True`: prompt tokens are ignored by the loss (labels = -100) but were still averaged into entropy.
- `assistant_only_loss=True`: same story for non-assistant turns.
- Packing: inter-sample boundaries are ignored by the loss but were included in the entropy average.

As a result, runs with and without these features produced entropy values that were not directly comparable: the metric was measuring the model's uncertainty on a different set of tokens than the loss objective. After this PR, the entropy metric always reflects the same tokens that drive the loss, so changes in entropy track changes in what the trainer is actually optimizing.

Beyond comparability, this is also simply the more correct behavior and likely closer to what users expect: when someone looks at the `entropy` metric of an SFT run, they expect a measure of the model's uncertainty on the tokens it is being trained to predict (not a diluted average that includes prompt tokens, masked turns,... the model is not being optimized on).

This PR allowed to properly benchmark the changes in #5575 where the entropy cannot (and shouldn't) be computed over the full sequence, because we don't compute the logits for these masked tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes how the `entropy` metric is computed/logged, not the loss or model updates; main risk is potential shape/masking edge cases in setups using `shift_labels` and virtual tokens.
> 
> **Overview**
> Updates `SFTTrainer.compute_loss` to compute the logged `entropy` metric over the **same token set as the loss** by deriving `shift_logits`/`shift_labels` and averaging entropy only where labels are not `-100` (instead of using `attention_mask`/`position_ids`). It also handles pre-shifted label setups via `inputs["shift_labels"]` and keeps Prompt/P-tuning virtual-token trimming consistent with the shifted logits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be048059152376a0f3c46f681a6bfe0ff35c4c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->