### PR TITLE
Replace isinstance with is_peft_model in experimental trainers

### DIFF
--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -555,7 +555,7 @@ class BCOTrainer(_BaseTrainer):
 
         if ref_model:
             self.ref_model = ref_model
-        elif self.is_peft_model or args.precompute_ref_log_probs:
+        elif is_peft_model(model) or args.precompute_ref_log_probs:
             # The `model` with adapters turned off will be used as the reference model
             self.ref_model = None
         else:
@@ -767,7 +767,7 @@ class BCOTrainer(_BaseTrainer):
                 )
 
         if self.ref_model is None:
-            if not (self.is_peft_model or self.precompute_ref_log_probs):
+            if not (is_peft_model(model) or self.precompute_ref_log_probs):
                 raise ValueError(
                     "No reference model and model is not a Peft model. Try setting `precompute_ref_log_probs=True`"
                 )
@@ -939,7 +939,7 @@ class BCOTrainer(_BaseTrainer):
         """Context manager for handling null reference model (that is, peft adapter manipulation)."""
         with (
             self.accelerator.unwrap_model(self.model).disable_adapter()
-            if self.is_peft_model and not self.ref_adapter_name
+            if is_peft_model(self.model) and not self.ref_adapter_name
             else nullcontext()
         ):
             if self.ref_adapter_name:

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -33,7 +33,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from accelerate import Accelerator, PartialState, logging
-from accelerate.utils import tqdm
+from accelerate.utils import is_peft_model, tqdm
 from datasets import Dataset
 from packaging.version import Version
 from torch import autocast
@@ -484,7 +484,7 @@ class BCOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-            if isinstance(model, PeftModel):
+            if is_peft_model(model):
                 raise ValueError(
                     "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first "
                     "merge and unload the existing adapter, save the resulting base model, and then pass that base "

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -65,7 +65,7 @@ from .bco_config import BCOConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+    from peft import PeftConfig, get_peft_model, prepare_model_for_kbit_training
 
 if is_wandb_available():
     import wandb
@@ -549,7 +549,6 @@ class BCOTrainer(_BaseTrainer):
         else:
             self.is_encoder_decoder = args.is_encoder_decoder
 
-        self.is_peft_model = is_peft_available() and isinstance(model, PeftModel)
         self.model_adapter_name = model_adapter_name
         self.ref_adapter_name = ref_adapter_name
 

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -28,6 +28,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from accelerate import PartialState, logging
+from accelerate.utils import is_peft_model
 from datasets import Dataset
 from packaging.version import Version
 from torch import autocast
@@ -61,7 +62,7 @@ from .cpo_config import CPOConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+    from peft import PeftConfig, get_peft_model, prepare_model_for_kbit_training
 
 
 if is_wandb_available():
@@ -184,7 +185,7 @@ class CPOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-            if isinstance(model, PeftModel):
+            if is_peft_model(model):
                 raise ValueError(
                     "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first "
                     "merge and unload the existing adapter, save the resulting base model, and then pass that base "

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -60,7 +60,7 @@ from .online_dpo_config import OnlineDPOConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig, PeftModel
+    from peft import PeftConfig
 
 
 if is_sagemaker_mp_enabled():
@@ -294,7 +294,7 @@ class OnlineDPOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-        if peft_config is not None or (is_peft_available() and isinstance(model, PeftModel)):
+        if peft_config is not None or is_peft_model(model):
             model = prepare_peft_model(model, peft_config, args)
 
         # Enable gradient checkpointing if requested

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -28,6 +28,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from accelerate import PartialState, logging
+from accelerate.utils import is_peft_model
 from datasets import Dataset
 from packaging.version import Version
 from torch import autocast
@@ -62,7 +63,7 @@ from .orpo_config import ORPOConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+    from peft import PeftConfig, get_peft_model, prepare_model_for_kbit_training
 
 
 if is_wandb_available():
@@ -193,7 +194,7 @@ class ORPOTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-            if isinstance(model, PeftModel):
+            if is_peft_model(model):
                 raise ValueError(
                     "You passed a `PeftModel` instance together with a `peft_config` to the trainer. Please first "
                     "merge and unload the existing adapter, save the resulting base model, and then pass that base "

--- a/trl/experimental/prm/prm_trainer.py
+++ b/trl/experimental/prm/prm_trainer.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import transformers
 from accelerate import PartialState, logging
+from accelerate.utils import is_peft_model
 from datasets import Dataset, features
 from packaging.version import Version
 from transformers import (
@@ -44,7 +45,7 @@ from .prm_config import PRMConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig, PeftModel
+    from peft import PeftConfig
 
 logger = logging.get_logger(__name__)
 
@@ -184,7 +185,7 @@ class PRMTrainer(_BaseTrainer):
                     f"`peft_config` must be a `peft.PeftConfig` instance (e.g. `peft.LoraConfig`), "
                     f"got {type(peft_config).__name__}."
                 )
-        if peft_config is not None or (is_peft_available() and isinstance(model, PeftModel)):
+        if peft_config is not None or is_peft_model(model):
             model = prepare_peft_model(model, peft_config, args)
 
         # Disable dropout in the model

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -373,7 +373,7 @@ class TPOTrainer(_BaseTrainer):
 
         # When using gradient checkpointing with PEFT, we need to enable input gradients. transformers.Trainer normally
         # handles this, but a bug currently prevents it; see https://github.com/huggingface/transformers/issues/42489
-        if is_peft_available() and isinstance(model, PeftModel) and args.gradient_checkpointing:
+        if is_peft_model(model) and args.gradient_checkpointing:
             model.enable_input_require_grads()
 
         # Data collator. When `tpo_alpha=0.0`, the NLL term on the gold response is disabled, so we can drop the


### PR DESCRIPTION
Replace `isinstance` with `is_peft_model` in experimental trainers.

This PR refactors the handling of PEFT (Parameter-Efficient Fine-Tuning) model detection across several experimental trainer modules. The main improvement is the consistent use of the `is_peft_model` utility function from `accelerate.utils` instead of directly checking for `isinstance(model, PeftModel)`. This change enhances compatibility and reduces direct dependencies on PEFT internals, making the codebase more robust to future changes in the PEFT library.

Related to:
- #5682

### Changes

**PEFT Model Detection Refactor:**

* Replaced all direct `isinstance(model, PeftModel)` checks with the `is_peft_model(model)` utility function in the following trainers: `BCO`, `CPO`, `ORPO`, PRM`, `OnlineDPO`, and `TPO`. This ensures a uniform and future-proof approach to identifying PEFT models.

* Updated import statements to import `is_peft_model` from `accelerate.utils` and removed unnecessary imports of `PeftModel` from the `peft` package in the affected files, further decoupling the trainers from PEFT internals.

**Other Related Adjustments:**

* Updated logic in several trainers to use `is_peft_model(model)` in conditional flows that previously depended on `self.is_peft_model` or direct `isinstance` checks, ensuring consistency throughout the codebase.

* Cleaned up PEFT-related import blocks by removing unused `PeftModel` imports and ensuring only necessary symbols are imported from `peft`.

These changes make the trainer modules more maintainable and less susceptible to breaking changes in the PEFT library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical refactor of type checks and imports; behavior should remain the same but could affect edge cases where models are PEFT-wrapped in non-`PeftModel` forms or mocked types.
> 
> **Overview**
> Standardizes PEFT detection across experimental trainers (`bco`, `cpo`, `orpo`, `prm`, `online_dpo`, `tpo`) by replacing `isinstance(model, PeftModel)` / `self.is_peft_model` branches with `accelerate.utils.is_peft_model(model)`.
> 
> Cleans up related imports by dropping direct `PeftModel` imports from `peft` and pulling `is_peft_model` from `accelerate.utils`, reducing coupling to PEFT internals while keeping existing PEFT control flow (e.g., adapter disabling, reference-model selection, gradient-checkpointing hooks) functionally the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9dc6851fa7ac88ac071fd554f502a94d215db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->