### PR TITLE
Fix token_type_ids requirement for gemma-3 models in GRPOTrainer

### DIFF
--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -978,6 +978,11 @@ class DPPOTrainer(GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/experimental/gfpo/gfpo_trainer.py
+++ b/trl/experimental/gfpo/gfpo_trainer.py
@@ -178,6 +178,11 @@ class GFPOTrainer(_GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -187,6 +187,11 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1938,6 +1938,11 @@ class GRPOTrainer(_BaseTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1171,6 +1171,11 @@ class RLOOTrainer(_BaseTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:


### PR DESCRIPTION
# What does this PR do?

Fixes #5032 — gemma-3 models require `token_type_ids` in the forward pass.

## Description

gemma-3 models require `token_type_ids` in the model forward pass, but TRL's GRPOTrainer does not include them in the prepared inputs for text-only training (only for VLM models with images). This causes a `ValueError: token_type_ids is required as a model input when training` when fine-tuning gemma-3 with QLoRA/GRPO.

## Changes

- Added automatic `token_type_ids` generation for text-only models whose forward pass expects them
- Applied to `GRPOTrainer._prepare_completion()` and `PPOTrainer`
- Uses a zero tensor matching the prompt length, which gets automatically padded with zeros for the completion part via the existing extension block

## AI Declaration

AI tools assisted with code generation and PR description. The bug was manually reproduced, the fix was reviewed and validated by a human (Robert Ruidisch). All changes are human-approved and tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small conditional to pass zero-initialized `token_type_ids` only when the underlying model forward signature requires it, mainly affecting text-only training on models like gemma-3.
> 
> **Overview**
> Fixes text-only GRPO-style training for models that *require* `token_type_ids` (e.g., gemma-3) by auto-adding a zero `token_type_ids` tensor when it’s present in `model_kwarg_keys`.
> 
> This behavior is applied consistently across `GRPOTrainer`, `RLOOTrainer`, and the experimental trainers (`DPPOTrainer`, `GFPOTrainer`, `GRPOWithReplayBufferTrainer`), relying on the existing logic to extend/pad `token_type_ids` for the completion portion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507b0e4811fdac6ce921b5c3382a706d11230a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->