### PR TITLE
Align KTO with DPO: Remove duplicate import of PreTrainedModel

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import torch
 import torch.nn as nn
@@ -65,10 +65,6 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     from peft import PeftConfig, PeftModel, get_peft_model
-
-
-if TYPE_CHECKING:
-    from transformers import PreTrainedModel
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
Align KTO with DPO: Remove duplicate import of PreTrainedModel

This PR makes minor cleanup changes to the `KTOTrainer`, focusing on removing unused imports related to type checking.

Part of:
- #4786

### Changes

* Removed the unused `TYPE_CHECKING` import and the associated type-checking block for `PreTrainedModel`, as these were not being used in the code. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes unused type-checking imports/blocks and should not affect runtime behavior.
> 
> **Overview**
> Removes the unused `TYPE_CHECKING` import and the associated type-only `PreTrainedModel` import guard in `trl/experimental/kto/kto_trainer.py`, aligning the KTO trainer’s imports with other trainers and reducing redundant type-checking code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a37cdafd8161b405477915e8b8e5cb9e3fe27c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->