### PR TITLE
[GRPO] update Liger-kernel grpo loss (delta, vespo, KL bias correction)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ kernels = [
     "kernels"
 ]
 liger = [
-    "liger-kernel>=0.7.0"
+    "liger-kernel>=0.8.0"
 ]
 peft = [
     "peft>=0.8.0"
@@ -103,7 +103,7 @@ dev = [
     # kernels
     "kernels",
     # liger
-    "liger-kernel>=0.7.0",
+    "liger-kernel>=0.8.0",
     # peft
     "peft>=0.8.0",
     # quality

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -277,9 +277,7 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.parametrize(
-        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
-    )
+    @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
     @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo"])
     def test_training_loss_types(self, loss_type, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
@@ -1192,9 +1190,7 @@ class TestGRPOTrainer(TrlTestCase):
 
         release_memory(trainer.model, trainer)
 
-    @pytest.mark.parametrize(
-        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
-    )
+    @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
     def test_training_with_bias_correction_kl(self, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(
@@ -1695,9 +1691,7 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.parametrize(
-        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
-    )
+    @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
     def test_training_delta_clipping(self, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -277,8 +277,11 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.parametrize(
+        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
+    )
     @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo"])
-    def test_training_loss_types(self, loss_type):
+    def test_training_loss_types(self, loss_type, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -290,6 +293,7 @@ class TestGRPOTrainer(TrlTestCase):
             max_completion_length=32,  # reduce the completion length to reduce memory usage
             gradient_accumulation_steps=2,  # set to 2 to test than DAPO can operate with accumulated batch
             loss_type=loss_type,
+            use_liger_kernel=use_liger_kernel,
             report_to="none",
         )
         trainer = GRPOTrainer(
@@ -1188,7 +1192,10 @@ class TestGRPOTrainer(TrlTestCase):
 
         release_memory(trainer.model, trainer)
 
-    def test_training_with_bias_correction_kl(self):
+    @pytest.mark.parametrize(
+        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
+    )
+    def test_training_with_bias_correction_kl(self, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
@@ -1198,6 +1205,7 @@ class TestGRPOTrainer(TrlTestCase):
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
+            use_liger_kernel=use_liger_kernel,
             report_to="none",
         )
         trainer = GRPOTrainer(
@@ -1687,7 +1695,10 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    def test_training_delta_clipping(self):
+    @pytest.mark.parametrize(
+        "use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)]
+    )
+    def test_training_delta_clipping(self, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -1697,6 +1708,7 @@ class TestGRPOTrainer(TrlTestCase):
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             delta=2.0,  # set delta to a non-None value
+            use_liger_kernel=use_liger_kernel,
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from packaging.version import Version
 
 
-LIGER_KERNEL_MIN_VERSION = "0.7.0"
+LIGER_KERNEL_MIN_VERSION = "0.8.0"
 PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
 
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -940,4 +940,3 @@ class GRPOConfig(_BaseConfig):
                 "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
                 f"{self.num_generations}, which is less than the minimum required."
             )
-

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -941,5 +941,3 @@ class GRPOConfig(_BaseConfig):
                 f"{self.num_generations}, which is less than the minimum required."
             )
 
-        if self.delta is not None and self.use_liger_kernel:
-            raise ValueError("Liger kernel does not support two-sided GRPO loss yet.")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -726,6 +726,14 @@ class GRPOTrainer(_BaseTrainer):
                 loss_type=self.loss_type,
                 max_completion_length=self.max_completion_length,
                 importance_sampling_level=self.importance_sampling_level,
+                delta=args.delta,
+                use_bias_correction_kl=args.use_bias_correction_kl,
+                sapo_temperature_pos=args.sapo_temperature_pos,
+                sapo_temperature_neg=args.sapo_temperature_neg,
+                vespo_k_pos=args.vespo_k_pos,
+                vespo_lambda_pos=args.vespo_lambda_pos,
+                vespo_k_neg=args.vespo_k_neg,
+                vespo_lambda_neg=args.vespo_lambda_neg,
             )
 
         # Initialize the metrics


### PR DESCRIPTION
Liger Kernel v0.8.0 ships delta (two-sided clipping), `use_bias_correction_kl`, `sapo_temperature_pos`/`neg`, and `vespo_k_pos`/`lambda_pos`/`k_neg`/`lambda_neg` on `LigerFusedLinearGRPOLoss`. 

Forward them from `GRPOConfig` in `compute_liger_loss`, drop the now-stale delta+use_liger_kernel guard, and bump the liger-kernel pin to >=0.8.0 in the liger and dev extras.

Cover the Liger paths by parametrizing `test_training_loss_types`, `test_training_delta_clipping`, and `test_training_with_bias_correction_kl` over `use_liger_kernel` (`require_liger_kernel` as a conditional skip mark) instead of adding parallel test functions.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GRPO training behavior when `use_liger_kernel` is enabled by wiring new loss parameters (e.g., `delta`, VESPO, and KL bias correction) into the fused Liger loss and removing a previous configuration guard. Risk is mainly around correctness/regressions in Liger-backed training and test coverage depending on optional kernel availability.
> 
> **Overview**
> **Updates GRPO’s Liger-kernel integration to v0.8.0.** The Liger optional dependency and runtime minimum version are bumped from `0.7.0` to `0.8.0`.
> 
> When `use_liger_kernel` is enabled, `GRPOTrainer` now forwards additional config knobs into `LigerFusedLinearGRPOLoss` (including `delta` two-sided clipping, `use_bias_correction_kl`, and SAPO/VESPO parameters), and the `GRPOConfig` validation that previously rejected `delta` with Liger is removed.
> 
> Tests are adjusted to parameterize key GRPO training tests over `use_liger_kernel`, increasing coverage of the Liger code path under the existing `require_liger_kernel` skip mark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268e3d977741e18aa0efa56b8c91b2640b66ba7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->