### PR TITLE
Align KTO with DPO: Move completion assembly from _prepare_dataset to data collator

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -128,43 +128,42 @@ class TestKTOTrainer(TrlTestCase):
             eval_dataset=dummy_dataset["test"],
         )
 
-        # Verify the tokenization step via trainer.train_dataset (aligned with DPO test style).
-        # prompt_input_ids must start with the tokenized prompt text.
+        # Verify the tokenization step: dataset stores raw token IDs (aligned with DPO style).
+        # prompt_ids must start with the tokenized prompt text.
         prompt_ids = self.tokenizer(train_dataset["prompt"][0])["input_ids"]
-        assert trainer.train_dataset[0]["prompt_input_ids"][: len(prompt_ids)] == prompt_ids
-        assert all(m == 1 for m in trainer.train_dataset[0]["prompt_attention_mask"])
-        # completion_input_ids = (BOS +) prompt + answer + EOS
-        assert trainer.train_dataset[0]["completion_input_ids"][-1] == self.tokenizer.eos_token_id
-        # completion_labels: -100 for the prompt part, actual token IDs for the answer+EOS part
-        n_prompt = len(trainer.train_dataset[0]["prompt_input_ids"])
-        assert trainer.train_dataset[0]["completion_labels"][:n_prompt] == [-100] * n_prompt
-        assert (
-            trainer.train_dataset[0]["completion_labels"][n_prompt:]
-            == trainer.train_dataset[0]["completion_input_ids"][n_prompt:]
-        )
+        assert trainer.train_dataset[0]["prompt_ids"][: len(prompt_ids)] == prompt_ids
+        # completion_ids are the raw answer tokens (no prompt prefix, no BOS/EOS added yet).
+        assert len(trainer.train_dataset[0]["completion_ids"]) > 0
+
+        # Verify the collator output (assembly, BOS/EOS insertion, labels).
+        example = trainer.train_dataset[0]
+        batch = trainer.data_collator([example])
+        # completion_input_ids ends with EOS
+        assert batch["completion_input_ids"][0, -1].item() == self.tokenizer.eos_token_id
+        # completion_labels: prompt prefix masked with -100, answer+EOS unmasked and matching input_ids
+        completion_input_ids = batch["completion_input_ids"][0].tolist()
+        completion_labels = batch["completion_labels"][0].tolist()
+        first_unmasked = next(i for i, lbl in enumerate(completion_labels) if lbl != -100)
+        assert first_unmasked > 0  # at least the prompt is masked
+        assert completion_labels[first_unmasked:] == completion_input_ids[first_unmasked:]
 
         # Test corruption of (prompt, completion) pairs for KL dataset.
-        # _get_kl_dataset shifts answer_input_ids by one within each batch; prompt_input_ids are unchanged.
-        # Use a synthetic dataset since answer_input_ids is dropped from trainer.train_dataset after assembly.
+        # _get_kl_dataset shifts completion_ids by one within each batch; prompt_ids are unchanged.
         synthetic = Dataset.from_dict(
             {
-                "prompt_input_ids": [[1, 2], [3, 4], [5, 6]],
-                "prompt_attention_mask": [[1, 1], [1, 1], [1, 1]],
-                "answer_input_ids": [[10, 11], [20, 21], [30, 31]],
-                "answer_attention_mask": [[1, 1], [1, 1], [1, 1]],
+                "prompt_ids": [[1, 2], [3, 4], [5, 6]],
+                "completion_ids": [[10, 11], [20, 21], [30, 31]],
+                "label": [True, False, True],
             }
         )
         for batch_size in [2, 3]:
             rotated = synthetic.map(_get_kl_dataset, batched=True, batch_size=batch_size)
 
-            # Verify that the "answer_input_ids" have been modified, meaning the new "answer_input_ids" differ
-            # from the original ones. However, when the length of the dataset modulo batch_size equals 1,
-            # the last batch remains unaltered. This is a rare scenario that does not impact the training
-            # process, so we exclude it from testing by iterating only up to len - 1.
+            # Verify that completion_ids have been rotated (differ from original). When the dataset length
+            # modulo batch_size equals 1, the last batch is unaltered: exclude it from the check.
             for i in range(len(rotated) - 1):
-                assert synthetic["prompt_input_ids"][i] == rotated["prompt_input_ids"][i]
-                assert synthetic["prompt_attention_mask"][i] == rotated["prompt_attention_mask"][i]
-                assert synthetic["answer_input_ids"][i] != rotated["answer_input_ids"][i]
+                assert synthetic["prompt_ids"][i] == rotated["prompt_ids"][i]
+                assert synthetic["completion_ids"][i] != rotated["completion_ids"][i]
 
     def test_kto_trainer_without_providing_ref_model(self):
         training_args = KTOConfig(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -96,38 +96,95 @@ def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
 @dataclass
 class DataCollatorForUnpairedPreference(DataCollatorMixin):
     """
-    Data collator for unpaired preference data. Pads sequences to the maximum length of the batch.
+    Data collator for unpaired preference data. Assembles completions from raw token IDs and pads sequences to the
+    maximum length of the batch.
 
     Args:
         pad_token_id (`int`, defaults to `0`):
             Token ID to use for padding `input_ids` sequences.
-        return_tensors (`str`, optional, defaults to `"pt"`):
+        max_length (`int`, *optional*):
+            Maximum sequence length after assembly. Sequences exceeding this limit are truncated from the end of
+            the completion before BOS/EOS tokens are added.
+        bos_token_id (`int`, *optional*):
+            Token ID for the beginning-of-sequence token. If set and not already present at the start of
+            `prompt_ids`, it is prepended to both prompt and completion.
+        eos_token_id (`int`, *optional*):
+            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`,
+            it is appended to the completion.
+        return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
     """
 
     pad_token_id: int = 0
+    max_length: int | None = None
+    bos_token_id: int | None = None
+    eos_token_id: int | None = None
     return_tensors: str = "pt"
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
         batch = {}
-        for k in examples[0]:
-            if k.endswith(("_input_ids", "_attention_mask", "_labels")):
-                padding_side = "left" if k in ("prompt_input_ids", "prompt_attention_mask") else "right"
-                if k.endswith("_input_ids"):
-                    padding_value = self.pad_token_id
-                elif k.endswith("_labels"):
-                    padding_value = -100
-                else:
-                    padding_value = 0
-                batch[k] = pad(
-                    [torch.tensor(ex[k], dtype=torch.int64) for ex in examples],
-                    padding_value=padding_value,
-                    padding_side=padding_side,
-                )
-            elif k.endswith("_logps"):
-                batch[k] = torch.tensor([ex[k] for ex in examples])
-            else:
-                batch[k] = [ex[k] for ex in examples]
+        for prefix, ids_key in [("completion", "completion_ids"), ("KL_completion", "KL_completion_ids")]:
+            if ids_key not in examples[0]:
+                continue
+
+            full_ids_list = []
+            labels_list = []
+            for ex in examples:
+                prompt_ids = ex["prompt_ids"]
+                answer_ids = ex[ids_key]
+
+                if self.max_length is not None:
+                    # Reserve budget for BOS/EOS tokens that will be added.
+                    # BOS: only if not already present (truncation never removes the first token)
+                    # EOS: always reserve a slot — truncation removes from the end, so EOS may be cut
+                    # even when it was present before truncation; the post-truncation guard re-appends it
+                    max_len = self.max_length
+                    if prompt_ids and self.bos_token_id != prompt_ids[0]:
+                        max_len -= 1
+                    if self.eos_token_id is not None:
+                        max_len -= 1
+                    if len(prompt_ids) + len(answer_ids) > max_len:
+                        answer_ids = answer_ids[: max_len - len(prompt_ids)]
+
+                # Assemble completion = prompt + (truncated) answer
+                completion_ids = prompt_ids + answer_ids
+
+                # Add BOS, which affects both prompt and the full completion
+                if self.bos_token_id is not None and (not prompt_ids or prompt_ids[0] != self.bos_token_id):
+                    prompt_ids = [self.bos_token_id] + prompt_ids
+                    completion_ids = [self.bos_token_id] + completion_ids
+
+                # Add EOS, which affects only the full completion
+                if not answer_ids or self.eos_token_id != answer_ids[-1]:
+                    completion_ids = completion_ids + [self.eos_token_id]
+
+                # Create labels: mask prompt tokens with -100
+                labels = [-100] * len(prompt_ids) + completion_ids[len(prompt_ids) :]
+
+                full_ids_list.append(completion_ids)
+                labels_list.append(labels)
+
+            batch[f"{prefix}_input_ids"] = pad(
+                [torch.tensor(ids, dtype=torch.int64) for ids in full_ids_list],
+                padding_value=self.pad_token_id,
+                padding_side="right",
+            )
+            batch[f"{prefix}_attention_mask"] = pad(
+                [torch.ones(len(ids), dtype=torch.int64) for ids in full_ids_list],
+                padding_value=0,
+                padding_side="right",
+            )
+            batch[f"{prefix}_labels"] = pad(
+                [torch.tensor(lbl, dtype=torch.int64) for lbl in labels_list],
+                padding_value=-100,
+                padding_side="right",
+            )
+
+        if "reference_logps" in examples[0]:
+            batch["reference_logps"] = torch.tensor([ex["reference_logps"] for ex in examples])
+        if "reference_KL_logps" in examples[0]:
+            batch["reference_KL_logps"] = torch.tensor([ex["reference_KL_logps"] for ex in examples])
+        batch["label"] = [ex["label"] for ex in examples]
         return batch
 
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -89,8 +89,7 @@ def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
     completions. For best results, the mismatched outputs y' used to estimate the KL term for a batch should be the
     same set as the matched outputs y used to estimate the rewards in that batch, just paired with different x.
     """
-    batch["answer_input_ids"] = [batch["answer_input_ids"][-1]] + batch["answer_input_ids"][:-1]
-    batch["answer_attention_mask"] = [batch["answer_attention_mask"][-1]] + batch["answer_attention_mask"][:-1]
+    batch["completion_ids"] = [batch["completion_ids"][-1]] + batch["completion_ids"][:-1]
     return batch
 
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -720,9 +720,6 @@ class KTOTrainer(_BaseTrainer):
                 # merge the datasets
                 dataset = concatenate_datasets([dataset, kl_dataset], axis=1)
 
-            # Drop intermediate columns retained only for KL rotation
-            dataset = dataset.remove_columns(["answer_input_ids", "answer_attention_mask"])
-
             # Calculate dataset desirability balance
             if dataset_name == "train" and isinstance(dataset, Dataset):  # IterableDataset does not support len
                 num_desirable = max(sum(dataset["label"]), 1)

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -640,8 +640,6 @@ class KTOTrainer(_BaseTrainer):
                 dataset = unpair_preference_dataset(dataset, **map_kwargs)
 
             tokenizer = getattr(processing_class, "tokenizer", processing_class)
-            bos_token_id = tokenizer.bos_token_id
-            eos_token_id = tokenizer.eos_token_id
 
             # Add EOS token if needed: non-conversational only
             first_example = next(iter(dataset))

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -155,7 +155,7 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
                     completion_ids = [self.bos_token_id] + completion_ids
 
                 # Add EOS, which affects only the full completion
-                if not answer_ids or self.eos_token_id != answer_ids[-1]:
+                if self.eos_token_id is not None and (not answer_ids or self.eos_token_id != answer_ids[-1]):
                     completion_ids = completion_ids + [self.eos_token_id]
 
                 # Create labels: mask prompt tokens with -100

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -155,7 +155,7 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
                     completion_ids = [self.bos_token_id] + completion_ids
 
                 # Add EOS, which affects only the full completion
-                if self.eos_token_id is not None and (not answer_ids or self.eos_token_id != answer_ids[-1]):
+                if not answer_ids or self.eos_token_id != answer_ids[-1]:
                     completion_ids = completion_ids + [self.eos_token_id]
 
                 # Create labels: mask prompt tokens with -100

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -100,25 +100,25 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
     maximum length of the batch.
 
     Args:
-        pad_token_id (`int`, defaults to `0`):
+        pad_token_id (`int`):
             Token ID to use for padding `input_ids` sequences.
+        bos_token_id (`int`):
+            Token ID for the beginning-of-sequence token. If set and not already present at the start of `prompt_ids`,
+            it is prepended to both prompt and completion.
+        eos_token_id (`int`):
+            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`, it
+            is appended to the completion.
         max_length (`int`, *optional*):
             Maximum sequence length after assembly. Sequences exceeding this limit are truncated from the end of the
             completion before BOS/EOS tokens are added.
-        bos_token_id (`int`, *optional*):
-            Token ID for the beginning-of-sequence token. If set and not already present at the start of `prompt_ids`,
-            it is prepended to both prompt and completion.
-        eos_token_id (`int`, *optional*):
-            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`, it
-            is appended to the completion.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
     """
 
-    pad_token_id: int = 0
+    pad_token_id: int
+    bos_token_id: int
+    eos_token_id: int
     max_length: int | None = None
-    bos_token_id: int | None = None
-    eos_token_id: int | None = None
     return_tensors: str = "pt"
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
@@ -412,9 +412,9 @@ class KTOTrainer(_BaseTrainer):
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=tokenizer.pad_token_id,
-                max_length=max_length,
                 bos_token_id=tokenizer.bos_token_id,
                 eos_token_id=tokenizer.eos_token_id,
+                max_length=max_length,
             )
 
             if args.remove_unused_columns:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -402,7 +402,7 @@ class KTOTrainer(_BaseTrainer):
 
         if args.max_length is None:
             logger.warning(
-                "When using DataCollatorForKTO, you should set `max_length` in the KTOTrainer's init"
+                "When using DataCollatorForUnpairedPreference, you should set `max_length` in the KTOTrainer's init"
                 " it will be set to `512` by default, but you should do it yourself in the future.",
             )
             max_length = 512
@@ -418,7 +418,7 @@ class KTOTrainer(_BaseTrainer):
                 args.remove_unused_columns = False
                 # warn users
                 logger.warning(
-                    "When using DataCollatorForKTO, you should set `remove_unused_columns=False` in your KTOConfig"
+                    "When using DataCollatorForUnpairedPreference, you should set `remove_unused_columns=False` in your KTOConfig"
                     " we have set it for you, but you should do it yourself in the future.",
                 )
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -222,8 +222,8 @@ class KTOTrainer(_BaseTrainer):
             `tokenizer.eos_token` will be used as the default.
         data_collator ([`~transformers.DataCollator`], *optional*):
             The data collator to use for training. If None is specified, the default data collator
-            ([`~experimental.kto.kto_trainer.DataCollatorForKTO`]) will be used which will pad the sequences to the
-            maximum length of the sequences in the batch.
+            ([`~experimental.kto.kto_trainer.DataCollatorForUnpairedPreference`]) will be used which will pad the
+            sequences to the maximum length of the sequences in the batch.
         model_init (`Callable[[], transformers.PreTrainedModel]`):
             The model initializer to use for training. If None is specified, the default model initializer will be
             used.

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -412,6 +412,9 @@ class KTOTrainer(_BaseTrainer):
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=tokenizer.pad_token_id,
+                max_length=max_length,
+                bos_token_id=tokenizer.bos_token_id,
+                eos_token_id=tokenizer.eos_token_id,
             )
 
             if args.remove_unused_columns:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -687,51 +687,9 @@ class KTOTrainer(_BaseTrainer):
                         "token handling. Verify that the tokenizer is processing text consistently."
                     )
 
-                answer_ids = prompt_completion_ids[len(prompt_ids) :]
-
-                # Reserve budget for BOS/EOS tokens that will be added.
-                # BOS: only if not already present (truncation never removes the first token)
-                # EOS: always reserve a slot — truncation removes from the end, so EOS may be cut
-                # even when it was present before truncation; the post-truncation guard re-appends it
-                max_len = self.max_length
-                if len(prompt_ids) > 0 and bos_token_id != prompt_ids[0]:
-                    max_len -= 1
-                if eos_token_id is not None:
-                    max_len -= 1
-
-                # If combined sequence is too long, truncate the answer from the end
-                if len(prompt_ids) + len(answer_ids) > max_len:
-                    answer_ids = answer_ids[: max_len - len(prompt_ids)]
-
-                # Assemble completion = prompt + truncated answer
-                completion_ids = prompt_ids + answer_ids
-                completion_mask = [1] * len(completion_ids)
-
-                # Save original prompt length before BOS may be prepended
-                orig_prompt_len = len(prompt_ids)
-
-                # Add BOS, which affects both prompt and the full completion
-                if bos_token_id is not None and (not prompt_ids or prompt_ids[0] != bos_token_id):
-                    prompt_ids = [bos_token_id] + prompt_ids
-                    completion_ids = [bos_token_id] + completion_ids
-                    completion_mask = [1] + completion_mask
-
-                # Add EOS, which affects only the full completion
-                if not answer_ids or eos_token_id != answer_ids[-1]:
-                    completion_ids = completion_ids + [eos_token_id]
-                    completion_mask = completion_mask + [1]
-
-                # Create labels: mask prompt tokens with -100
-                completion_labels = [-100] * len(prompt_ids) + completion_ids[len(prompt_ids) :]
-
                 return {
-                    "prompt_input_ids": prompt_ids,
-                    "prompt_attention_mask": [1] * len(prompt_ids),
-                    "answer_input_ids": prompt_completion_ids[orig_prompt_len:],  # untruncated, retained for KL
-                    "answer_attention_mask": [1] * (len(prompt_completion_ids) - orig_prompt_len),
-                    "completion_input_ids": completion_ids,
-                    "completion_attention_mask": completion_mask,
-                    "completion_labels": completion_labels,
+                    "prompt_ids": prompt_ids,
+                    "completion_ids": prompt_completion_ids[len(prompt_ids) :],
                 }
 
             dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -697,33 +697,8 @@ class KTOTrainer(_BaseTrainer):
             # Get KL datasets if needed
             if self.calculate_KL:
 
-                def assemble_kl_fn(example):
-                    prompt_ids = example["prompt_input_ids"]  # already has BOS from tokenize_fn
-                    answer_ids = example["answer_input_ids"]  # rotated, untruncated
-
-                    # Reserve budget: BOS already in prompt_ids; EOS: always reserve a slot
-                    max_len = self.max_length
-                    if eos_token_id is not None:
-                        max_len -= 1
-
-                    # If combined sequence is too long, truncate the answer from the end
-                    if len(prompt_ids) + len(answer_ids) > max_len:
-                        answer_ids = answer_ids[: max_len - len(prompt_ids)]
-
-                    # Assemble completion = prompt + truncated answer
-                    completion_ids = prompt_ids + answer_ids
-
-                    # Add EOS, which affects only the full completion
-                    if not answer_ids or eos_token_id != answer_ids[-1]:
-                        completion_ids = completion_ids + [eos_token_id]
-
-                    completion_labels = [-100] * len(prompt_ids) + completion_ids[len(prompt_ids) :]
-
-                    return {
-                        "KL_completion_input_ids": completion_ids,
-                        "KL_completion_attention_mask": [1] * len(completion_ids),
-                        "KL_completion_labels": completion_labels,
-                    }
+                def rename_kl_fn(example):
+                    return {"KL_completion_ids": example["completion_ids"]}
 
                 # create pairs for estimating the KL term by flipping the matched pairs in each batch of size total_batch_size
                 # i.e., (x_1, y_1), ..., (x_n, y_n) --> (x_1, y_n), ..., (x_n, y_1) = (x'_1, y'_1), ..., (x'_n, y'_n)
@@ -737,7 +712,7 @@ class KTOTrainer(_BaseTrainer):
                     map_kwargs["desc"] = f"Assembling KL {dataset_name} dataset"
                 column_names = get_dataset_column_names(dataset)
                 kl_dataset = kl_dataset.map(
-                    assemble_kl_fn,
+                    rename_kl_fn,
                     remove_columns=[c for c in get_dataset_column_names(kl_dataset) if c in column_names],
                     **map_kwargs,
                 )

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -103,14 +103,14 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
         pad_token_id (`int`, defaults to `0`):
             Token ID to use for padding `input_ids` sequences.
         max_length (`int`, *optional*):
-            Maximum sequence length after assembly. Sequences exceeding this limit are truncated from the end of
-            the completion before BOS/EOS tokens are added.
+            Maximum sequence length after assembly. Sequences exceeding this limit are truncated from the end of the
+            completion before BOS/EOS tokens are added.
         bos_token_id (`int`, *optional*):
-            Token ID for the beginning-of-sequence token. If set and not already present at the start of
-            `prompt_ids`, it is prepended to both prompt and completion.
+            Token ID for the beginning-of-sequence token. If set and not already present at the start of `prompt_ids`,
+            it is prepended to both prompt and completion.
         eos_token_id (`int`, *optional*):
-            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`,
-            it is appended to the completion.
+            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`, it
+            is appended to the completion.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
     """


### PR DESCRIPTION
Align KTO with DPO: Move completion assembly from `_prepare_dataset` to `DataCollatorForUnpairedPreference`.

This PR refactors the KTOTrainer data pipeline to simplify and standardize how prompts and completions are represented and processed. It moves completion assembly out of `_prepare_dataset` and into `DataCollatorForUnpairedPreference`, aligning the KTO data pipeline with DPO's: the dataset stores raw token IDs, and the collator handles truncation, BOS/EOS insertion, sequence assembly, and label creation at batch time. It replaces the previous use of multiple keys (such as `*_input_ids`, `*_attention_mask`, and `*_labels`) with a cleaner, more explicit use of `prompt_ids` and `completion_ids`. The data collator is also rewritten to assemble and pad sequences, add BOS/EOS tokens, and generate labels in a more modular way. The test suite and KL dataset handling are updated accordingly.

Part of:
- #4786

### Changes

**Refactoring of data representation and processing:**

* The data pipeline now consistently uses `prompt_ids` and `completion_ids` instead of multiple input/attention/label keys. This simplifies data handling and makes the dataset format clearer.
* The data collator (`DataCollatorForUnpairedPreference`) gains `max_length`, `bos_token_id`, and `eos_token_id` fields. The `torch_call` is rewritten to assemble completions from raw token IDs, handle BOS/EOS tokens, truncate sequences as needed, and generate labels with the correct masking.
* KL dataset rotation and assembly are simplified: the KL dataset is now created by rotating `completion_ids` only, and a simple renaming function is used instead of re-assembling sequences. 
* The `tokenize_fn`** is reduced to two output fields: `prompt_ids` (raw tokenized prompt) and `completion_ids` (raw answer tokens, no prompt prefix), matching DPO's `tokenize_fn` output style.
* The intermediate `answer_input_ids` / `answer_attention_mask` columns, and the corresponding `remove_columns` call, are gone: those fields are never created.

**Test and documentation updates:**

* The test suite is updated to match the new data format, checking that `prompt_ids` and `completion_ids` are correctly populated and that the collator output is as expected.
* Documentation and logging messages are updated to reference the new data collator and column names, ensuring clarity for users.

These changes make the KTOTrainer codebase more maintainable and less error-prone by unifying the handling of prompt and completion data throughout the pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors KTO’s input pipeline (tokenization, truncation, BOS/EOS handling, KL rotation), which can subtly change training/eval behavior and loss masking if any edge cases are missed.
> 
> **Overview**
> Refactors KTO data preparation to **store only raw `prompt_ids` and `completion_ids` in the dataset** and moves sequence assembly (prompt+completion), truncation, BOS/EOS insertion, attention masks, and label masking into `DataCollatorForUnpairedPreference` at batch time.
> 
> Simplifies KL dataset handling by rotating `completion_ids` only and carrying them as `KL_completion_ids` for the collator to assemble, removing the previous intermediate `answer_*` and pre-assembled `*_input_ids/*_labels` columns. Tests are updated to validate the new dataset format and to assert collator-produced `completion_*` tensors (including EOS and `-100` prompt masking).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b21e788237af7d4c6685c6b8c90888dd084b895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->