### PR TITLE
Fix OOM in CI by reducing image size of tiny Gemma3 model

### DIFF
--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -359,9 +359,12 @@ for model_id, model_class, dtype in [
     kwargs = {}
 
     if model_id == "google/gemma-3-4b-it":
-        # Gemma3 SigLIP processes images at 896×896 → 4,096 patches, producing 1 GB+ attention matrices per layer
-        # during training. Use 224×224 → 256 patches instead; this matches mm_tokens_per_image=256, so the
-        # projector's AvgPool2d degenerates to kernel_size=1 (identity) and memory stays manageable.
+        # Gemma3 SigLIP defaults to image_size=896 → 4,096 patches. With production-scale intermediate_size
+        # (~4,304), the vision FFN saves [batch, 4,096, 4,304] activations for backprop (~134 MB/layer).
+        # Use image_size=224 → 256 patches (matching mm_tokens_per_image=256, so the projector's AvgPool2d
+        # gets kernel_size=1, i.e. identity) and scale down intermediate_size to keep activations tiny.
+        text_config["intermediate_size"] = 32
+        vision_config["intermediate_size"] = 32
         vision_config["image_size"] = 224
         processor.image_processor.size = {"height": 224, "width": 224}
 

--- a/scripts/generate_tiny_models.py
+++ b/scripts/generate_tiny_models.py
@@ -358,6 +358,13 @@ for model_id, model_class, dtype in [
     }
     kwargs = {}
 
+    if model_id == "google/gemma-3-4b-it":
+        # Gemma3 SigLIP processes images at 896×896 → 4,096 patches, producing 1 GB+ attention matrices per layer
+        # during training. Use 224×224 → 256 patches instead; this matches mm_tokens_per_image=256, so the
+        # projector's AvgPool2d degenerates to kernel_size=1 (identity) and memory stays manageable.
+        vision_config["image_size"] = 224
+        processor.image_processor.size = {"height": 224, "width": 224}
+
     if issubclass(model_class.config_class, (Qwen2VLConfig, Qwen2_5_VLConfig)):
         text_config["rope_scaling"] = {"type": "default", "mrope_section": [1, 1], "rope_type": "default"}
         vision_config["depth"] = 2


### PR DESCRIPTION
Fix OOM in CI by reducing image size of tiny Gemma3 model.

This PR introduces a targeted adjustment for the `google/gemma-3-4b-it` model in the `generate_tiny_models` script to address memory usage issues related to image processing.

Partial fix for:
- #5207

### Motivation

The `tiny-Gemma3ForConditionalGeneration` model was generated with the default SigLIP image size of 896×896, which produces 4,096 patches per image. During training, the vision encoder attention maps have shape `[batch, heads, 4096, 4096]`, consuming ~1 GB per layer. With 2 vision layers and backpropagation, a single Gemma3 test consumes 5–7 GiB of GPU memory. Two such tests running concurrently on a 14.74 GiB GPU caused CUDA out-of-memory errors in all other parallel workers.

### Solution

Override `image_size=224` (256 patches) when generating the tiny Gemma3 model. This is consistent with `mm_tokens_per_image=256` in the Gemma3 config: the projector's `AvgPool2d` gets `kernel_size=1` (identity), which is architecturally valid. The processor's image processor size is updated to match so that test inputs are also resized to 224×224.


### Changes

Model-specific configuration:

* For the `google/gemma-3-4b-it` model, sets `vision_config["image_size"]` and `processor.image_processor.size` to 224x224 (instead of the default 896x896) to reduce memory consumption during training by limiting the number of image patches and ensuring the projector's average pooling layer acts as an identity function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted, model-specific config tweak in a test-only model generation script; low blast radius beyond the tiny Gemma3 artifacts and related CI tests.
> 
> **Overview**
> Reduces memory usage when generating the tiny `google/gemma-3-4b-it` VLM by overriding its vision settings in `scripts/generate_tiny_models.py`.
> 
> For this model only, the script now forces a smaller vision `image_size` (224) and scales down both text/vision `intermediate_size` to keep activations small, and updates the processor’s image resize settings to match so CI/unit tests don’t OOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad45e25b6e367f4e30997903bf44ebe7246b519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->