### PR TITLE
Add RLCR format and Brier calibration rewards

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -74,6 +74,27 @@ trainer.train()
 ```
 
 
+### Beyond Binary Rewards: Training LMs to Reason About Their Uncertainty
+
+**📜 Paper**: https://huggingface.co/papers/2507.16806
+
+RLCR trains reasoning models to report both an answer and a calibrated confidence estimate. The model is prompted to
+produce `<think>`, `<answer>`, `<analysis>`, and `<confidence>` blocks, then optimized with a correctness reward plus a
+Brier-style calibration reward.
+
+```python
+from trl import GRPOConfig, GRPOTrainer
+from trl.rewards import accuracy_reward, brier_score_reward, rlcr_format_reward
+
+training_args = GRPOConfig(...)
+
+trainer = GRPOTrainer(
+    ...,
+    args=training_args,
+    reward_funcs=[rlcr_format_reward, accuracy_reward, brier_score_reward],
+)
+```
+
 ### Group Sequence Policy Optimization
 
 **📜 Paper**: https://huggingface.co/papers/2507.18071

--- a/docs/source/rewards.md
+++ b/docs/source/rewards.md
@@ -10,9 +10,17 @@ This module contains some useful reward functions, primarily intended for use wi
 
 [[autodoc]] rewards.reasoning_accuracy_reward
 
+## brier_score_reward
+
+[[autodoc]] rewards.brier_score_reward
+
 ## think_format_reward
 
 [[autodoc]] rewards.think_format_reward
+
+## rlcr_format_reward
+
+[[autodoc]] rewards.rlcr_format_reward
 
 ## get_soft_overlong_punishment
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -12,11 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import threading
 
-from trl.rewards import accuracy_reward, get_soft_overlong_punishment, reasoning_accuracy_reward, think_format_reward
+import pytest
+
+from trl.rewards import (
+    accuracy_reward,
+    brier_score_reward,
+    get_soft_overlong_punishment,
+    reasoning_accuracy_reward,
+    rlcr_format_reward,
+    think_format_reward,
+)
 
 from .testing_utils import TrlTestCase, require_math_latex
+
+
+def exact_text_correctness(completions, solution, **kwargs):
+    return [
+        float(completion[0]["content"].strip() == target)
+        for completion, target in zip(completions, solution, strict=True)
+    ]
 
 
 class TestThinkFormatReward(TrlTestCase):
@@ -61,6 +78,239 @@ class TestThinkFormatReward(TrlTestCase):
         expected_rewards = [1.0, 1.0, 0.0, 0.0]
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
+
+
+class TestRLCRFormatReward(TrlTestCase):
+    def test_valid_format(self):
+        completions = [
+            (
+                "<think>Reasoning.</think>"
+                "<answer>42</answer>"
+                "<analysis>Direct arithmetic.</analysis>"
+                "<confidence>0.9</confidence>"
+            ),
+            (
+                "\n<think>\nReasoning.\n</think>\n"
+                "<answer>\n42\n</answer>\n"
+                "<analysis>\nDirect arithmetic.\n</analysis>\n"
+                "<confidence>\n.5\n</confidence>\n"
+            ),
+        ]
+        completions = [[{"content": completion}] for completion in completions]
+        rewards = rlcr_format_reward(completions)
+        assert rewards == [1.0, 1.0]
+
+    def test_confidence_boundaries(self):
+        completions = [
+            (
+                "<think>Reasoning.</think>"
+                "<answer>42</answer>"
+                "<analysis>Direct arithmetic.</analysis>"
+                f"<confidence>{confidence}</confidence>"
+            )
+            for confidence in ["0", "0.0", "1", "1.0", ".5", "0.73"]
+        ]
+        completions = [[{"content": completion}] for completion in completions]
+        rewards = rlcr_format_reward(completions)
+        assert rewards == [1.0] * len(completions)
+
+    def test_invalid_confidence(self):
+        completions = [
+            (
+                "<think>Reasoning.</think>"
+                "<answer>42</answer>"
+                "<analysis>Direct arithmetic.</analysis>"
+                f"<confidence>{confidence}</confidence>"
+            )
+            for confidence in ["", "nan", "inf", "-0.1", "1.1", "not sure"]
+        ]
+        completions = [[{"content": completion}] for completion in completions]
+        rewards = rlcr_format_reward(completions)
+        assert rewards == [0.0] * len(completions)
+
+    def test_invalid_structure(self):
+        completions = [
+            # missing analysis
+            "<think>Reasoning.</think><answer>42</answer><confidence>0.9</confidence>",
+            # wrong order
+            "<think>Reasoning.</think><analysis>Direct.</analysis><answer>42</answer><confidence>0.9</confidence>",
+            # duplicate tag
+            (
+                "<think>Reasoning.</think><answer>42</answer><answer>43</answer>"
+                "<analysis>Direct.</analysis><confidence>0.9</confidence>"
+            ),
+            # nested outer tag
+            (
+                "<think>Reasoning with <answer>42</answer>.</think>"
+                "<answer>42</answer><analysis>Direct.</analysis><confidence>0.9</confidence>"
+            ),
+            # preamble
+            "Here is my answer. <think>Reasoning.</think><answer>42</answer>"
+            "<analysis>Direct.</analysis><confidence>0.9</confidence>",
+            # trailing content
+            "<think>Reasoning.</think><answer>42</answer><analysis>Direct.</analysis><confidence>0.9</confidence>!",
+        ]
+        completions = [[{"content": completion}] for completion in completions]
+        rewards = rlcr_format_reward(completions)
+        assert rewards == [0.0] * len(completions)
+
+
+class TestBrierScoreReward(TrlTestCase):
+    def test_scores_calibrated_confidence(self):
+        completions = [
+            (
+                "<think>Reasoning.</think>"
+                "<answer>correct</answer>"
+                "<analysis>Direct.</analysis>"
+                "<confidence>1.0</confidence>"
+            ),
+            (
+                "<think>Reasoning.</think>"
+                "<answer>correct</answer>"
+                "<analysis>Some uncertainty.</analysis>"
+                "<confidence>0.25</confidence>"
+            ),
+            (
+                "<think>Reasoning.</think>"
+                "<answer>wrong</answer>"
+                "<analysis>Very uncertain.</analysis>"
+                "<confidence>0.0</confidence>"
+            ),
+            (
+                "<think>Reasoning.</think>"
+                "<answer>wrong</answer>"
+                "<analysis>Overconfident.</analysis>"
+                "<confidence>0.8</confidence>"
+            ),
+        ]
+        completions = [[{"content": completion}] for completion in completions]
+        rewards = brier_score_reward(
+            completions, ["correct", "correct", "correct", "correct"], correctness_reward_func=exact_text_correctness
+        )
+        expected_rewards = [1.0, 1 - 0.75**2, 1.0, 1 - 0.8**2]
+        assert rewards == expected_rewards
+
+    def test_invalid_format_returns_zero(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        "<think>Reasoning.</think>"
+                        "<answer>correct</answer>"
+                        "<analysis>Direct.</analysis>"
+                        "<confidence>not sure</confidence>"
+                    )
+                }
+            ],
+            [{"content": ("<think>Reasoning.</think><analysis>Direct.</analysis><confidence>0.9</confidence>")}],
+            [{"content": ("<think>Reasoning.</think><answer>correct</answer><confidence>0.9</confidence>")}],
+        ]
+
+        def raise_if_called(**kwargs):
+            raise AssertionError("Correctness reward should not be called when all rows are invalid.")
+
+        rewards = brier_score_reward(
+            completions, ["correct", "correct", "correct"], correctness_reward_func=raise_if_called
+        )
+        assert rewards == [0.0, 0.0, 0.0]
+
+    def test_none_correctness_propagates(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        "<think>Reasoning.</think>"
+                        "<answer>unknown</answer>"
+                        "<analysis>No parseable gold answer.</analysis>"
+                        "<confidence>0.4</confidence>"
+                    )
+                }
+            ]
+        ]
+        rewards = brier_score_reward(completions, ["unknown"], correctness_reward_func=lambda **kwargs: [None])
+        assert rewards == [None]
+
+    def test_custom_correctness_wrong_length_raises(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        "<think>Reasoning.</think>"
+                        "<answer>correct</answer>"
+                        "<analysis>Direct.</analysis>"
+                        "<confidence>0.9</confidence>"
+                    )
+                }
+            ]
+        ]
+        with pytest.raises(ValueError, match="one reward per completion"):
+            brier_score_reward(completions, ["correct"], correctness_reward_func=lambda **kwargs: [])
+
+    def test_custom_correctness_out_of_range_raises(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        "<think>Reasoning.</think>"
+                        "<answer>correct</answer>"
+                        "<analysis>Direct.</analysis>"
+                        "<confidence>0.9</confidence>"
+                    )
+                }
+            ]
+        ]
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            brier_score_reward(completions, ["correct"], correctness_reward_func=lambda **kwargs: [1.5])
+
+    def test_log_extra_receives_parsed_values(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        "<think>Reasoning.</think>"
+                        "<answer>correct</answer>"
+                        "<analysis>Direct.</analysis>"
+                        "<confidence>0.25</confidence>"
+                    )
+                }
+            ]
+        ]
+        extra_logs = {}
+
+        def log_extra(column, values):
+            extra_logs[column] = values
+
+        rewards = brier_score_reward(
+            completions,
+            ["correct"],
+            correctness_reward_func=exact_text_correctness,
+            log_extra=log_extra,
+        )
+
+        assert rewards == [1 - 0.75**2]
+        assert extra_logs == {
+            "rlcr_answer": ["correct"],
+            "rlcr_confidence": [0.25],
+            "rlcr_correctness": [1.0],
+            "brier_score_reward": [1 - 0.75**2],
+        }
+
+    @require_math_latex
+    def test_uses_accuracy_reward_by_default(self):
+        completions = [
+            [
+                {
+                    "content": (
+                        r"<think>Reasoning.</think>"
+                        r"<answer>\boxed{\frac{1}{3}}</answer>"
+                        r"<analysis>High confidence because the derivation is direct.</analysis>"
+                        r"<confidence>0.9</confidence>"
+                    )
+                }
+            ]
+        ]
+        rewards = brier_score_reward(completions, [r"\frac{1}{3}"])
+        assert math.isclose(rewards[0], 1 - (0.9 - 1.0) ** 2)
 
 
 class TestSoftOverlongPunishmentReward:

--- a/trl/rewards/__init__.py
+++ b/trl/rewards/__init__.py
@@ -20,14 +20,16 @@ from .._lazy_module import _LazyModule
 
 _import_structure = {
     "accuracy_rewards": ["accuracy_reward", "reasoning_accuracy_reward"],
-    "format_rewards": ["think_format_reward"],
+    "calibration_rewards": ["brier_score_reward"],
+    "format_rewards": ["rlcr_format_reward", "think_format_reward"],
     "other_rewards": ["get_soft_overlong_punishment"],
 }
 
 
 if TYPE_CHECKING:
     from .accuracy_rewards import accuracy_reward, reasoning_accuracy_reward
-    from .format_rewards import think_format_reward
+    from .calibration_rewards import brier_score_reward
+    from .format_rewards import rlcr_format_reward, think_format_reward
     from .other_rewards import get_soft_overlong_punishment
 
 

--- a/trl/rewards/calibration_rewards.py
+++ b/trl/rewards/calibration_rewards.py
@@ -1,0 +1,170 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import re
+from collections.abc import Callable
+
+from .accuracy_rewards import accuracy_reward
+from .format_rewards import rlcr_format_reward
+
+
+def _extract_last_tag(content: str, tag: str) -> str | None:
+    matches = re.findall(rf"<{tag}>(.*?)</{tag}>", content, re.DOTALL)
+    return matches[-1].strip() if matches else None
+
+
+def _parse_confidence(value: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        confidence = float(value.strip())
+    except ValueError:
+        return None
+
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return None
+
+    return confidence
+
+
+def _validate_correctness_rewards(rewards: list[float | None], expected_length: int) -> list[float | None]:
+    if len(rewards) != expected_length:
+        raise ValueError(
+            f"`correctness_reward_func` must return one reward per completion. Expected {expected_length} rewards, "
+            f"but got {len(rewards)}."
+        )
+
+    validated_rewards = []
+    for reward in rewards:
+        if reward is None:
+            validated_rewards.append(None)
+            continue
+
+        try:
+            reward = float(reward)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("`correctness_reward_func` must return floats in [0.0, 1.0] or None.") from exc
+
+        if not math.isfinite(reward) or reward < 0.0 or reward > 1.0:
+            raise ValueError("`correctness_reward_func` must return floats in [0.0, 1.0] or None.")
+
+        validated_rewards.append(reward)
+
+    return validated_rewards
+
+
+def brier_score_reward(
+    completions: list[list[dict[str, str]]],
+    solution: list[str],
+    correctness_reward_func: Callable | None = None,
+    log_extra: Callable[[str, list], None] | None = None,
+    **kwargs,
+) -> list[float | None]:
+    r"""
+    Reward function that scores how well a model's confidence matches answer correctness.
+
+    This function checks the RLCR format, extracts the last `"<answer>...</answer>"` and
+    `"<confidence>...</confidence>"` blocks from each completion, computes correctness on the extracted answer, then
+    returns `1 - (confidence - correctness) ** 2`. This is a calibration reward, not a complete RLCR objective by
+    itself. For RLCR-style training, combine it with an answer-correctness reward such as [`accuracy_reward`] and a
+    format reward such as [`rlcr_format_reward`].
+
+    Args:
+        completions (`list[list[dict[str, str]]]`):
+            List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
+            containing the key `"content"` with the value being the text of the completion.
+        solution (`list[str]`):
+            List of the raw-text solutions to the questions/problems/prompts.
+        correctness_reward_func (`Callable`, *optional*):
+            Function used to score the extracted answers. If `None`, defaults to [`accuracy_reward`]. The function must
+            return one float in `[0.0, 1.0]` or `None` per completion.
+        log_extra (`Callable`, *optional*):
+            Callable to log extra columns to the completions table, provided automatically by the trainer. Defaults to
+            `None` to allow calling the function directly outside of a trainer (e.g., for testing).
+        **kwargs:
+            Additional keyword arguments. Dataset columns are forwarded to `correctness_reward_func`; trainer-only
+            values such as `trainer_state`, `log_extra`, `log_metric`, and `completion_ids` are not forwarded.
+
+    Returns:
+        `list[float | None]`:
+            A list of calibration rewards. Invalid RLCR formatting receives `0.0`. If the correctness function returns
+            `None`, `None` is propagated for that completion.
+
+    Example:
+    ```python
+    >>> from trl.rewards import accuracy_reward, brier_score_reward, rlcr_format_reward
+
+    >>> completions = [
+    ...     [
+    ...         {
+    ...             "content": (
+    ...                 "<think>Reasoning.</think>"
+    ...                 "<answer>42</answer>"
+    ...                 "<analysis>Direct arithmetic.</analysis>"
+    ...                 "<confidence>0.9</confidence>"
+    ...             )
+    ...         }
+    ...     ]
+    ... ]
+    >>> solution = ["42"]
+    >>> brier_score_reward(completions, solution, correctness_reward_func=lambda **kwargs: [1.0])
+    [0.99]
+    ```
+    """
+    if correctness_reward_func is None:
+        correctness_reward_func = accuracy_reward
+
+    contents = [completion[0]["content"] for completion in completions]
+    answers = [_extract_last_tag(content, "answer") for content in contents]
+    confidences = [_parse_confidence(_extract_last_tag(content, "confidence")) for content in contents]
+    format_rewards = rlcr_format_reward(completions)
+    invalid_mask = [
+        format_reward == 0.0 or answer is None or confidence is None
+        for format_reward, answer, confidence in zip(format_rewards, answers, confidences, strict=True)
+    ]
+
+    rewards: list[float | None] = [0.0] * len(completions)
+    correctness_rewards: list[float | None] = [None] * len(completions)
+
+    if not all(invalid_mask):
+        answer_completions = [[{"content": answer or ""}] for answer in answers]
+        correctness_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in ("trainer_state", "log_extra", "log_metric", "completion_ids")
+        }
+        raw_correctness_rewards = correctness_reward_func(
+            completions=answer_completions, solution=solution, **correctness_kwargs
+        )
+        correctness_rewards = _validate_correctness_rewards(raw_correctness_rewards, len(completions))
+
+        for i, (confidence, correctness_reward, is_invalid) in enumerate(
+            zip(confidences, correctness_rewards, invalid_mask, strict=True)
+        ):
+            if is_invalid:
+                continue
+            if correctness_reward is None:
+                rewards[i] = None
+                continue
+            rewards[i] = 1.0 - (confidence - correctness_reward) ** 2
+
+    if log_extra is not None:
+        log_extra("rlcr_answer", answers)
+        log_extra("rlcr_confidence", confidences)
+        log_extra("rlcr_correctness", correctness_rewards)
+        log_extra("brier_score_reward", rewards)
+
+    return rewards

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -12,7 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import re
+
+
+_RLCR_TAGS = ("think", "answer", "analysis", "confidence")
+_RLCR_PATTERN = re.compile(
+    r"\A\s*<think>(?P<think>.*?)</think>\s*"
+    r"<answer>(?P<answer>.*?)</answer>\s*"
+    r"<analysis>(?P<analysis>.*?)</analysis>\s*"
+    r"<confidence>(?P<confidence>.*?)</confidence>\s*\Z",
+    re.DOTALL,
+)
+
+
+def _has_rlcr_tag(content: str) -> bool:
+    return any(f"<{tag}>" in content or f"</{tag}>" in content for tag in _RLCR_TAGS)
+
+
+def _parse_confidence(content: str) -> float | None:
+    try:
+        confidence = float(content.strip())
+    except ValueError:
+        return None
+
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return None
+
+    return confidence
 
 
 def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> list[float]:
@@ -48,3 +75,64 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]
+
+
+def rlcr_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> list[float]:
+    r"""
+    Reward function that checks whether completions follow the RLCR response format.
+
+    The expected format is exactly:
+    `"<think>...</think><answer>...</answer><analysis>...</analysis><confidence>...</confidence>"`.
+    The function returns 1.0 if the format is correct and the confidence is a finite number in `[0.0, 1.0]`, otherwise
+    0.0.
+
+    Args:
+        completions (`list[list[dict[str, str]]]`):
+            List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
+            containing the key `"content"` with the value being the text of the completion.
+        **kwargs:
+            Additional keyword arguments. This function does not use them, but they are required in the function
+            signature to ensure compatibility with trainers like [`GRPOTrainer`].
+
+    Returns:
+        `list[float]`:
+            A list of rewards, where each reward is 1.0 if the completion matches the expected RLCR format, otherwise
+            0.0.
+
+    Example:
+    ```python
+    >>> from trl.rewards import rlcr_format_reward
+
+    >>> completions = [
+    ...     [
+    ...         {
+    ...             "content": (
+    ...                 "<think>Reasoning.</think>"
+    ...                 "<answer>42</answer>"
+    ...                 "<analysis>Direct arithmetic.</analysis>"
+    ...                 "<confidence>0.9</confidence>"
+    ...             )
+    ...         }
+    ...     ],
+    ...     [{"content": "<think>Reasoning.</think><answer>42</answer><confidence>not sure</confidence>"}],
+    ... ]
+    >>> rlcr_format_reward(completions)
+    [1.0, 0.0]
+    ```
+    """
+    rewards = []
+    for completion in completions:
+        content = completion[0]["content"]
+        match = _RLCR_PATTERN.fullmatch(content)
+        if match is None:
+            rewards.append(0.0)
+            continue
+
+        sections = match.groupdict()
+        if any(_has_rlcr_tag(sections[tag]) for tag in _RLCR_TAGS):
+            rewards.append(0.0)
+            continue
+
+        rewards.append(1.0 if _parse_confidence(sections["confidence"]) is not None else 0.0)
+
+    return rewards

--- a/trl/scripts/grpo.py
+++ b/trl/scripts/grpo.py
@@ -42,7 +42,9 @@ class GRPOScriptArguments(ScriptArguments):
         reward_funcs (`list[str]`, *optional*):
             Reward functions to use. Supported values are:
                 - `"accuracy_reward"`
+                - `"brier_score_reward"`
                 - `"reasoning_accuracy_reward"`
+                - `"rlcr_format_reward"`
                 - `"think_format_reward"`
                 - `"get_soft_overlong_punishment"` (used value are `max_completion_len=1280`, `soft_punish_cache=256`)
                 - any dotted import path " (e.g., `'my_lib.rewards.custom_reward'`).
@@ -58,9 +60,10 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] | None = field(
         default=None,
         metadata={
-            "help": "Reward functions to use. Supported values are: `accuracy_reward`,  `reasoning_accuracy_reward`, `think_format_reward`, "
-            "`get_soft_overlong_punishment` (used values are `max_completion_len=1280`, `soft_punish_cache=256`), or "
-            "any dotted import path (e.g., `'my_lib.rewards.custom_reward'`)."
+            "help": "Reward functions to use. Supported values are: `accuracy_reward`, `brier_score_reward`, "
+            "`reasoning_accuracy_reward`, `rlcr_format_reward`, `think_format_reward`, `get_soft_overlong_punishment` "
+            "(used values are `max_completion_len=1280`, `soft_punish_cache=256`), or any dotted import path "
+            "(e.g., `'my_lib.rewards.custom_reward'`)."
         },
     )
 
@@ -73,8 +76,10 @@ def main(script_args, training_args, model_args, dataset_args):
     from trl import GRPOTrainer, get_dataset, get_kbit_device_map, get_peft_config, get_quantization_config
     from trl.rewards import (
         accuracy_reward,
+        brier_score_reward,
         get_soft_overlong_punishment,
         reasoning_accuracy_reward,
+        rlcr_format_reward,
         think_format_reward,
     )
 
@@ -82,7 +87,9 @@ def main(script_args, training_args, model_args, dataset_args):
 
     reward_funcs_registry = {
         "accuracy_reward": accuracy_reward,
+        "brier_score_reward": brier_score_reward,
         "reasoning_accuracy_reward": reasoning_accuracy_reward,
+        "rlcr_format_reward": rlcr_format_reward,
         "think_format_reward": think_format_reward,
         "get_soft_overlong_punishment": get_soft_overlong_punishment(max_completion_len=1280, soft_punish_cache=256),
     }

--- a/trl/scripts/rloo.py
+++ b/trl/scripts/rloo.py
@@ -42,7 +42,9 @@ class RLOOScriptArguments(ScriptArguments):
         reward_funcs (`list[str]`, *optional*):
             Reward functions to use. Supported values are:
                 - `"accuracy_reward"`
+                - `"brier_score_reward"`
                 - `"reasoning_accuracy_reward"`
+                - `"rlcr_format_reward"`
                 - `"think_format_reward"`
                 - `"get_soft_overlong_punishment"` (used value are `max_completion_len=1280`, `soft_punish_cache=256`)
                 - any dotted import path " (e.g., `'my_lib.rewards.custom_reward'`).
@@ -58,9 +60,10 @@ class RLOOScriptArguments(ScriptArguments):
     reward_funcs: list[str] | None = field(
         default=None,
         metadata={
-            "help": "Reward functions to use. Supported values are: `accuracy_reward`,  `reasoning_accuracy_reward`, `think_format_reward`, "
-            "`get_soft_overlong_punishment` (used values are `max_completion_len=1280`, `soft_punish_cache=256`), or "
-            "any dotted import path (e.g., `'my_lib.rewards.custom_reward'`)."
+            "help": "Reward functions to use. Supported values are: `accuracy_reward`, `brier_score_reward`, "
+            "`reasoning_accuracy_reward`, `rlcr_format_reward`, `think_format_reward`, `get_soft_overlong_punishment` "
+            "(used values are `max_completion_len=1280`, `soft_punish_cache=256`), or any dotted import path "
+            "(e.g., `'my_lib.rewards.custom_reward'`)."
         },
     )
 
@@ -72,8 +75,10 @@ def main(script_args, training_args, model_args, dataset_args):
     from trl import RLOOTrainer, get_dataset, get_peft_config
     from trl.rewards import (
         accuracy_reward,
+        brier_score_reward,
         get_soft_overlong_punishment,
         reasoning_accuracy_reward,
+        rlcr_format_reward,
         think_format_reward,
     )
 
@@ -81,7 +86,9 @@ def main(script_args, training_args, model_args, dataset_args):
 
     reward_funcs_registry = {
         "accuracy_reward": accuracy_reward,
+        "brier_score_reward": brier_score_reward,
         "reasoning_accuracy_reward": reasoning_accuracy_reward,
+        "rlcr_format_reward": rlcr_format_reward,
         "think_format_reward": think_format_reward,
         "get_soft_overlong_punishment": get_soft_overlong_punishment(max_completion_len=1280, soft_punish_cache=256),
     }


### PR DESCRIPTION
# What does this PR do?

Adds RLCR reward-function support requested in #3871.

This PR adds:

- `rlcr_format_reward`, which checks the required `<think>`, `<answer>`, `<analysis>`, and `<confidence>` response format.
- `brier_score_reward`, which computes a Brier-style calibration reward as `1 - (confidence - correctness) ** 2`.
- `trl.rewards` exports for both new rewards.
- GRPO/RLOO script registry entries so the rewards can be selected by short name.
- Reward documentation and a `paper_index.md` entry for the RLCR paper.
- Focused unit tests for valid/invalid format handling, confidence parsing, Brier scoring, `None` propagation, custom correctness validation, default `accuracy_reward` behavior, and `log_extra` output.

The calibration reward gates on the full RLCR format before assigning calibration credit, matching the referenced RLCR reward behavior and avoiding rewards for malformed completions that happen to contain answer/confidence tags.

Fixes #3871

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. #3871
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review this PR once the tests have passed.

## Validation

- `uv run --extra test python -m pytest tests/test_rewards.py`
- `uv run --with ruff ruff check trl/rewards trl/scripts/grpo.py trl/scripts/rloo.py tests/test_rewards.py`
- `uv run --with ruff ruff format --check trl/rewards trl/scripts/grpo.py trl/scripts/rloo.py tests/test_rewards.py`
- `uv run python -m py_compile trl/rewards/calibration_rewards.py trl/rewards/format_rewards.py trl/scripts/grpo.py trl/scripts/rloo.py`
- Import/API smoke for `trl.rewards` exports and GRPO/RLOO script help metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new reward functions, docs, and tests) with small updates to GRPO/RLOO reward registries and `trl.rewards` exports.
> 
> **Overview**
> Adds RLCR reward support by introducing `rlcr_format_reward` (strict `<think>/<answer>/<analysis>/<confidence>` structure with validated `[0,1]` confidence) and `brier_score_reward` (Brier-style calibration reward gated on valid RLCR format, with optional custom correctness scoring and extra logging).
> 
> Exports the new rewards via `trl.rewards`, wires them into the `grpo`/`rloo` scripts so they can be selected by short name, and updates docs (reward API page + paper index entry) plus unit tests covering format validation, confidence parsing, scoring behavior, `None` propagation, and correctness function validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8727d54600dba9357463071d3c5d0d17799792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->