### PR TITLE
Fix missing PEFT validation when passing peft_config to core trainers

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -568,6 +568,12 @@ class DPOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
+        # PEFT
+        if peft_config is not None and not is_peft_available():
+            raise ImportError(
+                "You passed `peft_config` but the `peft` library is not installed. "
+                "Install it with `pip install trl[peft]`."
+            )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -569,11 +569,17 @@ class DPOTrainer(_BaseTrainer):
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
         # PEFT
-        if peft_config is not None and not is_peft_available():
-            raise ImportError(
-                "You passed `peft_config` but the `peft` library is not installed. "
-                "Install it with `pip install trl[peft]`."
-            )
+        if peft_config is not None:
+            if not is_peft_available():
+                raise ImportError(
+                    "You passed `peft_config` but the `peft` library is not installed. "
+                    "Install it with `pip install trl[peft]`."
+                )
+            if not isinstance(peft_config, PeftConfig):
+                raise TypeError(
+                    f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
+                    f"got {type(peft_config).__name__}."
+                )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -344,6 +344,12 @@ class GRPOTrainer(_BaseTrainer):
             if tid != self._tokenizer.unk_token_id:
                 self._video_pad_token_id = tid
 
+        # PEFT
+        if peft_config is not None and not is_peft_available():
+            raise ImportError(
+                "You passed `peft_config` but the `peft` library is not installed. "
+                "Install it with `pip install trl[peft]`."
+            )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -345,11 +345,17 @@ class GRPOTrainer(_BaseTrainer):
                 self._video_pad_token_id = tid
 
         # PEFT
-        if peft_config is not None and not is_peft_available():
-            raise ImportError(
-                "You passed `peft_config` but the `peft` library is not installed. "
-                "Install it with `pip install trl[peft]`."
-            )
+        if peft_config is not None:
+            if not is_peft_available():
+                raise ImportError(
+                    "You passed `peft_config` but the `peft` library is not installed. "
+                    "Install it with `pip install trl[peft]`."
+                )
+            if not isinstance(peft_config, PeftConfig):
+                raise TypeError(
+                    f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
+                    f"got {type(peft_config).__name__}."
+                )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -405,11 +405,17 @@ class RewardTrainer(_BaseTrainer):
             added_tokens = []
 
         # PEFT
-        if peft_config is not None and not is_peft_available():
-            raise ImportError(
-                "You passed `peft_config` but the `peft` library is not installed. "
-                "Install it with `pip install trl[peft]`."
-            )
+        if peft_config is not None:
+            if not is_peft_available():
+                raise ImportError(
+                    "You passed `peft_config` but the `peft` library is not installed. "
+                    "Install it with `pip install trl[peft]`."
+                )
+            if not isinstance(peft_config, PeftConfig):
+                raise TypeError(
+                    f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
+                    f"got {type(peft_config).__name__}."
+                )
         if peft_config is not None:
             if added_tokens:
                 # Ensure that the added tokens are trainable

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -404,7 +404,12 @@ class RewardTrainer(_BaseTrainer):
         else:
             added_tokens = []
 
-        # PEFT configuration and model wrapping
+        # PEFT
+        if peft_config is not None and not is_peft_available():
+            raise ImportError(
+                "You passed `peft_config` but the `peft` library is not installed. "
+                "Install it with `pip install trl[peft]`."
+            )
         if peft_config is not None:
             if added_tokens:
                 # Ensure that the added tokens are trainable

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -276,6 +276,12 @@ class RLOOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
+        # PEFT
+        if peft_config is not None and not is_peft_available():
+            raise ImportError(
+                "You passed `peft_config` but the `peft` library is not installed. "
+                "Install it with `pip install trl[peft]`."
+            )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -277,11 +277,17 @@ class RLOOTrainer(_BaseTrainer):
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
         # PEFT
-        if peft_config is not None and not is_peft_available():
-            raise ImportError(
-                "You passed `peft_config` but the `peft` library is not installed. "
-                "Install it with `pip install trl[peft]`."
-            )
+        if peft_config is not None:
+            if not is_peft_available():
+                raise ImportError(
+                    "You passed `peft_config` but the `peft` library is not installed. "
+                    "Install it with `pip install trl[peft]`."
+                )
+            if not isinstance(peft_config, PeftConfig):
+                raise TypeError(
+                    f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
+                    f"got {type(peft_config).__name__}."
+                )
         if is_peft_available() and is_peft_model(model) and peft_config is not None:
             raise ValueError(
                 "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -755,11 +755,17 @@ class SFTTrainer(_BaseTrainer):
             )
 
         # PEFT
-        if peft_config is not None and not is_peft_available():
-            raise ImportError(
-                "You passed `peft_config` but the `peft` library is not installed. "
-                "Install it with `pip install trl[peft]`."
-            )
+        if peft_config is not None:
+            if not is_peft_available():
+                raise ImportError(
+                    "You passed `peft_config` but the `peft` library is not installed. "
+                    "Install it with `pip install trl[peft]`."
+                )
+            if not isinstance(peft_config, PeftConfig):
+                raise TypeError(
+                    f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
+                    f"got {type(peft_config).__name__}."
+                )
         if peft_config is not None:
             if added_tokens:
                 # Ensure that the added tokens are trainable

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -754,7 +754,12 @@ class SFTTrainer(_BaseTrainer):
                 "tokens in input_ids. Use truncation_mode='keep_start' (the default) or set max_length=None."
             )
 
-        # PEFT configuration and model wrapping
+        # PEFT
+        if peft_config is not None and not is_peft_available():
+            raise ImportError(
+                "You passed `peft_config` but the `peft` library is not installed. "
+                "Install it with `pip install trl[peft]`."
+            )
         if peft_config is not None:
             if added_tokens:
                 # Ensure that the added tokens are trainable


### PR DESCRIPTION
Fix missing PEFT availability check when passing `peft_config` to core trainers.

This PR adds consistent checks for the availability of the `peft` library across multiple trainer classes. Now, if a `peft_config` is provided but the `peft` library is not installed, a clear `ImportError` is raised with installation instructions. This ensures users are informed early about missing dependencies and prevents silent failures.

### Motivation

All trainers that accept a `peft_config` parameter (SFT, DPO, Reward, RLOO, GRPO) guarded their PEFT imports under `if is_peft_available():`, but never checked whether `peft` was actually installed before using those imports. Passing a `peft_config` without `peft` installed would reach an unconditional `get_peft_model(model, peft_config)` call and crash with a cryptic (instead of a helpful message):
> NameError: name 'get_peft_model' is not defined

### Solution

Add an early `ImportError` at the top of each trainer's PEFT section, before any attribute access on `peft_config` or any call into the `peft` library.

The check is placed before the first peft_config attribute access in each `__init__`, so the error is raised as early as possible regardless of how much pre-processing a given trainer does on `peft_config` before calling `get_peft_model` (SFT and Reward mutate `peft_config` fields before wrapping the model).

### Changes

Dependency management improvements:

* Added a check in `DPOTrainer`, `GRPOTrainer`, `RLOOTrainer`, `RewardTrainer`, and `SFTTrainer` to raise an `ImportError` with a helpful message if `peft_config` is provided but the `peft` library is not installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds upfront dependency/type checks for `peft_config` and improves error messages without changing training behavior when PEFT is correctly installed.
> 
> **Overview**
> Ensures all core trainers (`SFTTrainer`, `DPOTrainer`, `RewardTrainer`, `RLOOTrainer`, `GRPOTrainer`) *fail fast* when a `peft_config` is passed but the `peft` extra isn’t installed.
> 
> Adds consistent validation that `peft_config` is a `PeftConfig`, raising a clear `ImportError` (with install hint) or `TypeError` instead of later runtime failures during model wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f737bfa6286caa1e64fbaff5a586948b1079414f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->