### PR TITLE
Align tiny DeepSeekV3 config with deepseek-ai/DeepSeek-R1-0528

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
+++ b/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
@@ -36,11 +36,19 @@ tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = DeepseekV3Config(
     vocab_size=129280,
-    hidden_size=8,
+    # Every FP8Linear's `in_features` must be a multiple of 128 (the activation-quant kernel asserts
+    # `x.shape[-1] % 128 == 0`). That forces hidden_size, q_lora_rank, kv_lora_rank, intermediate_size,
+    # and `num_attention_heads * v_head_dim` (the o_proj input) to all be multiples of 128.
+    hidden_size=128,
     num_attention_heads=4,
-    num_key_value_heads=2,
+    # MLA already produces keys at `num_attention_heads`; setting `num_kv_heads < num_heads` makes
+    # `sdpa_attention_forward` call `repeat_kv` with groups>1 and double the key heads, breaking
+    # the matmul. The reference config keeps them equal — mirror that here.
+    num_key_value_heads=4,
     num_hidden_layers=2,
-    intermediate_size=32,
+    intermediate_size=128,
+    q_lora_rank=128,
+    kv_lora_rank=128,
     max_position_embeddings=163840,
     rope_scaling={
         "beta_fast": 32.0,

--- a/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
+++ b/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
@@ -15,6 +15,7 @@
 # Note: R1-0528 is kept in addition to R1 because it has a different chat template.
 
 import torch
+from torch import nn
 from transformers import AutoTokenizer, DeepseekV3Config, DeepseekV3ForCausalLM, GenerationConfig
 
 from .._common import (
@@ -34,16 +35,64 @@ MODEL_ID = "deepseek-ai/DeepSeek-R1-0528"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = DeepseekV3Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=129280,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=163840,
+    rope_scaling={
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 40.0,
+        "mscale": 1.0,
+        "mscale_all_dim": 1.0,
+        "original_max_position_embeddings": 4096,
+        "rope_type": "yarn",
+        "type": "yarn",
+    },
+    quantization_config={
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+    },
+    # Forwarded through to match the reference. These fields belong to the upstream remote-code
+    # `DeepseekV3Config` (trust_remote_code) and are not part of transformers' in-tree config; we
+    # carry them as arbitrary kwargs so the saved config.json mirrors the reference. `auto_map`
+    # is intentionally NOT forwarded — it points to remote-code modules (`configuration_deepseek`,
+    # `modeling_deepseek`) that this tiny repo does not ship.
+    ep_size=1,
+    moe_layer_freq=1,
+    num_nextn_predict_layers=1,
+    scoring_func="sigmoid",
+    topk_method="noaux_tc",
 )
 model = DeepseekV3ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)
 smoke_test(model, tokenizer)
+
+# Mirror the reference's FP8 layout: each Linear (except lm_head) gets a per-block (128x128)
+# `weight_scale_inv` companion, weight cast to F8_E4M3. Done after smoke_test — the cast severs
+# `nn.Linear.forward` (FP8 GEMM only runs via `FP8Linear`, installed by the quantizer on reload).
+_FP8_BLOCK = (128, 128)
+
+
+def _cdiv(a, b):
+    return (a + b - 1) // b
+
+
+for name, module in model.named_modules():
+    if not isinstance(module, nn.Linear) or name.endswith("lm_head"):
+        continue
+    out_f, in_f = module.out_features, module.in_features
+    scale = torch.ones(_cdiv(out_f, _FP8_BLOCK[0]), _cdiv(in_f, _FP8_BLOCK[1]), dtype=torch.float32)
+    module.register_parameter("weight_scale_inv", nn.Parameter(scale, requires_grad=False))
+    # int8 isn't a float dtype, so we drop grad before swapping storage.
+    module.weight.requires_grad_(False)
+    module.weight.data = module.weight.data.to(torch.float8_e4m3fn)
+
 check_dtype_pattern(MODEL_ID, model)
 print_config_diff(MODEL_ID, model)
 push_to_hub(model, tokenizer, generation_config, "tiny", "0528")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-DeepseekV3ForCausalLM-0528": "refs/pr/1",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-DeepseekV3ForCausalLM-0528": "refs/pr/1",
+    "trl-internal-testing/tiny-DeepseekV3ForCausalLM-0528": "refs/pr/3",
 }
 
 
@@ -64,7 +64,7 @@ def apply_model_revisions(monkeypatch):
     if not MODEL_REVISIONS:
         return
 
-    from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
+    from transformers import AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
 
     def create_classmethod_wrapper(original_classmethod):
         # Extract the underlying function from the classmethod
@@ -83,11 +83,7 @@ def apply_model_revisions(monkeypatch):
         return classmethod(wrapper)
 
     # Patch all transformers Auto* classes
-    for cls in [
-        PreTrainedModel,
-        PreTrainedTokenizerBase,
-        ProcessorMixin,
-    ]:
+    for cls in [AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin]:
         monkeypatch.setattr(cls, "from_pretrained", create_classmethod_wrapper(cls.from_pretrained))
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the generated tiny model’s config (rope/quantization/extra kwargs) and mutates Linear weights/params to FP8 with new `weight_scale_inv`, which can impact serialization, loading, and dtype checks.
> 
> **Overview**
> Updates the `deepseek_v3_for_causal_lm_0528` tiny-model generator to more closely mirror `deepseek-ai/DeepSeek-R1-0528` by hardcoding the reference `vocab_size`, adding long-context `max_position_embeddings` + YaRN `rope_scaling`, and including an FP8 `quantization_config` plus additional reference-only config kwargs (while intentionally *not* forwarding `auto_map`).
> 
> After the smoke test, it now emulates the reference FP8 checkpoint layout by adding per-block (128x128) `weight_scale_inv` parameters to each `nn.Linear` (excluding `lm_head`) and casting their weights to `torch.float8_e4m3fn`. CI model-revision overrides are updated to point `trl-internal-testing/tiny-DeepseekV3ForCausalLM-0528` at `refs/pr/1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079cb665db5f9444d22844d2646f516d3019e0bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->