### PR TITLE
Align KTO with DPO: Group training arguments

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -358,28 +358,22 @@ class KTOTrainer(_BaseTrainer):
         else:
             self.use_dpo_data_collator = False
 
-        self.loss_type = args.loss_type
-        self.max_length = max_length
-        self.precompute_ref_log_probs = args.precompute_ref_log_probs
-
-        # Not all losses require a KL calculation
-        self.calculate_KL = True
-        if self.loss_type in ["apo_zero_unpaired"]:
-            self.calculate_KL = False
-        if self.calculate_KL and args.per_device_train_batch_size <= 1:
-            raise ValueError(
-                "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
-            )
-
         # metric
         self._stored_metrics = defaultdict(lambda: defaultdict(list))
 
-        # KTO parameter
+        # Training arguments
         self.beta = args.beta
+        self.precompute_ref_log_probs = args.precompute_ref_log_probs
+        self.loss_type = args.loss_type
         self.desirable_weight = args.desirable_weight
         self.undesirable_weight = args.undesirable_weight
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
+        self.calculate_KL = False if self.loss_type in ["apo_zero_unpaired"] else True
+        if self.calculate_KL and args.per_device_train_batch_size <= 1:
+            raise ValueError(
+                "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
+            )
         if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
             logger.warning(
                 "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "


### PR DESCRIPTION
Align KTO with DPO: Group training arguments.

This PR refactors the initialization logic in the `KTOTrainer` class to improve clarity and organization, specifically around how training arguments and KL calculation are handled.

Part of:
- #4786

### Changes

* Moved the assignment of training arguments such as `loss_type`, `precompute_ref_log_probs`, and `beta` into a grouped "Training arguments" section for better readability and maintainability.
* Refactored the logic for determining whether to calculate KL divergence (`calculate_KL`) to be more concise, and kept the validation for batch size in place.

No functional changes were made; this is a code organization and clarity improvement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `KTOTrainer` initialization; behavior should remain the same aside from any unintended ordering/logic regression in `calculate_KL` and batch-size validation.
> 
> **Overview**
> Refactors `KTOTrainer` initialization to **group training-argument assignments** (`beta`, `loss_type`, `precompute_ref_log_probs`, weights) into a single "Training arguments" block.
> 
> Simplifies the **KL calculation toggle** by setting `calculate_KL` directly from `loss_type` (disabling it for `apo_zero_unpaired`) while keeping the existing **batch-size > 1** validation when KL is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f334dd7273e99933f08de669f7c0a4fce9103122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->