### PR TITLE
Align KTO with DPO: Simplify max_length init logic

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -350,7 +350,6 @@ class KTOTrainer(_BaseTrainer):
             self.use_dpo_data_collator = False
 
         self.loss_type = args.loss_type
-        self.max_length = max_length
         self.precompute_ref_log_probs = args.precompute_ref_log_probs
 
         # Not all losses require a KL calculation

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -331,12 +331,6 @@ class KTOTrainer(_BaseTrainer):
                 "Please use a causal LM (e.g., GPT, Llama, Mistral) instead of an encoder-decoder model (e.g., T5, BART)."
             )
 
-        if args.max_length is None:
-            logger.warning(
-                "When using DataCollatorForUnpairedPreference, you should set `max_length` in the KTOTrainer's init"
-                " it will be set to `512` by default, but you should do it yourself in the future.",
-            )
-            max_length = 512
         if args.max_length is not None:
             max_length = args.max_length
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -334,7 +334,7 @@ class KTOTrainer(_BaseTrainer):
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=self._tokenizer.pad_token_id,
-                max_length=max_length,
+                max_length=args.max_length,
             )
 
             if args.remove_unused_columns:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -331,6 +331,7 @@ class KTOTrainer(_BaseTrainer):
                 "Please use a causal LM (e.g., GPT, Llama, Mistral) instead of an encoder-decoder model (e.g., T5, BART)."
             )
 
+        # Data collator
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=self._tokenizer.pad_token_id,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -331,9 +331,6 @@ class KTOTrainer(_BaseTrainer):
                 "Please use a causal LM (e.g., GPT, Llama, Mistral) instead of an encoder-decoder model (e.g., T5, BART)."
             )
 
-        if args.max_length is not None:
-            max_length = args.max_length
-
         if data_collator is None:
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=self._tokenizer.pad_token_id,


### PR DESCRIPTION
Align KTO with DPO: Simplify max_length init logic.

This PR makes a change to the initialization logic for `max_length` in the `KTOTrainer` class. The defaulting behavior for `max_length` has been removed, and the code now directly uses `args.max_length` when constructing the data collator. Additionally, the redundant assignment to `self.max_length` has been eliminated.

Part of:
- #4786

### Changes

Initialization logic simplification:

* Removed the defaulting of `max_length` to `512` if not set, and now always passes `args.max_length` to the `DataCollatorForUnpairedPreference`. This means users are now responsible for explicitly setting `max_length` in the trainer arguments.
* Removed the assignment of `self.max_length`, as it is no longer needed with the updated logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default truncation behavior when `args.max_length` is unset/`None`, which can affect sequence lengths, memory use, and training stability. Scope is small and isolated to `KTOTrainer` initialization/data collation.
> 
> **Overview**
> **Simplifies `max_length` initialization in `KTOTrainer`.** The trainer no longer warns and falls back to a hard-coded `512` when `max_length` is missing; it now passes `args.max_length` directly into `DataCollatorForUnpairedPreference`.
> 
> Removes the redundant `self.max_length` assignment, making truncation behavior entirely driven by `KTOConfig.max_length` (including allowing `None` to mean *no truncation*).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465be97bf2f1c22f0a75584a829028eade920549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->