### PR TITLE
Fix OOM in CI by reducing batch size in VLM SFT tests

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1708,6 +1708,7 @@ class TestSFTTrainer(TrlTestCase):
         # Initialize the trainer
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
             report_to="none",
         )
@@ -1765,6 +1766,7 @@ class TestSFTTrainer(TrlTestCase):
         # Initialize the trainer
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
             report_to="none",
@@ -1812,6 +1814,7 @@ class TestSFTTrainer(TrlTestCase):
         # Initialize the trainer
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
             report_to="none",


### PR DESCRIPTION
Fix OOM in CI by reducing batch size in VLM SFT tests.

Partial fix for:
- #5207 

### Motivation

VLM training tests in `test_sft_trainer.py` were running with the default `per_device_train_batch_size=8`. For Gemma3, with `vocab_size=262208` (production-scale, never reduced for tiny models) and `mm_tokens_per_image=256`, each training step computes logits of shape `[8, 279, 262208]`. 

PyTorch needs several float32 copies of this tensor for log-softmax and its gradient, pushing peak GPU memory to ~9 GiB per worker. With 4 parallel pytest-xdist workers this caused CUDA out-of-memory errors for other concurrent tests.

### Solution

Set `per_device_train_batch_size=1` in `test_train_vlm`, `test_train_vlm_multi_image`, and `test_train_vlm_prompt_completion`, following the pattern already used in `test_train_vlm_gemma_3n`. This drops peak GPU memory to ~1.1 GiB per worker for Gemma3, leaving ample headroom for parallel execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that lowers batch size to avoid CI OOMs; no production code paths are modified.
> 
> **Overview**
> Reduces GPU memory pressure in vision-language SFT integration tests by explicitly setting `per_device_train_batch_size=1` in `test_train_vlm`, `test_train_vlm_multi_image`, and `test_train_vlm_prompt_completion`.
> 
> This prevents CI CUDA OOMs during parallel test execution while keeping the VLM-specific `max_length=None` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0480d772ac90361e961c54beedfc546e0f69f95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->