### PR TITLE
Add sentence-level importance sampling to GRPO

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -185,13 +185,29 @@ While training and evaluating, we record the following reward metrics:
 - `frac_reward_zero_std`: The fraction of samples in the generation batch with a reward std of zero, implying there is little diversity for that prompt (all answers are correct or incorrect).
 - `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.
-- `clip_ratio/region_mean`: The ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities where the GRPO objective is clipped to stay within the trust region:  \\( \text{clip}\left( r_{i,t}(\theta), 1 - \epsilon_\mathrm{low}, 1 + \epsilon_\mathrm{high} \right)\,, \quad r_{i,t}(\theta) = \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_{\text{old}}}(o_{i,t} \mid q, o_{i,< t})} \\). A higher value means more tokens are clipped, which constrains how much the policy $\pi_\theta$ can change.
-- `clip_ratio/low_mean`: The average ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
-- `clip_ratio/low_min`: The minimum ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
-- `clip_ratio/high_mean`: The average ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
-- `clip_ratio/high_max`: The maximum ratio of token (or sequence, if `importance_sampling_level="sequence"`) probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
+- `clip_ratio/region_mean`: The ratio of token probabilities, sentence probabilities (if `importance_sampling_level="sentence"`), or sequence probabilities (if `importance_sampling_level="sequence"`) where the GRPO objective is clipped to stay within the trust region:  \\( \text{clip}\left( r_{i,t}(\theta), 1 - \epsilon_\mathrm{low}, 1 + \epsilon_\mathrm{high} \right)\,, \quad r_{i,t}(\theta) = \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_{\text{old}}}(o_{i,t} \mid q, o_{i,< t})} \\). A higher value means more tokens are clipped, which constrains how much the policy $\pi_\theta$ can change. Sentence-level and sequence-level ratios are still reported as token-counted metrics, with each token inheriting its sentence or sequence clipping status.
+- `clip_ratio/low_mean`: The average ratio of token probabilities, sentence probabilities (if `importance_sampling_level="sentence"`), or sequence probabilities (if `importance_sampling_level="sequence"`) that were clipped on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
+- `clip_ratio/low_min`: The minimum ratio of token probabilities, sentence probabilities (if `importance_sampling_level="sentence"`), or sequence probabilities (if `importance_sampling_level="sequence"`) that were clipped on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
+- `clip_ratio/high_mean`: The average ratio of token probabilities, sentence probabilities (if `importance_sampling_level="sentence"`), or sequence probabilities (if `importance_sampling_level="sequence"`) that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
+- `clip_ratio/high_max`: The maximum ratio of token probabilities, sentence probabilities (if `importance_sampling_level="sentence"`), or sequence probabilities (if `importance_sampling_level="sequence"`) that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
 
 ## Customization
+
+### Choose importance sampling granularity
+
+By default, GRPO computes one importance sampling ratio per token. You can set `importance_sampling_level="sequence"` to use a single geometric-mean ratio for the whole completion, as in GSPO. You can also set `importance_sampling_level="sentence"` to use one geometric-mean ratio for each punctuation-delimited linguistic unit, as in LPO:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    importance_sampling_level="sentence",
+)
+```
+
+Sentence-level ratios are applied uniformly to all valid tokens in the corresponding sentence. Padding tokens, masked tool or environment tokens, and masked truncated completions are excluded from the sentence ratios. If no sentence boundary is detected, the completion is treated as one sentence unit.
+
+Sentence-level importance sampling is not supported with `use_liger_kernel=True` yet.
 
 ### Speed up training with vLLM-powered generation
 

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -124,6 +124,24 @@ $$
 
 This token-level ratio is then combined with a shared advantage  \\( \hat{A}_i \\), and the GRPO objective clips and optimizes each token independently across the sequence.
 
+### Ling 2.0: An Efficient, Reward-Driven Language Model with Reasoning Capability
+
+**📜 Paper**: https://huggingface.co/papers/2510.22115
+
+Introduces Linguistic-unit Policy Optimization (LPO), a GRPO-family method that computes importance sampling ratios at the sentence level. LPO segments each detokenized completion into punctuation-delimited linguistic units, computes a geometric-mean policy ratio for each unit, and applies that unit ratio to every token in the unit. To use this setting:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    importance_sampling_level="sentence",
+    loss_type="grpo",
+    epsilon=0.03,  # LPO paper training setting
+)
+```
+
+If a completion has no detected sentence boundary, the completion is treated as a single linguistic unit and the ratio matches the sequence-level formulation for that sample.
+
 ### DAPO: An Open-Source LLM Reinforcement Learning System at Scale
 
 **📜 Paper**: https://huggingface.co/papers/2503.14476

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -159,6 +159,79 @@ class TestGetHighEntropyMask(TrlTestCase):
         torch.testing.assert_close(entropy_mask, expected_mask)
 
 
+class _DummyTokenizer:
+    def __init__(self, pieces):
+        self.pieces = pieces
+
+    def decode(self, token_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False):
+        return self.pieces[int(token_ids[0])]
+
+
+class TestGRPOSentenceImportanceSampling:
+    def _make_trainer(self, pieces):
+        trainer = object.__new__(GRPOTrainer)
+        trainer._tokenizer = _DummyTokenizer(pieces)
+        return trainer
+
+    def test_sentence_ids_split_on_punctuation(self):
+        trainer = self._make_trainer({1: "First", 2: ".", 3: " Second", 4: "!"})
+        completion_ids = torch.tensor([[1, 2, 3, 4, 0]])
+        loss_mask = torch.tensor([[1, 1, 1, 1, 0]])
+
+        sentence_ids = trainer._get_sentence_ids(completion_ids, loss_mask)
+
+        expected_sentence_ids = torch.tensor([[0, 0, 1, 1, -1]])
+        torch.testing.assert_close(sentence_ids, expected_sentence_ids)
+
+    def test_sentence_ids_respect_loss_mask(self):
+        trainer = self._make_trainer({1: "First", 2: ".", 3: " tool.", 4: " Second"})
+        completion_ids = torch.tensor([[1, 2, 3, 4]])
+        loss_mask = torch.tensor([[1, 1, 0, 1]])
+
+        sentence_ids = trainer._get_sentence_ids(completion_ids, loss_mask)
+
+        expected_sentence_ids = torch.tensor([[0, 0, -1, 1]])
+        torch.testing.assert_close(sentence_ids, expected_sentence_ids)
+
+    def test_sentence_ids_no_punctuation_matches_sequence_unit(self):
+        trainer = self._make_trainer({1: "One", 2: " continuous", 3: " unit"})
+        completion_ids = torch.tensor([[1, 2, 3]])
+        loss_mask = torch.tensor([[1, 1, 1]])
+
+        sentence_ids = trainer._get_sentence_ids(completion_ids, loss_mask)
+
+        expected_sentence_ids = torch.tensor([[0, 0, 0]])
+        torch.testing.assert_close(sentence_ids, expected_sentence_ids)
+
+    def test_sentence_log_importance_weights(self):
+        log_ratio = torch.tensor([[0.1, 0.3, 1.0, 1.4]])
+        sentence_ids = torch.tensor([[0, 0, 1, 1]])
+
+        weights = GRPOTrainer._get_sentence_log_importance_weights(log_ratio, sentence_ids)
+
+        expected_weights = torch.tensor([[0.2, 0.2, 1.2, 1.2]])
+        torch.testing.assert_close(weights, expected_weights)
+
+    def test_sentence_log_importance_weights_ignore_negative_ids(self):
+        log_ratio = torch.tensor([[2.0, 4.0, 6.0, 8.0]])
+        sentence_ids = torch.tensor([[0, -1, 0, -1]])
+
+        weights = GRPOTrainer._get_sentence_log_importance_weights(log_ratio, sentence_ids)
+
+        expected_weights = torch.tensor([[4.0, 0.0, 4.0, 0.0]])
+        torch.testing.assert_close(weights, expected_weights)
+
+    def test_sentence_log_importance_weights_backpropagates(self):
+        log_ratio = torch.tensor([[0.1, 0.3, 1.0, 1.4]], requires_grad=True)
+        sentence_ids = torch.tensor([[0, 0, 1, 1]])
+
+        weights = GRPOTrainer._get_sentence_log_importance_weights(log_ratio, sentence_ids)
+        weights.sum().backward()
+
+        expected_grad = torch.ones_like(log_ratio)
+        torch.testing.assert_close(log_ratio.grad, expected_grad)
+
+
 class TestGRPORolloutDispatch:
     def _make_trainer(self):
         trainer = object.__new__(GRPOTrainer)
@@ -2339,6 +2412,59 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_training_sentence_importance_sampling(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            num_iterations=2,  # the importance sampling weights won't be 0 in this case
+            importance_sampling_level="sentence",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_liger_sentence_importance_sampling_not_supported(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            importance_sampling_level="sentence",
+            report_to="none",
+        )
+
+        with pytest.raises(NotImplementedError, match="sentence-level importance sampling"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
 
     def test_training_with_chat_template_kwargs(self):
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -197,9 +197,12 @@ class GRPOConfig(_BaseConfig):
             how aggressively we down-weight samples with high importance weights (when the importance sampling ratio >
             1).
         importance_sampling_level (`str`, *optional*, defaults to `"token"`):
-            Controls whether importance sampling ratios are computed at the `"token"` or `"sequence"` level. `"token"`
-            keeps the raw per-token log-probability ratios (one weight per token). `"sequence"` averages the
-            log-probability ratios across valid tokens to produce a single ratio per sequence. The [GSPO
+            Controls whether importance sampling ratios are computed at the `"token"`, `"sentence"`, or `"sequence"`
+            level. `"token"` keeps the raw per-token log-probability ratios (one weight per token). `"sentence"`
+            averages the log-probability ratios across valid tokens in each punctuation-delimited linguistic unit and
+            applies the resulting ratio to all tokens in that unit. This sentence-level formulation was introduced in
+            the [LPO paper](https://huggingface.co/papers/2510.22115). `"sequence"` averages the log-probability ratios
+            across valid tokens to produce a single ratio per sequence. The [GSPO
             paper](https://huggingface.co/papers/2507.18071) shows that sequence-level sampling often yields more
             stable training and better alignment with sequence-level rewards.
         reward_weights (`list[float]`, *optional*):
@@ -668,11 +671,13 @@ class GRPOConfig(_BaseConfig):
     importance_sampling_level: str = field(
         default="token",
         metadata={
-            "help": "Controls whether importance sampling ratios are computed at the `'token'` or `'sequence'` level. "
-            "`'token'` keeps the raw per-token log-probability ratios (one weight per token).  `'sequence'` averages "
-            "the log-probability ratios across valid tokens to produce a single ratio per sequence. The GSPO paper "
-            "shows that sequence-level sampling often yields more stable training and better alignment with "
-            "sequence-level rewards."
+            "help": "Controls whether importance sampling ratios are computed at the `'token'`, `'sentence'`, or "
+            "`'sequence'` level. `'token'` keeps the raw per-token log-probability ratios (one weight per token). "
+            "`'sentence'` averages the log-probability ratios across valid tokens in each punctuation-delimited "
+            "linguistic unit and applies the resulting ratio to all tokens in that unit, as introduced in the LPO "
+            "paper. `'sequence'` averages the log-probability ratios across valid tokens to produce a single ratio "
+            "per sequence. The GSPO paper shows that sequence-level sampling often yields more stable training and "
+            "better alignment with sequence-level rewards."
         },
     )
     reward_weights: list[float] | None = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -111,6 +111,8 @@ if is_trackio_available():
 
 logger = get_logger(__name__)
 
+_SENTENCE_BOUNDARY_CHARS = ".!?;:\n\u3002\uff01\uff1f\uff1b\uff1a"
+
 # A reward function can be a string, interpreted as a model ID and loaded as a pretrained model, a pretrained model, or
 # a callable that returns a list of floats (the rewards). The callable receives prompts, completions, and additional
 # arguments from the trainer (refer to the trainer's source for details). To ensure forward compatibility, it should
@@ -569,6 +571,8 @@ class GRPOTrainer(_BaseTrainer):
             raise NotImplementedError(
                 "Liger Kernels don't currently support masking token positions based on entropy."
             )
+        if self.use_liger_kernel and self.importance_sampling_level == "sentence":
+            raise NotImplementedError("Liger kernel does not support sentence-level importance sampling yet.")
         if self.use_liger_kernel and self.importance_sampling_level not in ("token", "sequence"):
             raise ValueError(
                 f"Unknown importance sampling level: {self.importance_sampling_level}. "
@@ -1908,6 +1912,11 @@ class GRPOTrainer(_BaseTrainer):
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
 
+        sentence_ids = None
+        if self.importance_sampling_level == "sentence":
+            loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+            sentence_ids = self._get_sentence_ids(completion_ids, loss_mask)
+
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)  # (B, P+C)
@@ -2264,6 +2273,8 @@ class GRPOTrainer(_BaseTrainer):
             output["sampling_per_token_logps"] = sampling_per_token_logps
         if ref_per_token_logps is not None:
             output["ref_per_token_logps"] = ref_per_token_logps
+        if sentence_ids is not None:
+            output["sentence_ids"] = sentence_ids
         if "pixel_values" in forward_kwargs:
             output["pixel_values"] = forward_kwargs["pixel_values"]
         if "image_grid_thw" in forward_kwargs:
@@ -2332,6 +2343,35 @@ class GRPOTrainer(_BaseTrainer):
         normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
         return loss / normalizer
 
+    def _get_sentence_ids(self, completion_ids: torch.Tensor, loss_mask: torch.Tensor) -> torch.Tensor:
+        sentence_ids = torch.full_like(completion_ids, -1, dtype=torch.long)
+        boundary_chars = set(_SENTENCE_BOUNDARY_CHARS)
+
+        for batch_idx in range(completion_ids.size(0)):
+            current_sentence_id = 0
+            start_new_sentence = False
+            for token_idx in range(completion_ids.size(1)):
+                if loss_mask[batch_idx, token_idx].item() == 0:
+                    continue
+
+                token_id = completion_ids[batch_idx, token_idx].item()
+                token_text = self._tokenizer.decode(
+                    [token_id], skip_special_tokens=True, clean_up_tokenization_spaces=False
+                )
+                has_boundary = any(char in boundary_chars for char in token_text)
+                has_text = any((not char.isspace()) and char not in boundary_chars for char in token_text)
+
+                if start_new_sentence and has_text:
+                    current_sentence_id += 1
+                    start_new_sentence = False
+
+                sentence_ids[batch_idx, token_idx] = current_sentence_id
+
+                if has_boundary:
+                    start_new_sentence = True
+
+        return sentence_ids
+
     @profiling_decorator
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         if return_outputs:
@@ -2364,6 +2404,26 @@ class GRPOTrainer(_BaseTrainer):
         is_pos_adv = advantages >= 0
         is_low_kl = avg_seq_kl <= off_policy_threshold
         return (is_pos_adv | is_low_kl).to(dtype=mask.dtype)  # (B, 1)
+
+    @staticmethod
+    def _get_sentence_log_importance_weights(log_ratio: torch.Tensor, sentence_ids: torch.Tensor) -> torch.Tensor:
+        log_importance_weights = torch.zeros_like(log_ratio)
+        for batch_idx in range(log_ratio.size(0)):
+            row_sentence_ids = sentence_ids[batch_idx]
+            valid = row_sentence_ids >= 0
+            if not valid.any():
+                continue
+
+            valid_sentence_ids = row_sentence_ids[valid]
+            num_sentences = valid_sentence_ids.max().item() + 1
+            sums = torch.zeros(num_sentences, dtype=log_ratio.dtype, device=log_ratio.device)
+            counts = torch.zeros(num_sentences, dtype=log_ratio.dtype, device=log_ratio.device)
+            sums.scatter_add_(0, valid_sentence_ids, log_ratio[batch_idx, valid])
+            counts.scatter_add_(0, valid_sentence_ids, torch.ones_like(log_ratio[batch_idx, valid]))
+            means = sums / counts.clamp(min=1.0)
+            log_importance_weights[batch_idx, valid] = means[valid_sentence_ids]
+
+        return log_importance_weights
 
     @staticmethod
     @torch.no_grad()
@@ -2478,13 +2538,17 @@ class GRPOTrainer(_BaseTrainer):
         log_ratio = per_token_logps - old_per_token_logps
         if self.importance_sampling_level == "token":
             log_importance_weights = log_ratio
+        elif self.importance_sampling_level == "sentence":
+            if "sentence_ids" not in inputs:
+                raise ValueError("`sentence_ids` is required when `importance_sampling_level='sentence'`.")
+            log_importance_weights = self._get_sentence_log_importance_weights(log_ratio, inputs["sentence_ids"])
         elif self.importance_sampling_level == "sequence":
             log_importance_weights = (log_ratio * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)
             log_importance_weights = log_importance_weights.unsqueeze(-1)
         else:
             raise ValueError(
-                f"Unknown importance sampling level: {self.importance_sampling_level}. Possible values are 'token' "
-                "and 'sequence'."
+                f"Unknown importance sampling level: {self.importance_sampling_level}. Possible values are 'token', "
+                "'sentence', and 'sequence'."
             )
 
         coef_1 = torch.exp(log_importance_weights)
@@ -2500,7 +2564,7 @@ class GRPOTrainer(_BaseTrainer):
                 per_token_kl = per_token_kl * coef_1
 
         # From here, log_importance_weights (and all subsequent tensors, coef_1, coef_2, etc.) shape depends on
-        # importance_sampling_level: "token" level: (B, T); "sequence" level: (B, 1)
+        # importance_sampling_level: "token" and "sentence" levels: (B, T); "sequence" level: (B, 1)
         if self.loss_type == "cispo":
             clamped_ratios = torch.clamp(coef_1, max=self.epsilon_high).detach()
             per_token_loss = -clamped_ratios * advantages * per_token_logps


### PR DESCRIPTION
## Summary

Adds sentence-level importance sampling to GRPO for the LPO / Ling 2.0 training path requested in #4443.

- Adds `importance_sampling_level="sentence"` to `GRPOConfig`.
- Computes row-local sentence IDs from completion tokens after completion/tool/truncation masks are finalized.
- Averages token log-ratios within each sentence and broadcasts the sentence-level log importance weight back to active tokens during loss computation.
- Keeps existing token-level and sequence-level behavior unchanged.
- Raises a clear `NotImplementedError` for `use_liger_kernel=True` with sentence-level importance sampling, because that fused loss path does not support sentence IDs yet.
- Updates GRPO docs and `paper_index.md` with the LPO / Ling 2.0 paper entry.

## Motivation

GRPO currently supports token-level and sequence-level importance sampling. Ling 2.0 / LPO needs an intermediate sentence-level granularity so token updates within the same sentence share one importance weight. This PR adds that mode directly in GRPO without introducing shared trainer abstractions or changing the existing duplicated trainer style.

Fixes #4443.

## Implementation Notes

- Sentence boundaries are detected from decoded token pieces ending in common sentence punctuation (`.`, `!`, `?`, `;`, `:`, newline, and CJK equivalents).
- Masked and padded tokens receive sentence ID `-1` and are ignored by sentence aggregation.
- Sentence log importance weights are computed with differentiable tensor ops, preserving gradients through the log-ratio inputs.
- The implementation intentionally stays local to GRPO because the new mode is specific to the issue request and RLOO/other trainers do not currently expose this option.

## Validation

- `uv run --extra test python -m pytest tests/test_grpo_trainer.py -k "sentence_log_importance_weights or sentence_ids or training_sentence_importance_sampling or liger_sentence_importance_sampling_not_supported or training_sequence_importance_sampling"`
- `uv run --extra test python -m pytest tests/test_grpo_trainer.py -k "training_loss_types"`
- `uv run --with ruff ruff check trl/trainer/grpo_config.py trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py`
- `uv run --with ruff ruff format --check trl/trainer/grpo_config.py trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py`
- `git diff --check`
