### PR TITLE
Fail early for unsupported PEFT + Liger Kernel in DPO

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -662,6 +662,25 @@ class TestDPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @require_liger_kernel
+    @require_peft
+    def test_init_fails_with_peft_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(NotImplementedError, match="Liger DPO loss is not implemented for PEFT models."):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+                peft_config=LoraConfig(),
+            )
+
     def test_train_with_iterable_dataset(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train", streaming=True)
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -709,6 +709,8 @@ class DPOTrainer(_BaseTrainer):
                     "Liger DPO loss does not support precomputing reference log probabilities. Either disable "
                     "`precompute_ref_log_probs` or set `use_liger_kernel` to False."
                 )
+            if is_peft_model(model):
+                raise NotImplementedError("Liger DPO loss is not implemented for PEFT models.")
 
         # Dataset
         # Skip dataset preparation if it's a VLM, where preprocessing (e.g., image-to-pixel conversion) is too costly

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1098,16 +1098,13 @@ class DPOTrainer(_BaseTrainer):
         weight = lm_head.weight
         bias = lm_head.bias
 
-        if is_peft_model(model):
-            raise NotImplementedError("Liger DPO loss is not implemented for PEFT models.")
-        else:
-            with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
-                ref_decoder = self.ref_model.get_decoder()
-                ref_outputs = ref_decoder(input_ids, attention_mask=attention_mask, use_cache=False)
-                ref_lm_head = self.ref_model.get_output_embeddings()
-                ref_hidden_states = ref_outputs.last_hidden_state[:, :-1].contiguous()
-                ref_weight = ref_lm_head.weight
-                ref_bias = ref_lm_head.bias
+        with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
+            ref_decoder = self.ref_model.get_decoder()
+            ref_outputs = ref_decoder(input_ids, attention_mask=attention_mask, use_cache=False)
+            ref_lm_head = self.ref_model.get_output_embeddings()
+            ref_hidden_states = ref_outputs.last_hidden_state[:, :-1].contiguous()
+            ref_weight = ref_lm_head.weight
+            ref_bias = ref_lm_head.bias
 
         shift_completion_mask = completion_mask[:, 1:].contiguous()
         labels = input_ids[:, 1:].clone()


### PR DESCRIPTION
Fail early for unsupported PEFT + Liger Kernel in DPO.

This pull request introduces a check to prevent the use of the Liger DPO loss with PEFT models, as this combination is not yet supported. It also adds a corresponding test to ensure that initializing a `DPOTrainer` with both Liger Kernel and PEFT raises a clear error.

### Changes

Validation and error handling improvements:

* Added a check in the `DPOTrainer` initializer to raise a `NotImplementedError` if both `use_liger_kernel` is enabled and the model is a PEFT model, with a clear error message.

Testing enhancements:

* Added a new test (`test_init_fails_with_peft_and_liger`) in `tests/test_dpo_trainer.py` to verify that initializing `DPOTrainer` with both Liger Kernel and PEFT fails as expected, raising the correct error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early validation guard and a regression test, without changing supported training flows beyond producing a clearer error sooner for an already-unsupported configuration.
> 
> **Overview**
> Prevents unsupported configurations by **failing fast** when initializing `DPOTrainer` with `use_liger_kernel=True` on a PEFT-wrapped model, raising a clear `NotImplementedError`.
> 
> Adds a regression test (`test_init_fails_with_peft_and_liger`) to ensure the PEFT+Liger combination errors at init time, and removes the now-redundant PEFT check from the Liger loss computation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623f1689e4b339098f47d8336fb4a0ae58f7ef41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->