### PR TITLE
Align KTO with DPO: Remove enforcement of causal language models

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -324,13 +324,6 @@ class KTOTrainer(_BaseTrainer):
                 if param.requires_grad:
                     param.data = param.data.to(torch.bfloat16)
 
-        # KTO only supports causal language models, not encoder-decoder models
-        if model is not None and hasattr(model.config, "is_encoder_decoder") and model.config.is_encoder_decoder:
-            raise ValueError(
-                "KTO only supports causal language models. Encoder-decoder models are not supported. "
-                "Please use a causal LM (e.g., GPT, Llama, Mistral) instead of an encoder-decoder model (e.g., T5, BART)."
-            )
-
         if args.max_length is None:
             logger.warning(
                 "When using DataCollatorForUnpairedPreference, you should set `max_length` in the KTOTrainer's init"


### PR DESCRIPTION
Align KTO with DPO: Remove enforcement of causal language models.


This PR makes a small change to the `KTOTrainer` by removing the check that raised an error when an encoder-decoder model was used. As a result, the restriction that KTO only supports causal language models is no longer enforced in the code.

Part of:
- #4786

@qgallouedec, shouldn't I enforce this in DPO instead?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a guardrail in `KTOTrainer` that previously blocked encoder-decoder models, which may expose unsupported/untested model architectures to KTO training and lead to runtime errors or incorrect loss computation.
> 
> **Overview**
> `KTOTrainer` no longer raises an error when the provided model is configured as encoder-decoder, aligning its initialization behavior with DPO by **removing the causal-LM-only enforcement**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577037c98174b456e7fd963ea294feadec776b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->