### PR TITLE
Fix GKD gradient accumulation token loss scaling

### DIFF
--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -21,6 +22,7 @@ from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
 from trl.experimental.gkd import GKDConfig, GKDTrainer
+from trl.trainer.sft_trainer import SFTTrainer
 
 from ..testing_utils import TrlTestCase, require_liger_kernel
 
@@ -196,6 +198,165 @@ class TestGeneralizedJSDLoss(TrlTestCase):
         identical_logits = torch.randn(self.batch_size, self.seq_length, self.vocab_size)
         loss = GKDTrainer.generalized_jsd_loss(identical_logits, identical_logits)
         assert round(abs(loss.item() - 0), 6) == 0
+
+    def test_accumulated_loss_matches_combined_batch_with_global_denominator(self):
+        torch.manual_seed(0)
+        student_logits_1 = torch.randn(1, 4, self.vocab_size)
+        teacher_logits_1 = torch.randn(1, 4, self.vocab_size)
+        labels_1 = torch.tensor([[0, -100, -100, -100]])
+
+        student_logits_2 = torch.randn(1, 4, self.vocab_size)
+        teacher_logits_2 = torch.randn(1, 4, self.vocab_size)
+        labels_2 = torch.tensor([[0, 1, 2, -100]])
+
+        total_tokens = labels_1.ne(-100).sum() + labels_2.ne(-100).sum()
+        accumulated = GKDTrainer.generalized_jsd_loss(
+            student_logits_1, teacher_logits_1, labels=labels_1, num_items_in_batch=total_tokens
+        ) + GKDTrainer.generalized_jsd_loss(
+            student_logits_2, teacher_logits_2, labels=labels_2, num_items_in_batch=total_tokens
+        )
+        combined = GKDTrainer.generalized_jsd_loss(
+            torch.cat([student_logits_1, student_logits_2]),
+            torch.cat([teacher_logits_1, teacher_logits_2]),
+            labels=torch.cat([labels_1, labels_2]),
+        )
+        old_style = GKDTrainer.generalized_jsd_loss(
+            student_logits_1, teacher_logits_1, labels=labels_1
+        ) + GKDTrainer.generalized_jsd_loss(student_logits_2, teacher_logits_2, labels=labels_2)
+
+        assert torch.allclose(accumulated, combined)
+        assert not torch.allclose(old_style, combined)
+
+    def test_batchmean_with_global_denominator_handles_zero_tokens(self):
+        student_logits = torch.randn(1, 3, self.vocab_size)
+        teacher_logits = torch.randn(1, 3, self.vocab_size)
+        labels = torch.full((1, 3), -100)
+
+        loss = GKDTrainer.generalized_jsd_loss(
+            student_logits, teacher_logits, labels=labels, num_items_in_batch=torch.tensor(0)
+        )
+
+        assert loss == 0
+
+    def test_generate_on_policy_outputs_masks_prompt_labels(self):
+        class DummyModel:
+            def generate(self, **kwargs):
+                return SimpleNamespace(sequences=torch.tensor([[0, 5, 6, 7, 0], [0, 8, 9, 10, 11]]))
+
+        inputs = {
+            "prompts": torch.tensor([[0, 5, 6], [0, 8, 9]]),
+            "prompt_attention_mask": torch.tensor([[0, 1, 1], [0, 1, 1]]),
+        }
+
+        _, new_attention_mask, new_labels = GKDTrainer.generate_on_policy_outputs(
+            DummyModel(), inputs, GenerationConfig(), pad_token_id=0
+        )
+
+        assert torch.all(new_labels[:, : inputs["prompts"].shape[1]] == -100)
+        assert new_labels[0, 3] == 7
+        assert new_labels[0, 4] == -100
+        assert new_attention_mask[0, 0] == 0
+        assert new_attention_mask[0, 4] == 0
+
+
+class TestGKDTrainerLossAccounting(TrlTestCase):
+    def test_compute_loss_forwards_num_items_in_batch(self, monkeypatch):
+        class DummyModel(torch.nn.Module):
+            def __init__(self, logits):
+                super().__init__()
+                self.logits = logits
+
+            def forward(self, input_ids, attention_mask):
+                return SimpleNamespace(logits=self.logits)
+
+        captured_kwargs = {}
+
+        def fake_generalized_jsd_loss(**kwargs):
+            captured_kwargs.update(kwargs)
+            return torch.tensor(1.0)
+
+        monkeypatch.setattr(GKDTrainer, "generalized_jsd_loss", staticmethod(fake_generalized_jsd_loss))
+
+        vocab_size = 11
+        trainer = GKDTrainer.__new__(GKDTrainer)
+        trainer.use_liger_gkd_loss = False
+        trainer.teacher_model = DummyModel(torch.randn(1, 5, vocab_size))
+        trainer.beta = 0.5
+        trainer.args = SimpleNamespace(average_tokens_across_devices=False, n_gpu=0)
+        trainer.model_accepts_loss_kwargs = True
+        trainer.accelerator = SimpleNamespace(num_processes=1)
+
+        denominator = torch.tensor(3)
+        inputs = {
+            "input_ids": torch.tensor([[1, 2, 3, 4, 5]]),
+            "attention_mask": torch.ones(1, 5),
+            "prompts": torch.tensor([[1, 2]]),
+            "labels": torch.tensor([[-100, -100, 3, 4, 5]]),
+        }
+
+        loss = trainer.compute_loss(
+            DummyModel(torch.randn(1, 5, vocab_size)),
+            inputs,
+            num_items_in_batch=denominator,
+        )
+
+        assert loss == 1.0
+        assert captured_kwargs["num_items_in_batch"] is denominator
+        assert captured_kwargs["labels"].shape == torch.Size([1, 3])
+
+    def test_get_batch_samples_counts_prepared_labels(self):
+        trainer = GKDTrainer.__new__(GKDTrainer)
+        trainer.model_accepts_loss_kwargs = True
+        trainer.compute_loss_func = None
+        trainer.args = SimpleNamespace(average_tokens_across_devices=False, n_gpu=0)
+        trainer.accelerator = SimpleNamespace(parallelism_config=None)
+        trainer.model_wrapped = object()
+        prepared_models = []
+
+        def prepare_inputs(model, inputs):
+            prepared_models.append(model)
+            inputs["labels"] = inputs["prepared_labels"]
+            inputs["_gkd_inputs_prepared"] = True
+
+        trainer._prepare_gkd_inputs_for_loss = prepare_inputs
+        original_labels = torch.tensor([[1, 2, 3, 4]])
+        batch_1 = {
+            "labels": original_labels.clone(),
+            "prepared_labels": torch.tensor([[1, -100, -100, -100]]),
+        }
+        batch_2 = {
+            "labels": original_labels.clone(),
+            "prepared_labels": torch.tensor([[1, 2, 3, -100]]),
+        }
+
+        batch_samples, num_items_in_batch = trainer.get_batch_samples(
+            iter([batch_1, batch_2]), num_batches=2, device=torch.device("cpu")
+        )
+
+        assert num_items_in_batch == 4
+        assert prepared_models == [trainer.model_wrapped, trainer.model_wrapped]
+        assert all(batch["_gkd_inputs_prepared"] for batch in batch_samples)
+
+    def test_training_step_skips_already_prepared_inputs(self, monkeypatch):
+        trainer = GKDTrainer.__new__(GKDTrainer)
+        prepare_calls = []
+
+        def prepare_inputs(model, inputs):
+            prepare_calls.append((model, inputs))
+
+        def fake_training_step(self, model, inputs, num_items_in_batch=None):
+            assert "_gkd_inputs_prepared" not in inputs
+            return torch.tensor(2.0)
+
+        trainer._prepare_gkd_inputs_for_loss = prepare_inputs
+        monkeypatch.setattr(SFTTrainer, "training_step", fake_training_step, raising=False)
+
+        inputs = {"_gkd_inputs_prepared": True}
+        loss = trainer.training_step(object(), inputs, num_items_in_batch=torch.tensor(4))
+
+        assert loss == 2.0
+        assert prepare_calls == []
+        assert inputs == {}
 
 
 class TestGKDTrainer(TrlTestCase):

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -14,7 +14,7 @@
 
 import random
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import torch
@@ -166,6 +166,9 @@ class GKDTrainer(SFTTrainer):
             formatting_func=formatting_func,
         )
 
+        # GKD computes the loss itself, so Trainer needs to provide the accumulation-window token count here.
+        self.model_accepts_loss_kwargs = True
+
         if args.teacher_model_init_kwargs is None:
             teacher_model_init_kwargs = {}
         elif not isinstance(teacher_model, str):
@@ -220,7 +223,13 @@ class GKDTrainer(SFTTrainer):
 
     @staticmethod
     def generalized_jsd_loss(
-        student_logits, teacher_logits, labels=None, beta=0.5, temperature=1.0, reduction="batchmean"
+        student_logits,
+        teacher_logits,
+        labels=None,
+        beta=0.5,
+        temperature=1.0,
+        reduction="batchmean",
+        num_items_in_batch=None,
     ):
         """
         Compute the generalized Jensen-Shannon Divergence loss for knowledge distillation using F.kl_div. See Eq. (1)
@@ -240,6 +249,8 @@ class GKDTrainer(SFTTrainer):
                 Softmax temperature (default: 1.0)
             reduction:
                 Specifies the reduction to apply to the output (default: 'batchmean')
+            num_items_in_batch (`int` or `torch.Tensor`, *optional*):
+                Number of valid tokens in the gradient accumulation window. If `None`, uses the local batch count.
 
         Returns:
             loss: Scalar tensor with the generalized JSD loss
@@ -281,13 +292,66 @@ class GKDTrainer(SFTTrainer):
 
         # Apply reduction
         if reduction == "batchmean":
-            return jsd.sum() / mask.sum() if labels is not None else jsd.sum() / jsd.size(0)
+            if labels is None:
+                return jsd.sum() / jsd.size(0)
+            denominator = mask.sum() if num_items_in_batch is None else num_items_in_batch
+            if torch.is_tensor(denominator):
+                denominator = denominator.to(jsd.device)
+                denominator = torch.clamp(denominator, min=1)
+            else:
+                denominator = max(denominator, 1)
+            return jsd.sum() / denominator
         elif reduction == "sum":
             return jsd.sum()
         elif reduction == "mean":
             return jsd.mean()
         else:
             return jsd
+
+    def _prepare_gkd_inputs_for_loss(self, model: nn.Module, inputs: dict[str, torch.Tensor | Any]) -> None:
+        if self.seq_kd:
+            with (
+                unwrap_model_for_generation(
+                    self.teacher_model,
+                    self.accelerator,
+                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
+                ) as unwrapped_model
+            ):
+                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
+                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
+                )
+            inputs["input_ids"] = new_input_ids
+            inputs["attention_mask"] = new_attention_mask
+            inputs["labels"] = new_labels
+        if random.random() <= self.lmbda:
+            with (
+                unwrap_model_for_generation(
+                    model,
+                    self.accelerator,
+                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
+                ) as unwrapped_model
+            ):
+                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
+                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
+                )
+            inputs["input_ids"] = new_input_ids
+            inputs["attention_mask"] = new_attention_mask
+            inputs["labels"] = new_labels
+        inputs["_gkd_inputs_prepared"] = True
+
+    def get_batch_samples(self, epoch_iterator: Iterator, num_batches: int, device: torch.device):
+        batch_samples = []
+        for _ in range(num_batches):
+            try:
+                batch_samples.append(next(epoch_iterator))
+            except StopIteration:
+                break
+
+        for inputs in batch_samples:
+            self._prepare_gkd_inputs_for_loss(self.model_wrapped, inputs)
+
+        num_items_in_batch = self._get_num_items_in_batch(batch_samples, device)
+        return batch_samples, num_items_in_batch
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         if self.use_liger_gkd_loss:
@@ -352,6 +416,15 @@ class GKDTrainer(SFTTrainer):
                 student_bias=getattr(student_head, "bias", None),
                 teacher_bias=getattr(teacher_head, "bias", None),
             )
+            if num_items_in_batch is not None:
+                local_num_items = true_labels.ne(-100).sum()
+                denominator = num_items_in_batch
+                if torch.is_tensor(denominator):
+                    denominator = denominator.to(loss.device)
+                    denominator = torch.clamp(denominator, min=1)
+                else:
+                    denominator = max(denominator, 1)
+                loss = loss * local_num_items.to(loss.device) / denominator
 
             # Release hidden states after loss computation
             del student_hidden, teacher_hidden, true_labels
@@ -382,7 +455,15 @@ class GKDTrainer(SFTTrainer):
                 teacher_logits=shifted_teacher_logits,
                 labels=shifted_labels,
                 beta=self.beta,
+                num_items_in_batch=num_items_in_batch,
             )
+
+        if (
+            self.args.average_tokens_across_devices
+            and self.model_accepts_loss_kwargs
+            and num_items_in_batch is not None
+        ):
+            loss *= self.accelerator.num_processes if self.args.n_gpu <= 1 else self.args.n_gpu
 
         # empty cache
         empty_cache()
@@ -405,6 +486,7 @@ class GKDTrainer(SFTTrainer):
         # Calculate new attention mask
         new_attention_mask = torch.ones_like(generated_tokens)
         new_labels = generated_tokens.clone()
+        new_labels[:, : inputs["prompts"].shape[1]] = -100
 
         # If there's pad_token_id, set attention mask to 0 for padding tokens
         if pad_token_id is not None:
@@ -423,34 +505,7 @@ class GKDTrainer(SFTTrainer):
         `self.lmbda`, it generates new responses using the student model, which are then used for training instead of
         the original inputs.
         """
-        if self.seq_kd:
-            with (
-                unwrap_model_for_generation(
-                    self.teacher_model,
-                    self.accelerator,
-                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
-                ) as unwrapped_model
-            ):
-                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
-                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
-                )
-            inputs["input_ids"] = new_input_ids
-            inputs["attention_mask"] = new_attention_mask
-            inputs["labels"] = new_labels
-        if random.random() <= self.lmbda:
-            with (
-                unwrap_model_for_generation(
-                    model,
-                    self.accelerator,
-                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
-                ) as unwrapped_model
-            ):
-                new_input_ids, new_attention_mask, new_labels = self.generate_on_policy_outputs(
-                    unwrapped_model, inputs, self.generation_config, self.processing_class.pad_token_id
-                )
-            inputs["input_ids"] = new_input_ids
-            inputs["attention_mask"] = new_attention_mask
-            inputs["labels"] = new_labels
-
+        if not inputs.pop("_gkd_inputs_prepared", False):
+            self._prepare_gkd_inputs_for_loss(model, inputs)
         loss = super().training_step(model, inputs, num_items_in_batch)
         return loss


### PR DESCRIPTION
# What does this PR do?

Fixes #4719.

This PR fixes GKD loss scaling when `GKDTrainer` runs with gradient accumulation. The trainer was reducing each microbatch with a local valid-token denominator, so splitting the same logical batch across accumulation steps could change the gradient scale. The fix makes GKD use the accumulation-window token count that `Trainer` computes for custom token-normalized losses.

Root cause:

- `GKDTrainer` did not opt into `Trainer`'s `num_items_in_batch` plumbing for custom loss functions.
- The standard generalized JSD path therefore used local `batchmean` normalization per microbatch instead of the full accumulation-window denominator.
- For on-policy and sequence-level KD, generated labels are created after the dataloader batch is read. Those generated labels must exist before `Trainer` counts valid tokens, and prompt tokens in generated labels must stay masked to `-100`.

Changes:

- Enables custom-loss token counting in `GKDTrainer`.
- Prepares GKD-generated inputs before the accumulation-window denominator is computed.
- Masks prompt labels in generated on-policy outputs.
- Passes `num_items_in_batch` into the generalized JSD loss path and uses it as the global token denominator.
- Preserves the old local reduction when no global denominator is supplied.
- Applies matching scaling for the Liger loss path.
- Adds focused regression tests for accumulated-vs-combined loss scaling, generated-label counting, prompt masking, denominator forwarding, zero-token behavior, and avoiding duplicate generation.

Validation:

- `uv run --extra test pytest tests/experimental/test_gkd_trainer.py -q`
  - `18 passed, 1 skipped`
- `uv run --extra test pytest tests/test_sft_trainer.py::TestDFTLoss -q`
  - `1 passed`
- `uv run --with ruff ruff check trl/experimental/gkd/gkd_trainer.py tests/experimental/test_gkd_trainer.py`
- `uv run --with ruff ruff format --check trl/experimental/gkd/gkd_trainer.py tests/experimental/test_gkd_trainer.py`
- `uv run python -m py_compile trl/experimental/gkd/gkd_trainer.py tests/experimental/test_gkd_trainer.py`
- `git diff --check`

<!-- Remove if not applicable -->

Fixes #4719

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. See #4719.
- [x] Did you make sure to update the documentation with your changes? No user-facing docs update is needed for this experimental trainer bug fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with `GKDTrainer`, `Trainer` loss normalization, or gradient accumulation behavior is welcome to review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches loss computation and batching/gradient-accumulation accounting in `GKDTrainer`, which can subtly change training dynamics; changes are scoped and covered by targeted regression tests.
> 
> **Overview**
> Fixes GKD loss normalization under gradient accumulation by opting `GKDTrainer` into Trainer’s `num_items_in_batch` plumbing and using that *global* valid-token denominator in `generalized_jsd_loss` (with safe clamping for zero tokens), plus matching rescaling for the Liger fused-loss path.
> 
> Refactors on-policy/seq-KD input generation into `_prepare_gkd_inputs_for_loss`, runs it in `get_batch_samples` so token counting sees the generated/masked labels, and ensures `generate_on_policy_outputs` masks prompt tokens to `-100`; `training_step` now skips duplicate generation via an `_gkd_inputs_prepared` flag. Adds regression tests covering accumulated-vs-combined batch equivalence, zero-token behavior, prompt masking, denominator forwarding, correct token counting after preparation, and avoiding double-preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86cb0b27116d483aa1f69eceef10c3d4730852b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->