### PR TITLE
feat: Expose vLLM multimodal caching and sequence scheduling arguments in vllm_serve

### DIFF
--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -218,6 +218,12 @@ class ScriptArguments:
         speculative_config (`str`, *optional*):
             JSON string for vLLM speculative decoding config, forwarded to `LLM(speculative_config=...)`. When unset,
             speculative decoding is disabled. Example: `'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'`.
+        mm_processor_cache_gb (`float`, *optional*):
+            Size of vLLM's multimodal processor cache in GiB. When unset, vLLM keeps its own default.
+        disable_chunked_mm_input (`bool`, *optional*, defaults to `False`):
+            Whether to disable vLLM chunking for multimodal inputs.
+        max_num_seqs (`int`, *optional*):
+            Maximum number of sequences scheduled by vLLM. When unset, vLLM keeps its own default.
     """
 
     model: str = field(
@@ -329,6 +335,18 @@ class ScriptArguments:
             'Example: \'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}\''
         },
     )
+    mm_processor_cache_gb: float | None = field(
+        default=None,
+        metadata={"help": "Size of vLLM's multimodal processor cache in GiB."},
+    )
+    disable_chunked_mm_input: bool = field(
+        default=False,
+        metadata={"help": "Disable vLLM chunking for multimodal inputs."},
+    )
+    max_num_seqs: int | None = field(
+        default=None,
+        metadata={"help": "Maximum number of sequences scheduled by vLLM."},
+    )
 
 
 def llm_worker(
@@ -341,6 +359,14 @@ def llm_worker(
     os.environ["VLLM_DP_RANK_LOCAL"] = str(data_parallel_rank)
     os.environ["VLLM_DP_SIZE"] = str(script_args.data_parallel_size)
     os.environ["VLLM_DP_MASTER_PORT"] = str(master_port)
+
+    extra_llm_kwargs = {}
+    if script_args.mm_processor_cache_gb is not None:
+        extra_llm_kwargs["mm_processor_cache_gb"] = script_args.mm_processor_cache_gb
+    if script_args.disable_chunked_mm_input:
+        extra_llm_kwargs["disable_chunked_mm_input"] = True
+    if script_args.max_num_seqs is not None:
+        extra_llm_kwargs["max_num_seqs"] = script_args.max_num_seqs
 
     llm = LLM(
         model=script_args.model,
@@ -362,6 +388,7 @@ def llm_worker(
         # Important so temperature scaling/logit tweaking affects the TIS log probs
         logprobs_mode="processed_logprobs",
         speculative_config=json.loads(script_args.speculative_config) if script_args.speculative_config else None,
+        **extra_llm_kwargs,
     )
 
     # Send ready signal to parent process


### PR DESCRIPTION
# What does this PR do?

This PR exposes three critical vLLM engine parameters in trl/scripts/vllm_serve.py to provide better control over multimodal (VLM) serving and sequence scheduling during RLHF rollouts:

   - mm_processor_cache_gb: Configures the size of vLLM's multimodal processor cache in GiB. 
   - disable_chunked_mm_input: A toggle to disable vLLM chunking for multimodal inputs.
   - max_num_seqs: Allows manual control over the maximum number of sequences scheduled by the vLLM engine.

  These parameters are added to the ScriptArguments dataclass and passed directly to the vllm.LLM initialization in llm_worker.

## Motivation
  As TRL's support for multimodal RLHF (e.g., GRPO with vision inputs) grows, users often encounter Out-of-Memory (OOM) errors or suboptimal scheduling performance when using the standalone vllm_serve script with large VLMs like Qwen2-VL. vLLM provides specific flags to manage multimodal
  memory and scheduling, but these were previously inaccessible via TRL's CLI. Exposing these flags allows for more robust and high-performance multimodal RL training.

## Before submitting

 - [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
 - [x] Did you read the [contributor guideline (https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
 - [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
 - [x] Did you make sure to update the documentation with your changes?
 - [ ] Did you write any new necessary tests?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI-configurable vLLM engine init parameters that can change runtime memory/scheduling behavior and may be version-sensitive if deployed with older vLLM releases.
> 
> **Overview**
> Exposes three additional vLLM engine knobs in `trl/scripts/vllm_serve.py` by adding `mm_processor_cache_gb`, `disable_chunked_mm_input`, and `max_num_seqs` to the script’s `ScriptArguments` and help text.
> 
> `llm_worker` now conditionally forwards these values into `vllm.LLM(...)` via `extra_llm_kwargs`, enabling multimodal processor cache sizing, toggling chunked multimodal inputs, and controlling sequence scheduling limits from the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277011113995e73200b04350fe14208172615b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->