### PR TITLE
fix: prevent 5 GB+ CUDA memory leak in activation offloading by syncing streams and clear stashes in OffloadActivations.__exit__

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -571,9 +571,8 @@ class OffloadActivations(saved_tensors_hooks):
     def __exit__(self, *args, **kwargs):
         """Sync streams and clear stashes before parent cleanup.
 
-        try/finally ensures the saved_tensors_hooks parent cleanup runs
-        even if stream sync raises — otherwise hooks stay permanently
-        installed, creating a silent memory leak.
+        try/finally ensures the saved_tensors_hooks parent cleanup runs even if stream sync raises — otherwise hooks
+        stay permanently installed, creating a silent memory leak.
         """
         try:
             if self.use_streams:

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -568,6 +568,24 @@ class OffloadActivations(saved_tensors_hooks):
 
         self.param_storages = param_storages
 
+    def __exit__(self, *args, **kwargs):
+        """Sync streams and clear stashes before parent cleanup.
+
+        try/finally ensures the saved_tensors_hooks parent cleanup runs
+        even if stream sync raises — otherwise hooks stay permanently
+        installed, creating a silent memory leak.
+        """
+        try:
+            if self.use_streams:
+                self.s0.synchronize()
+                self.s1.synchronize()
+                self.bwd_tensor_stash.clear()
+                self.bwd_ev_stash.clear()
+                self.fwd_stash.clear()
+        finally:
+            result = super().__exit__(*args, **kwargs)
+        return result
+
 
 class NoOpManager(saved_tensors_hooks):
     """


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                                                
                                               
  `OffloadActivations.__exit__` defers entirely to                                                                                                                                                                                          
  `torch.autograd.graph.saved_tensors_hooks.__exit__`, which does not                                                                                                                                                                       
  synchronize the offload CUDA stream (s1) or the compute stream (s0).                                                                                                                                                                      
  Async copies still in-flight when the context manager exits can leave                                                                                                                                                                     
  stashed tensors referencing a stream whose lifetime may already be                                                                                                                                                                        
  over, leaking CUDA blocks with garbage stream IDs.                                                                                                                                                                                        
                                                                                                                                                                                                                                            
  Observed via `torch.cuda.memory._dump_snapshot` during QLoRA vision                                                                                                                                                                       
  training on a 9B model (RTX 3090 24 GB):                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
  Stream 93898984661968 (garbage ID): 5.70 GB  ← likely orphaned offload tensors                                                                                                                                                            
  Stream 0 (compute):                 14.69 GB  ← normal model                                                                                                                                                                              
  Fragmented/unreleased:              5.83 GB                                                                                                                                                                                               
                                                                                                                                                                                                                                            
  The garbage stream blocks (~8.4 MB each) match the size of activation                                                                                                                                                                     
  offload buffers. After adding stream sync + stash clear, garbage-stream                                                                                                                                                                   
  blocks no longer appear in post-training snapshots.                                                                                                                                                                                       
                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  Add an `__exit__` method that runs BEFORE the parent's cleanup:                                                                                                                                                                           
                                                                  
  1. Synchronize s0 (compute stream) and s1 (offload stream)                                                                                                                                                                                
  2. Clear stashed tensors (bwd_tensor_stash, bwd_ev_stash, fwd_stash)
     — only when `use_streams=True` (stashes don't exist otherwise)                                                                                                                                                                         
                                                                                                                                                                                                                                            
  Tracker is intentionally NOT cleared — the backward pass unpacks                                                                                                                                                                          
  tensors via tracker AFTER `__exit__` (see class docstring example).                                                                                                                                                                       
                                                                                                                                                                                                                                            
  Zero performance impact — called once per context manager, sync+clear                                                                                                                                                                     
  takes ~0.1ms.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                            
  ## Verification                                                                                                                                                                                                                           
                                                                                                                                                                                                                                            
  Applied as a monkey-patch since May 2026. Post-training snapshots show                                                                                                                                                                    
  zero garbage-stream blocks. Without the fix, garbage-stream blocks
  accumulate monotonically per step at ~0.2 GiB/step.                                                                                                                                                                                       
                                                                                                                                                                                                                                            
  ---                     
                                                                                                                                                                                                                                            
  - [ ] This PR fixes a typo or improves the docs                                                                                                                                                                                           
  - [x] Read the contributor guideline                            
  - [ ] Discussed via GitHub issue (N/A — found during QLoRA debugging)                                                                                                                                                                     
  - [ ] Documentation update needed? No — internal behavior change only                                                                                                                                                                     
  - [ ] New tests? Not easily testable — requires CUDA memory snapshot assertions                                                                                                                                                           
                                                                                                                                                                                                                                            
  - [x] AI-assisted: PR text and structure refined with AI; root cause found                                                                                                                                                                
    through human debugging


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CUDA stream/autograd hook lifecycle in `OffloadActivations`, so mistakes could cause hangs or perf regressions, but the change is small and gated to `use_streams=True`.
> 
> **Overview**
> Prevents activation-offloading CUDA memory from being leaked after leaving the `OffloadActivations` context by adding a custom `__exit__`.
> 
> When `use_streams=True`, `__exit__` now synchronizes the compute/offload streams (`s0`, `s1`) and clears the forward/backward stash dictionaries before delegating to `saved_tensors_hooks.__exit__`, using a `try/finally` to ensure the parent hook cleanup always runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1377a4394ddbb33e07f114e3aba71b4fae05903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->