### PR TITLE
Hotfix CI: Add ruff dependency to doc-builder style check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
         name: Check style with doc-builder
         language: python
         entry: doc-builder style trl tests docs/source --max_len 119
-        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@2430c1ec91d04667414e2fa31ecfc36c153ea391"]
+        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@2430c1ec91d04667414e2fa31ecfc36c153ea391", ruff]  # See GH-5633
         pass_filenames: false
         types_or: [python, markdown, rst]

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -97,7 +97,7 @@ def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
 @dataclass
 class DataCollatorForUnpairedPreference(DataCollatorMixin):
     """
-    Data collator for unpaired preference data. Pads sequences to the maximum length of the batch.
+    Data collator for unpaired preference data. Pads sequences to the maximum length of the batch. Test.
 
     Args:
         pad_token_id (`int`, defaults to `0`):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -97,7 +97,7 @@ def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
 @dataclass
 class DataCollatorForUnpairedPreference(DataCollatorMixin):
     """
-    Data collator for unpaired preference data. Pads sequences to the maximum length of the batch. Test.
+    Data collator for unpaired preference data. Pads sequences to the maximum length of the batch.
 
     Args:
         pad_token_id (`int`, defaults to `0`):


### PR DESCRIPTION
Hotfix CI: Add ruff dependency to doc-builder style check.

Hotfix to:
- #5633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-commit hook dependencies and does not affect runtime code paths.
> 
> **Overview**
> Ensures the local `doc-builder-style` pre-commit hook has `ruff` installed by adding it to `additional_dependencies` in `.pre-commit-config.yaml`, addressing CI failures related to missing linting tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd04260a734f5c4e8c1cae902481973a44d4041c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->