### PR TITLE
Add dynamic reward weight scheduler support for GRPO and RLOO

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -178,10 +178,11 @@ While training and evaluating, we record the following reward metrics:
 - `completions/min_terminated_length`: The minimum length of generated completions that terminate with EOS. When using tools, only non-tool tokens are counted.
 - `completions/max_terminated_length`: The maximum length of generated completions that terminate with EOS. When using tools, only non-tool tokens are counted.
 - `completions/clipped_ratio`: The ratio of truncated (clipped) completions.
-- `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
-- `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
-- `reward`: The overall average reward after summing rewards across functions (weighted by `reward_weights`).
-- `reward_std`: The standard deviation of summed rewards across functions (weighted by `reward_weights`), computed over the full batch.
+- `rewards/{reward_func_name}/mean`: The average reward from a specific reward function.
+- `rewards/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
+- `reward_weights/{reward_func_name}`: The current weight applied to a specific reward function.
+- `reward`: The overall average reward after summing rewards across functions (weighted by `reward_weights` or `reward_weights_scheduler`).
+- `reward_std`: The standard deviation of summed rewards across functions (weighted by `reward_weights` or `reward_weights_scheduler`), computed over the full batch.
 - `frac_reward_zero_std`: The fraction of samples in the generation batch with a reward std of zero, implying there is little diversity for that prompt (all answers are correct or incorrect).
 - `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.
@@ -608,6 +609,26 @@ trainer = GRPOTrainer(
 ```
 
 and the reward will be computed as the sum of the rewards from each function, or the weighted sum if `reward_weights` is provided in the config.
+
+For dynamic reward weights, pass a `reward_weights_scheduler` callable to [`GRPOTrainer`]. The scheduler receives the trainer state and returns one weight per reward function. Raw per-function reward metrics stay unweighted, while the aggregate reward and advantages use the scheduled weights.
+
+```python
+from trl import GRPOTrainer
+
+
+def reward_weights_scheduler(state):
+    progress = state.global_step / max(state.max_steps, 1)
+    dense_reward_weight = max(0.0, 1.0 - progress)
+    sparse_reward_weight = 1.0
+    return [sparse_reward_weight, dense_reward_weight]
+
+
+trainer = GRPOTrainer(
+    reward_funcs=[sparse_reward_func, dense_reward_func],
+    reward_weights_scheduler=reward_weights_scheduler,
+    ...,
+)
+```
 
 Note that [`GRPOTrainer`] supports multiple reward functions of different types. See the parameters documentation for more details.
 

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -136,10 +136,11 @@ While training and evaluating, we record the following reward metrics:
 - `completions/min_terminated_length`: The minimum length of generated completions that terminate with EOS.
 - `completions/max_terminated_length`: The maximum length of generated completions that terminate with EOS.
 - `completions/clipped_ratio`: The ratio of truncated (clipped) completions.
-- `reward/{reward_func_name}/mean`: The average reward from a specific reward function.
-- `reward/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
-- `reward`: The overall average reward after summing rewards across functions (weighted by `reward_weights`).
-- `reward_std`: The standard deviation of summed rewards across functions (weighted by `reward_weights`), computed over the full batch.
+- `rewards/{reward_func_name}/mean`: The average reward from a specific reward function.
+- `rewards/{reward_func_name}/std`: The standard deviation of the reward from a specific reward function.
+- `reward_weights/{reward_func_name}`: The current weight applied to a specific reward function.
+- `reward`: The overall average reward after summing rewards across functions (weighted by `reward_weights` or `reward_weights_scheduler`).
+- `reward_std`: The standard deviation of summed rewards across functions (weighted by `reward_weights` or `reward_weights_scheduler`), computed over the full batch.
 - `frac_reward_zero_std`: The fraction of samples in the generation batch with a reward std of zero, implying there is little diversity for that prompt (all answers are correct or incorrect).
 - `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.
@@ -531,6 +532,26 @@ trainer = RLOOTrainer(
 ```
 
 and the reward will be computed as the sum of the rewards from each function, or the weighted sum if `reward_weights` is provided in the config.
+
+For dynamic reward weights, pass a `reward_weights_scheduler` callable to [`RLOOTrainer`]. The scheduler receives the trainer state and returns one weight per reward function. Raw per-function reward metrics stay unweighted, while the aggregate reward and advantages use the scheduled weights.
+
+```python
+from trl import RLOOTrainer
+
+
+def reward_weights_scheduler(state):
+    progress = state.global_step / max(state.max_steps, 1)
+    dense_reward_weight = max(0.0, 1.0 - progress)
+    sparse_reward_weight = 1.0
+    return [sparse_reward_weight, dense_reward_weight]
+
+
+trainer = RLOOTrainer(
+    reward_funcs=[sparse_reward_func, dense_reward_func],
+    reward_weights_scheduler=reward_weights_scheduler,
+    ...,
+)
+```
 
 Note that [`RLOOTrainer`] supports multiple reward functions of different types. See the parameters documentation for more details.
 

--- a/tests/experimental/test_gfpo_trainer.py
+++ b/tests/experimental/test_gfpo_trainer.py
@@ -1,0 +1,59 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from datasets import load_dataset
+
+from trl.experimental.gfpo import GFPOConfig, GFPOTrainer
+
+from ..testing_utils import TrlTestCase
+
+
+@pytest.mark.low_priority
+class TestGFPOTrainer(TrlTestCase):
+    def test_reward_metric_reflects_reward_weights_scheduler(self):
+        """Test that GFPOTrainer uses scheduled reward weights in its GRPO override."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def constant_reward_1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def constant_reward_0(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GFPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        trainer = GFPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[constant_reward_1, constant_reward_0],
+            reward_weights_scheduler=lambda state: [0.7, 0.3],
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        log = trainer.state.log_history[-1]
+        assert abs(log["reward"] - 0.7) < 1e-5, (
+            f"Expected logged reward to be ~0.7 (weighted), got {log['reward']}. "
+            "The reward metric should reflect reward_weights_scheduler."
+        )
+        assert abs(log["reward_weights/constant_reward_1"] - 0.7) < 1e-5
+        assert abs(log["reward_weights/constant_reward_0"] - 0.3) < 1e-5

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -802,6 +802,75 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_reward_weights_scheduler(self):
+        """Test that GRPOTrainer can get dynamic reward weights from the scheduler."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        def reward_weights_scheduler(state):
+            return [1.0 + state.global_step, 0.5]
+
+        training_args = GRPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[reward_func1, reward_func2],
+            reward_weights_scheduler=reward_weights_scheduler,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.state.global_step = 2
+        reward_weights = trainer._get_reward_weights(trainer.accelerator.device)
+
+        assert torch.allclose(reward_weights.cpu(), torch.tensor([3.0, 0.5]))
+        assert torch.allclose(trainer.reward_weights, torch.tensor([3.0, 0.5]))
+
+    def test_reward_weights_scheduler_validation(self):
+        """Test that GRPOTrainer validates dynamic reward weights."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[reward_func1, reward_func2],
+            reward_weights_scheduler=lambda state: [1.0],
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        with pytest.raises(ValueError, match="Number of reward weights"):
+            trainer._get_reward_weights(trainer.accelerator.device)
+
+    def test_reward_weights_scheduler_conflict(self):
+        """Test that static and dynamic reward weights cannot be used together."""
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(output_dir=self.tmp_dir, report_to="none", reward_weights=[0.7, 0.3])
+        with pytest.raises(ValueError, match="cannot both be provided"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=[reward_func1, reward_func2],
+                reward_weights_scheduler=lambda state: [0.7, 0.3],
+                args=training_args,
+                train_dataset=None,
+            )
+
     @pytest.mark.parametrize("multi_objective_aggregation", ["sum_then_normalize", "normalize_then_sum"])
     def test_reward_metric_reflects_reward_weights(self, multi_objective_aggregation):
         """Test that the logged 'reward' metric uses reward_weights, not an unweighted sum."""
@@ -840,6 +909,44 @@ class TestGRPOTrainer(TrlTestCase):
             f"Expected logged reward to be ~0.7 (weighted), got {log['reward']}. "
             "The reward metric should reflect reward_weights."
         )
+
+    @pytest.mark.parametrize("multi_objective_aggregation", ["sum_then_normalize", "normalize_then_sum"])
+    def test_reward_metric_reflects_reward_weights_scheduler(self, multi_objective_aggregation):
+        """Test that the logged 'reward' metric uses scheduled reward weights."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def constant_reward_1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def constant_reward_0(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+            multi_objective_aggregation=multi_objective_aggregation,
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[constant_reward_1, constant_reward_0],
+            reward_weights_scheduler=lambda state: [0.7, 0.3],
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        log = trainer.state.log_history[-1]
+        assert abs(log["reward"] - 0.7) < 1e-5, (
+            f"Expected logged reward to be ~0.7 (weighted), got {log['reward']}. "
+            "The reward metric should reflect reward_weights_scheduler."
+        )
+        assert abs(log["reward_weights/constant_reward_1"] - 0.7) < 1e-5
+        assert abs(log["reward_weights/constant_reward_0"] - 0.3) < 1e-5
 
     def test_training_multiple_mixed_reward_funcs(self):
         # Test if the trainer can handle a mix of reward functions and reward models

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -541,6 +541,75 @@ class TestRLOOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_reward_weights_scheduler(self):
+        """Test that RLOOTrainer can get dynamic reward weights from the scheduler."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        def reward_weights_scheduler(state):
+            return [1.0 + state.global_step, 0.5]
+
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[reward_func1, reward_func2],
+            reward_weights_scheduler=reward_weights_scheduler,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.state.global_step = 2
+        reward_weights = trainer._get_reward_weights(trainer.accelerator.device)
+
+        assert torch.allclose(reward_weights.cpu(), torch.tensor([3.0, 0.5]))
+        assert torch.allclose(trainer.reward_weights, torch.tensor([3.0, 0.5]))
+
+    def test_reward_weights_scheduler_validation(self):
+        """Test that RLOOTrainer validates dynamic reward weights."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[reward_func1, reward_func2],
+            reward_weights_scheduler=lambda state: [1.0],
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        with pytest.raises(ValueError, match="Number of reward weights"):
+            trainer._get_reward_weights(trainer.accelerator.device)
+
+    def test_reward_weights_scheduler_conflict(self):
+        """Test that static and dynamic reward weights cannot be used together."""
+
+        def reward_func1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def reward_func2(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none", reward_weights=[0.7, 0.3])
+        with pytest.raises(ValueError, match="cannot both be provided"):
+            RLOOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=[reward_func1, reward_func2],
+                reward_weights_scheduler=lambda state: [0.7, 0.3],
+                args=training_args,
+                train_dataset=None,
+            )
+
     def test_reward_metric_reflects_reward_weights(self):
         """Test that the logged 'reward' metric uses reward_weights, not an unweighted sum."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
@@ -577,6 +646,42 @@ class TestRLOOTrainer(TrlTestCase):
             f"Expected logged reward to be ~0.7 (weighted), got {log['reward']}. "
             "The reward metric should reflect reward_weights."
         )
+
+    def test_reward_metric_reflects_reward_weights_scheduler(self):
+        """Test that the logged 'reward' metric uses scheduled reward weights."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def constant_reward_1(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        def constant_reward_0(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[constant_reward_1, constant_reward_0],
+            reward_weights_scheduler=lambda state: [0.7, 0.3],
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        log = trainer.state.log_history[-1]
+        assert abs(log["reward"] - 0.7) < 1e-5, (
+            f"Expected logged reward to be ~0.7 (weighted), got {log['reward']}. "
+            "The reward metric should reflect reward_weights_scheduler."
+        )
+        assert abs(log["reward_weights/constant_reward_1"] - 0.7) < 1e-5
+        assert abs(log["reward_weights/constant_reward_0"] - 0.3) < 1e-5
 
     def test_training_multiple_mixed_reward_funcs(self):
         # Test if the trainer can handle a mix of reward functions and reward models

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -46,7 +46,7 @@ from ...data_utils import (
 from ...extras.profiling import profiling_context, profiling_decorator
 from ...models import unwrap_model_for_generation
 from ...models.utils import disable_gradient_checkpointing
-from ...trainer.grpo_trainer import EnvironmentFactory, GRPOTrainer, RewardFunc, RolloutFunc
+from ...trainer.grpo_trainer import EnvironmentFactory, GRPOTrainer, RewardFunc, RewardWeightsScheduler, RolloutFunc
 from ...trainer.utils import (
     entropy_from_logits,
     nanstd,
@@ -169,6 +169,9 @@ class DPPOTrainer(GRPOTrainer):
             process and the trainer instance. It must return a dict with `"prompt_ids"`, `"completion_ids"`, and
             `"logprobs"` fields. Any other fields are forwarded to the reward functions. This feature is experimental
             and may change or be removed at any time without prior notice.
+        reward_weights_scheduler (`Callable[[TrainerState], Sequence[float] | torch.Tensor]`, *optional*):
+            Function that returns the current reward weights from the [`~transformers.TrainerState`]. It must return
+            one weight for each reward function. This argument cannot be used together with `args.reward_weights`.
     """
 
     _tag_names = ["trl", "dppo"]
@@ -201,6 +204,7 @@ class DPPOTrainer(GRPOTrainer):
         tools: list[Callable] | None = None,
         rollout_func: RolloutFunc | None = None,
         environment_factory: EnvironmentFactory | None = None,
+        reward_weights_scheduler: RewardWeightsScheduler | None = None,
     ):
         if args is None:
             model_name = model if isinstance(model, str) else model.config._name_or_path
@@ -219,6 +223,7 @@ class DPPOTrainer(GRPOTrainer):
             eval_dataset=eval_dataset,
             processing_class=processing_class,
             reward_processing_classes=reward_processing_classes,
+            reward_weights_scheduler=reward_weights_scheduler,
             callbacks=callbacks,
             optimizers=optimizers,
             peft_config=peft_config,
@@ -1057,10 +1062,11 @@ class DPPOTrainer(GRPOTrainer):
         # rewards_per_func to extract each process's subset.
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
+        reward_weights = self._get_reward_weights(device)
 
         if self.multi_objective_aggregation == "sum_then_normalize":
             # Apply weights to each reward function's output and sum
-            rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
             mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1)
             mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
@@ -1092,7 +1098,7 @@ class DPPOTrainer(GRPOTrainer):
             std_k = nanstd(grouped, dim=1, keepdim=True) if num_generations > 1 else torch.zeros_like(mean_k)
             reward_k = (grouped - mean_k) / (std_k + 1e-4)
             reward_k = reward_k.view(-1, len(self.reward_funcs))
-            rewards = (reward_k * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards = (reward_k * reward_weights.unsqueeze(0)).nansum(dim=1)
             std_rewards = rewards.std().expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
             advantages = (rewards - rewards.mean()) / (std_rewards + 1e-4)
             is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))  # for logging
@@ -1117,7 +1123,8 @@ class DPPOTrainer(GRPOTrainer):
             self._metrics[mode][f"rewards/{reward_func_name}/mean"].append(mean_rewards)
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
-        rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
+            self._metrics[mode][f"reward_weights/{reward_func_name}"].append(reward_weights[i].item())
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
         self._metrics[mode]["reward"].append(rewards.mean().item())
         self._metrics[mode]["reward_std"].append(rewards.std().item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())

--- a/trl/experimental/gfpo/gfpo_trainer.py
+++ b/trl/experimental/gfpo/gfpo_trainer.py
@@ -44,6 +44,7 @@ class GFPOTrainer(_GRPOTrainer):
         callbacks=None,
         optimizers=(None, None),
         peft_config=None,
+        reward_weights_scheduler=None,
     ):
         super().__init__(
             model=model,
@@ -53,6 +54,7 @@ class GFPOTrainer(_GRPOTrainer):
             eval_dataset=eval_dataset,
             processing_class=processing_class,
             reward_processing_classes=reward_processing_classes,
+            reward_weights_scheduler=reward_weights_scheduler,
             callbacks=callbacks,
             optimizers=optimizers,
             peft_config=peft_config,
@@ -285,9 +287,10 @@ class GFPOTrainer(_GRPOTrainer):
         # important because rewards will be normalized per group, and completions are distributed. We will later slice
         # rewards_per_func to extract each process's subset.
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
+        reward_weights = self._get_reward_weights(device)
 
         # Apply weights to each reward function's output and sum
-        rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
 
         num_in_group = self.num_generations
         num_inputs_in_device = len(prompts)
@@ -376,7 +379,8 @@ class GFPOTrainer(_GRPOTrainer):
             self._metrics[mode][f"rewards/{reward_func_name}/mean"].append(mean_rewards)
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
-        rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
+            self._metrics[mode][f"reward_weights/{reward_func_name}"].append(reward_weights[i].item())
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
         self._metrics[mode]["reward"].append(rewards.mean().item())
         self._metrics[mode]["reward_std"].append(rewards.std().item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -293,9 +293,10 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         # important because rewards will be normalized per group, and completions are distributed. We will later slice
         # rewards_per_func to extract each process's subset.
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
+        reward_weights = self._get_reward_weights(device)
 
         # Apply weights to each reward function's output and sum
-        rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
 
         # Compute grouped-wise rewards
         mean_grouped_rewards = rewards.view(-1, self.num_generations).mean(dim=1)
@@ -337,7 +338,8 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             self._metrics[mode][f"rewards/{reward_func_name}/mean"].append(mean_rewards)
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
-        rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
+            self._metrics[mode][f"reward_weights/{reward_func_name}"].append(reward_weights[i].item())
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
         self._metrics[mode]["reward"].append(rewards.mean().item())
         self._metrics[mode]["reward_std"].append(rewards.std().item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -24,7 +24,7 @@ import textwrap
 import time
 import warnings
 from collections import defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Protocol
@@ -51,6 +51,7 @@ from transformers import (
     PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
+    TrainerState,
     is_trackio_available,
     is_wandb_available,
 )
@@ -116,6 +117,7 @@ logger = get_logger(__name__)
 # arguments from the trainer (refer to the trainer's source for details). To ensure forward compatibility, it should
 # accept **kwargs.
 RewardFunc = str | PreTrainedModel | Callable[..., list[float | None]]
+RewardWeightsScheduler = Callable[[TrainerState], Sequence[float] | torch.Tensor]
 
 # What we call a rollout function is a callable that takes prompts (list) and the trainer instance as parameters and
 # returns a dict of generation results. Those results must include "prompt_ids", "completion_ids", and "logprobs"
@@ -250,6 +252,9 @@ class GRPOTrainer(_BaseTrainer):
             method should return either `None` or a string: when it returns a string, that string is appended to the
             last user message before generation. This feature is experimental and may change or be removed at any time
             without prior notice.
+        reward_weights_scheduler (`Callable[[TrainerState], Sequence[float] | torch.Tensor]`, *optional*):
+            Function that returns the current reward weights from the [`~transformers.TrainerState`]. It must return
+            one weight for each reward function. This argument cannot be used together with `args.reward_weights`.
     """
 
     _tag_names = ["trl", "grpo"]
@@ -282,12 +287,18 @@ class GRPOTrainer(_BaseTrainer):
         tools: list[Callable] | None = None,
         rollout_func: RolloutFunc | None = None,
         environment_factory: EnvironmentFactory | None = None,
+        reward_weights_scheduler: RewardWeightsScheduler | None = None,
     ):
         # Args
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
             args = GRPOConfig(f"{model_name}-GRPO")
+        if args.reward_weights is not None and reward_weights_scheduler is not None:
+            raise ValueError(
+                "`reward_weights` and `reward_weights_scheduler` cannot both be provided. Include any static weights "
+                "in the scheduler output."
+            )
 
         # Model
         if isinstance(model, str):
@@ -399,6 +410,7 @@ class GRPOTrainer(_BaseTrainer):
         self.reward_funcs = reward_funcs
 
         # Reward weights
+        self.reward_weights_scheduler = reward_weights_scheduler
         if args.reward_weights is not None:
             if len(args.reward_weights) != len(reward_funcs):
                 raise ValueError(
@@ -1172,6 +1184,20 @@ class GRPOTrainer(_BaseTrainer):
                 Scalar value for this batch.
         """
         self._pending_metrics[name].append(value)
+
+    def _get_reward_weights(self, device: torch.device) -> torch.Tensor:
+        if self.reward_weights_scheduler is None:
+            return self.reward_weights.to(device)
+
+        reward_weights = torch.as_tensor(self.reward_weights_scheduler(self.state), dtype=torch.float32, device=device)
+        if reward_weights.numel() != len(self.reward_funcs):
+            raise ValueError(
+                f"Number of reward weights ({reward_weights.numel()}) must match number of reward "
+                f"functions ({len(self.reward_funcs)})"
+            )
+        reward_weights = reward_weights.reshape(len(self.reward_funcs)).detach()
+        self.reward_weights = reward_weights.cpu()
+        return reward_weights
 
     @profiling_decorator
     def _calculate_rewards(self, inputs, prompts, completions, completion_ids_list):
@@ -2120,10 +2146,11 @@ class GRPOTrainer(_BaseTrainer):
         # rewards_per_func to extract each process's subset.
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
+        reward_weights = self._get_reward_weights(device)
 
         if self.multi_objective_aggregation == "sum_then_normalize":
             # Apply weights to each reward function's output and sum
-            rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
             mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1)
             mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
@@ -2155,7 +2182,7 @@ class GRPOTrainer(_BaseTrainer):
             std_k = nanstd(grouped, dim=1, keepdim=True) if num_generations > 1 else torch.zeros_like(mean_k)
             reward_k = (grouped - mean_k) / (std_k + 1e-4)
             reward_k = reward_k.view(-1, len(self.reward_funcs))
-            rewards = (reward_k * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards = (reward_k * reward_weights.unsqueeze(0)).nansum(dim=1)
             std_rewards = rewards.std().expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
             advantages = (rewards - rewards.mean()) / (std_rewards + 1e-4)
             is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))  # for logging
@@ -2180,7 +2207,8 @@ class GRPOTrainer(_BaseTrainer):
             self._metrics[mode][f"rewards/{reward_func_name}/mean"].append(mean_rewards)
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
-        rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
+            self._metrics[mode][f"reward_weights/{reward_func_name}"].append(reward_weights[i].item())
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
         self._metrics[mode]["reward"].append(rewards.mean().item())
         self._metrics[mode]["reward_std"].append(rewards.std().item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -20,7 +20,7 @@ import math
 import textwrap
 import time
 from collections import defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
@@ -46,6 +46,7 @@ from transformers import (
     PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
+    TrainerState,
     is_trackio_available,
     is_wandb_available,
 )
@@ -100,6 +101,7 @@ logger = get_logger(__name__)
 # arguments from the trainer (refer to the trainer's source for details). To ensure forward compatibility, it should
 # accept **kwargs.
 RewardFunc = str | PreTrainedModel | Callable[..., list[float | None]]
+RewardWeightsScheduler = Callable[[TrainerState], Sequence[float] | torch.Tensor]
 
 
 class RLOOTrainer(_BaseTrainer):
@@ -198,6 +200,9 @@ class RLOOTrainer(_BaseTrainer):
             model and a scheduler given by [`~transformers.get_linear_schedule_with_warmup`] controlled by `args`.
         peft_config ([`~peft.PeftConfig`], *optional*):
             PEFT configuration used to wrap the model. If `None`, the model is not wrapped.
+        reward_weights_scheduler (`Callable[[TrainerState], Sequence[float] | torch.Tensor]`, *optional*):
+            Function that returns the current reward weights from the [`~transformers.TrainerState`]. It must return
+            one weight for each reward function. This argument cannot be used together with `args.reward_weights`.
     """
 
     _tag_names = ["trl", "rloo"]
@@ -230,12 +235,18 @@ class RLOOTrainer(_BaseTrainer):
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         peft_config: "PeftConfig | None" = None,
+        reward_weights_scheduler: RewardWeightsScheduler | None = None,
     ):
         # Args
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
             args = RLOOConfig(f"{model_name}-RLOO")
+        if args.reward_weights is not None and reward_weights_scheduler is not None:
+            raise ValueError(
+                "`reward_weights` and `reward_weights_scheduler` cannot both be provided. Include any static weights "
+                "in the scheduler output."
+            )
 
         # Model
         if isinstance(model, str):
@@ -340,6 +351,7 @@ class RLOOTrainer(_BaseTrainer):
             atexit.register(shutdown_event_loop_in_daemon, self.async_loop_thread, self.async_loop)
 
         # Reward weights
+        self.reward_weights_scheduler = reward_weights_scheduler
         if args.reward_weights is not None:
             if len(args.reward_weights) != len(reward_funcs):
                 raise ValueError(
@@ -810,6 +822,20 @@ class RLOOTrainer(_BaseTrainer):
         """
         self._pending_metrics[name].append(value)
 
+    def _get_reward_weights(self, device: torch.device) -> torch.Tensor:
+        if self.reward_weights_scheduler is None:
+            return self.reward_weights.to(device)
+
+        reward_weights = torch.as_tensor(self.reward_weights_scheduler(self.state), dtype=torch.float32, device=device)
+        if reward_weights.numel() != len(self.reward_funcs):
+            raise ValueError(
+                f"Number of reward weights ({reward_weights.numel()}) must match number of reward "
+                f"functions ({len(self.reward_funcs)})"
+            )
+        reward_weights = reward_weights.reshape(len(self.reward_funcs)).detach()
+        self.reward_weights = reward_weights.cpu()
+        return reward_weights
+
     @profiling_decorator
     def _calculate_rewards(self, inputs, prompts, completions, completion_ids_list):
         device = self.accelerator.device
@@ -1255,9 +1281,10 @@ class RLOOTrainer(_BaseTrainer):
         # rewards_per_func to extract each process's subset.
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
+        reward_weights = self._get_reward_weights(device)
 
         # Apply weights to each reward function's output and sum
-        rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
 
         # Apply reward clipping if specified
         if self.reward_clip_range:
@@ -1312,7 +1339,8 @@ class RLOOTrainer(_BaseTrainer):
             self._metrics[mode][f"rewards/{reward_func_name}/mean"].append(mean_rewards)
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
-        rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
+            self._metrics[mode][f"reward_weights/{reward_func_name}"].append(reward_weights[i].item())
+        rewards = (rewards_per_func * reward_weights.unsqueeze(0)).nansum(dim=1)
         self._metrics[mode]["reward"].append(rewards.mean().item())
         self._metrics[mode]["reward_std"].append(rewards.std().item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())


### PR DESCRIPTION
# What does this PR do?

Adds a Python API hook, `reward_weights_scheduler`, for dynamic reward-function weighting during online training. The scheduler receives the current `TrainerState` and returns one weight per reward function, allowing curricula such as decaying dense shaping rewards while keeping raw per-reward logs truthful.

Changes include:
- add `reward_weights_scheduler` to `GRPOTrainer` and `RLOOTrainer` without changing the existing static `reward_weights` config field
- reject simultaneous static `reward_weights` and dynamic scheduler usage with a clear error
- use scheduled weights consistently for reward aggregation, advantage computation, and aggregate reward logging
- keep raw per-function reward metrics unweighted and add `reward_weights/{reward_func_name}` metrics for observability
- propagate the same behavior to GRPO-derived experimental overrides in GFPO, GRPO with replay buffer, and DPPO
- document dynamic reward weights for GRPO/RLOO and add focused regression coverage

Fixes #3036.

## Design notes

This intentionally keeps scheduling as a direct trainer constructor argument rather than a config dataclass field. `GRPOConfig`/`RLOOConfig` remain CLI/YAML-friendly for static weights, while arbitrary Python callables stay in the Python API where existing custom reward functions already live.

The implementation is deliberately small and trainer-local: no schedule DSL, registry, factory, or new shared trainer abstraction. That keeps the change aligned with TRL trainer conventions while preserving consistency across duplicated GRPO/RLOO reward aggregation paths.

## Validation

- `uv run --extra quality pre-commit run ruff-format --files trl/trainer/grpo_trainer.py trl/trainer/rloo_trainer.py trl/experimental/gfpo/gfpo_trainer.py trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py trl/experimental/dppo/dppo_trainer.py tests/test_grpo_trainer.py tests/test_rloo_trainer.py tests/experimental/test_gfpo_trainer.py`
- `uv run --extra quality pre-commit run ruff-check --files trl/trainer/grpo_trainer.py trl/trainer/rloo_trainer.py trl/experimental/gfpo/gfpo_trainer.py trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py trl/experimental/dppo/dppo_trainer.py tests/test_grpo_trainer.py tests/test_rloo_trainer.py tests/experimental/test_gfpo_trainer.py`
- `uv run --extra quality pre-commit run doc-builder-style --files trl/trainer/grpo_trainer.py trl/trainer/rloo_trainer.py trl/experimental/dppo/dppo_trainer.py docs/source/grpo_trainer.md docs/source/rloo_trainer.md tests/experimental/test_gfpo_trainer.py`
- `git diff --check`
- `uv run --extra test pytest tests/test_grpo_trainer.py -k reward_weights -q`
- `uv run --extra test pytest tests/test_rloo_trainer.py -k reward_weights -q`
- `uv run --extra test pytest tests/experimental/test_gfpo_trainer.py tests/experimental/test_grpo_with_replay_buffer_trainer.py tests/experimental/test_dppo_trainer.py -q`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. Issue: #3036.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review once checks have passed. Maintainers familiar with GRPO/RLOO reward aggregation may be especially helpful.
