### PR TITLE
Fix spurious KL gradients for zero-std reward groups in GRPOTrainer

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2179,7 +2179,7 @@ class GRPOTrainer(_BaseTrainer):
         # However, the KL penalty term (beta * per_token_kl) still produces gradients that
         # pull the model toward the reference policy without any reward signal. Zeroing
         # the completion mask for these groups eliminates the spurious KL gradients.
-        # See https://arxiv.org/abs/2505.22257 (Section 3.2).
+        # See https://huggingface.co/papers/2505.22257 (Section 3.2).
         is_std_zero_local = is_std_zero[process_slice]
         completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2174,6 +2174,15 @@ class GRPOTrainer(_BaseTrainer):
         all_process_advantages = advantages.clone()  # keep the aggregated advantages for logging
         advantages = advantages[process_slice]
 
+        # Mask out completions from groups with zero reward std (all rewards identical).
+        # When std=0, advantages are 0, so the policy loss contribution is already zero.
+        # However, the KL penalty term (beta * per_token_kl) still produces gradients that
+        # pull the model toward the reference policy without any reward signal. Zeroing
+        # the completion mask for these groups eliminates the spurious KL gradients.
+        # See https://arxiv.org/abs/2505.22257 (Section 3.2).
+        is_std_zero_local = is_std_zero[process_slice]
+        completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
+
         # Calculate mean reward per function, but only for samples where the function was applied (non-NaN values)
         for i, reward_func_name in enumerate(self.reward_func_names):
             mean_rewards = torch.nanmean(rewards_per_func[:, i]).item()


### PR DESCRIPTION
# What does this PR do?

Fixes #5588: In GRPOTrainer, groups with identical rewards (zero reward std) produce spurious KL gradients when `beta > 0`.

When std=0, advantages are 0, so policy loss contribution is zero. But the KL penalty term still produces gradients pulling the model toward the reference policy without any reward signal.

Fix: mask out completions from groups with zero reward std by multiplying `completion_mask` with `(~is_std_zero_local).unsqueeze(1).int()`. This eliminates the spurious KL gradients while preserving the zero policy loss.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (no code changes needed)
- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue? (refs #5588)
- [ ] Did you make sure to update the documentation?
- [ ] Did you write any new necessary tests?

## AI writing disclosure
- [x] AI-assisted (AI tools assisted with code generation; all changes reviewed and verified by a human before submission)

<!--
## What does this PR do?

Fixes #5588

When all completions in a group receive the same reward (zero std), advantages are zero and the policy loss contribution is correctly zero. However, the KL penalty term (`beta * per_token_kl`) still produces non-zero gradients through the model's log-probabilities, pulling the model toward the reference policy without any reward signal guiding the direction.

This fix masks out completions from zero-std groups, eliminating the spurious KL gradients. This is consistent with DAPO (arXiv:2505.22257, Section 3.2, "On-Policy Clipped Objective with Zero Variance Masking").

### Design

- After slicing advantages for the local process, also slice `is_std_zero` and apply it as a mask on `completion_mask`
- Since `completion_mask` is used throughout the loss computation as the primary mask for loss/attention, zeroing it for zero-std groups naturally eliminates both the (already-zero) policy loss and the KL gradients
- The `tool_mask` (when present) is multiplied with `completion_mask` at loss time, so this fix also correctly handles tool-calling scenarios

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue? #5588
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
-->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GRPOTrainer loss masking so completions from zero reward-variance groups are excluded, which can alter optimization dynamics and convergence but is localized to the GRPO training loop.
> 
> **Overview**
> Prevents **spurious KL-only updates** in `GRPOTrainer` when a prompt group’s rewards have zero variance by masking those completions out of `completion_mask` after per-process slicing.
> 
> This ensures groups with `std_rewards == 0` contribute no gradients (including the `beta * per_token_kl` term), aligning behavior with the referenced DAPO “zero variance masking” approach while preserving existing reward/std logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc4e54ae537c7c5d6e69582877f4086abbac57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->