### PR TITLE
Reject parallelism_config with cp_size>1 or sp_size>1 in GRPO/RLOO

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -886,6 +886,16 @@ class GRPOConfig(_BaseConfig):
                 stacklevel=3,
             )
 
+        if self.parallelism_config is not None and (
+            self.parallelism_config.cp_enabled or self.parallelism_config.sp_enabled
+        ):
+            raise ValueError(
+                "GRPOTrainer does not support sequence-dim parallelism (`parallelism_config.cp_size > 1` or "
+                "`parallelism_config.sp_size > 1`) yet. GRPO builds model inputs after generation inside the trainer, "
+                "so Transformers' context-parallel / Ulysses sequence-parallel input sharding cannot be applied to the "
+                "raw generation batch. Set both `cp_size=1` and `sp_size=1`, or disable `parallelism_config`."
+            )
+
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
 
         if self.log_completions_hub_repo is not None and not self.log_completions:

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -564,6 +564,16 @@ class RLOOConfig(_BaseConfig):
                 stacklevel=3,
             )
 
+        if self.parallelism_config is not None and (
+            self.parallelism_config.cp_enabled or self.parallelism_config.sp_enabled
+        ):
+            raise ValueError(
+                "RLOOTrainer does not support sequence-dim parallelism (`parallelism_config.cp_size > 1` or "
+                "`parallelism_config.sp_size > 1`) yet. RLOO builds model inputs after generation inside the trainer, "
+                "so Transformers' context-parallel / Ulysses sequence-parallel input sharding cannot be applied to the "
+                "raw generation batch. Set both `cp_size=1` and `sp_size=1`, or disable `parallelism_config`."
+            )
+
         num_processes = self.world_size
         # The current default effective batch size
         if self.generation_batch_size is None and self.steps_per_generation is None:


### PR DESCRIPTION
Both context parallelism (cp_size > 1) and DeepSpeed Ulysses sequence parallelism (sp_size > 1) shard the sequence dimension of inputs before the trainer's _prepare_inputs runs. GRPO/RLOO build their model inputs after generation inside _prepare_inputs, so transformers' CP / accelerate's Ulysses adapter both crash on the raw generation batch (e.g. issue #4016).

Raise a clear ValueError at config init instead of letting the user hit a confusing low-level TypeError or AttributeError at the first training step.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new upfront `ValueError` for users enabling `parallelism_config` with context/sequence parallelism, which may change startup behavior but avoids later runtime crashes in training.
> 
> **Overview**
> Adds early validation in `GRPOConfig.__post_init__` and `RLOOConfig.__post_init__` to **reject sequence-dimension sharding** when `parallelism_config` has context parallelism (`cp_size > 1`) or Ulysses sequence parallelism (`sp_size > 1`).
> 
> Instead of failing mid-training with low-level errors, these trainers now raise a clear `ValueError` instructing users to set `cp_size=1` and `sp_size=1` (or disable `parallelism_config`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8cb6fa42750f201e52806d1ee1d3be3cd0eca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->