### PR TITLE
fix: prevent RuntimeError crash in activation offloading for non-contiguous tensors

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -303,6 +303,16 @@ class OffloadActivations(saved_tensors_hooks):
                     cpu_tensor = cpu_storage
                 else:
                     # No broadcast - use normal contiguous copy
+                    # .contiguous() can be a no-op for contiguous views with
+                    # non-zero storage_offset. Force a clone for those views
+                    # so later as_strided reconstruction stays in bounds.
+                    if not activation.is_contiguous() or activation.storage_offset() != 0:
+                        if activation.storage_offset() != 0:
+                            activation = activation.clone(memory_format=torch.contiguous_format)
+                        else:
+                            activation = activation.contiguous()
+                        original_stride = activation.stride()
+                        original_storage_offset = activation.storage_offset()
                     cpu_tensor = torch.empty_like(activation, pin_memory=self.use_pin_memory, device="cpu")
                     cpu_tensor.copy_(activation, non_blocking=True)
 


### PR DESCRIPTION
                                                                                                                                                                                                                                   
  Description:                                                         
  # What does this PR do?                                                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  Fixes a crash in `OffloadActivations.pack_tensor` when processing                                                                                                                                                                         
  non-contiguous tensors (e.g. slices with `storage_offset != 0`).                                                                                                                                                                          
                                                                                                                                                                                                                                            
  `torch.empty_like` creates a contiguous CPU copy but the original                                                                                                                                                                         
  non-zero offset/stride are preserved. During unpack, `torch.as_strided`                                                                                                                                                                   
  with the original offset accesses past the end of contiguous storage:                                                                                                                                                                     
                                                                                                                                                                                                                                            
  RuntimeError: setStorage: sizes [1591], strides [1], storage offset 1,                                                                                                                                                                    
  requiring storage size of 12736 are out of bounds for storage of 12728                                                                                                                                                                    
                                                                                                                                                                                                                                            
  Fix: `activation.contiguous()` before `empty_like` in the non-broadcast                                                                                                                                                                   
  path, which correctly resets stride and offset.                                                                                                                                                                                           
                                                                                                                                                                                                                                            
  Triggered reliably during QLoRA vision training with                                                                                                                                                                                      
  `use_streams=False` on Qwen3-VL-9B.                                                                                                                                                                                                       
                                                                                                                                                                                                                                            
  ## Before submitting                                                                                                                                                                                                                      
  - [ ] This PR fixes a typo or improves the docs                                                                                                                                                                                           
  - [x] Did you read the [contributor guideline]?                                                                                                                                                                                           
  - [x] Did you discuss this via a GitHub issue?                                                                                                                                                                                            
  - [ ] Did you update the documentation?                                                                                                                                                                                                   
  - [ ] Did you write any new necessary tests?                                                                                                                                                                                              
                                                                                                                                                                                                                                            
  ## AI writing disclosure                                                                                                                                                                                                                  
  - [ ] No AI usage                                                                                                                                                                                                                         
  - [x] AI-assisted                                                                                                                                                                                                                         
  - [ ] AI-generated                                                                                                                                                                                                                        
                                                                                                                                                                                                                                            
  @butterwecksolutions                                                                                                                                                                                                                      
                                                                                                                                                                                                                                            

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core activation offloading packing logic; while localized, it changes how tensors are copied/offloaded and could affect memory/perf or stride/offset restoration for edge-case views.
> 
> **Overview**
> Prevents a `RuntimeError` during activation offloading/unpacking when given non-contiguous tensors or contiguous views with non-zero `storage_offset`.
> 
> In the non-broadcast offload path, `pack_tensor` now forces a real contiguous copy (using `.clone()` when `storage_offset != 0`, otherwise `.contiguous()`) before `torch.empty_like`/`copy_`, and updates the saved stride/offset metadata accordingly so later `torch.as_strided` reconstruction stays in-bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e71d9b5ce13a77fb4eb2b875da8feddf23e2128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->