### PR TITLE
Add doc-builder style check to pre-commit and CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,12 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
 
-  # - repo: https://github.com/codespell-project/codespell
-  #   rev: v2.1.0
-  #   hooks:
-  #     - id: codespell
-  #       args:
-  #         - --ignore-words-list=nd,reacher,thist,ths,magent,ba
-  #         - --skip=docs/css/termynal.css,docs/js/termynal.js
+  - repo: local
+    hooks:
+      - id: doc-builder-style
+        name: Check style with doc-builder
+        language: python
+        entry: doc-builder style trl tests docs/source --max_len 119
+        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@2430c1ec91d04667414e2fa31ecfc36c153ea391"]
+        pass_filenames: false
+        types_or: [python, markdown, rst]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ test:
 precommit:
 	python scripts/add_copyrights.py
 	pre-commit run --all-files
-	doc-builder style trl tests docs/source --max_len 119
 
 slow_tests:
 	pytest -m "slow" tests/ $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)


### PR DESCRIPTION
Add doc-builder style check to pre-commit and CI.

This PR updates the project's code style checking setup by moving the documentation style check from the `Makefile` to a new pre-commit hook, and adds a local pre-commit hook configuration for running the `doc-builder` style check. This change ensures that style checks are consistently enforced before commits, rather than requiring manual execution.

### Motivation

The `check_code_quality` CI job was only running `ruff-check` and `ruff-format`, missing the `doc-builder style` check that was part of `make precommit` locally but never enforced in CI.

This was creating recurrent issues with malformed docstrings landing on main without being flagged by the CI. For example:
- #5628

This PR adds a local pre-commit hook that runs `doc-builder style trl tests docs/source --max_len 119`, installed directly from the pinned `huggingface/doc-builder` GitHub commit (consistent with other doc workflows in this repo). The hook auto-fixes files in place; pre-commit exits non-zero if any files were modified, which is what causes CI to fail: the same mechanism used by `ruff-format`.

The now-redundant explicit `doc-builder style` line in the `precommit` Makefile target is removed, since it is already covered by `pre-commit run --all-files`.

### Changes

Pre-commit hook improvements:

* Added a local pre-commit hook named `doc-builder-style` to `.pre-commit-config.yaml`, which runs the `doc-builder style` command on relevant files with specified options and dependencies.
* Removed the manual `doc-builder style` command from the `precommit` target in the `Makefile`, as this is now handled by the pre-commit hook.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts developer/CI linting by adding a new `doc-builder` style hook and removing the redundant Makefile invocation, with no runtime code changes.
> 
> **Overview**
> Adds a local pre-commit hook (`doc-builder-style`) that runs `doc-builder style` over `trl`, `tests`, and `docs/source`, installing `doc-builder` from a pinned Git commit and applying to Python/Markdown/RST files.
> 
> Removes the standalone `doc-builder style` command from `make precommit` since it is now enforced through `pre-commit run --all-files`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8abd9e828a0ffb0a66b01a6a09ba27aebb34f554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->