### PR TITLE
Align and update doc-builder commit hash in CI GitHub Actions

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.sha }}
       package: trl

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       package_name: trl
     secrets:


### PR DESCRIPTION
Align and update doc-builder commit hash in CI GitHub Actions.

This PR updates the GitHub Actions workflows to use a newer version of the shared `doc-builder` workflows from Hugging Face. The main goal is to ensure all documentation-related workflows use the **same**, latest workflow version for consistency and to benefit from upstream improvements or fixes.
- Note that before this PR, the hashes were not aligned across GitHub Actions

### Changes

**Workflow version updates:**

* `.github/workflows/build_documentation.yml`: Updated the referenced commit hash for the `build_main_documentation.yml` reusable workflow 
  * from `90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3` 
  * to `2430c1ec91d04667414e2fa31ecfc36c153ea391`.
* `.github/workflows/build_pr_documentation.yml`: Updated the referenced commit hash for the `build_pr_documentation.yml` reusable workflow 
  * from `90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3` 
  * to `2430c1ec91d04667414e2fa31ecfc36c153ea391`.
* `.github/workflows/upload_pr_documentation.yml`: Updated the referenced commit hash for the `upload_pr_documentation.yml` reusable workflow 
  * from `9ad2de8582b56c017cb530c1165116d40433f1c6` 
  * to `2430c1ec91d04667414e2fa31ecfc36c153ea391`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the pinned commit SHA for reusable `huggingface/doc-builder` GitHub Actions workflows, affecting documentation CI behavior but not runtime code.
> 
> **Overview**
> Updates the documentation CI workflows to **pin all doc build/upload jobs to the same newer `huggingface/doc-builder` commit** (`2430c1e...`).
> 
> This aligns `build_documentation.yml`, `build_pr_documentation.yml`, and `upload_pr_documentation.yml` so main-branch docs, PR docs, and PR doc uploads all run against the same upstream workflow version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb2f6c1c6925377e5f4aab0e21a6b9dcec1c6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->