### PR TITLE
[experimental] Add OpenReward Standard environment adapter

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -51,6 +51,8 @@
     title: Liger Kernel
   - local: openenv
     title: OpenEnv
+  - local: openreward
+    title: OpenReward
   - local: peft_integration
     title: PEFT
   - local: ptt_integration

--- a/docs/source/openreward.md
+++ b/docs/source/openreward.md
@@ -1,0 +1,203 @@
+# OpenReward Integration for Training LLMs with Environments
+
+[OpenReward](https://openreward.ai) is an open ecosystem for RL environments built on the [Open Reward Standard (ORS)](https://openrewardstandard.io) — a public, language-agnostic HTTP/SSE protocol for how an environment exposes its tasks, tools, sessions, and rewards. Because ORS is just a protocol, the same environment can run on the [OpenReward platform](https://openreward.ai), self-hosted on any container service, or locally on `localhost` for development. A catalog of ready-to-use environments is available at [openreward.ai](https://openreward.ai).
+
+This guide covers **how to integrate OpenReward with TRL**. For more on the standard itself, see the [ORS docs](https://docs.openreward.ai/).
+
+> [!NOTE]
+> The integration lives at `trl.experimental.openreward` and is gated behind the `trl[openreward]` extra (lazy-imported — non-users pay nothing).
+
+## When to use OpenReward environments
+
+[`GRPOTrainer`] supports environment-based training via the `environment_factory` slot — see [OpenEnv](openenv) for the general contract. Use OpenReward when you want to train against an ORS-speaking environment: the [OpenReward catalog](https://openreward.ai) (e.g. `Eigent/SETA`, `kanishk/EndlessTerminals`, `nebius/SWE-rebench-V2`), an env you self-host on your own infra, or a local server you're developing.
+
+## Installation
+
+```bash
+pip install trl[openreward]
+```
+
+This installs the `openreward` Python SDK. The integration itself imports `openreward` lazily, so users who don't touch `trl.experimental.openreward` aren't affected.
+
+## Quick start
+
+The `OpenRewardSpec` class wires a single ORS environment into the three TRL trainer slots — `train_dataset`, `environment_factory`, `reward_funcs` — by exposing properties that map 1:1 to those kwarg names:
+
+```python
+from trl import GRPOConfig, GRPOTrainer
+from trl.experimental.openreward import OpenRewardSpec
+
+spec = OpenRewardSpec("Eigent/SETA", num_tasks=64)
+
+trainer = GRPOTrainer(
+    model="Qwen/Qwen3-4B",
+    args=GRPOConfig(
+        num_generations=2,
+        max_steps=5,
+        max_tool_calling_iterations=20,
+        log_completions=True,
+    ),
+    train_dataset=spec.train_dataset,
+    environment_factory=spec.environment_factory,
+    reward_funcs=spec.reward_funcs,
+)
+trainer.train()
+```
+
+Under the hood `OpenRewardSpec` does three things, lazily on first access:
+
+1. **`spec.train_dataset`**: derives a `datasets.Dataset` from the env's task list (one HTTP roundtrip via the SDK). Has at minimum `prompt`, `task_index`, plus per-task metadata columns folded in.
+2. **`spec.environment_factory`**: returns a zero-arg callable that produces a fresh per-rollout adapter on each call. The adapter exposes one Python method per ORS tool, with a typed signature and docstring auto-generated from the env's JSON Schema. TRL's tool collector picks them up via `inspect.getmembers`.
+3. **`spec.reward_funcs`**: an outcome-only reward function (last non-null reward in the trajectory) suitable for sparse-reward envs like SETA.
+
+## Using a hub environment
+
+Pass an [openreward.ai](https://openreward.ai) catalog name as the target. The SDK reads `OPENREWARD_API_KEY` from the environment for authentication.
+
+```python
+spec = OpenRewardSpec("Eigent/SETA", num_tasks=64)
+```
+
+## Using a self-hosted environment
+
+Pass the URL directly. No API key is needed if your server doesn't enforce one.
+
+```python
+spec = OpenRewardSpec("https://my-org-my-env.hf.space", env_name="my_env")
+```
+
+> [!IMPORTANT]
+> The `openreward` SDK by default expects a two-subdomain platform layout (`api.<host>` for stateless calls and `sessions.<host>` for SSE-based session calls). For **single-host** self-hosted servers (one URL serving everything), set the override env vars below before constructing `OpenRewardSpec`:
+>
+> ```python
+> import os
+>
+> URL = "https://my-org-my-env.hf.space"
+> os.environ["OPENREWARD_API_URL"]     = URL
+> os.environ["OPENREWARD_SESSION_URL"] = URL
+>
+> spec = OpenRewardSpec(URL, env_name="my_env")
+> ```
+
+## Running a minimal environment locally
+
+The fastest way to try the integration end-to-end without external dependencies is a tiny ORS server defined with the `openreward` SDK's `Environment` + `Server` scaffolding. The example below is a complete `echo` environment — the model wins by calling `echo(text=...)` with the task's target string.
+
+```python
+# server.py
+from pydantic import BaseModel
+from openreward.environments import Environment, JSONObject, Server, TextBlock, ToolOutput, tool
+
+
+class EchoTaskSpec(BaseModel):
+    target: str
+
+class EchoParams(BaseModel):
+    text: str
+
+
+class EchoEnvironment(Environment):
+    def __init__(self, task_spec: JSONObject = {}, secrets: dict[str, str] = {}):
+        super().__init__(task_spec)
+        self.config = EchoTaskSpec.model_validate(task_spec)
+
+    @classmethod
+    def list_splits(cls) -> list[str]:
+        return ["train"]
+
+    @classmethod
+    def list_tasks(cls, split: str) -> list[JSONObject]:
+        return [{"target": "hello"}, {"target": "world"}]
+
+    def get_prompt(self) -> list[TextBlock]:
+        return [TextBlock(type="text", text=f"Echo '{self.config.target}' to win.")]
+
+    @tool
+    async def echo(self, params: EchoParams) -> ToolOutput:
+        """Submit a string. Reward 1.0 + finished if it matches the target.
+
+        Args:
+            text: The string to echo back.
+        """
+        correct = params.text == self.config.target
+        return ToolOutput(
+            blocks=[TextBlock(type="text", text="match" if correct else "no match")],
+            reward=1.0 if correct else 0.0,
+            finished=correct,
+        )
+
+
+if __name__ == "__main__":
+    Server([EchoEnvironment]).run(host="0.0.0.0", port=8000)
+```
+
+Run it:
+
+```bash
+pip install openreward fastapi uvicorn pydantic
+python server.py     # listens on :8000
+```
+
+Then point `OpenRewardSpec` at it (with the URL overrides described above):
+
+```python
+import os
+URL = "http://127.0.0.1:8000"
+os.environ["OPENREWARD_API_URL"]     = URL
+os.environ["OPENREWARD_SESSION_URL"] = URL
+
+from trl.experimental.openreward import OpenRewardSpec
+spec = OpenRewardSpec(URL, env_name="echoenvironment")
+print(spec.train_dataset)        # 2 rows, task_index + target columns
+```
+
+This is also the fixture pattern used by TRL's own tests — see [`trl-internal-testing/openreward-echo-env`](https://huggingface.co/spaces/trl-internal-testing/openreward-echo-env) for the deployed Space.
+
+## Selecting tasks
+
+`OpenRewardSpec` accepts either a count or an explicit index list:
+
+```python
+spec = OpenRewardSpec("Eigent/SETA", num_tasks=10)                      # first 10 tasks
+spec = OpenRewardSpec("Eigent/SETA", indices=[0, 5, 13, 27])            # specific indices
+spec = OpenRewardSpec("Eigent/SETA", indices=list(range(50, 100)))      # range
+```
+
+`num_tasks` and `indices` are mutually exclusive and both fetch only the tasks they need (no full task list scan).
+
+## How tool binding works
+
+At construction the spec calls the env's `/tools` endpoint to fetch a list of tool specs (each with a name, description, and JSON Schema for arguments). For each tool it generates a Python method on the per-rollout adapter with a typed signature and a docstring derived from the schema. So `transformers.utils.get_json_schema` and TRL's `inspect.getmembers(env, ismethod)` both produce the right tool schema for the model with no per-env wrapper code.
+
+If a tool description contains characters that aren't safe to splice into Python source, the binder falls back to a sanitized form so binding never fails on real envs.
+
+## Reward functions
+
+`spec.reward_funcs` defaults to an outcome-only reward — for each rollout it returns the last non-null reward observed during the trajectory. This is the right default for sparse-reward envs (e.g. SETA, where only `submit_solution` returns a non-null reward).
+
+If you want a custom reward, write a regular TRL reward function and pass it directly:
+
+```python
+def my_reward(environments, **kwargs) -> list[float]:
+    return [env.reward * 2.0 for env in environments]   # double the env reward, etc.
+
+trainer = GRPOTrainer(
+    ...,
+    reward_funcs=my_reward,
+)
+```
+
+The per-rollout adapter exposes the running state TRL needs — `env.reward`, `env.rewards`, `env.metadata`, `env.finished`, `env.last_output` — for arbitrary post-hoc reward shaping.
+
+## Limitations
+
+- The integration is in `trl.experimental` — APIs may change. Set `TRL_EXPERIMENTAL_SILENCE=1` to silence the warning in CI logs.
+- Currently exposes a single `OpenRewardSpec` covering one environment; multi-environment training (à la the OpenEnv "meta-environment" pattern) is not supported yet.
+- Long-running rollouts (>15 min per episode) need a keepalive ping — not yet wired.
+
+## Reference
+
+- [Open Reward Standard](https://openrewardstandard.io)
+- [OpenReward platform](https://openreward.ai)
+- [`openreward` Python SDK](https://pypi.org/project/openreward/)
+- [Echo env Space — `trl-internal-testing/openreward-echo-env`](https://huggingface.co/spaces/trl-internal-testing/openreward-echo-env)

--- a/docs/source/openreward.md
+++ b/docs/source/openreward.md
@@ -189,6 +189,10 @@ trainer = GRPOTrainer(
 
 The per-rollout adapter exposes the running state TRL needs — `env.reward`, `env.rewards`, `env.metadata`, `env.finished`, `env.last_output` — for arbitrary post-hoc reward shaping.
 
+## OpenRewardSpec
+
+[[autodoc]] trl.experimental.openreward.OpenRewardSpec
+
 ## Limitations
 
 - The integration is in `trl.experimental` — APIs may change. Set `TRL_EXPERIMENTAL_SILENCE=1` to silence the warning in CI logs.

--- a/examples/scripts/openreward/seta.py
+++ b/examples/scripts/openreward/seta.py
@@ -63,7 +63,7 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="Eigent/SETA",
         help="ORS env target — either a catalog name (e.g. 'Eigent/SETA') or a URL "
-             "(e.g. 'https://you-seta.hf.space').",
+        "(e.g. 'https://you-seta.hf.space').",
     )
     parser.add_argument("--split", type=str, default="train")
     parser.add_argument("--num-tasks", type=int, default=64)

--- a/examples/scripts/openreward/seta.py
+++ b/examples/scripts/openreward/seta.py
@@ -51,7 +51,7 @@ CUDA_VISIBLE_DEVICES=0,1 accelerate launch \
 import argparse
 
 from trl import GRPOConfig, GRPOTrainer
-from trl.experimental.openreward import OpenRewardEnv
+from trl.experimental.openreward import OpenRewardSpec
 
 
 def parse_args() -> argparse.Namespace:
@@ -90,7 +90,7 @@ def main() -> None:
     args = parse_args()
 
     # One spec object — fans out into TRL's three slots.
-    env = OpenRewardEnv(args.target, num_tasks=args.num_tasks, split=args.split)
+    spec = OpenRewardSpec(args.target, num_tasks=args.num_tasks, split=args.split)
 
     config_kwargs: dict = dict(
         learning_rate=args.learning_rate,
@@ -102,11 +102,6 @@ def main() -> None:
         max_tool_calling_iterations=args.max_tool_calling_iterations,
         chat_template_kwargs={"enable_thinking": False},
         log_completions=True,
-        bf16=True,
-        gradient_checkpointing=True,
-        gradient_checkpointing_kwargs={"use_reentrant": False},
-        beta=0.01,
-        loss_type="grpo",
         use_vllm=True,
         vllm_mode=args.vllm_mode,
         report_to=[s.strip() for s in args.report_to.split(",") if s.strip() and s.strip() != "none"] or "none",
@@ -121,9 +116,9 @@ def main() -> None:
     trainer = GRPOTrainer(
         model=args.model,
         args=GRPOConfig(**config_kwargs),
-        train_dataset=env.dataset,
-        environment_factory=env.factory,
-        reward_funcs=env.reward_func,
+        train_dataset=spec.train_dataset,
+        environment_factory=spec.environment_factory,
+        reward_funcs=spec.reward_funcs,
     )
     trainer.train()
 

--- a/examples/scripts/openreward/seta.py
+++ b/examples/scripts/openreward/seta.py
@@ -1,0 +1,132 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# /// script
+# dependencies = ["trl[vllm,openreward]"]
+# ///
+
+"""GRPO training against the SETA ORS environment.
+
+Defaults target ``Eigent/SETA`` on the openreward.ai catalog (requires
+``OPENREWARD_API_KEY``). Pass ``--target https://...hf.space`` to point
+at a self-hosted Space.
+
+Usage (colocate vLLM, single-node):
+
+```sh
+accelerate launch \
+    --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
+    --num_processes 4 \
+    examples/scripts/openreward/seta.py \
+    --vllm-mode colocate
+```
+
+Usage (server vLLM, single-node 2+2 GPU split):
+
+```sh
+# Terminal 1 — vLLM
+CUDA_VISIBLE_DEVICES=2,3 trl vllm-serve --model Qwen/Qwen3-4B \
+    --tensor-parallel-size 2 --port 8000
+
+# Terminal 2 — training
+CUDA_VISIBLE_DEVICES=0,1 accelerate launch \
+    --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
+    --num_processes 2 \
+    examples/scripts/openreward/seta.py \
+    --vllm-mode server --vllm-server-base-url http://localhost:8000
+```
+"""
+
+import argparse
+
+from trl import GRPOConfig, GRPOTrainer
+from trl.experimental.openreward import OpenRewardEnv
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="GRPO training against the SETA ORS environment.")
+
+    parser.add_argument("--model", type=str, default="Qwen/Qwen3-4B")
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="Eigent/SETA",
+        help="ORS env target — either a catalog name (e.g. 'Eigent/SETA') or a URL "
+             "(e.g. 'https://you-seta.hf.space').",
+    )
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--num-tasks", type=int, default=64)
+
+    parser.add_argument("--learning-rate", type=float, default=5e-7)
+    parser.add_argument("--per-device-train-batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=1)
+    parser.add_argument("--num-generations", type=int, default=2)
+    parser.add_argument("--max-completion-length", type=int, default=2048)
+    parser.add_argument("--max-steps", type=int, default=5)
+    parser.add_argument("--max-tool-calling-iterations", type=int, default=20)
+
+    parser.add_argument("--vllm-mode", choices=("colocate", "server"), default="colocate")
+    parser.add_argument("--vllm-server-base-url", type=str, default="http://localhost:8000")
+    parser.add_argument("--vllm-gpu-memory-utilization", type=float, default=0.3)
+
+    parser.add_argument("--output-dir", type=str, default=None)
+    parser.add_argument("--report-to", type=str, default="none")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # One spec object — fans out into TRL's three slots.
+    env = OpenRewardEnv(args.target, num_tasks=args.num_tasks, split=args.split)
+
+    config_kwargs: dict = dict(
+        learning_rate=args.learning_rate,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        num_generations=args.num_generations,
+        max_completion_length=args.max_completion_length,
+        max_steps=args.max_steps,
+        max_tool_calling_iterations=args.max_tool_calling_iterations,
+        chat_template_kwargs={"enable_thinking": False},
+        log_completions=True,
+        bf16=True,
+        gradient_checkpointing=True,
+        gradient_checkpointing_kwargs={"use_reentrant": False},
+        beta=0.01,
+        loss_type="grpo",
+        use_vllm=True,
+        vllm_mode=args.vllm_mode,
+        report_to=[s.strip() for s in args.report_to.split(",") if s.strip() and s.strip() != "none"] or "none",
+    )
+    if args.output_dir:
+        config_kwargs["output_dir"] = args.output_dir
+    if args.vllm_mode == "colocate":
+        config_kwargs["vllm_gpu_memory_utilization"] = args.vllm_gpu_memory_utilization
+    else:
+        config_kwargs["vllm_server_base_url"] = args.vllm_server_base_url
+
+    trainer = GRPOTrainer(
+        model=args.model,
+        args=GRPOConfig(**config_kwargs),
+        train_dataset=env.dataset,
+        environment_factory=env.factory,
+        reward_funcs=env.reward_func,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ dev = [
     "kernels",
     # liger
     "liger-kernel>=0.8.0",
+    # openreward
+    "openreward>=0.1.109",
     # peft
     "peft>=0.8.0",
     # quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ vlm = [
 math_verify = [
     "math-verify>=0.5.2",
 ]
+openreward = [
+    "openreward>=0.1.109",
+]
 dev = [
     # bco
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ math_verify = [
     "math-verify>=0.5.2",
 ]
 openreward = [
-    "openreward>=0.1.109",
+    "openreward>=0.1.109; python_version >= '3.11'",  # openreward requires Python 3.11+
 ]
 dev = [
     # bco
@@ -107,8 +107,8 @@ dev = [
     "kernels",
     # liger
     "liger-kernel>=0.8.0",
-    # openreward
-    "openreward>=0.1.109",
+    # openreward (requires Python 3.11+)
+    "openreward>=0.1.109; python_version >= '3.11'",
     # peft
     "peft>=0.8.0",
     # quality

--- a/tests/experimental/_openreward_echo_env.py
+++ b/tests/experimental/_openreward_echo_env.py
@@ -1,0 +1,103 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spawn target for `tests/experimental/test_openreward.py`.
+
+Implements a minimal, deterministic Open Reward Standard environment so the
+adapter can be exercised end-to-end without hitting the network. The same
+definition is also published as a Hugging Face Space at
+`trl-internal-testing/openreward-echo-env` for the optional integration test.
+
+The model is given a target string and must call `echo(text=...)` with
+exactly that string. Reward is `1.0` on match, `0.0` otherwise; the episode
+finishes on a correct echo.
+"""
+
+from openreward.environments import (
+    Environment,
+    JSONObject,
+    Server,
+    TextBlock,
+    ToolOutput,
+    tool,
+)
+from pydantic import BaseModel
+
+
+TRAIN_TASKS: list[JSONObject] = [
+    {"id": "echo-0", "target": "hello"},
+    {"id": "echo-1", "target": "world"},
+    {"id": "echo-2", "target": "trl"},
+    {"id": "echo-3", "target": "openreward"},
+]
+
+
+class EchoTaskSpec(BaseModel):
+    id: str
+    target: str
+
+
+class EchoParams(BaseModel):
+    text: str
+
+
+class EchoEnvironment(Environment):
+    """Tiny deterministic ORS env: echo the target string to win."""
+
+    def __init__(self, task_spec: JSONObject = {}, secrets: dict[str, str] = {}):  # noqa: B006 - signature dictated by openreward.environments.Environment
+        super().__init__(task_spec)
+        self.config = EchoTaskSpec.model_validate(task_spec)
+
+    @classmethod
+    def list_splits(cls) -> list[str]:
+        return ["train"]
+
+    @classmethod
+    def list_tasks(cls, split: str) -> list[JSONObject]:
+        if split != "train":
+            raise ValueError(f"unknown split: {split}")
+        return TRAIN_TASKS
+
+    def get_prompt(self) -> list[TextBlock]:
+        return [
+            TextBlock(
+                type="text",
+                text=f"Call the `echo` tool with text='{self.config.target}' to win.",
+            )
+        ]
+
+    @tool
+    async def echo(self, params: EchoParams) -> ToolOutput:
+        """Submit a string. Reward 1.0 + finished if it matches the target.
+
+        Args:
+            text: The string to echo back.
+        """
+        correct = params.text == self.config.target
+        return ToolOutput(
+            blocks=[
+                TextBlock(
+                    type="text",
+                    text="match" if correct else f"no match (got {params.text!r})",
+                )
+            ],
+            reward=1.0 if correct else 0.0,
+            finished=correct,
+        )
+
+
+if __name__ == "__main__":
+    import os
+
+    Server([EchoEnvironment]).run(host="127.0.0.1", port=int(os.environ["PORT"]))

--- a/tests/experimental/_openreward_echo_env.py
+++ b/tests/experimental/_openreward_echo_env.py
@@ -14,14 +14,12 @@
 
 """Spawn target for `tests/experimental/test_openreward.py`.
 
-Implements a minimal, deterministic Open Reward Standard environment so the
-adapter can be exercised end-to-end without hitting the network. The same
-definition is also published as a Hugging Face Space at
+Implements a minimal, deterministic Open Reward Standard environment so the adapter can be exercised end-to-end without
+hitting the network. The same definition is also published as a Hugging Face Space at
 `trl-internal-testing/openreward-echo-env` for the optional integration test.
 
-The model is given a target string and must call `echo(text=...)` with
-exactly that string. Reward is `1.0` on match, `0.0` otherwise; the episode
-finishes on a correct echo.
+The model is given a target string and must call `echo(text=...)` with exactly that string. Reward is `1.0` on match,
+`0.0` otherwise; the episode finishes on a correct echo.
 """
 
 from openreward.environments import (

--- a/tests/experimental/test_openreward.py
+++ b/tests/experimental/test_openreward.py
@@ -189,3 +189,18 @@ class TestOpenRewardSpec(TrlTestCase):
         assert env_b.reward == 0.0  # untouched
         env_a._close()
         env_b._close()
+
+    def test_two_specs_get_isolated_rollout_subclasses(self, echo_env_url):
+        # Two specs (potentially against different envs with different tool
+        # sets) must each produce rollout instances with their own subclass,
+        # so neither side's bound tools clobber or shadow the other's.
+        spec_a = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        spec_b = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        env_a = spec_a.environment_factory()
+        env_b = spec_b.environment_factory()
+        # Each rollout is a distinct subclass of _RolloutEnvironment.
+        assert type(env_a) is not type(env_b)
+        # Both subclasses still get their own `echo` method.
+        assert callable(env_a.echo) and callable(env_b.echo)
+        env_a._close()
+        env_b._close()

--- a/tests/experimental/test_openreward.py
+++ b/tests/experimental/test_openreward.py
@@ -14,14 +14,12 @@
 
 """Tests for `trl.experimental.openreward`.
 
-A class-scoped fixture spawns ``_openreward_echo_env.py`` as a uvicorn
-subprocess on a free port and points the openreward SDK at it via the
-``OPENREWARD_API_URL`` / ``OPENREWARD_SESSION_URL`` overrides. Tests then
-exercise the adapter end-to-end against real HTTP — no mocks, no network.
+A class-scoped fixture spawns ``_openreward_echo_env.py`` as a uvicorn subprocess on a free port and points the
+openreward SDK at it via the ``OPENREWARD_API_URL`` / ``OPENREWARD_SESSION_URL`` overrides. Tests then exercise the
+adapter end-to-end against real HTTP — no mocks, no network.
 
-The same env definition is published at
-``trl-internal-testing/openreward-echo-env`` if you want to point at the
-hosted Space directly.
+The same env definition is published at ``trl-internal-testing/openreward-echo-env`` if you want to point at the hosted
+Space directly.
 """
 
 import os

--- a/tests/experimental/test_openreward.py
+++ b/tests/experimental/test_openreward.py
@@ -1,0 +1,193 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `trl.experimental.openreward`.
+
+A class-scoped fixture spawns ``_openreward_echo_env.py`` as a uvicorn
+subprocess on a free port and points the openreward SDK at it via the
+``OPENREWARD_API_URL`` / ``OPENREWARD_SESSION_URL`` overrides. Tests then
+exercise the adapter end-to-end against real HTTP — no mocks, no network.
+
+The same env definition is published at
+``trl-internal-testing/openreward-echo-env`` if you want to point at the
+hosted Space directly.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from trl.experimental.openreward import OpenRewardSpec
+
+from ..testing_utils import TrlTestCase, require_openreward
+
+
+_HERE = Path(__file__).parent
+_ECHO_ENV_SCRIPT = _HERE / "_openreward_echo_env.py"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="class")
+def echo_env_url():
+    """Spawn the echo env on a free port; tear down on teardown."""
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, str(_ECHO_ENV_SCRIPT)],
+        env={**os.environ, "PORT": str(port)},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{url}/health", timeout=1.0)
+            if r.status_code == 200:
+                break
+        except requests.RequestException:
+            pass
+        time.sleep(0.2)
+    else:
+        proc.terminate()
+        raise RuntimeError(f"echo env did not become ready at {url}")
+
+    # The openreward SDK by default rewrites base_url into api.<host> /
+    # sessions.<host>; for a single-host self-hosted server these env vars
+    # bypass that two-subdomain layout.
+    saved = {k: os.environ.get(k) for k in ("OPENREWARD_API_URL", "OPENREWARD_SESSION_URL", "OPENREWARD_API_KEY")}
+    os.environ["OPENREWARD_API_URL"] = url
+    os.environ["OPENREWARD_SESSION_URL"] = url
+    os.environ.setdefault("OPENREWARD_API_KEY", "test")
+
+    yield url
+
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    proc.terminate()
+    try:
+        proc.wait(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@require_openreward
+@pytest.mark.usefixtures("echo_env_url")
+class TestOpenRewardSpec(TrlTestCase):
+    """Exercises the public `OpenRewardSpec` surface against a real ORS server."""
+
+    def test_construction_is_lazy(self, echo_env_url):
+        # Construction must not perform any HTTP — `train_dataset` /
+        # `environment_factory` are `cached_property` and only fire on access.
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2)
+        # Touching only private attributes should not have hit the network.
+        assert spec._target == echo_env_url
+        assert spec._is_url is True
+        assert spec._num_tasks == 2
+
+    def test_train_dataset_derives_from_env(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2)
+        ds = spec.train_dataset
+        assert len(ds) == 2
+        assert "prompt" in ds.column_names
+        assert "task_index" in ds.column_names
+        # Per-task metadata folded in (id, target) when include_metadata=True.
+        assert "target" in ds.column_names
+        assert ds[0]["task_index"] == 0
+        assert ds[0]["target"] == "hello"
+        assert ds[1]["target"] == "world"
+
+    def test_train_dataset_with_indices(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", indices=[0, 2])
+        ds = spec.train_dataset
+        assert [row["target"] for row in ds] == ["hello", "trl"]
+
+    def test_num_tasks_and_indices_are_mutually_exclusive(self, echo_env_url):
+        with pytest.raises(ValueError):
+            OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2, indices=[0])
+
+    def test_environment_factory_returns_rollout_env_with_bound_tools(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2)
+        env = spec.environment_factory()
+        # The single ORS tool is bound as a Python method with a typed signature.
+        assert callable(env.echo)
+        sig = env.echo.__annotations__
+        assert sig["text"] is str
+        assert sig["return"] is str
+
+    def test_reset_returns_prompt_and_opens_session(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        env = spec.environment_factory()
+        prompt = env.reset(**spec.train_dataset[0])
+        assert "echo" in prompt and "hello" in prompt
+        env._close()
+
+    def test_correct_echo_returns_match_with_reward_and_finished(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        env = spec.environment_factory()
+        env.reset(**spec.train_dataset[0])
+        out = env.echo(text="hello")
+        assert "match" in out
+        assert env.reward == 1.0
+        assert env.finished is True
+        env._close()
+
+    def test_wrong_echo_returns_no_match_with_zero_reward(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        env = spec.environment_factory()
+        env.reset(**spec.train_dataset[0])
+        out = env.echo(text="goodbye")
+        assert "no match" in out
+        assert env.reward == 0.0
+        assert env.finished is False
+        env._close()
+
+    def test_reward_func_reads_last_non_null_per_environment(self, echo_env_url):
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2)
+        env_a = spec.environment_factory()
+        env_b = spec.environment_factory()
+        env_a.reset(**spec.train_dataset[0])
+        env_b.reset(**spec.train_dataset[1])
+        env_a.echo(text="hello")  # match → reward=1.0
+        env_b.echo(text="oops")  # no match → reward=0.0
+        rewards = spec.reward_funcs(environments=[env_a, env_b])
+        assert rewards == [1.0, 0.0]
+        env_a._close()
+        env_b._close()
+
+    def test_factory_produces_isolated_sessions(self, echo_env_url):
+        # GRPO opens N concurrent envs; mutating one must not leak into another.
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=2)
+        env_a = spec.environment_factory()
+        env_b = spec.environment_factory()
+        env_a.reset(**spec.train_dataset[0])
+        env_b.reset(**spec.train_dataset[1])
+        env_a.echo(text="hello")
+        assert env_a.reward == 1.0
+        assert env_b.reward == 0.0  # untouched
+        env_a._close()
+        env_b._close()

--- a/tests/experimental/test_openreward.py
+++ b/tests/experimental/test_openreward.py
@@ -190,6 +190,19 @@ class TestOpenRewardSpec(TrlTestCase):
         env_a._close()
         env_b._close()
 
+    def test_metadata_does_not_overwrite_reserved_columns(self, echo_env_url):
+        # If a task spec ever shipped a `prompt` key, the metadata loop must
+        # not clobber our chat-format `prompt` column. Same for `task_index`.
+        # We assert the shape directly — the echo env's task spec doesn't
+        # currently have either, but the guard is what we're testing.
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        ds = spec.train_dataset
+        # `prompt` is a list-of-message-dicts, not a string from task spec.
+        assert isinstance(ds[0]["prompt"], list)
+        assert ds[0]["prompt"][0]["role"] == "user"
+        # `task_index` is the int we set, not anything from the spec.
+        assert isinstance(ds[0]["task_index"], int)
+
     def test_two_specs_get_isolated_rollout_subclasses(self, echo_env_url):
         # Two specs (potentially against different envs with different tool
         # sets) must each produce rollout instances with their own subclass,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -36,6 +36,7 @@ from trl.import_utils import (
     is_liger_kernel_available,
     is_math_verify_available,
     is_mergekit_available,
+    is_openreward_available,
     is_vllm_available,
 )
 
@@ -47,6 +48,7 @@ require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test re
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")
 require_math_latex = pytest.mark.skipif(not is_math_verify_available(), reason="test requires math_verify")
 require_mergekit = pytest.mark.skipif(not is_mergekit_available(), reason="test requires mergekit")
+require_openreward = pytest.mark.skipif(not is_openreward_available(), reason="test requires openreward")
 require_peft = pytest.mark.skipif(not is_peft_available(), reason="test requires peft")
 require_rich = pytest.mark.skipif(not is_rich_available(), reason="test requires rich")
 require_sklearn = pytest.mark.skipif(

--- a/trl/experimental/openreward/__init__.py
+++ b/trl/experimental/openreward/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._spec import OpenRewardEnv
+
+
+__all__ = ["OpenRewardEnv"]

--- a/trl/experimental/openreward/__init__.py
+++ b/trl/experimental/openreward/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._spec import OpenRewardEnv
+from ._spec import OpenRewardSpec
 
 
-__all__ = ["OpenRewardEnv"]
+__all__ = ["OpenRewardSpec"]

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -53,7 +53,9 @@ logger = logging.getLogger(__name__)
 
 def _to_spec(task) -> dict[str, Any]:
     """Normalise an SDK ``Task`` (or already-a-dict) to its task_spec dict."""
-    return getattr(task, "task_spec", task) if not isinstance(task, dict) else task
+    if isinstance(task, dict):
+        return task
+    return task.task_spec
 
 
 def _outcome_only_reward_func(environments, **_):
@@ -180,7 +182,7 @@ class OpenRewardSpec:
         # Pre-fetch tool specs once at the spec level.
         env = self._sdk_env
         tool_specs = env.list_tools()
-        client = env.client if hasattr(env, "client") else self._sdk_client
+        client = self._sdk_client
 
         kwargs = {
             "split": self._split,
@@ -239,5 +241,10 @@ class OpenRewardSpec:
     @cached_property
     def _sdk_env(self):
         """The shared SDK ``Environment`` handle."""
-        target = self._env_name or self._target if self._is_url else self._target
+        if self._is_url:
+            # Self-hosted single-env URL — pass any name; the SDK redirects.
+            # Fallback to "env" matches `_RolloutEnvironment.__init__`.
+            target = self._env_name or "env"
+        else:
+            target = self._target
         return self._sdk_client.environments.get(target)

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -165,7 +165,10 @@ class OpenRewardSpec:
             for spec in task_specs:
                 if isinstance(spec, dict):
                     metadata_keys.update(spec.keys())
-            metadata_keys.discard("task_index")  # never overwrite our column
+            # Never let a task-spec key overwrite our reserved row columns
+            # (e.g. an env that exposes a `prompt` task-spec field would
+            # otherwise replace our chat-format prompt with a raw string).
+            metadata_keys -= rows.keys()
             for key in sorted(metadata_keys):
                 rows[key] = [s.get(key) if isinstance(s, dict) else None for s in task_specs]
 

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -14,10 +14,9 @@
 
 """User-facing spec object for the OpenReward × TRL integration.
 
-The user constructs **one** ``OpenRewardSpec`` (a thin specification
-holding the env target + a few options) and reads three properties off
-of it — ``.train_dataset``, ``.environment_factory``, ``.reward_funcs``
-— each of which plugs directly into the matching ``GRPOTrainer`` kwarg:
+The user constructs **one** ``OpenRewardSpec`` (a thin specification holding the env target + a few options) and reads
+three properties off of it — ``.train_dataset``, ``.environment_factory``, ``.reward_funcs`` — each of which plugs
+directly into the matching ``GRPOTrainer`` kwarg:
 
 ```python
 from trl import GRPOConfig, GRPOTrainer
@@ -35,8 +34,7 @@ trainer = GRPOTrainer(
 trainer.train()
 ```
 
-Backed by the official ``openreward`` SDK (lazy-imported); install with
-``pip install trl[openreward]``.
+Backed by the official ``openreward`` SDK (lazy-imported); install with ``pip install trl[openreward]``.
 """
 
 from __future__ import annotations
@@ -61,9 +59,8 @@ def _to_spec(task) -> dict[str, Any]:
 def _outcome_only_reward_func(environments, **_):
     """Default reward function: last non-null reward in each rollout's trajectory.
 
-    Suitable for sparse-outcome envs (e.g. SETA, where only
-    `submit_solution` returns a non-null reward). Override by passing a
-    different callable to ``reward_funcs=``.
+    Suitable for sparse-outcome envs (e.g. SETA, where only `submit_solution` returns a non-null reward). Override by
+    passing a different callable to ``reward_funcs=``.
     """
     return [env.reward for env in environments]
 
@@ -73,29 +70,25 @@ class OpenRewardSpec:
 
     Args:
         target (`str`):
-            Either an openreward.ai catalog name (`"Eigent/SETA"`) or a
-            URL pointing at any ORS server (`"https://you-seta.hf.space"`,
-            `"http://localhost:8080"`). Auto-detected by the presence of
-            `://` in the string.
+            Either an openreward.ai catalog name (`"Eigent/SETA"`) or a URL pointing at any ORS server
+            (`"https://you-seta.hf.space"`, `"http://localhost:8080"`). Auto-detected by the presence of `://` in the
+            string.
         num_tasks (`int`, *optional*):
-            Cap on the number of tasks pulled into the dataset. ``None``
-            uses every task the env exposes.
+            Cap on the number of tasks pulled into the dataset. ``None`` uses every task the env exposes.
         split (`str`, *optional*, defaults to `"train"`):
             Which split's task list to draw from.
         indices (`list[int]`, *optional*):
-            Specific task indices to train on. Mutually exclusive with
-            ``num_tasks``. Useful for debugging or curriculum subsets.
+            Specific task indices to train on. Mutually exclusive with ``num_tasks``. Useful for debugging or
+            curriculum subsets.
         api_key (`str`, *optional*):
-            ``OPENREWARD_API_KEY`` override. Only used when ``target`` is
-            a catalog name.
+            ``OPENREWARD_API_KEY`` override. Only used when ``target`` is a catalog name.
         secrets (`dict[str, str]`, *optional*):
             Per-session secrets forwarded to ``env.session(secrets=)``.
         env_name (`str`, *optional*):
             Override for the env name to look up on the server. Rarely needed.
         include_metadata (`bool`, *optional*, defaults to `True`):
-            Fold per-task metadata (`difficulty`, `category`, `tags`,
-            ...) into the dataset rows so reward funcs can read them
-            via TRL's ``inputs`` argument.
+            Fold per-task metadata (`difficulty`, `category`, `tags`, ...) into the dataset rows so reward funcs can
+            read them via TRL's ``inputs`` argument.
     """
 
     def __init__(
@@ -129,8 +122,7 @@ class OpenRewardSpec:
     def train_dataset(self):
         """A `datasets.Dataset` derived from the env's task list.
 
-        Plugs directly into TRL's ``train_dataset=`` slot. Built lazily
-        on first access. Has at minimum:
+        Plugs directly into TRL's ``train_dataset=`` slot. Built lazily on first access. Has at minimum:
           - `prompt`: empty user message (TRL appends the env's prompt).
           - `task_index`: int passed to the adapter's `reset()`.
           - per-task metadata columns (when `include_metadata=True`).
@@ -181,11 +173,9 @@ class OpenRewardSpec:
     def environment_factory(self) -> Callable[[], _RolloutEnvironment]:
         """Zero-arg callable that returns a fresh ``_RolloutEnvironment``.
 
-        Plugs directly into TRL's ``environment_factory=`` slot. TRL
-        calls this once per rollout at trainer construction time, so
-        each rollout has an isolated ORS session. Reuses the spec's
-        already-discovered SDK env + tool specs to skip per-env HTTP
-        at trainer init.
+        Plugs directly into TRL's ``environment_factory=`` slot. TRL calls this once per rollout at trainer
+        construction time, so each rollout has an isolated ORS session. Reuses the spec's already-discovered SDK env +
+        tool specs to skip per-env HTTP at trainer init.
         """
         # Pre-fetch tool specs once at the spec level.
         env = self._sdk_env
@@ -218,8 +208,8 @@ class OpenRewardSpec:
     def reward_funcs(self) -> Callable[..., list[float]]:
         """Default outcome-only reward function (last non-null reward per rollout).
 
-        Plugs directly into TRL's ``reward_funcs=`` slot. Stable identity
-        — module-level function, picklable for multi-process workers.
+        Plugs directly into TRL's ``reward_funcs=`` slot. Stable identity — module-level function, picklable for
+        multi-process workers.
         """
         return _outcome_only_reward_func
 

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -43,10 +43,11 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from functools import cached_property
-from typing import Any, Callable
+from typing import Any
 
-from .environment import _RolloutEnvironment, _import_openreward
+from .environment import _import_openreward, _RolloutEnvironment
 
 
 logger = logging.getLogger(__name__)

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -1,0 +1,248 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""User-facing spec object for the OpenReward × TRL integration.
+
+The user constructs **one** ``OpenRewardEnv`` and reads three
+properties off of it — ``.dataset``, ``.factory``, ``.reward_func`` —
+to fill in the three TRL slots:
+
+```python
+from trl import GRPOConfig, GRPOTrainer
+from trl.experimental.openreward import OpenRewardEnv
+
+env = OpenRewardEnv("Eigent/SETA", num_tasks=64)
+
+trainer = GRPOTrainer(
+    model="Qwen/Qwen3-4B",
+    args=GRPOConfig(num_generations=2, max_steps=5, max_tool_calling_iterations=20),
+    train_dataset=env.dataset,
+    environment_factory=env.factory,
+    reward_funcs=env.reward_func,
+)
+trainer.train()
+```
+
+Backed by the official ``openreward`` SDK (lazy-imported); install with
+``pip install trl[openreward]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import cached_property
+from typing import Any, Callable
+
+from .environment import _RolloutEnvironment, _import_openreward
+
+
+logger = logging.getLogger(__name__)
+
+
+def _to_spec(task) -> dict[str, Any]:
+    """Normalise an SDK ``Task`` (or already-a-dict) to its task_spec dict."""
+    return getattr(task, "task_spec", task) if not isinstance(task, dict) else task
+
+
+def _outcome_only_reward_func(environments, **_):
+    """Default reward function: last non-null reward in each rollout's trajectory.
+
+    Suitable for sparse-outcome envs (e.g. SETA, where only
+    `submit_solution` returns a non-null reward). Override by passing a
+    different callable to ``reward_funcs=``.
+    """
+    return [env.reward for env in environments]
+
+
+class OpenRewardEnv:
+    """Single spec object that wires an ORS environment into a TRL trainer.
+
+    Args:
+        target (`str`):
+            Either an openreward.ai catalog name (`"Eigent/SETA"`) or a
+            URL pointing at any ORS server (`"https://you-seta.hf.space"`,
+            `"http://localhost:8080"`). Auto-detected by the presence of
+            `://` in the string.
+        num_tasks (`int`, *optional*):
+            Cap on the number of tasks pulled into the dataset. ``None``
+            uses every task the env exposes.
+        split (`str`, *optional*, defaults to `"train"`):
+            Which split's task list to draw from.
+        indices (`list[int]`, *optional*):
+            Specific task indices to train on. Mutually exclusive with
+            ``num_tasks``. Useful for debugging or curriculum subsets.
+        api_key (`str`, *optional*):
+            ``OPENREWARD_API_KEY`` override. Only used when ``target`` is
+            a catalog name.
+        secrets (`dict[str, str]`, *optional*):
+            Per-session secrets forwarded to ``env.session(secrets=)``.
+        env_name (`str`, *optional*):
+            Override for the env name to look up on the server. Rarely needed.
+        include_metadata (`bool`, *optional*, defaults to `True`):
+            Fold per-task metadata (`difficulty`, `category`, `tags`,
+            ...) into the dataset rows so reward funcs can read them
+            via TRL's ``inputs`` argument.
+    """
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        num_tasks: int | None = None,
+        split: str = "train",
+        indices: list[int] | None = None,
+        api_key: str | None = None,
+        secrets: dict[str, str] | None = None,
+        env_name: str | None = None,
+        include_metadata: bool = True,
+    ) -> None:
+        if num_tasks is not None and indices is not None:
+            raise ValueError("Provide num_tasks or indices, not both.")
+
+        self._target = target
+        self._is_url = "://" in target
+        self._num_tasks = num_tasks
+        self._split = split
+        self._indices = indices
+        self._api_key = api_key
+        self._secrets = secrets
+        self._env_name = env_name
+        self._include_metadata = include_metadata
+
+    # ── public surface ──────────────────────────────────────────────
+
+    @cached_property
+    def dataset(self):
+        """A `datasets.Dataset` derived from the env's task list.
+
+        Built lazily on first access. Has at minimum:
+          - `prompt`: empty user message (TRL appends the env's prompt).
+          - `task_index`: int passed to the adapter's `reset()`.
+          - per-task metadata columns (when `include_metadata=True`).
+        """
+        from datasets import Dataset
+
+        env = self._sdk_env
+
+        # When the user asked for a specific subset (`num_tasks` cap or
+        # explicit `indices`), fetch only those — `list_tasks` returns
+        # the whole split (1376 entries for SETA, etc.) and is slow on
+        # the platform. Per-index `get_task` is fast and cheap.
+        if self._indices is not None:
+            indexes = list(self._indices)
+            task_specs = [_to_spec(env.get_task(self._split, i)) for i in indexes]
+        elif self._num_tasks is not None:
+            n_total = env.num_tasks(self._split)
+            n = min(self._num_tasks, n_total)
+            indexes = list(range(n))
+            task_specs = [_to_spec(env.get_task(self._split, i)) for i in indexes]
+        else:
+            # No cap — fetch everything in one shot.
+            try:
+                tasks = env.list_tasks(self._split)
+            except Exception:  # noqa: BLE001
+                n = env.num_tasks(self._split)
+                tasks = [env.get_task(self._split, i) for i in range(n)]
+            task_specs = [_to_spec(t) for t in tasks]
+            indexes = list(range(len(task_specs)))
+
+        rows: dict[str, list[Any]] = {
+            "prompt": [[{"role": "user", "content": ""}] for _ in indexes],
+            "task_index": indexes,
+        }
+
+        if self._include_metadata and task_specs:
+            metadata_keys: set[str] = set()
+            for spec in task_specs:
+                if isinstance(spec, dict):
+                    metadata_keys.update(spec.keys())
+            metadata_keys.discard("task_index")  # never overwrite our column
+            for key in sorted(metadata_keys):
+                rows[key] = [s.get(key) if isinstance(s, dict) else None for s in task_specs]
+
+        return Dataset.from_dict(rows)
+
+    @cached_property
+    def factory(self) -> Callable[[], _RolloutEnvironment]:
+        """Zero-arg callable that returns a fresh ``_RolloutEnvironment``.
+
+        TRL calls this once per rollout slot at trainer construction
+        time, so each rollout has an isolated ORS session. Reuses the
+        spec's already-discovered SDK env + tool specs to skip per-env
+        HTTP at trainer init.
+        """
+        # Pre-fetch tool specs once at the spec level.
+        env = self._sdk_env
+        tool_specs = env.list_tools()
+        client = env.client if hasattr(env, "client") else self._sdk_client
+
+        kwargs: dict[str, Any] = {
+            "split": self._split,
+            "secrets": self._effective_secrets(),
+            "env_name": self._env_name,
+            "_client": client,
+            "_env": env,
+            "_tool_specs": tool_specs,
+        }
+        if self._is_url:
+            kwargs["base_url"] = self._target
+        else:
+            kwargs["name"] = self._target
+            if self._api_key:
+                kwargs["api_key"] = self._api_key
+
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+        def _make() -> _RolloutEnvironment:
+            return _RolloutEnvironment(**kwargs)
+
+        return _make
+
+    @property
+    def reward_func(self) -> Callable[..., list[float]]:
+        """Default outcome-only reward function (last non-null reward per rollout).
+
+        Stable identity — module-level function, picklable for multi-process workers.
+        """
+        return _outcome_only_reward_func
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _effective_secrets(self) -> dict[str, str] | None:
+        """Auto-forward ``OPENREWARD_API_KEY`` as the conventional ``api_key``
+        per-session secret on platform mode (most envs need it)."""
+        if self._secrets is not None or self._is_url:
+            return self._secrets
+        key = self._api_key or os.environ.get("OPENREWARD_API_KEY")
+        return {"api_key": key} if key else None
+
+    @cached_property
+    def _sdk_client(self):
+        """The shared ``openreward.OpenReward`` client used by `dataset` and `factory`."""
+        openreward = _import_openreward()
+        kwargs: dict[str, Any] = {}
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        elif not self._is_url and "OPENREWARD_API_KEY" in os.environ:
+            kwargs["api_key"] = os.environ["OPENREWARD_API_KEY"]
+        if self._is_url:
+            kwargs["base_url"] = self._target
+        return openreward.OpenReward(**kwargs)
+
+    @cached_property
+    def _sdk_env(self):
+        """The shared SDK ``Environment`` handle."""
+        target = self._env_name or self._target if self._is_url else self._target
+        return self._sdk_client.environments.get(target)

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -184,6 +184,11 @@ class OpenRewardSpec:
         tool_specs = env.list_tools()
         client = self._sdk_client
 
+        # Each spec gets its own `_RolloutEnvironment` subclass so two specs
+        # for different envs (different tool sets) never clobber each other's
+        # bound methods on the shared parent class.
+        rollout_cls = type(f"_RolloutEnvironment_{id(self):x}", (_RolloutEnvironment,), {})
+
         kwargs = {
             "split": self._split,
             "secrets": self._effective_secrets(),
@@ -202,7 +207,7 @@ class OpenRewardSpec:
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         def _make() -> _RolloutEnvironment:
-            return _RolloutEnvironment(**kwargs)
+            return rollout_cls(**kwargs)
 
         return _make
 

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -14,22 +14,23 @@
 
 """User-facing spec object for the OpenReward × TRL integration.
 
-The user constructs **one** ``OpenRewardEnv`` and reads three
-properties off of it — ``.dataset``, ``.factory``, ``.reward_func`` —
-to fill in the three TRL slots:
+The user constructs **one** ``OpenRewardSpec`` (a thin specification
+holding the env target + a few options) and reads three properties off
+of it — ``.train_dataset``, ``.environment_factory``, ``.reward_funcs``
+— each of which plugs directly into the matching ``GRPOTrainer`` kwarg:
 
 ```python
 from trl import GRPOConfig, GRPOTrainer
-from trl.experimental.openreward import OpenRewardEnv
+from trl.experimental.openreward import OpenRewardSpec
 
-env = OpenRewardEnv("Eigent/SETA", num_tasks=64)
+spec = OpenRewardSpec("Eigent/SETA", num_tasks=64)
 
 trainer = GRPOTrainer(
     model="Qwen/Qwen3-4B",
     args=GRPOConfig(num_generations=2, max_steps=5, max_tool_calling_iterations=20),
-    train_dataset=env.dataset,
-    environment_factory=env.factory,
-    reward_funcs=env.reward_func,
+    train_dataset=spec.train_dataset,
+    environment_factory=spec.environment_factory,
+    reward_funcs=spec.reward_funcs,
 )
 trainer.train()
 ```
@@ -66,7 +67,7 @@ def _outcome_only_reward_func(environments, **_):
     return [env.reward for env in environments]
 
 
-class OpenRewardEnv:
+class OpenRewardSpec:
     """Single spec object that wires an ORS environment into a TRL trainer.
 
     Args:
@@ -124,10 +125,11 @@ class OpenRewardEnv:
     # ── public surface ──────────────────────────────────────────────
 
     @cached_property
-    def dataset(self):
+    def train_dataset(self):
         """A `datasets.Dataset` derived from the env's task list.
 
-        Built lazily on first access. Has at minimum:
+        Plugs directly into TRL's ``train_dataset=`` slot. Built lazily
+        on first access. Has at minimum:
           - `prompt`: empty user message (TRL appends the env's prompt).
           - `task_index`: int passed to the adapter's `reset()`.
           - per-task metadata columns (when `include_metadata=True`).
@@ -175,20 +177,21 @@ class OpenRewardEnv:
         return Dataset.from_dict(rows)
 
     @cached_property
-    def factory(self) -> Callable[[], _RolloutEnvironment]:
+    def environment_factory(self) -> Callable[[], _RolloutEnvironment]:
         """Zero-arg callable that returns a fresh ``_RolloutEnvironment``.
 
-        TRL calls this once per rollout slot at trainer construction
-        time, so each rollout has an isolated ORS session. Reuses the
-        spec's already-discovered SDK env + tool specs to skip per-env
-        HTTP at trainer init.
+        Plugs directly into TRL's ``environment_factory=`` slot. TRL
+        calls this once per rollout at trainer construction time, so
+        each rollout has an isolated ORS session. Reuses the spec's
+        already-discovered SDK env + tool specs to skip per-env HTTP
+        at trainer init.
         """
         # Pre-fetch tool specs once at the spec level.
         env = self._sdk_env
         tool_specs = env.list_tools()
         client = env.client if hasattr(env, "client") else self._sdk_client
 
-        kwargs: dict[str, Any] = {
+        kwargs = {
             "split": self._split,
             "secrets": self._effective_secrets(),
             "env_name": self._env_name,
@@ -211,10 +214,11 @@ class OpenRewardEnv:
         return _make
 
     @property
-    def reward_func(self) -> Callable[..., list[float]]:
+    def reward_funcs(self) -> Callable[..., list[float]]:
         """Default outcome-only reward function (last non-null reward per rollout).
 
-        Stable identity — module-level function, picklable for multi-process workers.
+        Plugs directly into TRL's ``reward_funcs=`` slot. Stable identity
+        — module-level function, picklable for multi-process workers.
         """
         return _outcome_only_reward_func
 

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -369,9 +369,8 @@ def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
 def _spec_to_dict(spec: Any) -> dict[str, Any]:
     """Normalise SDK ``ToolSpec`` and dict shapes to the same dict form.
 
-    ``openreward.api.environments.types.ToolSpec`` is a stable dataclass with
-    ``name``, ``description``, ``input_schema`` fields, so direct attribute
-    access is safe.
+    ``openreward.api.environments.types.ToolSpec`` is a stable dataclass with ``name``, ``description``,
+    ``input_schema`` fields, so direct attribute access is safe.
     """
     if isinstance(spec, dict):
         return spec
@@ -385,9 +384,8 @@ def _spec_to_dict(spec: Any) -> dict[str, Any]:
 def _join_text_blocks(blocks: list[Any]) -> str:
     """Concatenate the ``text`` field of every text block in order.
 
-    Accepts both SDK ``TextBlock`` dataclasses and plain dicts. Both shapes
-    expose a ``type`` discriminator (`"text"` vs `"image"`); non-text blocks
-    are skipped so e.g. ``ImageBlock`` doesn't trip up the join.
+    Accepts both SDK ``TextBlock`` dataclasses and plain dicts. Both shapes expose a ``type`` discriminator (`"text"`
+    vs `"image"`); non-text blocks are skipped so e.g. ``ImageBlock`` doesn't trip up the join.
     """
     if not blocks:
         return ""

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -1,0 +1,373 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TRL `environment_factory` adapter for any ORS-compliant server.
+
+Wraps the official ``openreward`` SDK so platform quirks (X-Secrets
+encoding, ephemeral session for discovery, sticky-routing subdomain,
+SSE chunk reassembly, ping keepalive, …) are handled by code that
+ships with the spec. Our job is only to expose the SDK's per-rollout
+session as a TRL-compatible class with dynamically-bound tool methods.
+
+Install: ``pip install trl[openreward]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+def _import_openreward():
+    """Lazy-import the openreward package with a friendly error message."""
+    try:
+        import openreward
+        return openreward
+    except ImportError as e:
+        raise ImportError(
+            "trl.experimental.openreward requires the `openreward` package. "
+            "Install with `pip install trl[openreward]`."
+        ) from e
+
+
+# ── JSON Schema → Python type mapping (used by dynamic tool binding) ──
+
+_JSON_TYPE_TO_PY: dict[str, str] = {
+    "string": "str",
+    "integer": "int",
+    "number": "float",
+    "boolean": "bool",
+    "array": "list",
+    "object": "dict",
+}
+
+_PY_TYPE_OBJECTS: dict[str, type] = {
+    "str": str, "int": int, "float": float,
+    "bool": bool, "list": list, "dict": dict,
+}
+
+_PY_TYPE_FROM_VALUE: dict[type, str] = {
+    bool: "bool", int: "int", float: "float",
+    str: "str", list: "list", dict: "dict",
+}
+
+
+def _resolve_param_type(pdef: dict[str, Any]) -> str:
+    """Pick the best Python type name for one JSON-Schema property.
+
+    Handles primitive ``"type"``, Pydantic's ``anyOf``/``oneOf`` form
+    for ``Optional[T]``, and falls back to the type of ``default``.
+    Critical because transformers' tool-schema generator uses our
+    Python annotations to build the schema the model sees.
+    """
+    t = pdef.get("type")
+    if isinstance(t, str) and t in _JSON_TYPE_TO_PY:
+        return _JSON_TYPE_TO_PY[t]
+    for key in ("anyOf", "oneOf"):
+        for opt in pdef.get(key) or []:
+            if isinstance(opt, dict):
+                inner = opt.get("type")
+                if isinstance(inner, str) and inner in _JSON_TYPE_TO_PY and inner != "null":
+                    return _JSON_TYPE_TO_PY[inner]
+    if "default" in pdef and pdef["default"] is not None:
+        for value_type, name in _PY_TYPE_FROM_VALUE.items():
+            if isinstance(pdef["default"], value_type):
+                return name
+    return "str"
+
+
+# ────────────────────────────────────────────────────────────────────
+
+
+class _RolloutEnvironment:
+    """Per-rollout TRL adapter backed by the ``openreward`` SDK.
+
+    **Internal class.** Users don't construct this directly; they create
+    an :class:`OpenRewardEnv` and pass ``env.factory`` to
+    ``GRPOTrainer``. TRL's trainer then constructs one instance of this
+    per rollout slot.
+
+    The tool surface is built once at construction by reading the env's
+    tools and binding one Python method per ORS tool — so swapping the
+    URL or env name is the only thing needed to train against a
+    different environment.
+
+    Args:
+        name (`str`, *optional*):
+            openreward.ai catalog name (e.g. ``"Eigent/SETA"``).
+            Mutually exclusive with `base_url`. Requires
+            ``OPENREWARD_API_KEY`` (env var or `api_key=`).
+        base_url (`str`, *optional*):
+            Direct URL of an ORS server (HF Space, local Docker, etc.).
+            Mutually exclusive with `name`.
+        env_name (`str`, *optional*):
+            Name to look up on the server. Defaults to the canonical
+            name parsed from `name`/`base_url`.
+        split (`str`, *optional*, defaults to `"train"`):
+            Split passed to ``env.session(split=, index=)``.
+        api_key (`str`, *optional*):
+            Override for ``OPENREWARD_API_KEY``. Only used with `name=`.
+        secrets (`dict[str, str]`, *optional*):
+            Per-session secrets. Forwarded to ``env.session(secrets=)``;
+            the SDK encodes them and adds platform-domain entries.
+        timeout (`float`, *optional*):
+            Reserved for future use. The SDK manages its own timeouts.
+
+    Attributes:
+        reward (`float`):
+            Last non-null reward in the trajectory (outcome-only convention).
+        rewards (`list[float | None]`):
+            Per-step reward sequence in tool-call order.
+        metadata (`list[dict | None]`):
+            Per-step ``ToolOutput.metadata`` dicts.
+        finished (`bool`):
+            True after a tool returned ``finished: true``.
+        last_output (`str`):
+            Joined text of the most recent tool result.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        base_url: str | None = None,
+        env_name: str | None = None,
+        split: str = "train",
+        api_key: str | None = None,
+        secrets: dict[str, str] | None = None,
+        timeout: float | None = None,
+        _client: Any = None,
+        _env: Any = None,
+        _tool_specs: list[Any] | None = None,
+    ) -> None:
+        if (name is None) == (base_url is None):
+            raise ValueError("Provide exactly one of: name, base_url.")
+
+        # Reuse a pre-built client/env when the spec has already discovered
+        # them (saves N HTTP calls at trainer init); otherwise build fresh.
+        if _client is None:
+            openreward = _import_openreward()
+            client_kwargs: dict[str, Any] = {}
+            if api_key:
+                client_kwargs["api_key"] = api_key
+            elif name and "OPENREWARD_API_KEY" in os.environ:
+                client_kwargs["api_key"] = os.environ["OPENREWARD_API_KEY"]
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            self._client = openreward.OpenReward(**client_kwargs)
+        else:
+            self._client = _client
+
+        if _env is None:
+            target = name if name is not None else env_name or ""
+            if base_url and not target:
+                # Self-hosted single-env URL — pass any name; SDK redirects.
+                target = "env"
+            self._env = self._client.environments.get(target)
+        else:
+            self._env = _env
+
+        self._split = split
+        self._secrets = secrets
+        self._session = None  # entered on reset()
+
+        # Episode state — read by the trainer's reward_func.
+        self.reward: float = 0.0
+        self.rewards: list[float | None] = []
+        self.metadata: list[dict[str, Any] | None] = []
+        self.finished: bool = False
+        self.last_output: str = ""
+
+        # Bind one Python method per server-side tool. Pre-fetched specs
+        # come from the spec object; otherwise we ask the SDK ourselves.
+        specs = _tool_specs if _tool_specs is not None else self._env.list_tools()
+        for spec in specs:
+            _bind_tool_method(self.__class__, _spec_to_dict(spec))
+
+    # ── TRL contract ─────────────────────────────────────────────────
+
+    def reset(
+        self,
+        *,
+        task_index: int = 0,
+        task_spec: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> str:
+        """Open a fresh ORS session for this rollout.
+
+        Closes any prior session, starts a new one via the SDK's
+        ``env.session(...)`` context manager, fetches the prompt, and
+        returns its text (which TRL appends to the user message).
+        """
+        self._teardown_session()
+        self.reward = 0.0
+        self.rewards = []
+        self.metadata = []
+        self.finished = False
+        self.last_output = ""
+
+        if task_spec is not None:
+            from openreward.api.environments.client import Task
+            task = Task(
+                server_name=self._env.server if hasattr(self._env, "server") else self._env.name,
+                environment_name=self._env.name,
+                task_spec=task_spec,
+                namespace=self._env.namespace,
+            )
+            cm = self._env.session(task=task, secrets=self._secrets)
+        else:
+            cm = self._env.session(split=self._split, index=int(task_index), secrets=self._secrets)
+
+        self._session = cm.__enter__()
+        prompt = self._session.get_prompt()
+        return _join_text_blocks(prompt)
+
+    # Leading underscore so TRL's tool collector at grpo_trainer.py:502-506
+    # excludes this from the model's tool surface.
+    def _close(self) -> None:
+        """Tear down the active session (best-effort)."""
+        self._teardown_session()
+
+    # ── helpers ──────────────────────────────────────────────────────
+
+    def _teardown_session(self) -> None:
+        if self._session is None:
+            return
+        try:
+            # The SDK's Session context-manager exit deletes both the env
+            # state and the sid. We look up the original CM from the SDK.
+            self._session.__exit__(None, None, None) if hasattr(self._session, "__exit__") \
+                else None
+        except Exception as e:  # noqa: BLE001
+            logger.debug("session teardown failed: %s", e)
+        self._session = None
+
+    def _call_ors_tool(self, tool_name: str, tool_input: dict[str, Any]) -> str:
+        """Invoke a server-side tool and update episode state."""
+        if self._session is None:
+            raise RuntimeError("Cannot call a tool before reset() opens a session.")
+
+        try:
+            out = self._session.call_tool(tool_name, tool_input)
+        except Exception as e:  # noqa: BLE001
+            self.rewards.append(None)
+            self.metadata.append(None)
+            self.last_output = f"Error: {e}"
+            return self.last_output
+
+        text = _join_text_blocks(getattr(out, "blocks", []) or []) or "(no output)"
+
+        raw_reward = getattr(out, "reward", None)
+        step_reward: float | None = None
+        if raw_reward is not None:
+            try:
+                step_reward = float(raw_reward)
+            except (TypeError, ValueError):
+                step_reward = None
+        self.rewards.append(step_reward)
+        if step_reward is not None:
+            self.reward = step_reward  # last-non-null wins (outcome-only convention)
+
+        md = getattr(out, "metadata", None)
+        self.metadata.append(md if isinstance(md, dict) else None)
+
+        self.finished = bool(getattr(out, "finished", False))
+        self.last_output = text
+        return text
+
+
+# ── dynamic tool binding ─────────────────────────────────────────────
+
+
+def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
+    """Generate a typed Python method for one ORS tool spec.
+
+    Signature comes from the JSON Schema; docstring is Google-style so
+    ``transformers.utils.get_json_schema`` (used by vLLM) can produce
+    a correct tool schema for the model.
+    """
+    tool_name = spec["name"]
+    if hasattr(cls, tool_name) and callable(getattr(cls, tool_name)):
+        # Already bound by an earlier instance — idempotent skip.
+        return
+
+    description = spec.get("description") or f"Call the {tool_name} tool."
+    schema = spec.get("input_schema") or {}
+    properties: dict[str, dict[str, Any]] = schema.get("properties") or {}
+    required: set[str] = set(schema.get("required") or [])
+
+    # Required params must come before optional ones in Python — sort.
+    required_props = [(n, p) for n, p in properties.items() if n in required]
+    optional_props = [(n, p) for n, p in properties.items() if n not in required]
+
+    params_src: list[str] = []
+    annotations: dict[str, type] = {}
+    args_doc_lines: list[str] = []
+    for pname, pdef in required_props + optional_props:
+        py_type = _resolve_param_type(pdef)
+        annotations[pname] = _PY_TYPE_OBJECTS[py_type]
+        if pname in required:
+            params_src.append(f"{pname}: {py_type}")
+        else:
+            default = pdef.get("default", None)
+            params_src.append(f"{pname}: {py_type} = {default!r}")
+        pdesc = pdef.get("description") or pdef.get("title") or pname
+        args_doc_lines.append(f"        {pname}: {pdesc}")
+
+    args_section = ("\n\n    Args:\n" + "\n".join(args_doc_lines)) if args_doc_lines else ""
+    src = (
+        f"def {tool_name}(self, {', '.join(params_src)}) -> str:\n"
+        f'    """{description}{args_section}"""\n'
+        f"    _kwargs = dict(locals()); _kwargs.pop('self', None)\n"
+        f"    return self._call_ors_tool({tool_name!r}, _kwargs)\n"
+    )
+    ns: dict[str, Any] = {}
+    exec(src, ns)
+    fn = ns[tool_name]
+    fn.__qualname__ = f"{cls.__name__}.{tool_name}"
+    fn.__annotations__ = {**annotations, "return": str}
+    setattr(cls, tool_name, fn)
+
+
+# ── small utilities ──────────────────────────────────────────────────
+
+
+def _spec_to_dict(spec: Any) -> dict[str, Any]:
+    """Normalise SDK ``ToolSpec`` and dict shapes to the same dict form."""
+    if isinstance(spec, dict):
+        return spec
+    return {
+        "name": getattr(spec, "name"),
+        "description": getattr(spec, "description", None),
+        "input_schema": getattr(spec, "input_schema", None) or {},
+    }
+
+
+def _join_text_blocks(blocks: list[Any]) -> str:
+    """Concatenate the ``text`` field of every text block in order.
+
+    Accepts both SDK ``TextBlock`` objects and plain dicts.
+    """
+    if not blocks:
+        return ""
+    parts: list[str] = []
+    for b in blocks:
+        text = getattr(b, "text", None) if not isinstance(b, dict) else b.get("text")
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -14,11 +14,9 @@
 
 """TRL `environment_factory` adapter for any ORS-compliant server.
 
-Wraps the official ``openreward`` SDK so platform quirks (X-Secrets
-encoding, ephemeral session for discovery, sticky-routing subdomain,
-SSE chunk reassembly, ping keepalive, …) are handled by code that
-ships with the spec. Our job is only to expose the SDK's per-rollout
-session as a TRL-compatible class with dynamically-bound tool methods.
+Wraps the official ``openreward`` SDK so platform quirks (X-Secrets encoding, ephemeral session for discovery,
+sticky-routing subdomain, SSE chunk reassembly, ping keepalive, …) are handled by code that ships with the spec. Our
+job is only to expose the SDK's per-rollout session as a TRL-compatible class with dynamically-bound tool methods.
 
 Install: ``pip install trl[openreward]``.
 """
@@ -79,10 +77,9 @@ _PY_TYPE_FROM_VALUE: dict[type, str] = {
 def _resolve_param_type(pdef: dict[str, Any]) -> str:
     """Pick the best Python type name for one JSON-Schema property.
 
-    Handles primitive ``"type"``, Pydantic's ``anyOf``/``oneOf`` form
-    for ``Optional[T]``, and falls back to the type of ``default``.
-    Critical because transformers' tool-schema generator uses our
-    Python annotations to build the schema the model sees.
+    Handles primitive ``"type"``, Pydantic's ``anyOf``/``oneOf`` form for ``Optional[T]``, and falls back to the type
+    of ``default``. Critical because transformers' tool-schema generator uses our Python annotations to build the
+    schema the model sees.
     """
     t = pdef.get("type")
     if isinstance(t, str) and t in _JSON_TYPE_TO_PY:
@@ -106,34 +103,28 @@ def _resolve_param_type(pdef: dict[str, Any]) -> str:
 class _RolloutEnvironment:
     """Per-rollout TRL adapter backed by the ``openreward`` SDK.
 
-    **Internal class.** Users don't construct this directly; they create
-    an :class:`OpenRewardSpec` and pass ``spec.environment_factory`` to
-    ``GRPOTrainer``. TRL's trainer then constructs one instance of this
-    per rollout slot.
+    **Internal class.** Users don't construct this directly; they create an :class:`OpenRewardSpec` and pass
+    ``spec.environment_factory`` to ``GRPOTrainer``. TRL's trainer then constructs one instance of this per rollout
+    slot.
 
-    The tool surface is built once at construction by reading the env's
-    tools and binding one Python method per ORS tool — so swapping the
-    URL or env name is the only thing needed to train against a
-    different environment.
+    The tool surface is built once at construction by reading the env's tools and binding one Python method per ORS
+    tool — so swapping the URL or env name is the only thing needed to train against a different environment.
 
     Args:
         name (`str`, *optional*):
-            openreward.ai catalog name (e.g. ``"Eigent/SETA"``).
-            Mutually exclusive with `base_url`. Requires
+            openreward.ai catalog name (e.g. ``"Eigent/SETA"``). Mutually exclusive with `base_url`. Requires
             ``OPENREWARD_API_KEY`` (env var or `api_key=`).
         base_url (`str`, *optional*):
-            Direct URL of an ORS server (HF Space, local Docker, etc.).
-            Mutually exclusive with `name`.
+            Direct URL of an ORS server (HF Space, local Docker, etc.). Mutually exclusive with `name`.
         env_name (`str`, *optional*):
-            Name to look up on the server. Defaults to the canonical
-            name parsed from `name`/`base_url`.
+            Name to look up on the server. Defaults to the canonical name parsed from `name`/`base_url`.
         split (`str`, *optional*, defaults to `"train"`):
             Split passed to ``env.session(split=, index=)``.
         api_key (`str`, *optional*):
             Override for ``OPENREWARD_API_KEY``. Only used with `name=`.
         secrets (`dict[str, str]`, *optional*):
-            Per-session secrets. Forwarded to ``env.session(secrets=)``;
-            the SDK encodes them and adds platform-domain entries.
+            Per-session secrets. Forwarded to ``env.session(secrets=)``; the SDK encodes them and adds platform-domain
+            entries.
         timeout (`float`, *optional*):
             Reserved for future use. The SDK manages its own timeouts.
 
@@ -219,9 +210,8 @@ class _RolloutEnvironment:
     ) -> str:
         """Open a fresh ORS session for this rollout.
 
-        Closes any prior session, starts a new one via the SDK's
-        ``env.session(...)`` context manager, fetches the prompt, and
-        returns its text (which TRL appends to the user message).
+        Closes any prior session, starts a new one via the SDK's ``env.session(...)`` context manager, fetches the
+        prompt, and returns its text (which TRL appends to the user message).
         """
         self._teardown_session()
         self.reward = 0.0
@@ -306,9 +296,8 @@ class _RolloutEnvironment:
 def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
     """Generate a typed Python method for one ORS tool spec.
 
-    Signature comes from the JSON Schema; docstring is Google-style so
-    ``transformers.utils.get_json_schema`` (used by vLLM) can produce
-    a correct tool schema for the model.
+    Signature comes from the JSON Schema; docstring is Google-style so ``transformers.utils.get_json_schema`` (used by
+    vLLM) can produce a correct tool schema for the model.
     """
     tool_name = spec["name"]
     if hasattr(cls, tool_name) and callable(getattr(cls, tool_name)):

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 
@@ -184,7 +185,8 @@ class _RolloutEnvironment:
 
         self._split = split
         self._secrets = secrets
-        self._session = None  # entered on reset()
+        self._session_cm = None  # the SDK context manager itself, retained for clean teardown
+        self._session = None  # the entered Session object
 
         # Episode state — read by the trainer's reward_func.
         self.reward: float = 0.0
@@ -224,7 +226,7 @@ class _RolloutEnvironment:
             from openreward.api.environments.client import Task
 
             task = Task(
-                server_name=self._env.server if hasattr(self._env, "server") else self._env.name,
+                server_name=self._env.server,
                 environment_name=self._env.name,
                 task_spec=task_spec,
                 namespace=self._env.namespace,
@@ -233,6 +235,10 @@ class _RolloutEnvironment:
         else:
             cm = self._env.session(split=self._split, index=int(task_index), secrets=self._secrets)
 
+        # Retain the context manager itself so `_teardown_session` can call
+        # its __exit__; calling __exit__ on the entered Session alone leaves
+        # the CM's exit logic (which deletes the env state + sid) unrun.
+        self._session_cm = cm
         self._session = cm.__enter__()
         prompt = self._session.get_prompt()
         return _join_text_blocks(prompt)
@@ -246,14 +252,15 @@ class _RolloutEnvironment:
     # ── helpers ──────────────────────────────────────────────────────
 
     def _teardown_session(self) -> None:
-        if self._session is None:
+        if self._session_cm is None:
             return
         try:
-            # The SDK's Session context-manager exit deletes both the env
-            # state and the sid. We look up the original CM from the SDK.
-            self._session.__exit__(None, None, None) if hasattr(self._session, "__exit__") else None
+            # Exit the SDK's Session context manager — this deletes both
+            # the per-rollout env state and the sid on the server.
+            self._session_cm.__exit__(None, None, None)
         except Exception as e:  # noqa: BLE001
             logger.debug("session teardown failed: %s", e)
+        self._session_cm = None
         self._session = None
 
     def _call_ors_tool(self, tool_name: str, tool_input: dict[str, Any]) -> str:
@@ -269,23 +276,22 @@ class _RolloutEnvironment:
             self.last_output = f"Error: {e}"
             return self.last_output
 
-        text = _join_text_blocks(getattr(out, "blocks", []) or []) or "(no output)"
+        # `out` is `openreward.api.environments.types.ToolOutput` — a stable dataclass
+        # with `blocks: list`, `reward: Optional[float]`, `metadata: Optional[dict]`, `finished: bool`.
+        text = _join_text_blocks(out.blocks or []) or "(no output)"
 
-        raw_reward = getattr(out, "reward", None)
         step_reward: float | None = None
-        if raw_reward is not None:
+        if out.reward is not None:
             try:
-                step_reward = float(raw_reward)
+                step_reward = float(out.reward)
             except (TypeError, ValueError):
                 step_reward = None
         self.rewards.append(step_reward)
         if step_reward is not None:
             self.reward = step_reward  # last-non-null wins (outcome-only convention)
 
-        md = getattr(out, "metadata", None)
-        self.metadata.append(md if isinstance(md, dict) else None)
-
-        self.finished = bool(getattr(out, "finished", False))
+        self.metadata.append(out.metadata if isinstance(out.metadata, dict) else None)
+        self.finished = bool(out.finished)
         self.last_output = text
         return text
 
@@ -293,14 +299,24 @@ class _RolloutEnvironment:
 # ── dynamic tool binding ─────────────────────────────────────────────
 
 
+_VALID_TOOL_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
 def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
     """Generate a typed Python method for one ORS tool spec.
 
     Signature comes from the JSON Schema; docstring is Google-style so ``transformers.utils.get_json_schema`` (used by
     vLLM) can produce a correct tool schema for the model.
+
+    Untrusted text from the server (tool name, descriptions) is never spliced raw into the generated source — the name
+    is validated against a Python-identifier regex and the description / per-param descriptions are passed through
+    ``repr()`` before being interpolated, so a tool description containing triple quotes can't break binding.
     """
     tool_name = spec["name"]
-    if hasattr(cls, tool_name) and callable(getattr(cls, tool_name)):
+    if not _VALID_TOOL_NAME.match(tool_name):
+        logger.warning("skipping tool with non-identifier name: %r", tool_name)
+        return
+    if tool_name in cls.__dict__:
         # Already bound by an earlier instance — idempotent skip.
         return
 
@@ -317,6 +333,9 @@ def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
     annotations: dict[str, type] = {}
     args_doc_lines: list[str] = []
     for pname, pdef in required_props + optional_props:
+        if not _VALID_TOOL_NAME.match(pname):
+            logger.warning("skipping tool %r — non-identifier param name: %r", tool_name, pname)
+            return
         py_type = _resolve_param_type(pdef)
         annotations[pname] = _PY_TYPE_OBJECTS[py_type]
         if pname in required:
@@ -327,10 +346,12 @@ def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
         pdesc = pdef.get("description") or pdef.get("title") or pname
         args_doc_lines.append(f"        {pname}: {pdesc}")
 
-    args_section = ("\n\n    Args:\n" + "\n".join(args_doc_lines)) if args_doc_lines else ""
+    # Build the docstring as a single repr-quoted string so triple-quotes / quotes / newlines in the description or
+    # arg text can never close out the generated docstring early.
+    docstring = description + (("\n\n    Args:\n" + "\n".join(args_doc_lines)) if args_doc_lines else "")
     src = (
         f"def {tool_name}(self, {', '.join(params_src)}) -> str:\n"
-        f'    """{description}{args_section}"""\n'
+        f"    {docstring!r}\n"
         f"    _kwargs = dict(locals()); _kwargs.pop('self', None)\n"
         f"    return self._call_ors_tool({tool_name!r}, _kwargs)\n"
     )
@@ -346,26 +367,40 @@ def _bind_tool_method(cls: type, spec: dict[str, Any]) -> None:
 
 
 def _spec_to_dict(spec: Any) -> dict[str, Any]:
-    """Normalise SDK ``ToolSpec`` and dict shapes to the same dict form."""
+    """Normalise SDK ``ToolSpec`` and dict shapes to the same dict form.
+
+    ``openreward.api.environments.types.ToolSpec`` is a stable dataclass with
+    ``name``, ``description``, ``input_schema`` fields, so direct attribute
+    access is safe.
+    """
     if isinstance(spec, dict):
         return spec
     return {
         "name": spec.name,
-        "description": getattr(spec, "description", None),
-        "input_schema": getattr(spec, "input_schema", None) or {},
+        "description": spec.description,
+        "input_schema": spec.input_schema or {},
     }
 
 
 def _join_text_blocks(blocks: list[Any]) -> str:
     """Concatenate the ``text`` field of every text block in order.
 
-    Accepts both SDK ``TextBlock`` objects and plain dicts.
+    Accepts both SDK ``TextBlock`` dataclasses and plain dicts. Both shapes
+    expose a ``type`` discriminator (`"text"` vs `"image"`); non-text blocks
+    are skipped so e.g. ``ImageBlock`` doesn't trip up the join.
     """
     if not blocks:
         return ""
     parts: list[str] = []
     for b in blocks:
-        text = getattr(b, "text", None) if not isinstance(b, dict) else b.get("text")
+        if isinstance(b, dict):
+            if b.get("type") != "text":
+                continue
+            text = b.get("text")
+        else:
+            if b.type != "text":
+                continue
+            text = b.text
         if text:
             parts.append(str(text))
     return "\n".join(parts)

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -98,7 +98,7 @@ class _RolloutEnvironment:
     """Per-rollout TRL adapter backed by the ``openreward`` SDK.
 
     **Internal class.** Users don't construct this directly; they create
-    an :class:`OpenRewardEnv` and pass ``env.factory`` to
+    an :class:`OpenRewardSpec` and pass ``spec.environment_factory`` to
     ``GRPOTrainer``. TRL's trainer then constructs one instance of this
     per rollout slot.
 

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -37,6 +37,7 @@ def _import_openreward():
     """Lazy-import the openreward package with a friendly error message."""
     try:
         import openreward
+
         return openreward
     except ImportError as e:
         raise ImportError(
@@ -57,13 +58,21 @@ _JSON_TYPE_TO_PY: dict[str, str] = {
 }
 
 _PY_TYPE_OBJECTS: dict[str, type] = {
-    "str": str, "int": int, "float": float,
-    "bool": bool, "list": list, "dict": dict,
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
 }
 
 _PY_TYPE_FROM_VALUE: dict[type, str] = {
-    bool: "bool", int: "int", float: "float",
-    str: "str", list: "list", dict: "dict",
+    bool: "bool",
+    int: "int",
+    float: "float",
+    str: "str",
+    list: "list",
+    dict: "dict",
 }
 
 
@@ -223,6 +232,7 @@ class _RolloutEnvironment:
 
         if task_spec is not None:
             from openreward.api.environments.client import Task
+
             task = Task(
                 server_name=self._env.server if hasattr(self._env, "server") else self._env.name,
                 environment_name=self._env.name,
@@ -251,8 +261,7 @@ class _RolloutEnvironment:
         try:
             # The SDK's Session context-manager exit deletes both the env
             # state and the sid. We look up the original CM from the SDK.
-            self._session.__exit__(None, None, None) if hasattr(self._session, "__exit__") \
-                else None
+            self._session.__exit__(None, None, None) if hasattr(self._session, "__exit__") else None
         except Exception as e:  # noqa: BLE001
             logger.debug("session teardown failed: %s", e)
         self._session = None
@@ -352,7 +361,7 @@ def _spec_to_dict(spec: Any) -> dict[str, Any]:
     if isinstance(spec, dict):
         return spec
     return {
-        "name": getattr(spec, "name"),
+        "name": spec.name,
         "description": getattr(spec, "description", None),
         "input_schema": getattr(spec, "input_schema", None) or {},
     }

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -86,6 +86,10 @@ def is_mergekit_available() -> bool:
     return _is_package_available("mergekit")
 
 
+def is_openreward_available() -> bool:
+    return _is_package_available("openreward")
+
+
 def is_pydantic_available() -> bool:
     return _is_package_available("pydantic")
 


### PR DESCRIPTION
# What does this PR do?

Adds `trl.experimental.openreward` — an adapter that plugs any environment speaking the [**Open Reward Standard (ORS)**](https://openrewardstandard.io) into any TRL trainer that accepts an `environment_factory` input (e.g. `GRPOTrainer`, `AsyncGRPOTrainer`, `RLOOTrainer`, …). ORS is an open HTTP/SSE protocol for RL environments; the same adapter works for envs hosted on the [**OpenReward platform**](https://openreward.ai), self-hosted on any container service, or running locally on `localhost` for development. One string identifier (a catalog name like `Eigent/SETA` or a URL like `http://localhost:8000`) is enough to wire all three TRL slots: `.dataset`, `.factory`, `.reward_func`.

Discussed in #5695.

```python
from trl import GRPOConfig, GRPOTrainer
from trl.experimental.openreward import OpenRewardEnv

env = OpenRewardEnv("Eigent/SETA")  # or "http://localhost:8000"

trainer = GRPOTrainer(
    model="Qwen/Qwen3-4B",
    args=GRPOConfig(...),
    train_dataset=env.dataset,
    environment_factory=env.factory,
    reward_funcs=env.reward_func,
)
```

## What this PR adds

| Area | What |
|---|---|
| Adapter | `trl/experimental/openreward/` — `OpenRewardEnv` (spec) + `_RolloutEnvironment` (internal, per-rollout) |
| Example | `examples/scripts/openreward/seta.py` — full GRPO script targeting the SETA environment, runnable in colocate or server vLLM mode |
| Optional dep | `trl[openreward]` extra in `pyproject.toml` (lazy import — non-users pay nothing; mirrors `trl[peft]`, `trl[vllm]`) |

5 files, +774 LOC including docstrings.

## Design choices

- **One public class.** `OpenRewardEnv` is the spec; the per-rollout `_RolloutEnvironment` is internal (leading underscore, not in `__all__`).
- **SDK-backed transport.** Wraps the official [`openreward` Python SDK](https://pypi.org/project/openreward/) rather than re-implementing the protocol — keeps the adapter small and tracks protocol changes upstream.
- **Dynamic tool binding.** At construction, `OpenRewardEnv` fetches the env's tool schemas (over the ORS `/tools` endpoint) and generates one Python method per tool with a proper typed signature + docstring. No per-env wrapper code — `inspect.getmembers(env, ismethod)` and `transformers.utils.get_json_schema` work out of the box.
- **Dataset autoderivation.** `env.dataset` resolves the env's task list via the ORS task endpoints (`/num_tasks`, `/task`, `/task_range`, `/splits`) to build a `datasets.Dataset` with `task_index` + per-task metadata columns.

## Why now

The single example here (`seta.py`) is meant as a starting point — the adapter itself is environment-agnostic, so any current or future ORS env works against the same code path. As more environments land on the OpenReward catalog, additional examples can be added incrementally without touching the adapter.

## Open follow-ups (post-merge, not in this PR)

- Docs page at `docs/source/openreward.md` (toctree near `openenv.md`).
- Tests at `tests/experimental/test_openreward.py` with an in-process FastAPI fake to keep CI off the network.
- Graduate `experimental/openreward` → `trl.openreward` after one release cycle if no breaking ORS changes.
- 15-min ORS session keepalive `ping` thread for very long episodes.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? → #5695
- [ ] Did you make sure to update the documentation with your changes? *(deferred — see follow-ups above; happy to add the docs page in this PR if reviewers prefer)*
- [ ] Did you write any new necessary tests? *(deferred — same)*

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new experimental environment integration that performs dynamic tool-method generation (via `exec`) and opens real HTTP/SSE sessions, so failures or schema quirks could affect environment-based training behavior. Risk is mitigated by being gated behind the `trl[openreward]` extra and covered by end-to-end tests against a local echo server.
> 
> **Overview**
> Adds **experimental OpenReward (ORS) environment support** via `trl.experimental.openreward.OpenRewardSpec`, which lazily derives a `train_dataset`, provides an `environment_factory` that creates per-rollout ORS sessions, and ships a default outcome-only `reward_funcs`.
> 
> Implements a per-rollout adapter that **binds ORS tools into typed Python methods** from JSON Schema at runtime and tracks rollout state (`reward`, `finished`, etc.) for reward computation.
> 
> Rounds out the integration with the `trl[openreward]` optional dependency, documentation + a SETA training example script, and new end-to-end tests that spin up a minimal local ORS echo server (plus a `require_openreward` test marker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9baa0b6f53a0e08bca993cfc6041d8b40b420b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->