### PR TITLE
Explicitly set model_accepts_loss_kwargs=False in DPO and Reward

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -778,6 +778,11 @@ class DPOTrainer(_BaseTrainer):
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
 
+        # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
+        # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set
+        # self.model_accepts_loss_kwargs to False to enable scaling.
+        self.model_accepts_loss_kwargs = False
+
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -533,6 +533,11 @@ class RewardTrainer(_BaseTrainer):
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
 
+        # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
+        # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set
+        # self.model_accepts_loss_kwargs to False to enable scaling.
+        self.model_accepts_loss_kwargs = False
+
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 


### PR DESCRIPTION
Explicitly set model_accepts_loss_kwargs=False in DPO and Reward.

This PR set `self.model_accepts_loss_kwargs = False` in `DPOTrainer` and `RewardTrainer` initialization, following the guidance given by `transformers` and aligning with the pattern already established in `GRPOTrainer`, `RLOOTrainer`.

### Motivation

Both trainers compute their own loss and do not use the `num_items_in_batch` argument passed by the parent `Trainer`.

The transformers `Trainer` docstring explicitly states:
> If you are not using `num_items_in_batch` when computing your loss, make sure to overwrite `self.model_accepts_loss_kwargs` to `False`. Otherwise, the loss calculating might be slightly inaccurate when performing gradient accumulation.

### Changes

Trainer initialization and gradient accumulation:

* Set `self.model_accepts_loss_kwargs = False` in the `__init__` method to ensure proper loss scaling during gradient accumulation, as the trainer handles its own loss computation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training loss normalization behavior for `DPOTrainer` and `RewardTrainer` when gradient accumulation is enabled, which can affect optimization dynamics and reported metrics. Scope is small (single flag set in init), but impacts core training behavior.
> 
> **Overview**
> Fixes gradient-accumulation loss scaling in `DPOTrainer` and `RewardTrainer` by explicitly setting `self.model_accepts_loss_kwargs = False`, ensuring the parent `Trainer` applies its standard loss scaling even though these trainers compute loss internally.
> 
> Adds brief inline comments explaining why the usual model-kwargs detection is bypassed for these trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbecc9bca0c0a629674a6cf42b6ea36e0430075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->