### PR TITLE
Align KTO with DPO: Use _metrics attribute

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -371,9 +371,6 @@ class KTOTrainer(_BaseTrainer):
                 "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
             )
 
-        # Initialize the metrics
-        self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
-
         # KTO parameter
         self.beta = args.beta
         self.desirable_weight = args.desirable_weight
@@ -441,6 +438,9 @@ class KTOTrainer(_BaseTrainer):
             disable_dropout_in_model(model)
             if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
+
+        # Initialize the metrics
+        self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -372,7 +372,7 @@ class KTOTrainer(_BaseTrainer):
             )
 
         # metric
-        self._stored_metrics = defaultdict(lambda: defaultdict(list))
+        self._metrics = defaultdict(lambda: defaultdict(list))
 
         # KTO parameter
         self.beta = args.beta
@@ -1164,7 +1164,7 @@ class KTOTrainer(_BaseTrainer):
 
     def store_metrics(self, metrics: dict[str, float], train_eval: Literal["train", "eval"] = "train") -> None:
         for key, value in metrics.items():
-            self._stored_metrics[train_eval][key].append(value)
+            self._metrics[train_eval][key].append(value)
 
     def _get_train_sampler(self, dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:
         if dataset is None:
@@ -1224,23 +1224,22 @@ class KTOTrainer(_BaseTrainer):
         prefix = "eval_" if train_eval == "eval" else ""
         # accumulate average metrics from sums and lengths
         for split in ["chosen", "rejected"]:
-            if f"count/{split}" in self._stored_metrics[train_eval]:
-                count_sum = torch.Tensor(self._stored_metrics[train_eval][f"count/{split}"]).sum().item()
+            if f"count/{split}" in self._metrics[train_eval]:
+                count_sum = torch.Tensor(self._metrics[train_eval][f"count/{split}"]).sum().item()
                 for metric in ["rewards", "logps", "logits"]:
                     logs[f"{prefix}{metric}/{split}"] = (
-                        torch.Tensor(self._stored_metrics[train_eval][f"{metric}/{split}_sum"]).sum().item()
-                        / count_sum
+                        torch.Tensor(self._metrics[train_eval][f"{metric}/{split}_sum"]).sum().item() / count_sum
                     )
                     # delete obsolete metric
-                    del self._stored_metrics[train_eval][f"{metric}/{split}_sum"]
-                del self._stored_metrics[train_eval][f"count/{split}"]
+                    del self._metrics[train_eval][f"{metric}/{split}_sum"]
+                del self._metrics[train_eval][f"count/{split}"]
         # calculate reward margin
         if f"{prefix}rewards/chosen" in logs and f"{prefix}rewards/rejected" in logs:
             logs[f"{prefix}rewards/margins"] = logs[f"{prefix}rewards/chosen"] - logs[f"{prefix}rewards/rejected"]
         # Add averaged stored metrics to logs
-        for key, metrics in self._stored_metrics[train_eval].items():
+        for key, metrics in self._metrics[train_eval].items():
             logs[f"{prefix}{key}"] = torch.Tensor(metrics).mean().item()
-        del self._stored_metrics[train_eval]
+        del self._metrics[train_eval]
         return super().log(logs, start_time)
 
     # Ensure the model card is saved along with the checkpoint

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1239,7 +1239,7 @@ class KTOTrainer(_BaseTrainer):
         # Add averaged stored metrics to logs
         for key, metrics in self._metrics[train_eval].items():
             logs[f"{prefix}{key}"] = torch.Tensor(metrics).mean().item()
-        del self._metrics[train_eval]
+        self._metrics[train_eval].clear()
         return super().log(logs, start_time)
 
     # Ensure the model card is saved along with the checkpoint

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -371,8 +371,8 @@ class KTOTrainer(_BaseTrainer):
                 "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
             )
 
-        # metric
-        self._metrics = defaultdict(lambda: defaultdict(list))
+        # Initialize the metrics
+        self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
 
         # KTO parameter
         self.beta = args.beta


### PR DESCRIPTION
Align KTO with DPO: Use `_metrics` attribute.

Part of:
- #4786

This PR refactors how training and evaluation metrics are stored and managed in the `KTOTrainer` class, replacing the previous `_stored_metrics` structure with a new `_metrics` dictionary. This change centralizes metric tracking and simplifies metric handling throughout the class.

### Changes

**Metrics storage and management:**

* Replaced the `_stored_metrics` attribute (a nested `defaultdict`) with a new `_metrics` dictionary, initialized to separately track "train" and "eval" metrics.
* Updated all methods (`store_metrics`, `log`) to use the new `_metrics` structure instead of `_stored_metrics`, ensuring consistent metric accumulation and cleanup.

These changes improve code clarity and reduce the risk of errors when handling training and evaluation metrics.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to how `KTOTrainer` accumulates and clears train/eval metrics, but it could affect what gets logged if the new containers are mishandled.
> 
> **Overview**
> Updates `KTOTrainer` to use a unified `_metrics` container (split into `train` and `eval`) instead of `_stored_metrics`, aligning metric bookkeeping with DPO.
> 
> Metric accumulation (`store_metrics`) and log-time aggregation/cleanup (`log`) are refactored to write into and clear from the new structure, including the chosen/rejected count-based averaging logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881aec378253c3293e4f6b1f362a9db1ebfdf9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->