### PR TITLE
feat(vllm-serve): add --reasoning-parser and --reasoning-config flags

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -218,6 +218,14 @@ class ScriptArguments:
         speculative_config (`str`, *optional*):
             JSON string for vLLM speculative decoding config, forwarded to `LLM(speculative_config=...)`. When unset,
             speculative decoding is disabled. Example: `'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'`.
+        reasoning_parser (`str`, *optional*):
+            Reasoning parser for thinking models (e.g., `"qwen3"`, `"deepseek_r1"`). When set, vLLM configures a
+            `ReasoningConfig` on the engine so that `thinking_token_budget` can be used in `generation_kwargs`.
+        reasoning_config (`str`, *optional*):
+            JSON string for vLLM reasoning config specifying thinking delimiters, forwarded to
+            `LLM(reasoning_config=...)`. Example:
+            `'{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'`. If only `reasoning_parser` is set,
+            this is not required — vLLM will infer the delimiters from the parser.
     """
 
     model: str = field(
@@ -329,6 +337,20 @@ class ScriptArguments:
             'Example: \'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}\''
         },
     )
+    reasoning_parser: str | None = field(
+        default=None,
+        metadata={
+            "help": "Reasoning parser for thinking models (e.g., 'qwen3', 'deepseek_r1'). "
+            "Enables vLLM's ReasoningConfig so that thinking_token_budget works in generation_kwargs."
+        },
+    )
+    reasoning_config: str | None = field(
+        default=None,
+        metadata={
+            "help": "JSON string for vLLM reasoning config. "
+            'Example: \'{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}\''
+        },
+    )
 
 
 def llm_worker(
@@ -362,6 +384,8 @@ def llm_worker(
         # Important so temperature scaling/logit tweaking affects the TIS log probs
         logprobs_mode="processed_logprobs",
         speculative_config=json.loads(script_args.speculative_config) if script_args.speculative_config else None,
+        reasoning_config=json.loads(script_args.reasoning_config) if script_args.reasoning_config else None,
+        reasoning_parser=script_args.reasoning_parser,
     )
 
     # Send ready signal to parent process


### PR DESCRIPTION
## Summary

`trl vllm-serve` currently doesn't expose vLLM's `--reasoning-parser` or `--reasoning-config` options. When using thinking models (Qwen3.5, DeepSeek-R1, etc.) with GRPO and `thinking_token_budget` in `generation_kwargs`, the vLLM engine returns a 400 error:

> thinking_token_budget is set but reasoning_config is not configured. Please set --reasoning-config to use thinking_token_budget.

This is because vLLM requires a `ReasoningConfig` on the engine to activate its `ThinkingTokenBudgetLogitsProcessor`, but `trl vllm-serve` has no way to set it.

## Changes

Adds two new `ScriptArguments` fields in `vllm_serve.py`:
- `reasoning_parser` — e.g., `"qwen3"`, `"deepseek_r1"` — forwarded to `LLM(reasoning_parser=...)`
- `reasoning_config` — JSON string forwarded to `LLM(reasoning_config=...)` for explicit delimiter control

Both are passed through to the `LLM()` constructor, enabling `thinking_token_budget` in `generation_kwargs` to work end-to-end.

## Example

```bash
trl vllm-serve \
    --model Qwen/Qwen3.5-9B \
    --reasoning_parser qwen3
```

Then in the training script:

```python
GRPOConfig(
    ...,
    generation_kwargs={"thinking_token_budget": 1024},
)
```

## Motivation

When RL fine-tuning thinking models with GRPO, controlling the thinking budget is critical to ensure the model leaves enough token space for the actual task output (e.g., JSON). vLLM natively supports `thinking_token_budget` via `ThinkingTokenBudgetLogitsProcessor`, but it requires `reasoning_config` on the server side. The current workaround is to launch vLLM manually outside of TRL, which defeats the purpose of `trl vllm-serve`.

## Test plan
- [x] `trl vllm-serve --model Qwen/Qwen3.5-9B --reasoning_parser qwen3` starts successfully
- [x] `thinking_token_budget` in `generation_kwargs` works without 400 errors
- [x] Existing behavior without the new flags is unchanged (defaults to `None`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional CLI flags and forwards them into the vLLM `LLM()` constructor; main failure mode is user-supplied invalid JSON for `--reasoning-config`.
> 
> **Overview**
> `trl vllm-serve` now accepts `--reasoning-parser` and `--reasoning-config` to configure vLLM’s `ReasoningConfig` for “thinking” models.
> 
> The new arguments are plumbed through `ScriptArguments` and forwarded into `LLM(reasoning_parser=..., reasoning_config=...)` (with `reasoning_config` parsed from JSON), enabling `thinking_token_budget` usage without server-side 400 errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a1272fdf40acf9f938ec1bbfe75c7726571da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->