### PR TITLE
Align KTO with DPO: Remove BOS/EOS handling

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -102,22 +102,13 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
     Args:
         pad_token_id (`int`):
             Token ID to use for padding `input_ids` sequences.
-        bos_token_id (`int`):
-            Token ID for the beginning-of-sequence token. If set and not already present at the start of `prompt_ids`,
-            it is prepended to both prompt and completion.
-        eos_token_id (`int`):
-            Token ID for the end-of-sequence token. If set and not already present at the end of `completion_ids`, it
-            is appended to the completion.
         max_length (`int`, *optional*):
-            Maximum sequence length after assembly. Sequences exceeding this limit are truncated from the end of the
-            completion before BOS/EOS tokens are added.
+            Maximum sequence length after assembly. Sequences longer than `max_length` are truncated from the end.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
     """
 
     pad_token_id: int
-    bos_token_id: int
-    eos_token_id: int
     max_length: int | None = None
     return_tensors: str = "pt"
 
@@ -132,36 +123,12 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
             for ex in examples:
                 prompt_ids = ex["prompt_ids"]
                 answer_ids = ex[ids_key]
-
+                full_ids = prompt_ids + answer_ids
+                labels = [-100] * len(prompt_ids) + answer_ids
                 if self.max_length is not None:
-                    # Reserve budget for BOS/EOS tokens that will be added.
-                    # BOS: only if not already present (truncation never removes the first token)
-                    # EOS: always reserve a slot — truncation removes from the end, so EOS may be cut
-                    # even when it was present before truncation; the post-truncation guard re-appends it
-                    max_len = self.max_length
-                    if prompt_ids and self.bos_token_id != prompt_ids[0]:
-                        max_len -= 1
-                    if self.eos_token_id is not None:
-                        max_len -= 1
-                    if len(prompt_ids) + len(answer_ids) > max_len:
-                        answer_ids = answer_ids[: max_len - len(prompt_ids)]
-
-                # Assemble completion = prompt + (truncated) answer
-                completion_ids = prompt_ids + answer_ids
-
-                # Add BOS, which affects both prompt and the full completion
-                if self.bos_token_id is not None and (not prompt_ids or prompt_ids[0] != self.bos_token_id):
-                    prompt_ids = [self.bos_token_id] + prompt_ids
-                    completion_ids = [self.bos_token_id] + completion_ids
-
-                # Add EOS, which affects only the full completion
-                if not answer_ids or self.eos_token_id != answer_ids[-1]:
-                    completion_ids = completion_ids + [self.eos_token_id]
-
-                # Create labels: mask prompt tokens with -100
-                labels = [-100] * len(prompt_ids) + completion_ids[len(prompt_ids) :]
-
-                full_ids_list.append(completion_ids)
+                    full_ids = full_ids[: self.max_length]
+                    labels = labels[: self.max_length]
+                full_ids_list.append(full_ids)
                 labels_list.append(labels)
 
             batch[f"{prefix}_input_ids"] = pad(
@@ -412,8 +379,6 @@ class KTOTrainer(_BaseTrainer):
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=tokenizer.pad_token_id,
-                bos_token_id=tokenizer.bos_token_id,
-                eos_token_id=tokenizer.eos_token_id,
                 max_length=max_length,
             )
 


### PR DESCRIPTION
Align KTO with DPO: Remove BOS/EOS handling.

This PR removes explicit BOS/EOS handling from KTO, fully matching the behavior of DPO, which has no BOS or EOS logic of its own. This PR simplifies and streamlines the `DataCollatorForUnpairedPreference` logic in `KTOTrainer` by removing handling for BOS (beginning-of-sequence) and EOS (end-of-sequence) tokens, and by simplifying sequence truncation and assembly. The changes make the code fully aligned with DPO's approach: easier to maintain and reduce unnecessary complexity in sequence preparation.

Part of:
- #4786

### Motivation

This matches DPO exactly:
- EOS: added as text by `add_eos` in `_prepare_dataset` before tokenization; already present in `completion_ids` when the collator sees it. No integer-level EOS logic anywhere.
- BOS: not handled at all. Left entirely to the tokenizer.
- Data Collator: pure concatenate + truncate + pad. No BOS or EOS.

### Changes

**Simplification of Data Collator Arguments and Logic:**
* Removed `bos_token_id` and `eos_token_id` as arguments and related logic from `DataCollatorForUnpairedPreference`, so the collator no longer prepends/appends these tokens or reserves sequence budget for them.
* Simplified the truncation logic: sequences are now truncated directly to `max_length` from the end, without accounting for extra BOS/EOS tokens.

**Code Usage Updates:**
* Updated instantiation of `DataCollatorForUnpairedPreference` to no longer pass `bos_token_id` or `eos_token_id` from the tokenizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how KTO assembles and truncates training sequences, which can subtly shift labels, masking, and effective context length during training/eval.
> 
> **Overview**
> Aligns KTO’s `DataCollatorForUnpairedPreference` with DPO by **removing all BOS/EOS token injection and related truncation budget logic**.
> 
> The collator now does a simple `prompt_ids + completion_ids` concatenate, builds labels as `-100` for the prompt and raw completion tokens for the rest, and truncates both `input_ids` and labels directly to `max_length`. `KTOTrainer` no longer passes `bos_token_id`/`eos_token_id` when constructing the default collator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e1cb9cc643c8655d6869a8eb243eb9ac17b7e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->