### PR TITLE
Use `PreTrainedTokenizerBase` for tokenizer type hints

### DIFF
--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TypeVar
 
 from jinja2 import TemplateError
-from transformers import AddedToken, AutoTokenizer, PreTrainedModel, PreTrainedTokenizer, ProcessorMixin
+from transformers import AddedToken, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
 
 from .data_utils import prepare_multimodal_messages
 
@@ -26,10 +26,10 @@ _CHAT_TEMPLATES_DIR = Path(__file__).parent / "chat_templates"
 
 def clone_chat_template(
     model: PreTrainedModel,
-    tokenizer: PreTrainedTokenizer,
+    tokenizer: PreTrainedTokenizerBase,
     source_tokenizer_path: str,
     resize_to_multiple_of: int | None = 64,
-) -> tuple[PreTrainedModel, PreTrainedTokenizer, list[int]]:
+) -> tuple[PreTrainedModel, PreTrainedTokenizerBase, list[int]]:
     """
     Clones a chat template from a source tokenizer to the target tokenizer and updates the model accordingly.
 
@@ -44,7 +44,7 @@ def clone_chat_template(
     Args:
         model ([`~transformers.PreTrainedModel`]):
             Model to update.
-        tokenizer ([`~transformers.PreTrainedTokenizer`]):
+        tokenizer ([`~transformers.PreTrainedTokenizerBase`]):
             Tokenizer to update.
         source_tokenizer_path (`str`):
             Path or identifier of the pretrained tokenizer to clone from.
@@ -55,7 +55,7 @@ def clone_chat_template(
     Returns:
         model ([`~transformers.PreTrainedModel`]):
             Updated model with resized token embeddings and EOS token configured.
-        tokenizer ([`~transformers.PreTrainedTokenizer`]):
+        tokenizer ([`~transformers.PreTrainedTokenizerBase`]):
             Updated tokenizer with the chat template and special tokens applied.
         added_tokens (`list[int]`):
             List of tokens that were added to the tokenizer from the source tokenizer.
@@ -331,7 +331,7 @@ qwen3_5_chat_template_2b_and_below = (_CHAT_TEMPLATES_DIR / "qwen3_5_2b_and_belo
 qwen3_5_chat_template_4b_and_above = (_CHAT_TEMPLATES_DIR / "qwen3_5_4b_and_above.jinja").read_text()
 
 
-ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizer, ProcessorMixin)
+ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizerBase, ProcessorMixin)
 
 
 def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
@@ -346,11 +346,11 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
     and reads `self.response_schema` from the tokenizer instance.
 
     Args:
-        processing_class (`PreTrainedTokenizer` or `ProcessorMixin`):
+        processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or VLM processor to which the response schema will be added.
 
     Returns:
-        `PreTrainedTokenizer` or `ProcessorMixin`:
+        `PreTrainedTokenizerBase` or `ProcessorMixin`:
             The same object that was passed in, with the response schema set on the underlying tokenizer.
 
     Examples:
@@ -408,7 +408,7 @@ def supports_tool_calling(processing_class) -> bool:
     [`~trl.data_utils.prepare_multimodal_messages`] before rendering.
 
     Args:
-        processing_class (`PreTrainedTokenizer` or `ProcessorMixin`):
+        processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or processor instance to check.
 
     Returns:
@@ -460,7 +460,7 @@ def supports_tool_calling(processing_class) -> bool:
     return all(s in rendered for s in (_name_sentinel, _arg_key_sentinel, _arg_val_sentinel, _content_sentinel))
 
 
-def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizer | ProcessorMixin) -> bool:
+def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizerBase | ProcessorMixin) -> bool:
     """
     Check whether the chat template preserves prefixes when applied.
 
@@ -469,7 +469,7 @@ def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizer | P
     tokenizations with and without tool messages appended.
 
     Args:
-        processing_class (`PreTrainedTokenizer` or `ProcessorMixin`):
+        processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or processor instance to check.
 
     Returns:
@@ -536,7 +536,7 @@ qwen2_5_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5_training.jinja"
 qwen3_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_training.jinja").read_text()
 
 
-def get_training_chat_template(tokenizer: PreTrainedTokenizer) -> str | None:
+def get_training_chat_template(tokenizer: PreTrainedTokenizerBase) -> str | None:
     r"""
     Get a training-compatible chat template, if needed.
 
@@ -545,7 +545,7 @@ def get_training_chat_template(tokenizer: PreTrainedTokenizer) -> str | None:
     requirements. Currently DeepSeek-V3, Gemma, Gemma2, GLM-4-MoE, GPT-OSS, LLaMA 3, Qwen2.5, and Qwen3 are supported.
 
     Args:
-        tokenizer (`PreTrainedTokenizer`):
+        tokenizer (`PreTrainedTokenizerBase`):
             Tokenizer instance to check.
 
     Returns:
@@ -659,7 +659,7 @@ def _validate_tool_calls(tool_calls: list | None) -> None:
                 tool_call["arguments"] = {}
 
 
-def parse_response(processing_class: PreTrainedTokenizer | ProcessorMixin, ids: list[int]) -> dict:
+def parse_response(processing_class: PreTrainedTokenizerBase | ProcessorMixin, ids: list[int]) -> dict:
     r"""
     Parse a token sequence into structured response dictionaries with fallback handling.
 
@@ -672,7 +672,7 @@ def parse_response(processing_class: PreTrainedTokenizer | ProcessorMixin, ids: 
     For VLM processors, automatically uses the inner tokenizer for parsing.
 
     Args:
-        processing_class (`PreTrainedTokenizer` or VLM processor):
+        processing_class (`PreTrainedTokenizerBase` or VLM processor):
             Tokenizer or processor with a `parse_response()` method (directly or via inner tokenizer).
         ids (`list[int]`):
             List of token sequences.

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -44,7 +44,7 @@ from transformers import (
     DataCollator,
     FeatureExtractionMixin,
     PreTrainedModel,
-    PreTrainedTokenizerBase,
+    PreTrainedTokenizerBaseBase,
     ProcessorMixin,
     TrainerCallback,
     TrainingArguments,
@@ -77,7 +77,7 @@ if is_joblib_available():
     import joblib
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizer
+    from transformers import PreTrainedTokenizerBase
 
 logger = logging.get_logger(__name__)
 
@@ -167,8 +167,8 @@ class RunningMoments:
 
 def _tokenize(
     batch: dict[str, list[Any]],
-    tokenizer: "PreTrainedTokenizer",
-    embedding_tokenizer: Optional["PreTrainedTokenizer"] = None,
+    tokenizer: "PreTrainedTokenizerBase",
+    embedding_tokenizer: Optional["PreTrainedTokenizerBase"] = None,
 ) -> dict[str, list[Any]]:
     """Tokenize a batch from a BCO specific dataset."""
     prompt_tokenized = tokenizer(batch["prompt"], add_special_tokens=False)
@@ -363,7 +363,7 @@ class BCOTrainer(_BaseTrainer):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):
             The dataset to use for evaluation.
-        processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`], *optional*):
+        processing_class ([`~transformers.PreTrainedTokenizerBaseBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`], *optional*):
             Processing class used to process the data. If provided, will be used to automatically process the inputs
             for the model, and it will be saved along the model to make it easier to rerun an interrupted training or
             reuse the fine-tuned model.
@@ -414,7 +414,7 @@ class BCOTrainer(_BaseTrainer):
         args: BCOConfig = None,
         train_dataset: Dataset | None = None,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
-        processing_class: PreTrainedTokenizerBase
+        processing_class: PreTrainedTokenizerBaseBase
         | BaseImageProcessor
         | FeatureExtractionMixin
         | ProcessorMixin
@@ -429,7 +429,7 @@ class BCOTrainer(_BaseTrainer):
         model_adapter_name: str | None = None,
         ref_adapter_name: str | None = None,
         embedding_func: Callable | None = None,
-        embedding_tokenizer: PreTrainedTokenizerBase | None = None,
+        embedding_tokenizer: PreTrainedTokenizerBaseBase | None = None,
     ):
         if embedding_func is not None and not (is_sklearn_available() and is_joblib_available()):
             raise ImportError(

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -44,7 +44,6 @@ from transformers import (
     DataCollator,
     FeatureExtractionMixin,
     PreTrainedModel,
-    PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
     TrainingArguments,

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -44,7 +44,7 @@ from transformers import (
     DataCollator,
     FeatureExtractionMixin,
     PreTrainedModel,
-    PreTrainedTokenizerBaseBase,
+    PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
     TrainingArguments,
@@ -363,7 +363,7 @@ class BCOTrainer(_BaseTrainer):
             The dataset to use for training.
         eval_dataset ([`~datasets.Dataset`]):
             The dataset to use for evaluation.
-        processing_class ([`~transformers.PreTrainedTokenizerBaseBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`], *optional*):
+        processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`], *optional*):
             Processing class used to process the data. If provided, will be used to automatically process the inputs
             for the model, and it will be saved along the model to make it easier to rerun an interrupted training or
             reuse the fine-tuned model.
@@ -414,7 +414,7 @@ class BCOTrainer(_BaseTrainer):
         args: BCOConfig = None,
         train_dataset: Dataset | None = None,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
-        processing_class: PreTrainedTokenizerBaseBase
+        processing_class: PreTrainedTokenizerBase
         | BaseImageProcessor
         | FeatureExtractionMixin
         | ProcessorMixin
@@ -429,7 +429,7 @@ class BCOTrainer(_BaseTrainer):
         model_adapter_name: str | None = None,
         ref_adapter_name: str | None = None,
         embedding_func: Callable | None = None,
-        embedding_tokenizer: PreTrainedTokenizerBaseBase | None = None,
+        embedding_tokenizer: PreTrainedTokenizerBase | None = None,
     ):
         if embedding_func is not None and not (is_sklearn_available() and is_joblib_available()):
             raise ImportError(

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from operator import itemgetter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -44,6 +44,7 @@ from transformers import (
     DataCollator,
     FeatureExtractionMixin,
     PreTrainedModel,
+    PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
     TrainingArguments,
@@ -74,9 +75,6 @@ if is_sklearn_available():
 
 if is_joblib_available():
     import joblib
-
-if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizerBase
 
 logger = logging.get_logger(__name__)
 
@@ -166,8 +164,8 @@ class RunningMoments:
 
 def _tokenize(
     batch: dict[str, list[Any]],
-    tokenizer: "PreTrainedTokenizerBase",
-    embedding_tokenizer: Optional["PreTrainedTokenizerBase"] = None,
+    tokenizer: PreTrainedTokenizerBase,
+    embedding_tokenizer: PreTrainedTokenizerBase | None = None,
 ) -> dict[str, list[Any]]:
     """Tokenize a batch from a BCO specific dataset."""
     prompt_tokenized = tokenizer(batch["prompt"], add_special_tokens=False)


### PR DESCRIPTION
In TRL, type hints for tokenizer parameters should use `PreTrainedTokenizerBase`, not `PreTrainedTokenizer`.

In transformers, `PreTrainedTokenizer` is an alias for `PythonBackend` (slow tokenizer only). The fast tokenizer (`TokenizersBackend`) inherits directly from `PreTrainedTokenizerBase` and is NOT a `PreTrainedTokenizer`. Since `AutoTokenizer.from_pretrained(...)` returns a fast tokenizer by default for most models, `PreTrainedTokenizer` hints fail to cover the common case. `PreTrainedTokenizerBase` is the common ancestor and exposes `.apply_chat_template`, `.chat_template`, `.vocab`, `.eos_token`, etc.

**How to apply:** When adding or editing a function that accepts a tokenizer (not model-specific), use `PreTrainedTokenizerBase`. Only use `PreTrainedTokenizer` if the code truly requires slow-tokenizer-only behavior (rare).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-hint-only change; runtime behavior should be unchanged, but downstream type checkers may surface new/changed annotations.
> 
> **Overview**
> Broadens tokenizer type annotations from `PreTrainedTokenizer` to `PreTrainedTokenizerBase` across chat-template utilities (e.g. `clone_chat_template`, `get_training_chat_template`, `parse_response`) and BCO dataset tokenization (`_tokenize`) so fast tokenizers and processors are covered.
> 
> Cleans up related typing imports (drops `TYPE_CHECKING`/`Optional` usage) and updates the `ProcessingClassT` `TypeVar`/docstrings to match the new base type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c2dbf1337b90a99cef6235aa7cd8b08450b84e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->