### PR TITLE
Align KTO with DPO: Replace direct type check with is_peft_model

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -299,7 +299,7 @@ class KTOTrainer(_BaseTrainer):
             # Create PEFT model
             model = get_peft_model(model, peft_config)
 
-        elif is_peft_available() and is_peft_model(model) and ref_model is None:
+        elif is_peft_model(model) and ref_model is None:
             # If the model is a PEFT model with a pretrained adapter, we need to create a "ref" adapter that is a copy
             # of the "default" adapter, so that we can use it as the reference model during KTO training.
             model.add_adapter("ref", model.peft_config["default"])
@@ -311,7 +311,7 @@ class KTOTrainer(_BaseTrainer):
 
         # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally
         # handles this, but a bug currently prevents it; see https://github.com/huggingface/transformers/issues/42489
-        if is_peft_available() and is_peft_model(model) and args.gradient_checkpointing:
+        if is_peft_model(model) and args.gradient_checkpointing:
             model.enable_input_require_grads()
 
         # When using QLoRA, the PEFT adapter weights are converted to bf16 to follow the recommendations from the

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -477,7 +477,7 @@ class KTOTrainer(_BaseTrainer):
                     "You cannot use `precompute_ref_log_probs=True` with liger kernel. Please set "
                     "`precompute_ref_log_probs=False`."
                 )
-            if self.is_peft_model:
+            if is_peft_model(self.model):
                 raise ValueError(
                     "You cannot use `use_liger_kernel=True` with Peft models. Please set `use_liger_kernel=False`."
                 )
@@ -676,7 +676,7 @@ class KTOTrainer(_BaseTrainer):
     @contextmanager
     def null_ref_context(self):
         """Context manager for handling null reference model (that is, peft adapter manipulation)."""
-        if self.is_peft_model:
+        if is_peft_model(self.model):
             model = self.accelerator.unwrap_model(self.model)
             with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
                 yield

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -290,7 +290,7 @@ class KTOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-            if isinstance(model, PeftModel):
+            if is_peft_model(model):
                 raise ValueError(
                     "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first merge "
                     "and unload the existing adapter, save the resulting base model, and then pass that base model along "
@@ -299,7 +299,7 @@ class KTOTrainer(_BaseTrainer):
             # Create PEFT model
             model = get_peft_model(model, peft_config)
 
-        elif is_peft_available() and isinstance(model, PeftModel) and ref_model is None:
+        elif is_peft_available() and is_peft_model(model) and ref_model is None:
             # If the model is a PEFT model with a pretrained adapter, we need to create a "ref" adapter that is a copy
             # of the "default" adapter, so that we can use it as the reference model during KTO training.
             model.add_adapter("ref", model.peft_config["default"])
@@ -311,7 +311,7 @@ class KTOTrainer(_BaseTrainer):
 
         # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally
         # handles this, but a bug currently prevents it; see https://github.com/huggingface/transformers/issues/42489
-        if is_peft_available() and isinstance(model, PeftModel) and args.gradient_checkpointing:
+        if is_peft_available() and is_peft_model(model) and args.gradient_checkpointing:
             model.enable_input_require_grads()
 
         # When using QLoRA, the PEFT adapter weights are converted to bf16 to follow the recommendations from the

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -331,8 +331,6 @@ class KTOTrainer(_BaseTrainer):
                 "Please use a causal LM (e.g., GPT, Llama, Mistral) instead of an encoder-decoder model (e.g., T5, BART)."
             )
 
-        self.is_peft_model = is_peft_available() and isinstance(model, PeftModel)
-
         if args.max_length is None:
             logger.warning(
                 "When using DataCollatorForUnpairedPreference, you should set `max_length` in the KTOTrainer's init"


### PR DESCRIPTION
Align KTO with DPO: Replace direct type check with `is_peft_model`.

This PR refactors how the codebase checks for PEFT (Parameter-Efficient Fine-Tuning) models in the `KTOTrainer` class by replacing direct type checks with the `is_peft_model` utility function. This change improves code readability, maintainability, and consistency across the file. The redundant `self.is_peft_model` attribute is also removed in favor of direct function calls.

Part of:
- #4786

### Changes

**Refactoring PEFT model checks:**

* Replaced all instances of `isinstance(model, PeftModel)` with the `is_peft_model(model)` utility function to standardize PEFT model detection throughout `trl/experimental/kto/kto_trainer.py`.

**Code cleanup:**

* Removed the `self.is_peft_model` attribute, eliminating redundancy and ensuring that PEFT model checks are always up to date by using the utility function directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to PEFT model detection/branching; behavior should be equivalent but could affect edge cases where wrappers previously bypassed `isinstance(PeftModel)`.
> 
> **Overview**
> Refactors `KTOTrainer` PEFT detection to use `accelerate.utils.is_peft_model()` instead of direct `PeftModel` type checks, aligning behavior with other trainers and making PEFT handling more robust.
> 
> Removes the cached `self.is_peft_model` flag and updates PEFT-gated paths (adapter/ref-adapter setup, gradient-checkpointing input grads, liger-kernel validation, and `null_ref_context`) to query the model type directly at use sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ce86198c0716f1386022813434a4f22cb0d322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->