### PR TITLE
Add RepeatSampler regression coverage for generation batch reuse

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -498,6 +498,98 @@ class TestRepeatRandomSampler(TrlTestCase):
         assert sampled[12:16] == sampled[16:20] == sampled[20:24]
         assert sampled[24:28] == sampled[28:32] == sampled[32:36]
 
+    def test_sampler_repeats_global_generation_chunks_before_advancing(self):
+        dataset = list(range(20))
+        num_generations = 4
+        num_iterations = 3
+        world_size = 8
+        per_device_train_batch_size = 4
+        steps_per_generation = 1
+        generation_batch_size = world_size * per_device_train_batch_size * steps_per_generation
+        unique_prompts_per_generation = generation_batch_size // num_generations
+        repeat_count = num_iterations * steps_per_generation
+        full_generation_chunks = len(dataset) // unique_prompts_per_generation
+
+        sampler = RepeatSampler(
+            dataset,
+            mini_repeat_count=num_generations,
+            batch_size=unique_prompts_per_generation,
+            repeat_count=repeat_count,
+            shuffle=False,
+        )
+        sampled = list(sampler)
+        generation_batches = [
+            sampled[i : i + generation_batch_size] for i in range(0, len(sampled), generation_batch_size)
+        ]
+
+        expected_first_generation_batch = [
+            idx for idx in range(unique_prompts_per_generation) for _ in range(num_generations)
+        ]
+        expected_second_generation_batch = [
+            idx
+            for idx in range(unique_prompts_per_generation, 2 * unique_prompts_per_generation)
+            for _ in range(num_generations)
+        ]
+
+        assert len(generation_batches) == full_generation_chunks * repeat_count
+        assert generation_batches[:repeat_count] == [expected_first_generation_batch] * repeat_count
+        assert generation_batches[repeat_count : 2 * repeat_count] == [expected_second_generation_batch] * repeat_count
+        assert set(sampled) == set(range(full_generation_chunks * unique_prompts_per_generation))
+        assert full_generation_chunks * unique_prompts_per_generation not in sampled
+
+    def test_sampler_layout_matches_distributed_generation_reuse(self):
+        dataset = list(range(20))
+        world_size = 8
+        per_device_train_batch_size = 4
+        steps_per_generation = 1
+        num_generations = 4
+        num_iterations = 3
+
+        generation_batch_size = world_size * per_device_train_batch_size * steps_per_generation
+        local_batch_size = per_device_train_batch_size * steps_per_generation
+        unique_prompts_per_generation = generation_batch_size // num_generations
+        repeat_count = num_iterations * steps_per_generation
+        full_generation_chunks = len(dataset) // unique_prompts_per_generation
+
+        sampler = RepeatSampler(
+            dataset,
+            mini_repeat_count=num_generations,
+            batch_size=unique_prompts_per_generation,
+            repeat_count=repeat_count,
+            shuffle=False,
+        )
+        sampled = list(sampler)
+        local_batches = [sampled[i : i + local_batch_size] for i in range(0, len(sampled), local_batch_size)]
+        global_steps = [
+            local_batches[step * world_size : (step + 1) * world_size]
+            for step in range(len(local_batches) // world_size)
+        ]
+        assert len(local_batches) == len(global_steps) * world_size
+        assert len(global_steps) == full_generation_chunks * repeat_count
+        rank_steps = [
+            [local_batches[step * world_size + rank] for step in range(len(global_steps))]
+            for rank in range(world_size)
+        ]
+
+        for rank in range(world_size):
+            assert rank_steps[rank][:repeat_count] == [[rank] * local_batch_size] * repeat_count
+            assert (
+                rank_steps[rank][repeat_count : 2 * repeat_count]
+                == [[rank + unique_prompts_per_generation] * local_batch_size] * repeat_count
+            )
+
+        first_generation_prompt_sets = [
+            sorted({idx for batch in step for idx in batch}) for step in global_steps[:repeat_count]
+        ]
+        second_generation_prompt_sets = [
+            sorted({idx for batch in step for idx in batch}) for step in global_steps[repeat_count : 2 * repeat_count]
+        ]
+        assert first_generation_prompt_sets == [list(range(unique_prompts_per_generation))] * repeat_count
+        assert (
+            second_generation_prompt_sets
+            == [list(range(unique_prompts_per_generation, 2 * unique_prompts_per_generation))] * repeat_count
+        )
+
 
 class TestEntropyFromLogits(TrlTestCase):
     @pytest.mark.parametrize("shape", [(768,), (32, 768), (8, 16, 768), (2, 4, 8, 768)])


### PR DESCRIPTION
# What does this PR do?

This PR adds regression coverage for the `RepeatSampler` ordering discussed in #4531.

It verifies that a full global generation batch is repeated for every `num_iterations` reuse pass before the sampler advances to the next generation chunk. It also adds a lightweight distributed-layout simulation that checks each rank keeps the same local prompt group across reuse passes.

Issue #4531 reports that GRPO sampling can over-repeat individual prompts when `num_iterations > 1`, producing an order like `0 x 12, 1 x 12, ...` instead of repeating the whole generation batch. Current `main` already passes a generation-batch-aware unique-prompt chunk size to `RepeatSampler`, so this PR locks down that behavior with focused tests rather than changing runtime trainer logic.

The new tests capture both important invariants:

- The raw sampler stream repeats complete generation chunks before advancing.
- The simulated distributed layout keeps each rank's local prompt batch stable while buffered completions are reused.

This preserves the existing incomplete-final-chunk behavior, where prompts that do not fill a complete unique-prompt generation chunk are dropped.

Fixes #4531

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. #4531
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed because this is regression test coverage for existing behavior.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

Additional local validation:

- `uv run python -m pytest tests/test_utils.py -k RepeatRandomSampler`
- `uv run python -m pytest tests/test_utils.py`
- `uv run python -m pytest tests/test_grpo_trainer.py -k test_prepare_input_called_with_correct_data`
- `uv run python -m pytest tests/test_rloo_trainer.py -k test_prepare_input_called_with_correct_data`
- `uv run ruff check tests/test_utils.py`
- `uv run ruff format --check tests/test_utils.py`
- `git diff --check`

I also ran a small local `accelerate.data_loader.BatchSamplerShard` probe to confirm the test's simulated rank layout matches Accelerate's non-split batch sharding behavior for the issue setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds test coverage and does not change runtime sampling or trainer logic. Failures would surface ordering regressions in `RepeatSampler` usage for multi-iteration generation reuse.
> 
> **Overview**
> Adds focused regression tests for `RepeatSampler` to lock down **generation-batch reuse ordering** when `repeat_count` (e.g., `num_iterations * steps_per_generation`) is greater than 1.
> 
> The new cases assert that the sampler repeats an entire global generation chunk before advancing to the next chunk, and that a simulated distributed sharding layout keeps each rank’s local prompt group stable across reuse passes (while still dropping incomplete final chunks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c2f5cdbea4078df6570080b6b0adfdccea1b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->