### PR TITLE
Fix docstring style in vllm-serve script

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -217,8 +217,7 @@ class ScriptArguments:
             vLLM defaults to the multiproc backend (single-node only).
         speculative_config (`str`, *optional*):
             JSON string for vLLM speculative decoding config, forwarded to `LLM(speculative_config=...)`. When unset,
-            speculative decoding is disabled. Example:
-            `'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'`.
+            speculative decoding is disabled. Example: `'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'`.
     """
 
     model: str = field(


### PR DESCRIPTION
Fix docstring style in vllm-serve script: `make precommit`.

Issue introduced by:
- #5605

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only formatting change in `trl/scripts/vllm_serve.py` with no runtime behavior impact. Risk is limited to documentation rendering/style.
> 
> **Overview**
> Adjusts the `ScriptArguments` docstring in `trl/scripts/vllm_serve.py` to keep the `speculative_config` example on a single line, aligning with pre-commit/docstring style expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8538cc7f367b8990768bafacb403680f4aa365b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->