### PR TITLE
Align KTO with DPO: Remove preprocess_logits_for_metrics parameter

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -198,8 +198,6 @@ class KTOTrainer(_BaseTrainer):
             The callbacks to use for training.
         optimizers (`tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR]`):
             The optimizer and scheduler to use for training.
-        preprocess_logits_for_metrics (`Callable[[torch.Tensor, torch.Tensor], torch.Tensor]`):
-            The function to use to preprocess the logits before computing the metrics.
         peft_config (`dict`, defaults to `None`):
             The PEFT configuration to use for training. If you pass a PEFT configuration, the model will be wrapped in
             a PEFT model.
@@ -235,7 +233,6 @@ class KTOTrainer(_BaseTrainer):
         model_init: Callable[[], PreTrainedModel] | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
-        preprocess_logits_for_metrics: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
         peft_config: dict | None = None,
         compute_metrics: Callable[[EvalLoopOutput], dict] | None = None,
     ):
@@ -454,7 +451,6 @@ class KTOTrainer(_BaseTrainer):
             compute_metrics=compute_metrics,
             callbacks=callbacks,
             optimizers=optimizers,
-            preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
 
         # Reference model


### PR DESCRIPTION
Align KTO with DPO: Remove `preprocess_logits_for_metrics` parameter.

This PR removes the `preprocess_logits_for_metrics` parameter and related documentation from the `KTOTrainer` class. This helps simplify the code and avoid confusion about unused parameters.

Part of:
- #4786

### Changes

- Removed the `preprocess_logits_for_metrics` argument from the `KTOTrainer` constructor, its docstring, and its usage in the superclass constructor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low implementation risk since behavior is unchanged, but it is a minor breaking change for any downstream code still passing `preprocess_logits_for_metrics` into `KTOTrainer`.
> 
> **Overview**
> Removes the unused `preprocess_logits_for_metrics` argument from `KTOTrainer` (constructor signature + docstring) and stops forwarding it to the base `Trainer` initializer, aligning KTO’s public API with other preference trainers.
> 
> This is a small *API surface change* for callers instantiating `KTOTrainer` with that kwarg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6dd2a12566b81546a2c7ad46c8c53b79865c0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->