### PR TITLE
Align KTO with DPO: Remove model_init parameter

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -191,9 +191,6 @@ class KTOTrainer(_BaseTrainer):
             The data collator to use for training. If None is specified, the default data collator
             ([`~experimental.kto.kto_trainer.DataCollatorForUnpairedPreference`]) will be used which will pad the
             sequences to the maximum length of the sequences in the batch.
-        model_init (`Callable[[], transformers.PreTrainedModel]`):
-            The model initializer to use for training. If None is specified, the default model initializer will be
-            used.
         callbacks (`list[transformers.TrainerCallback]`):
             The callbacks to use for training.
         optimizers (`tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR]`):
@@ -232,7 +229,6 @@ class KTOTrainer(_BaseTrainer):
         eval_dataset: Dataset | IterableDataset | dict[str, Dataset | IterableDataset] | None = None,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
         data_collator: DataCollator | None = None,
-        model_init: Callable[[], PreTrainedModel] | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         preprocess_logits_for_metrics: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
@@ -450,7 +446,6 @@ class KTOTrainer(_BaseTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
-            model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,
             optimizers=optimizers,


### PR DESCRIPTION
Align KTO with DPO: Remove `model_init` parameter.

This PR removes support for the `model_init` parameter from the `KTOTrainer` class. This simplifies the class interface by eliminating the option to provide a custom model initializer.

Part of:
- #4786

### Changes

Parameter removal:

* Removed the `model_init` parameter and its documentation from the `KTOTrainer` class, including its usage in the constructor and internal calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a public API change that will break callers passing `model_init`, though it does not alter the core training logic.
> 
> **Overview**
> **Simplifies `KTOTrainer`’s initialization API** by removing the `model_init` constructor parameter and its documentation.
> 
> The trainer no longer forwards `model_init` into the base trainer initialization, aligning KTO’s interface with DPO and leaving model instantiation to `model` (and `args.model_init_kwargs` when `model` is a string).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3059caa92dd738676d72acbbb5d8fed53920e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->