### PR TITLE
Simplify peft_config handling in experimental trainers

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -299,7 +299,7 @@ class KTOTrainer(_BaseTrainer):
             # Create PEFT model
             model = get_peft_model(model, peft_config)
 
-        if is_peft_available() and isinstance(model, PeftModel) and ref_model is None:
+        elif is_peft_available() and isinstance(model, PeftModel) and ref_model is None:
             # If the model is a PEFT model with a pretrained adapter, we need to create a "ref" adapter that is a copy
             # of the "default" adapter, so that we can use it as the reference model during KTO training.
             model.add_adapter("ref", model.peft_config["default"])

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -296,6 +296,9 @@ class KTOTrainer(_BaseTrainer):
                     "and unload the existing adapter, save the resulting base model, and then pass that base model along "
                     "with the new `peft_config` to the trainer."
                 )
+            # Create PEFT model
+            model = get_peft_model(model, peft_config)
+
         if is_peft_available() and isinstance(model, PeftModel) and ref_model is None:
             # If the model is a PEFT model with a pretrained adapter, we need to create a "ref" adapter that is a copy
             # of the "default" adapter, so that we can use it as the reference model during KTO training.
@@ -305,10 +308,6 @@ class KTOTrainer(_BaseTrainer):
                     ref_name = name.replace(".default.", ".ref.")
                     ref_param = model.get_parameter(ref_name)
                     ref_param.data.copy_(param.data)
-
-        # Create PEFT model
-        if peft_config is not None:
-            model = get_peft_model(model, peft_config)
 
         # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally
         # handles this, but a bug currently prevents it; see https://github.com/huggingface/transformers/issues/42489

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -207,11 +207,11 @@ class SDFTTrainer(SelfDistillationMixin, _BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-        if is_peft_available() and is_peft_model(model) and peft_config is not None:
-            raise ValueError(
-                "You passed a `PeftModel` instance together with a `peft_config` to SDFTTrainer. Pass either a base "
-                "model with `peft_config`, or a pre-wrapped PEFT model."
-            )
+            if is_peft_model(model):
+                raise ValueError(
+                    "You passed a `PeftModel` instance together with a `peft_config` to SDFTTrainer. Pass either a base "
+                    "model with `peft_config`, or a pre-wrapped PEFT model."
+                )
         if peft_config is not None or (is_peft_available() and getattr(model, "peft_config", None) is not None):
             model = prepare_peft_model(model, peft_config, args)
 

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -147,11 +147,11 @@ class SSDTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-        if is_peft_available() and is_peft_model(model) and peft_config is not None:
-            raise ValueError(
-                "You passed a `PeftModel` instance together with a `peft_config` to SSDTrainer. Pass either a base "
-                "model with `peft_config`, or a pre-wrapped PEFT model."
-            )
+            if is_peft_model(model):
+                raise ValueError(
+                    "You passed a `PeftModel` instance together with a `peft_config` to SSDTrainer. Pass either a base "
+                    "model with `peft_config`, or a pre-wrapped PEFT model."
+                )
         if peft_config is not None or (is_peft_available() and getattr(model, "peft_config", None) is not None):
             model = prepare_peft_model(model, peft_config, args)
 

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -362,15 +362,13 @@ class TPOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-        if is_peft_available() and is_peft_model(model) and peft_config is not None:
-            raise ValueError(
-                "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "
-                "and unload the existing adapter, save the resulting base model, and then pass that base model along "
-                "with the new `peft_config` to the trainer."
-            )
-
-        # Create PEFT model
-        if peft_config is not None:
+            if is_peft_model(model):
+                raise ValueError(
+                    "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "
+                    "and unload the existing adapter, save the resulting base model, and then pass that base model along "
+                    "with the new `peft_config` to the trainer."
+                )
+            # Create PEFT model
             model = get_peft_model(model, peft_config)
 
         # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally


### PR DESCRIPTION
Simplify `peft_config` handling in experimental trainers.

Follow-up to this review: https://github.com/huggingface/trl/pull/5664#discussion_r3148858422
> Redundant consecutive if peft_config is not None checks
> These two consecutive identical conditions could be a single block

Related to:
- #5673

This PR refactors how PEFT (Parameter-Efficient Fine-Tuning) models and configurations are handled across experimental trainer classes. The main improvements are the simplification of the initialization logic, removing redundant and unnecessary branching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to PEFT initialization/validation paths in experimental trainers, but could affect edge cases around when models are wrapped or rejected when combining `PeftModel` and `peft_config`.
> 
> **Overview**
> Simplifies `peft_config` handling across experimental trainers by collapsing redundant conditionals and making PEFT wrapping happen directly inside the `peft_config is not None` branch.
> 
> In `KTOTrainer`/`TPOTrainer`, the PEFT model is now created immediately when `peft_config` is provided, and the separate post-check PEFT-wrapping block is removed; `KTOTrainer` keeps the existing special-case logic for creating a `ref` adapter only when a pre-wrapped `PeftModel` is passed without an explicit `ref_model`. In `SDFTTrainer` and `SSDTrainer`, the "base model vs pre-wrapped PEFT model" validation is simplified by checking `is_peft_model(model)` only when `peft_config` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a48c6f39d9ed1b3f23cf27612e8485bf5ccf74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->