### PR TITLE
feat: Add generation_kwargs support to LogCompletionsCallback and Wea…

### DIFF
--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -66,6 +66,7 @@ def _generate_completions(
     accelerator: Accelerator,
     generation_config: GenerationConfig | None,
     batch_size: int = 1,
+    **generation_kwargs,
 ) -> list[str]:
     """
     Generates completions for a list of pre-formatted prompts from the given model.
@@ -77,12 +78,14 @@ def _generate_completions(
         accelerator (Accelerator): The accelerator to be used for model execution.
         generation_config (GenerationConfig): Configuration for text generation.
         batch_size (int, optional): The number of prompts to process in each batch. Default is 1.
+        **generation_kwargs: Additional keyword arguments forwarded to `model.generate`. These
+            override any matching fields in `generation_config` (e.g. `max_new_tokens=50`,
+            `temperature=0.8`).
 
     Returns:
         list[str]: A list of generated text completions corresponding to the input prompts.
     """
     completions = []
-    # TODO: Override model.generation_config with generation_kwargs
     with unwrap_model_for_generation(model, accelerator) as unwrapped_model:
         for idx in range(0, len(prompts), batch_size):
             batch = prompts[idx : idx + batch_size]
@@ -90,6 +93,7 @@ def _generate_completions(
             generations = unwrapped_model.generate(
                 **tokenized_batch,
                 generation_config=generation_config,
+                **generation_kwargs,
             )
             for prompt, generation in zip(tokenized_batch.input_ids, generations, strict=True):
                 # Remove prompt from generation
@@ -258,7 +262,7 @@ class LogCompletionsCallback(TrainerCallback):
     Usage:
     ```python
     trainer = DPOTrainer(...)
-    completions_callback = LogCompletionsCallback(trainer=trainer)
+    completions_callback = LogCompletionsCallback(trainer=trainer, max_new_tokens=50)
     trainer.add_callback(completions_callback)
     ```
 
@@ -273,6 +277,9 @@ class LogCompletionsCallback(TrainerCallback):
             the evaluation dataset.
         freq (`int`, *optional*):
             The frequency at which to log completions. If not provided, defaults to the trainer's `eval_steps`.
+        **generation_kwargs:
+            Additional keyword arguments forwarded to `model.generate`. These override any matching fields in
+            `generation_config` (e.g. `max_new_tokens=50`, `temperature=0.8`).
     """
 
     def __init__(
@@ -281,9 +288,11 @@ class LogCompletionsCallback(TrainerCallback):
         generation_config: GenerationConfig | None = None,
         num_prompts: int | None = None,
         freq: int | None = None,
+        **generation_kwargs,
     ):
         self.trainer = trainer
         self.generation_config = generation_config
+        self.generation_kwargs = generation_kwargs
         self.freq = freq
         self.table = []
         self._last_logged_step = -1
@@ -319,6 +328,7 @@ class LogCompletionsCallback(TrainerCallback):
                 accelerator=accelerator,
                 generation_config=self.generation_config,
                 batch_size=args.per_device_eval_batch_size,
+                **self.generation_kwargs,
             )
             completions = gather_object(completions)
             prompts = gather_object(prompts)
@@ -405,6 +415,9 @@ class WeaveCallback(TrainerCallback):
             Name for the dataset metadata in Weave.
         model_name (`str`, *optional*):
             Name for the model metadata in Weave. If not provided, attempts to extract from model config.
+        **generation_kwargs:
+            Additional keyword arguments forwarded to `model.generate`. These override any matching fields in
+            `generation_config` (e.g. `max_new_tokens=50`, `temperature=0.8`).
     """
 
     def __init__(
@@ -416,11 +429,13 @@ class WeaveCallback(TrainerCallback):
         num_prompts: int | None = None,
         dataset_name: str = "eval_dataset",
         model_name: str | None = None,
+        **generation_kwargs,
     ):
         self.trainer = trainer
         self.project_name = project_name
         self.scorers = scorers or {}
         self.generation_config = generation_config
+        self.generation_kwargs = generation_kwargs
         self.dataset_name = dataset_name
         self.model_name = model_name
         self._last_logged_step = -1
@@ -503,6 +518,7 @@ class WeaveCallback(TrainerCallback):
                 accelerator=accelerator,
                 generation_config=self.generation_config,
                 batch_size=args.per_device_eval_batch_size,
+                **self.generation_kwargs,
             )
 
             all_prompts = gather_object(prompts)


### PR DESCRIPTION
# Add `generation_kwargs` support to `LogCompletionsCallback` & `WeaveCallback`

## What does this PR do?

Resolves a `TODO` in `_generate_completions` (`callbacks.py`) that originally requested `generation_kwargs` support.

### The Problem
Before this PR, the `LogCompletionsCallback` and `WeaveCallback` only accepted a full `GenerationConfig` object for controlling generation. This meant users couldn't pass simple, common keyword arguments like `max_new_tokens=50` or `temperature=0.8` directly to the callbacks.

### The Solution
This PR introduces `**generation_kwargs` to the following methods:
- `_generate_completions()` (the core utility)
- `LogCompletionsCallback.__init__()`
- `WeaveCallback.__init__()`

These kwargs are stored and seamlessly forwarded to `model.generate()`, where they will automatically override any matching fields in the base `generation_config`—adhering perfectly to standard `transformers` behavior.

## Usage Example

```python
from trl import LogCompletionsCallback

# Users can now directly pass arbitrary generation kwargs:
cb = LogCompletionsCallback(
    trainer=trainer, 
    max_new_tokens=50, 
    temperature=0.8,
    do_sample=True
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to evaluation-time completion generation/logging and mainly thread through extra `model.generate` kwargs; main impact is altered generation behavior if callers provide overrides.
> 
> **Overview**
> Adds support for passing arbitrary `**generation_kwargs` through the completion-generation path.
> 
> `_generate_completions` now forwards these kwargs to `model.generate`, and both `LogCompletionsCallback` and `WeaveCallback` accept/store the kwargs and pass them along when generating eval completions (enabling simple overrides like `max_new_tokens` or `temperature` without constructing a full `GenerationConfig`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b1df0d7ec55a32c32d8f4a1c736dc458d715ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->