### PR TITLE
Fix generate_tiny_models for gpt-oss

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -212,8 +212,10 @@ for model_id, config_class, model_class, dtype, suffix in [
     kwargs = {}
     if model_id == "zai-org/GLM-4.5":
         kwargs["n_routed_experts"] = 4
-    elif model_id in ("Qwen/Qwen3-30B-A3B", "openai/gpt-oss-20b"):
+    elif model_id == "Qwen/Qwen3-30B-A3B":
         kwargs["num_experts"] = 4
+    elif model_id == "openai/gpt-oss-20b":
+        kwargs["num_local_experts"] = 4
 
     config = config_class(
         vocab_size=len(tokenizer.vocab),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ import torch
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-GptOssForCausalLM": "refs/pr/2",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,6 @@ import torch
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-GptOssForCausalLM": "refs/pr/2",
 }
 
 


### PR DESCRIPTION
Fix generate_tiny_models for gpt-oss.

This PR updates the initialization logic for tiny model weights in `generate_tiny_models.py`, specifically refining how expert-related configuration parameters are set for different model IDs.

Fix #5621.

Fixing PR for "trl-internal-testing/tiny-GptOssForCausalLM":
- [x] https://huggingface.co/trl-internal-testing/tiny-GptOssForCausalLM/discussions/2
  - See Files changed: https://huggingface.co/trl-internal-testing/tiny-GptOssForCausalLM/discussions/2/files

Fix issue introduced by:
- #3848

### Motivation

When GptOss was added to generate_tiny_models in #3848, it was added to an existing loop that already used `num_experts=4` for Qwen3MoeConfig. For Qwen3Moe, `num_experts` is the declared field name. GptOss was included in the same loop body without noticing that GptOss uses a different field name (`num_local_experts`). It was a copy-paste oversight.

From the very first commit adding GptOssConfig (huggingface/transformers#39923), the declared field was always `num_local_experts: int = 128`. There was never a `num_experts` field.

When the generate script passed `num_experts=4`, it was silently stored as an unknown extra kwarg with zero effect on model construction: `config.num_local_experts` stayed at 128, so the checkpoint was saved with 128 experts.

### Changes

Model configuration improvements:

* Split the handling of `"Qwen/Qwen3-30B-A3B"` and `"openai/gpt-oss-20b"` models so that each receives the appropriate expert configuration parameter: `"num_experts"` for `"Qwen/Qwen3-30B-A3B"` and `"num_local_experts"` for `"openai/gpt-oss-20b"`. This ensures each model is initialized with the correct configuration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a test-model generation script; main risk is regenerating/publishing different tiny checkpoints for GPT-OSS.
> 
> **Overview**
> Fixes MoE tiny-model generation for `openai/gpt-oss-20b` by setting the correct expert-count config field.
> 
> In `scripts/generate_tiny_models.py`, the MoE loop now uses `num_experts=4` only for `Qwen/Qwen3-30B-A3B`, and sets `num_local_experts=4` for `openai/gpt-oss-20b` (keeping `n_routed_experts=4` for `zai-org/GLM-4.5`), ensuring the generated GPT-OSS tiny checkpoint has the intended number of experts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2632c641a6fd9779a660fc3024fbf07693cbafd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->