### PR TITLE
Add adaptive beta-DPO strategy to DPOTrainer

### DIFF
--- a/docs/source/dpo_trainer.md
+++ b/docs/source/dpo_trainer.md
@@ -121,6 +121,26 @@ Several formulations of the objective have been proposed in the literature. Init
 | `"discopop"` | The [DiscoPOP](https://huggingface.co/papers/2406.08414) paper uses LLMs to discover more efficient offline preference optimization losses. In the paper the proposed DiscoPOP loss (which is a log-ratio modulated loss) outperformed other optimization losses on different tasks (IMDb positive text generation, Reddit TLDR summarization, and Alpaca Eval 2.0). |
 | `"sft"` | SFT (Supervised Fine-Tuning) loss is the negative log likelihood loss, used to train the model to generate preferred responses. |
 
+#### Adaptive beta
+
+[`DPOConfig`] supports the [beta-DPO](https://huggingface.co/papers/2407.08639) dynamic beta strategy with `adaptive_beta="beta_dpo"`. Instead of using the same `beta` for every batch, the trainer computes a batch-level beta from the current implicit reward margin:
+
+$$
+\beta_{\text{batch}} = \left[1 + \alpha\left(\overline{M}_{\text{batch}} - M_0\right)\right]\beta_0
+$$
+
+where  \\( \beta_0 \\)  is the configured `beta`,  \\( \alpha \\)  is `beta_alpha`, and  \\( M_0 \\)  is either `beta_reference_margin` or an exponential moving average of train-batch margins. Because this changes the beta scale rather than the loss formulation, it can be combined with existing DPO loss types such as `"sigmoid"`, `"ipo"`, `"sppo_hard"`, and multi-loss combinations.
+
+```python
+from trl import DPOConfig
+
+training_args = DPOConfig(
+    beta=0.1,
+    adaptive_beta="beta_dpo",
+    beta_alpha=0.5,
+)
+```
+
 ## Logged metrics
 
 While training and evaluating we record the following reward metrics:
@@ -137,10 +157,14 @@ While training and evaluating we record the following reward metrics:
 * `logits/rejected`: The average logit values assigned by the model to the tokens in the rejected completion.
 * `logps/chosen`: The average log-probability assigned by the model to the tokens in the chosen completion.
 * `logps/rejected`: The average log-probability assigned by the model to the tokens in the rejected completion.
-* `rewards/chosen`: The average implicit reward computed for the chosen completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y^{+}\!\mid x)}{\pi_{\mathrm{ref}}(y^{+}\!\mid x)} \\).
-* `rewards/rejected`: The average implicit reward computed for the rejected completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y^{-}\!\mid x)}{\pi_{\mathrm{ref}}(y^{-}\!\mid x)} \\).
+* `rewards/chosen`: The average implicit reward computed for the chosen completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y^{+}\!\mid x)}{\pi_{\mathrm{ref}}(y^{+}\!\mid x)} \\), where  \\( \beta \\)  is the configured beta or the adaptive batch beta.
+* `rewards/rejected`: The average implicit reward computed for the rejected completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y^{-}\!\mid x)}{\pi_{\mathrm{ref}}(y^{-}\!\mid x)} \\), where  \\( \beta \\)  is the configured beta or the adaptive batch beta.
 * `rewards/margins`: The average implicit reward margin between the chosen and rejected completions.
 * `rewards/accuracies`: The proportion of examples where the implicit reward for the chosen completion is higher than that for the rejected completion.
+* `adaptive_beta/effective_beta`: The batch-level beta used for the loss, logged only when `adaptive_beta="beta_dpo"`.
+* `adaptive_beta/base_beta`: The configured base beta, logged only when `adaptive_beta="beta_dpo"`.
+* `adaptive_beta/batch_margin`: The average batch margin used to compute the adaptive beta, logged only when `adaptive_beta="beta_dpo"`.
+* `adaptive_beta/reference_margin`: The fixed or moving reference margin used to compute the adaptive beta, logged only when `adaptive_beta="beta_dpo"`.
 
 ## Customization
 
@@ -152,7 +176,8 @@ Some argument combinations are intentionally restricted in the current [`DPOTrai
 * With `use_liger_kernel=True`:
   * only a single `loss_type` is supported,
   * `compute_metrics` is not supported,
-  * `precompute_ref_log_probs=True` is not supported.
+  * `precompute_ref_log_probs=True` is not supported,
+  * `adaptive_beta="beta_dpo"` is not supported.
 * `sync_ref_model=True` is not supported when training with PEFT models that do not keep a standalone `ref_model`.
 * `sync_ref_model=True` cannot be combined with `precompute_ref_log_probs=True`.
 * `precompute_ref_log_probs=True` is not supported with `IterableDataset` (train or eval).

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1068,6 +1068,29 @@ training_args = DPOConfig(
 )
 ```
 
+### Understanding the Performance Gap between Online and Offline Alignment Algorithms
+
+**📜 Paper**: https://huggingface.co/papers/2407.08639
+
+The paper introduces beta-DPO, which adapts DPO's β at the batch level based on the current implicit reward margin. Instead of changing the preference loss itself, beta-DPO scales the existing β parameter:
+
+$$
+\beta_{\text{batch}} = \left[1 + \alpha\left(\overline{M}_{\text{batch}} - M_0\right)\right]\beta_0
+$$
+
+where  \\( \beta_0 \\)  is the base β,  \\( \alpha \\)  controls the update strength, and  \\( M_0 \\)  is a fixed or moving reference margin. In TRL, this strategy is enabled with `adaptive_beta="beta_dpo"` and can be combined with existing DPO loss types.
+
+```python
+from trl import DPOConfig
+
+training_args = DPOConfig(
+    loss_type="sigmoid",
+    beta=0.1,
+    adaptive_beta="beta_dpo",
+    beta_alpha=0.5,
+)
+```
+
 ### Anchored Preference Optimization and Contrastive Revisions: Addressing Underspecification in Alignment
 
 **📜 Paper**: https://huggingface.co/papers/2408.06266

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -345,6 +345,155 @@ class TestDPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.allclose(param, new_param), f"Parameter {n} has not changed"
 
+    def test_adaptive_beta_config_validation(self):
+        DPOConfig(output_dir=self.tmp_dir, adaptive_beta="beta_dpo", beta_alpha=0.0, report_to="none")
+        DPOConfig(output_dir=self.tmp_dir, adaptive_beta="beta_dpo", beta_alpha=1.0, report_to="none")
+
+        with pytest.raises(ValueError, match="`adaptive_beta` must be `None` or `'beta_dpo'`"):
+            DPOConfig(output_dir=self.tmp_dir, adaptive_beta="beta-dpo", beta_alpha=0.5, report_to="none")
+
+        with pytest.raises(ValueError, match="`beta_alpha` must be provided"):
+            DPOConfig(output_dir=self.tmp_dir, adaptive_beta="beta_dpo", report_to="none")
+
+        with pytest.raises(ValueError, match="`beta_alpha` must be in the range"):
+            DPOConfig(output_dir=self.tmp_dir, adaptive_beta="beta_dpo", beta_alpha=1.1, report_to="none")
+
+    def test_train_with_adaptive_beta(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        # Initialize the trainer
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            loss_type=["sigmoid", "bco_pair", "sft"],  # check adaptive beta with a multi-loss setup
+            adaptive_beta="beta_dpo",
+            beta_alpha=0.5,
+            max_steps=2,
+            logging_steps=1,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # Train the model
+        trainer.train()
+
+        # Check that the training loss and adaptive beta metrics are logged
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        adaptive_beta_logs = [log for log in trainer.state.log_history if "adaptive_beta/effective_beta" in log]
+        assert adaptive_beta_logs
+        assert adaptive_beta_logs[-1]["adaptive_beta/effective_beta"] > 0
+        assert "adaptive_beta/batch_margin" in adaptive_beta_logs[-1]
+        assert "adaptive_beta/reference_margin" in adaptive_beta_logs[-1]
+        assert trainer._beta_reference_margin is not None
+
+    def test_adaptive_beta_alpha_zero_matches_static_beta(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
+
+        # Initialize the trainers
+        training_args = DPOConfig(
+            output_dir=f"{self.tmp_dir}/static",
+            report_to="none",
+        )
+        adaptive_training_args = DPOConfig(
+            output_dir=f"{self.tmp_dir}/adaptive",
+            adaptive_beta="beta_dpo",
+            beta_alpha=0.0,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+        )
+        adaptive_trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=adaptive_training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+        )
+
+        # Compute the eval loss on the same batch
+        batch = next(iter(trainer.get_eval_dataloader()))
+        adaptive_batch = next(iter(adaptive_trainer.get_eval_dataloader()))
+        trainer.model.eval()
+        adaptive_trainer.model.eval()
+        with torch.no_grad():
+            loss = trainer.compute_loss(trainer.model, trainer._prepare_inputs(batch))
+            adaptive_loss = adaptive_trainer.compute_loss(
+                adaptive_trainer.model, adaptive_trainer._prepare_inputs(adaptive_batch)
+            )
+
+        torch.testing.assert_close(adaptive_loss, loss)
+
+    def test_adaptive_beta_eval_does_not_initialize_reference_margin(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
+
+        # Initialize the trainer
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            adaptive_beta="beta_dpo",
+            beta_alpha=0.5,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+        )
+
+        # Compute one eval batch before any train batch
+        batch = next(iter(trainer.get_eval_dataloader()))
+        trainer.model.eval()
+        with torch.no_grad():
+            trainer.compute_loss(trainer.model, trainer._prepare_inputs(batch))
+
+        assert trainer._beta_reference_margin is None
+
+    def test_adaptive_beta_fixed_reference_margin(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
+
+        # Initialize the trainer
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            beta=0.2,
+            adaptive_beta="beta_dpo",
+            beta_alpha=0.5,
+            beta_reference_margin=0.25,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+        )
+
+        # Compute one eval batch and check the fixed-margin beta formula
+        batch = next(iter(trainer.get_eval_dataloader()))
+        trainer.model.eval()
+        with torch.no_grad():
+            trainer.compute_loss(trainer.model, trainer._prepare_inputs(batch))
+
+        metrics = trainer._metrics["eval"]
+        batch_margin = metrics["adaptive_beta/batch_margin"][-1]
+        expected_beta = training_args.beta * (
+            1 + training_args.beta_alpha * (batch_margin - training_args.beta_reference_margin)
+        )
+        expected_beta = max(expected_beta, 1e-6)
+        assert metrics["adaptive_beta/reference_margin"][-1] == pytest.approx(training_args.beta_reference_margin)
+        assert metrics["adaptive_beta/effective_beta"][-1] == pytest.approx(expected_beta)
+        assert trainer._beta_reference_margin is None
+
     def test_train_with_wpo(self):
         # Get the dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
@@ -746,6 +895,25 @@ class TestDPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.allclose(param, new_param), f"Parameter {n} has not changed"
+
+    def test_adaptive_beta_with_liger_raises(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        # Initialize the trainer
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            adaptive_beta="beta_dpo",
+            beta_alpha=0.5,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="Adaptive beta is not supported with the Liger DPO loss"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
 
     def test_train_with_iterable_dataset(self):
         # Get the dataset

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -96,6 +96,15 @@ class DPOConfig(_BaseConfig):
             Parameter controlling the deviation from the reference model. Higher β means less deviation from the
             reference model. For the IPO loss (`loss_type='ipo'`), this value is the regularization parameter denoted
             by τ in the [paper](https://huggingface.co/papers/2310.12036).
+        adaptive_beta (`str`, *optional*):
+            Adaptive β strategy to use. Currently, the only supported value is `"beta_dpo"`, which scales `beta`
+            dynamically per batch based on the batch preference margin.
+        beta_alpha (`float`, *optional*):
+            Scaling factor α for the adaptive β update. Required when `adaptive_beta="beta_dpo"` and must be in
+            `[0.0, 1.0]`.
+        beta_reference_margin (`float`, *optional*):
+            Fixed reference margin M₀ used by `adaptive_beta="beta_dpo"`. If `None`, the trainer uses an exponential
+            moving average of train-batch margins.
         use_weighting (`bool`, *optional*, defaults to `False`):
             Whether to apply WPO-style weighting (https://huggingface.co/papers/2406.11827) to preference pairs using
             the policy's length-normalized sequence probabilities.
@@ -265,6 +274,27 @@ class DPOConfig(_BaseConfig):
             "denoted by τ in the [paper](https://huggingface.co/papers/2310.12036)."
         },
     )
+    adaptive_beta: str | None = field(
+        default=None,
+        metadata={
+            "help": "Adaptive β strategy to use. Currently, the only supported value is `'beta_dpo'`, which scales "
+            "`beta` dynamically per batch based on the batch preference margin."
+        },
+    )
+    beta_alpha: float | None = field(
+        default=None,
+        metadata={
+            "help": "Scaling factor α for the adaptive β update. Required when `adaptive_beta='beta_dpo'` and must "
+            "be in `[0.0, 1.0]`."
+        },
+    )
+    beta_reference_margin: float | None = field(
+        default=None,
+        metadata={
+            "help": "Fixed reference margin M₀ used by `adaptive_beta='beta_dpo'`. If `None`, the trainer uses an "
+            "exponential moving average of train-batch margins."
+        },
+    )
     use_weighting: bool = field(
         default=False,
         metadata={
@@ -325,6 +355,13 @@ class DPOConfig(_BaseConfig):
                 "`loss_weights` must have the same length as `loss_type` when combining multiple losses. "
                 f"Got {len(self.loss_weights)} weights for {len(self.loss_type)} loss types."
             )
+        if self.adaptive_beta is not None:
+            if self.adaptive_beta != "beta_dpo":
+                raise ValueError("`adaptive_beta` must be `None` or `'beta_dpo'`.")
+            if self.beta_alpha is None:
+                raise ValueError("`beta_alpha` must be provided when `adaptive_beta='beta_dpo'`.")
+            if not (0.0 <= self.beta_alpha <= 1.0):
+                raise ValueError(f"`beta_alpha` must be in the range [0.0, 1.0], but got {self.beta_alpha}.")
         if self.pad_token is not None:
             warnings.warn(
                 "`pad_token` is deprecated and will be removed in v2.0.0. "

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -518,6 +518,8 @@ class DPOTrainer(_BaseTrainer):
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
             args = DPOConfig(f"{model_name}-DPO")
+        if args.use_liger_kernel and args.adaptive_beta is not None:
+            raise NotImplementedError("Adaptive beta is not supported with the Liger DPO loss.")
 
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")
@@ -652,6 +654,11 @@ class DPOTrainer(_BaseTrainer):
 
         # Training arguments
         self.beta = args.beta
+        self.adaptive_beta = args.adaptive_beta
+        self.beta_alpha = args.beta_alpha
+        self.beta_reference_margin = args.beta_reference_margin
+        self._adaptive_beta_momentum = 0.9
+        self._beta_reference_margin = None
         self.precompute_ref_logps = args.precompute_ref_log_probs
         self.loss_types = args.loss_type  # args.loss_type is already a list
         self.loss_weights = args.loss_weights or [1.0] * len(self.loss_types)
@@ -1237,14 +1244,42 @@ class DPOTrainer(_BaseTrainer):
             raise ValueError(f"Unknown f_divergence_type: {self.f_divergence_type}")
 
         delta_score = chosen_scores - rejected_scores
+        effective_beta = torch.tensor(self.beta, device=device, dtype=delta_score.dtype)
+        batch_margin = None
+        reference_margin = None
+
+        if self.adaptive_beta == "beta_dpo":
+            raw_delta_logratio = chosen_logratios - rejected_logratios
+            batch_margins = self.beta * raw_delta_logratio.detach()
+            batch_margin = self.accelerator.gather_for_metrics(batch_margins).mean()
+
+            if self.beta_reference_margin is None:
+                if mode == "train":
+                    if self._beta_reference_margin is None:
+                        self._beta_reference_margin = batch_margin.detach()
+                    else:
+                        momentum = self._adaptive_beta_momentum
+                        self._beta_reference_margin = (
+                            momentum * self._beta_reference_margin + (1 - momentum) * batch_margin.detach()
+                        )
+                    reference_margin = self._beta_reference_margin
+                else:
+                    reference_margin = self._beta_reference_margin
+                    if reference_margin is None:
+                        reference_margin = batch_margin.detach()
+            else:
+                reference_margin = torch.tensor(self.beta_reference_margin, device=device, dtype=delta_score.dtype)
+
+            effective_beta = self.beta * (1 + self.beta_alpha * (batch_margin - reference_margin))
+            effective_beta = effective_beta.clamp_min(1e-6).detach()
 
         loss = 0.0
         for loss_type, loss_weight in zip(self.loss_types, self.loss_weights, strict=True):
             if loss_type == "sigmoid":
-                per_sequence_loss = -F.logsigmoid(self.beta * delta_score)
+                per_sequence_loss = -F.logsigmoid(effective_beta * delta_score)
 
             elif loss_type == "hinge":
-                per_sequence_loss = torch.relu(1 - self.beta * delta_score)
+                per_sequence_loss = torch.relu(1 - effective_beta * delta_score)
 
             elif loss_type == "ipo":
                 # IPO uses sequence-level log-prob differences; in code these are token-summed over the completion,
@@ -1257,24 +1292,24 @@ class DPOTrainer(_BaseTrainer):
                 rejected_avg_score = rejected_scores / rejected_mask.sum(dim=1).clamp(min=1.0)
                 ipo_delta = chosen_avg_score - rejected_avg_score
                 # (Eq. 17) of the paper where beta is the regularization parameter for the IPO loss, denoted by τ.
-                per_sequence_loss = (ipo_delta - 1 / (2 * self.beta)) ** 2
+                per_sequence_loss = (ipo_delta - 1 / (2 * effective_beta)) ** 2
 
             elif loss_type == "exo_pair":
                 # Implements EXO-pref from the paper https://huggingface.co/papers/2402.00856, (Eq. 16)
                 # Minimize KL(p_fθ || p_rh) for K=2; p_fθ = softmax(βπ * (log πθ − log π_ref)) over {chosen, rejected}
                 # p_rh = [(1−ε), ε]; expanded KL gives the weighted logsigmoid form below
                 epsilon = torch.tensor(self.label_smoothing, device=device)
-                qw = torch.sigmoid(self.beta * delta_score)
-                log_qw = F.logsigmoid(self.beta * delta_score)
+                qw = torch.sigmoid(effective_beta * delta_score)
+                log_qw = F.logsigmoid(effective_beta * delta_score)
                 log_pw = torch.log1p(-epsilon)
-                ql = torch.sigmoid(-self.beta * delta_score)
-                log_ql = F.logsigmoid(-self.beta * delta_score)
+                ql = torch.sigmoid(-effective_beta * delta_score)
+                log_ql = F.logsigmoid(-effective_beta * delta_score)
                 log_pl = torch.log(epsilon)
                 per_sequence_loss = qw * (log_qw - log_pw) + ql * (log_ql - log_pl)
 
             elif loss_type == "nca_pair":
-                chosen_rewards = self.beta * chosen_scores
-                rejected_rewards = self.beta * rejected_scores
+                chosen_rewards = effective_beta * chosen_scores
+                rejected_rewards = effective_beta * rejected_scores
                 per_sequence_loss = (
                     -F.logsigmoid(chosen_rewards)
                     - 0.5 * F.logsigmoid(-chosen_rewards)
@@ -1282,13 +1317,13 @@ class DPOTrainer(_BaseTrainer):
                 )
 
             elif loss_type == "robust":
-                clean_loss_term = -(1 - self.label_smoothing) * F.logsigmoid(self.beta * delta_score)
-                flipped_loss_term = -self.label_smoothing * F.logsigmoid(-self.beta * delta_score)
+                clean_loss_term = -(1 - self.label_smoothing) * F.logsigmoid(effective_beta * delta_score)
+                flipped_loss_term = -self.label_smoothing * F.logsigmoid(-effective_beta * delta_score)
                 per_sequence_loss = (clean_loss_term - flipped_loss_term) / (1 - 2 * self.label_smoothing)
 
             elif loss_type == "bco_pair":
-                chosen_rewards = self.beta * chosen_scores
-                rejected_rewards = self.beta * rejected_scores
+                chosen_rewards = effective_beta * chosen_scores
+                rejected_rewards = effective_beta * rejected_scores
                 per_sequence_loss = -F.logsigmoid(chosen_rewards) - F.logsigmoid(-rejected_rewards)
 
             elif loss_type == "sppo_hard":
@@ -1296,8 +1331,8 @@ class DPOTrainer(_BaseTrainer):
                 # estimated using the PairRM score. The probability calculation is conducted outside of the trainer
                 # class. The version described here is the hard probability version, where P in Equation (4.7) of
                 # Algorithm 1 is set to 1 for the winner and 0 for the loser.
-                winner_margin_error = (chosen_scores - 0.5 / self.beta) ** 2
-                loser_margin_error = (rejected_scores + 0.5 / self.beta) ** 2
+                winner_margin_error = (chosen_scores - 0.5 / effective_beta) ** 2
+                loser_margin_error = (rejected_scores + 0.5 / effective_beta) ** 2
                 per_sequence_loss = winner_margin_error + loser_margin_error
 
             elif loss_type == "aot":
@@ -1307,8 +1342,8 @@ class DPOTrainer(_BaseTrainer):
                 ref_logratios_sorted, _ = torch.sort(ref_logratios, dim=0)
                 delta = logratios_sorted - ref_logratios_sorted
                 per_sequence_loss = (
-                    -F.logsigmoid(self.beta * delta) * (1 - self.label_smoothing)
-                    - F.logsigmoid(-self.beta * delta) * self.label_smoothing
+                    -F.logsigmoid(effective_beta * delta) * (1 - self.label_smoothing)
+                    - F.logsigmoid(-effective_beta * delta) * self.label_smoothing
                 )
 
             elif loss_type == "aot_unpaired":
@@ -1316,29 +1351,29 @@ class DPOTrainer(_BaseTrainer):
                 rejected_logratios_sorted, _ = torch.sort(rejected_logratios, dim=0)
                 delta = chosen_logratios_sorted - rejected_logratios_sorted
                 per_sequence_loss = (
-                    -F.logsigmoid(self.beta * delta) * (1 - self.label_smoothing)
-                    - F.logsigmoid(-self.beta * delta) * self.label_smoothing
+                    -F.logsigmoid(effective_beta * delta) * (1 - self.label_smoothing)
+                    - F.logsigmoid(-effective_beta * delta) * self.label_smoothing
                 )
 
             elif loss_type == "apo_zero":
                 # Eqn (7) of the APO paper (https://huggingface.co/papers/2408.06266)
                 # Use this loss when you believe the chosen outputs are better than your model's default output
                 # Increase chosen likelihood and decrease rejected likelihood
-                losses_chosen = 1 - torch.sigmoid(self.beta * chosen_logratios)
-                losses_rejected = torch.sigmoid(self.beta * rejected_logratios)
+                losses_chosen = 1 - torch.sigmoid(effective_beta * chosen_logratios)
+                losses_rejected = torch.sigmoid(effective_beta * rejected_logratios)
                 per_sequence_loss = losses_chosen + losses_rejected
 
             elif loss_type == "apo_down":
                 # Eqn (8) of the APO paper (https://huggingface.co/papers/2408.06266)
                 # Use this loss when you believe the chosen outputs are worse than your model's default output.
                 # Decrease chosen likelihood and decrease rejected likelihood more
-                losses_chosen = torch.sigmoid(self.beta * chosen_logratios)
-                losses_rejected = 1 - torch.sigmoid(self.beta * delta_score)
+                losses_chosen = torch.sigmoid(effective_beta * chosen_logratios)
+                losses_rejected = 1 - torch.sigmoid(effective_beta * delta_score)
                 per_sequence_loss = losses_chosen + losses_rejected
 
             elif loss_type == "discopop":
                 # Eqn (5) of the DiscoPOP paper (https://huggingface.co/papers/2406.08414)
-                logits = delta_score * self.beta
+                logits = delta_score * effective_beta
                 # Modulate the mixing coefficient based on the log ratio magnitudes
                 log_ratio_modulation = torch.sigmoid(logits / self.args.discopop_tau)
                 logistic_component = -F.logsigmoid(logits)
@@ -1428,8 +1463,8 @@ class DPOTrainer(_BaseTrainer):
         self._metrics[mode]["mean_token_accuracy"].append(accuracy)
 
         # Rewards for chosen and rejected completions
-        chosen_rewards = self.beta * chosen_logratios.detach()
-        rejected_rewards = self.beta * rejected_logratios.detach()
+        chosen_rewards = effective_beta * chosen_logratios.detach()
+        rejected_rewards = effective_beta * rejected_logratios.detach()
         agg_chosen_rewards = self.accelerator.gather(chosen_rewards)
         agg_rejected_rewards = self.accelerator.gather(rejected_rewards)
         self._metrics[mode]["rewards/chosen"].append(agg_chosen_rewards.mean().item())
@@ -1448,6 +1483,12 @@ class DPOTrainer(_BaseTrainer):
         # Average log probabilities for chosen and rejected completions
         self._metrics[mode]["logps/chosen"].append(self.accelerator.gather(chosen_logps).mean().item())
         self._metrics[mode]["logps/rejected"].append(self.accelerator.gather(rejected_logps).mean().item())
+
+        if self.adaptive_beta == "beta_dpo":
+            self._metrics[mode]["adaptive_beta/effective_beta"].append(effective_beta.item())
+            self._metrics[mode]["adaptive_beta/base_beta"].append(self.beta)
+            self._metrics[mode]["adaptive_beta/batch_margin"].append(batch_margin.item())
+            self._metrics[mode]["adaptive_beta/reference_margin"].append(reference_margin.item())
 
         return (loss, outputs) if return_outputs else loss
 


### PR DESCRIPTION
## Summary

Adds an adaptive beta strategy to `DPOTrainer` for beta-DPO-style dynamic batch scaling.

This PR introduces:

- `DPOConfig.adaptive_beta`, with initial support for `adaptive_beta="beta_dpo"`
- `DPOConfig.beta_alpha` as the adaptive scaling factor
- `DPOConfig.beta_reference_margin` as an optional fixed reference margin override
- Batch-level `effective_beta` computation in the standard DPO loss path
- Adaptive beta metrics for effective beta, base beta, batch margin, and reference margin
- Documentation and paper index coverage for beta-DPO

## Motivation

Issue #5211 requests adaptive beta support in `DPOTrainer`, starting with beta-DPO. The key design point is that beta-DPO modifies the beta scaling parameter rather than introducing a separate preference loss, so this implementation keeps it orthogonal to `loss_type`.

That means the strategy can compose with the existing DPO-family losses, including sigmoid DPO, IPO, SPPO hard, BCO pair, AOT, APO, DiscoPOP, and multi-loss combinations.

Closes #5211.

## Implementation Details

- Computes one scalar `effective_beta` per loss batch when `adaptive_beta="beta_dpo"`.
- Estimates the batch margin from the raw chosen/rejected policy-reference log-ratio gap.
- Uses a fixed `beta_reference_margin` when provided.
- Otherwise maintains an in-memory exponential moving average of train-batch margins.
- Keeps eval non-mutating: eval can use the existing EMA, or the current eval batch as a temporary neutral reference before training.
- Applies `effective_beta` consistently across every beta-dependent DPO loss branch.
- Leaves `loss_type="sft"` unchanged because it has no beta term.
- Rejects `use_liger_kernel=True` with adaptive beta for now, because the current Liger DPO loss is initialized with a fixed beta.

## Tests

Validated locally with:

```bash
uv run --with ruff ruff check trl/trainer/dpo_config.py trl/trainer/dpo_trainer.py tests/test_dpo_trainer.py
uv run --with ruff ruff format --check trl/trainer/dpo_config.py trl/trainer/dpo_trainer.py tests/test_dpo_trainer.py
uv run --extra test python -m pytest tests/test_dpo_trainer.py -k adaptive_beta
uv run --extra test python -m pytest tests/test_dpo_trainer.py -k "adaptive_beta or train_loss_types or train_multi_loss_types"
uv run --extra test python -m pytest tests/test_dpo_trainer.py
git diff --check
```

Full DPO trainer test result:

```text
46 passed, 23 skipped
```
