### PR TITLE
Fix OOM in CI test reruns due to GPU memory leak from traceback frame locals

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,27 @@
 # limitations under the License.
 
 import gc
+import traceback
 from functools import wraps
 
 import pytest
 import torch
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Clear traceback frame locals after a failed test to release CUDA tensor references.
+
+    When a test fails (especially with OOM), the exception traceback holds references to every local variable in every
+    frame on the call stack at the time of failure — including the model, trainer, and all intermediate tensors.
+    gc.collect() cannot free objects that are still reachable through a live traceback, so memory accumulates across
+    reruns (~2 GiB per rerun for Gemma4, reaching 5 × 2.38 GiB = 11.89 GiB after 5 reruns). Clearing the frame locals
+    breaks those reference chains so that the subsequent gc.collect() + empty_cache() in cleanup_gpu can actually
+    reclaim the CUDA memory before the next attempt.
+    """
+    yield
+    if call.when == "call" and call.excinfo is not None:
+        traceback.clear_frames(call.excinfo.tb)
 
 
 # ============================================================================


### PR DESCRIPTION
Fix OOM in CI test reruns due to GPU memory leak from traceback frame locals.

This PR adds a new pytest hook to improve memory management during test failures, particularly for tests that use CUDA tensors. The main change ensures that local variables in traceback frames are cleared after a failed test, allowing garbage collection to reclaim GPU memory and preventing memory accumulation across test reruns.

Partial fix for:
- #5207

### Motivation

When a test fails, Python keeps the exception traceback alive until the next test starts. Each traceback frame retains its `f_locals`, which for trainer tests includes the model, optimizer, and all associated CUDA tensors. `gc.collect()` and `torch.cuda.empty_cache()` cannot reclaim this memory because the traceback holds live references.

With pytest-rerunfailures, this compounds: each rerun creates a new failure traceback while the previous one is still alive. A single Gemma3 test consuming ~2.4 GiB leaves that memory pinned across all reruns, accumulating ~12 GiB over 5 reruns and causing OOM in other parallel workers.

### Solution

Add a + pytest_runtest_makereport` hook to `conftest.py` that calls `traceback.clear_frames()` on the exception traceback immediately after each failed report. This wipes `f_locals` from all frames, breaking the reference chain so the GC can free the CUDA tensors before the next rerun begins.

### Changes

**Test infrastructure improvements:**

* Added a `pytest_runtest_makereport` hook in `tests/conftest.py` to clear traceback frame locals after a failed test, releasing references to CUDA tensors and enabling proper memory cleanup between test reruns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that runs only on failures; main risk is reduced post-failure debugging visibility if cleared frame locals are needed.
> 
> **Overview**
> Prevents GPU memory from accumulating across pytest reruns by adding a `pytest_runtest_makereport` hook in `tests/conftest.py` that clears exception traceback frame locals (`traceback.clear_frames`) after a test failure.
> 
> This breaks reference chains to CUDA tensors/models held by the traceback so the existing post-test `gc.collect()`/`torch.cuda.empty_cache()` cleanup can actually reclaim memory before the next rerun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e995ed3ecba54093fbf104c5a611c4242e195c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->