### PR TITLE
Fix token_type_ids requirement for gemma-3 models in GRPOTrainer

### DIFF
--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -978,6 +978,11 @@ class DPPOTrainer(GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/experimental/gfpo/gfpo_trainer.py
+++ b/trl/experimental/gfpo/gfpo_trainer.py
@@ -178,6 +178,11 @@ class GFPOTrainer(_GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -187,6 +187,11 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1938,6 +1938,11 @@ class GRPOTrainer(_BaseTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1171,6 +1171,11 @@ class RLOOTrainer(_BaseTrainer):
             forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
         else:
             forward_kwargs = {}
+            # For text-only models whose forward pass expects token_type_ids (e.g., gemma-3),
+            # create a zero tensor matching the prompt length. The extension block below will
+            # automatically pad it with zeros for the completion part.
+            if "token_type_ids" in self.model_kwarg_keys:
+                forward_kwargs["token_type_ids"] = torch.zeros_like(prompt_ids)
 
         # If token_type_ids are used, extend them with zeros for the completion part
         if "token_type_ids" in forward_kwargs:


### PR DESCRIPTION
# What does this PR do?

Fixes #5032: gemma-3 models crash during GRPO/RLOO training with `ValueError: token_type_ids is required` when no processor (e.g. VLM processor) is available.

Root cause: in the text-only forward path, `forward_kwargs` is empty. Models like gemma-3 that include `token_type_ids` in their forward signature receive no `token_type_ids`, causing a crash.

Fix: Before the text-only forward pass, if `"token_type_ids" in self.model_kwarg_keys`, create a zero tensor matching the prompt length. The existing extension block then pads zeros for completion tokens automatically.

Applied across 5 trainers: GRPOTrainer, RLOOTrainer, DPPOTrainer, GFPOTrainer, GRPOWithReplayBufferTrainer.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can leave this unchecked)
- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue? (#5032)
- [ ] Did you make sure to update the documentation? No — the fix has no user-facing API change.
- [ ] Did you write any new necessary tests? No — the change is a guarded zero-tensor creation. Existing training CI exercises the text-only path for gemma models.

## AI writing disclosure
- [x] AI-assisted (AI tools assisted with code generation; all changes reviewed and verified by a human before submission)