### PR TITLE
fix: force contiguous in pack_tensor for non-broadcast tensors

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -303,6 +303,10 @@ class OffloadActivations(saved_tensors_hooks):
                     cpu_tensor = cpu_storage
                 else:
                     # No broadcast - use normal contiguous copy
+                    if not activation.is_contiguous():
+                        activation = activation.contiguous()
+                        original_stride = activation.stride()
+                        original_storage_offset = activation.storage_offset()
                     cpu_tensor = torch.empty_like(activation, pin_memory=self.use_pin_memory, device="cpu")
                     cpu_tensor.copy_(activation, non_blocking=True)
 


### PR DESCRIPTION
                                                                                                                                                                                                         
  ```markdown                                                                                                                                                                                                                               
  ## Problem                                                           
                                                                                                                                                                                                                                            
  When `OffloadActivations.pack_tensor` processes a non-contiguous                                                                                                                                                                          
  tensor (e.g. a slice with `storage_offset != 0`), `torch.empty_like`                                                                                                                                                                      
  creates a contiguous CPU copy with `storage_offset=0`. However,                                                                                                                                                                           
  the original non-zero offset and stride are saved in the tracker.                                                                                                                                                                         
                                                                                                                                                                                                                                            
  During `unpack_tensor_single_stream`, `torch.as_strided` with the                                                                                                                                                                         
  original non-zero `storage_offset` tries to access past the end                                                                                                                                                                           
  of the contiguous storage:                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  RuntimeError: setStorage: sizes [1591], strides [1], storage offset 1,                                                                                                                                                                    
  and itemsize 8 requiring a storage size of 12736 are out of bounds                                                                                                                                                                        
  for storage of size 12728                                                                                                                                                                                                                 
                                                                                                                                                                                                                                            
  This occurs when `use_streams=False` and the model processes                                                                                                                                                                              
  non-contiguous activation views (common in attention slicing).                                                                                                                                                                            
                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  Force `activation.contiguous()` before creating the CPU copy when                                                                                                                                                                         
  in the non-broadcast path. This ensures `storage_offset=0` and       
  contiguous stride, which match the `empty_like` + `copy_` layout.                                                                                                                                                                         
                                                                                                                                                                                                                                            
                                                                                                                                                                                                                      
  if not activation.is_contiguous():                                                                                                                                                                                                        
      activation = activation.contiguous()                                                                                                                                                                                                  
      original_stride = activation.stride()                                                                                                                                                                                                 
      original_storage_offset = activation.storage_offset()                                                                                                                                                                                 
                                                                                                                                                                                                                                            
  Only affects the non-broadcast path. Broadcast tensors are handled                                                                                                                                                                        
  separately and were already correct.                                                                                                                                                                                                      
                                                                                                                                                                                                                                            
  Verification                                                         
                                                                                                                                                                                                                                            
  Triggered consistently during Qwen3-VL-9B vision training with                                                                                                                                                                            
  use_streams=False. After fix, training completes without the
  storage_offset crash.                                                                                                                                                                                                                     

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches activation offloading pack/unpack behavior; while small and targeted, it changes tensor layout/stride handling and could impact memory/perf or edge-case correctness for view tensors.
> 
> **Overview**
> Fixes a crash when offloading **non-contiguous, non-broadcast** activation views by forcing `activation.contiguous()` before the CPU `empty_like` + `copy_` path in `OffloadActivations.pack_tensor`.
> 
> This ensures the saved `original_stride`/`storage_offset` metadata matches the actual contiguous CPU storage, preventing out-of-bounds `torch.as_strided` during `unpack_tensor_single_stream` when restoring the tensor back to the accelerator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90741f696852690d6585973f5d4d443cab415d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->