### PR TITLE
[feat, algo] Support RandOpt algo

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -131,6 +131,8 @@
     title: PPO
   - local: prm_trainer
     title: PRM
+  - local: randopt
+    title: RandOpt
   - local: sdft_trainer
     title: SDFT
   - local: sdpo_trainer

--- a/docs/source/randopt.md
+++ b/docs/source/randopt.md
@@ -1,0 +1,22 @@
+# RandOpt
+
+`RandOpt` provides a lightweight experimental implementation of random parameter-space search, inspired by perturbation
+sampling workflows where you evaluate many noisy model variants and keep the best performers.
+
+It is designed as a small utility that can be integrated with existing trainers and custom evaluation loops.
+
+## Experiment script
+
+An end-to-end GSM8K experiment script for RandOpt is available at:
+
+- `examples/scripts/randopt.py`
+
+The script is kept in `examples/` so the package module `trl.experimental.randopt` stays focused on reusable library APIs.
+
+## Core API
+
+[[autodoc]] experimental.randopt.RandOptConfig
+
+[[autodoc]] experimental.randopt.RandOptSearch
+
+[[autodoc]] experimental.randopt.majority_vote

--- a/examples/scripts/randopt.py
+++ b/examples/scripts/randopt.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime
+import json
+import multiprocessing as mp
+import os
+import random
+import re
+import time
+
+from datasets import load_dataset
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from trl.data_utils import maybe_apply_chat_template
+from trl.experimental.randopt import RandOptConfig, majority_vote
+from trl.experimental.sdpo.sdpo import _extract_predicted_answer, _make_conversation
+
+ANSWER_TAG_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", flags=re.IGNORECASE | re.DOTALL)
+HASH_ANSWER_RE = re.compile(r"####\s*([^\n]+)")
+NUMBER_RE = re.compile(r"-?\$?[0-9][0-9,]*(?:\.[0-9]+)?")
+_WORKER_STATE: dict = {}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="GSM8K RandOpt full experiment")
+    parser.add_argument("--model_name", type=str, default="Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--population_size", type=int, default=500)
+    parser.add_argument("--top_k", type=int, default=50)
+    parser.add_argument("--sigma_values", type=str, default="0.0001,0.0005,0.001,0.002")
+    parser.add_argument("--train_samples", type=int, default=200)
+    parser.add_argument("--test_samples", type=int, default=200)
+    parser.add_argument("--max_new_tokens", type=int, default=256)
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output_dir", type=str, default="logs")
+    parser.add_argument("--log_every", type=int, default=5)
+    parser.add_argument("--test_log_every", type=int, default=2)
+    parser.add_argument("--prompt_style", type=str, choices=["plain", "sdpo"], default="plain")
+    parser.add_argument("--num_workers", type=int, default=1, help="Number of parallel GPU workers for perturbation eval.")
+    return parser.parse_args()
+
+
+def build_prompt_texts(tokenizer, prompts: list[list[dict]], questions: list[str], prompt_style: str) -> list[str]:
+    if prompt_style == "sdpo":
+        return [maybe_apply_chat_template({"prompt": prompt}, tokenizer)["prompt"] for prompt in prompts]
+
+    # Plain prompt style keeps only user question and tends to be a stronger base-eval setting for instruct models.
+    prompt_texts: list[str] = []
+    for question in questions:
+        prompt = [{"role": "user", "content": question}]
+        prompt_texts.append(maybe_apply_chat_template({"prompt": prompt}, tokenizer)["prompt"])
+    return prompt_texts
+
+
+def generate_answers(model, tokenizer, prompt_texts: list[str], batch_size: int, max_new_tokens: int) -> list[str]:
+    out_texts: list[str] = []
+    model.eval()
+    for i in range(0, len(prompt_texts), batch_size):
+        batch_prompts = prompt_texts[i : i + batch_size]
+        inputs = tokenizer(
+            batch_prompts,
+            return_tensors="pt",
+            padding=True,
+            padding_side="left",
+            truncation=True,
+            add_special_tokens=False,
+        ).to(model.device)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                do_sample=False,
+                max_new_tokens=max_new_tokens,
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id,
+            )
+        new_tokens = outputs[:, inputs["input_ids"].shape[1] :]
+        out_texts.extend(tokenizer.batch_decode(new_tokens, skip_special_tokens=True))
+    return out_texts
+
+
+def _normalize_numeric_text(text: str | None) -> str:
+    if text is None:
+        return ""
+    cleaned = str(text).strip().replace("$", "").replace(",", "")
+    if not cleaned:
+        return ""
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return cleaned
+    if value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _extract_predicted_answer_robust(completion_text: str) -> str:
+    # First try TRL's native GSM8K extractor.
+    pred = _extract_predicted_answer(completion_text)
+    normalized = _normalize_numeric_text(pred)
+    if normalized:
+        return normalized
+
+    # If model outputs XML-like tags, prefer the last <answer>...</answer>.
+    tag_matches = ANSWER_TAG_RE.findall(completion_text)
+    if tag_matches:
+        nums = NUMBER_RE.findall(tag_matches[-1])
+        if nums:
+            return _normalize_numeric_text(nums[-1])
+        return _normalize_numeric_text(tag_matches[-1])
+
+    # If multiple "#### ..." segments exist, take the last one.
+    hash_matches = HASH_ANSWER_RE.findall(completion_text)
+    if hash_matches:
+        nums = NUMBER_RE.findall(hash_matches[-1])
+        if nums:
+            return _normalize_numeric_text(nums[-1])
+        return _normalize_numeric_text(hash_matches[-1])
+
+    # Final fallback: last number anywhere in completion.
+    nums = NUMBER_RE.findall(completion_text)
+    if nums:
+        return _normalize_numeric_text(nums[-1])
+    return ""
+
+
+def score_gsm8k_completions(completions: list[str], solutions: list[str]) -> tuple[float, int, list[str]]:
+    preds = [_extract_predicted_answer_robust(completion) for completion in completions]
+    normalized_solutions = [_normalize_numeric_text(solution) for solution in solutions]
+    correct = sum(
+        1
+        for pred, gold in zip(preds, normalized_solutions, strict=True)
+        if pred != "" and gold != "" and pred == gold
+    )
+    total = max(len(solutions), 1)
+    return correct / total, correct, preds
+
+
+@torch.no_grad()
+def _apply_noise_inplace(params: list[torch.nn.Parameter], seed: int, sigma: float):
+    generators: dict[torch.device, torch.Generator] = {}
+    for param in params:
+        device = param.device
+        if device not in generators:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(seed)
+            generators[device] = generator
+        noise = torch.randn(param.shape, generator=generators[device], device=device, dtype=param.dtype)
+        param.add_(noise, alpha=sigma)
+
+
+@torch.no_grad()
+def _restore_base_inplace(params: list[torch.nn.Parameter], base_state: list[torch.Tensor]):
+    for param, base in zip(params, base_state, strict=True):
+        param.copy_(base)
+
+
+def _worker_init(
+    model_name: str,
+    dtype_name: str,
+    visible_devices: list[str],
+    train_prompts: list[str],
+    train_solutions: list[str],
+    test_prompts: list[str],
+    test_solutions: list[str],
+    batch_size: int,
+    max_new_tokens: int,
+):
+    rank = max(0, mp.current_process()._identity[0] - 1) if mp.current_process()._identity else 0
+    local_device = rank % max(1, len(visible_devices))
+    torch.cuda.set_device(local_device)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+
+    dtype = torch.bfloat16 if dtype_name == "bfloat16" else torch.float32
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        dtype=dtype,
+        device_map={"": f"cuda:{local_device}"},
+    )
+    params = [param for param in model.parameters() if param.requires_grad and torch.is_floating_point(param)]
+    base_state = [param.detach().clone() for param in params]
+
+    _WORKER_STATE.update(
+        {
+            "tokenizer": tokenizer,
+            "model": model,
+            "params": params,
+            "base_state": base_state,
+            "train_prompts": train_prompts,
+            "train_solutions": train_solutions,
+            "test_prompts": test_prompts,
+            "test_solutions": test_solutions,
+            "batch_size": batch_size,
+            "max_new_tokens": max_new_tokens,
+            "local_device": local_device,
+        }
+    )
+
+
+def _worker_generate(prompt_texts: list[str]) -> list[str]:
+    tokenizer = _WORKER_STATE["tokenizer"]
+    model = _WORKER_STATE["model"]
+    batch_size = _WORKER_STATE["batch_size"]
+    max_new_tokens = _WORKER_STATE["max_new_tokens"]
+    return generate_answers(model, tokenizer, prompt_texts, batch_size=batch_size, max_new_tokens=max_new_tokens)
+
+
+def _worker_eval_train(task: tuple[int, float]) -> tuple[int, float, float]:
+    seed, sigma = task
+    params = _WORKER_STATE["params"]
+    base_state = _WORKER_STATE["base_state"]
+    with torch.no_grad():
+        _apply_noise_inplace(params, seed=seed, sigma=sigma)
+    outputs = _worker_generate(_WORKER_STATE["train_prompts"])
+    acc, _, _ = score_gsm8k_completions(outputs, _WORKER_STATE["train_solutions"])
+    with torch.no_grad():
+        _restore_base_inplace(params, base_state)
+    return seed, sigma, acc
+
+
+def _worker_eval_test(task: tuple[int, float]) -> tuple[int, float, float, list[str]]:
+    seed, sigma = task
+    params = _WORKER_STATE["params"]
+    base_state = _WORKER_STATE["base_state"]
+    with torch.no_grad():
+        _apply_noise_inplace(params, seed=seed, sigma=sigma)
+    outputs = _worker_generate(_WORKER_STATE["test_prompts"])
+    acc, _, preds = score_gsm8k_completions(outputs, _WORKER_STATE["test_solutions"])
+    with torch.no_grad():
+        _restore_base_inplace(params, base_state)
+    return seed, sigma, acc, preds
+
+
+def _worker_eval_base() -> tuple[float, int]:
+    outputs = _worker_generate(_WORKER_STATE["test_prompts"])
+    acc, correct, _ = score_gsm8k_completions(outputs, _WORKER_STATE["test_solutions"])
+    return acc, correct
+
+
+def _get_visible_devices() -> list[str]:
+    env_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if env_devices:
+        devices = [item.strip() for item in env_devices.split(",") if item.strip() != ""]
+        if devices:
+            return devices
+    return [str(i) for i in range(torch.cuda.device_count())]
+
+
+def run_experiment(args):
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = os.path.join(args.output_dir, f"gsm8k_pop{args.population_size}_top{args.top_k}_{ts}")
+    os.makedirs(run_dir, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+
+    print("[INFO] loading gsm8k dataset (trl/sdpo format)...", flush=True)
+    train_raw = load_dataset("openai/gsm8k", "main", split=f"train[:{args.train_samples}]")
+    test_raw = load_dataset("openai/gsm8k", "main", split=f"test[:{args.test_samples}]")
+    train_data = [dict(example) for example in train_raw]
+    test_data = [dict(example) for example in test_raw]
+    train_conv = [_make_conversation(example, feedback_column=None, feedback_from_solution="final_answer") for example in train_data]
+    test_conv = [_make_conversation(example, feedback_column=None, feedback_from_solution="final_answer") for example in test_data]
+    train_solutions = [example["solution"] for example in train_conv]
+    test_solutions = [example["solution"] for example in test_conv]
+    train_questions = [example["question"] for example in train_data]
+    test_questions = [example["question"] for example in test_data]
+    train_prompts = build_prompt_texts(
+        tokenizer, [example["prompt"] for example in train_conv], train_questions, args.prompt_style
+    )
+    test_prompts = build_prompt_texts(tokenizer, [example["prompt"] for example in test_conv], test_questions, args.prompt_style)
+    print(
+        f"[INFO] eval config: prompt_style={args.prompt_style} max_new_tokens={args.max_new_tokens} "
+        f"train_samples={args.train_samples} test_samples={args.test_samples}",
+        flush=True,
+    )
+
+    sigma_values = [float(x.strip()) for x in args.sigma_values.split(",") if x.strip()]
+    config = RandOptConfig(population_size=args.population_size, sigma_values=sigma_values, top_k=args.top_k, base_seed=args.seed)
+    rng = random.Random(args.seed)
+    candidate_tasks = [(args.seed + i, rng.choice(sigma_values)) for i in range(args.population_size)]
+
+    visible_devices = _get_visible_devices()
+    worker_count = min(args.num_workers, len(visible_devices), args.population_size)
+    if worker_count < 1:
+        raise RuntimeError("No CUDA devices available for RandOpt parallel execution.")
+
+    print(
+        f"[INFO] running RandOpt search in parallel: workers={worker_count} visible_devices={visible_devices}",
+        flush=True,
+    )
+    start_time = time.time()
+    perf: dict[tuple[int, float], float] = {}
+    ctx = mp.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=worker_count,
+        mp_context=ctx,
+        initializer=_worker_init,
+        initargs=(
+            args.model_name,
+            "bfloat16" if torch.cuda.is_available() else "float32",
+            visible_devices,
+            train_prompts,
+            train_solutions,
+            test_prompts,
+            test_solutions,
+            args.batch_size,
+            args.max_new_tokens,
+        ),
+    ) as pool:
+        print("[INFO] evaluating base model...", flush=True)
+        base_acc, base_correct = pool.submit(_worker_eval_base).result()
+        print(f"[BASE] test_acc={base_acc:.4f} ({base_correct}/{len(test_solutions)})", flush=True)
+
+        futures = [pool.submit(_worker_eval_train, task) for task in candidate_tasks]
+        for idx, future in enumerate(as_completed(futures), start=1):
+            seed, sigma, acc = future.result()
+            perf[(seed, sigma)] = acc
+            best_score = max(perf.values()) if perf else 0.0
+            if args.log_every > 0 and (idx % args.log_every == 0 or idx == 1 or idx == args.population_size):
+                elapsed = time.time() - start_time
+                speed = idx / elapsed if elapsed > 0 else 0.0
+                remain = (args.population_size - idx) / speed if speed > 0 else float("inf")
+                remain_str = f"{remain/60:.1f}m" if remain != float("inf") else "inf"
+                print(
+                    f"[RANDOPT] {idx}/{args.population_size} seed={seed} sigma={sigma} "
+                    f"train_score={acc:.4f} best={best_score:.4f} eta={remain_str}",
+                    flush=True,
+                )
+
+        sorted_items = sorted(perf.items(), key=lambda item: item[1], reverse=True)
+        top_candidate_pairs = [(seed, sigma) for (seed, sigma), _ in sorted_items[: config.top_k]]
+        top_candidate_scores = [score for _, score in sorted_items[: config.top_k]]
+
+        print(f"[INFO] search complete. kept top={len(top_candidate_pairs)}", flush=True)
+        test_futures = [pool.submit(_worker_eval_test, task) for task in top_candidate_pairs]
+        test_map: dict[tuple[int, float], tuple[float, list[str]]] = {}
+        test_start_time = time.time()
+        total_test = len(top_candidate_pairs)
+        for idx, future in enumerate(as_completed(test_futures), start=1):
+            seed, sigma, acc, preds = future.result()
+            test_map[(seed, sigma)] = (acc, preds)
+            if args.test_log_every > 0 and (idx % args.test_log_every == 0 or idx == 1 or idx == total_test):
+                elapsed = time.time() - test_start_time
+                speed = idx / elapsed if elapsed > 0 else 0.0
+                remain = (total_test - idx) / speed if speed > 0 else float("inf")
+                remain_str = f"{remain/60:.1f}m" if remain != float("inf") else "inf"
+                print(
+                    f"[TOPK-EVAL] {idx}/{total_test} seed={seed} sigma={sigma} "
+                    f"test_acc={acc:.4f} eta={remain_str}",
+                    flush=True,
+                )
+
+    # Evaluate top-k candidates on test split and majority-vote ensembles at K={1,5,10,20,50}
+    model_answers: list[list[str]] = []
+    top_candidates = []
+    for rank, ((seed, sigma), train_score) in enumerate(zip(top_candidate_pairs, top_candidate_scores, strict=True), start=1):
+        test_acc, preds = test_map[(seed, sigma)]
+        model_answers.append(preds)
+        top_candidates.append({"rank": rank, "seed": seed, "sigma": sigma, "train_score": train_score})
+        print(
+            f"[CANDIDATE {rank:03d}] seed={seed} sigma={sigma} train_score={train_score:.4f} test_acc={test_acc:.4f}",
+            flush=True,
+        )
+
+    k_values = list(dict.fromkeys([1, 5, 10, 20, args.top_k]))
+    k_values = [k for k in k_values if k <= len(model_answers)]
+    ensemble_results = {}
+    for k in k_values:
+        voted = majority_vote(model_answers, k=k, empty_answer="")
+        normalized_solutions = [_normalize_numeric_text(solution) for solution in test_solutions]
+        correct = sum(
+            1
+            for pred, gold in zip(voted, normalized_solutions, strict=True)
+            if pred != "" and gold != "" and pred == gold
+        )
+        acc = correct / len(test_solutions)
+        ensemble_results[str(k)] = {"acc": acc, "correct": int(correct), "total": len(test_solutions)}
+        print(f"[ENSEMBLE K={k}] test_acc={acc:.4f} ({correct}/{len(test_solutions)})", flush=True)
+
+    results = {
+        "args": vars(args),
+        "base_test_acc": base_acc,
+        "top_candidates": top_candidates,
+        "ensemble_results": ensemble_results,
+    }
+    result_path = os.path.join(run_dir, "results.json")
+    with open(result_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+    print(f"[DONE] results saved to {result_path}", flush=True)
+
+
+if __name__ == "__main__":
+    run_experiment(parse_args())

--- a/tests/experimental/test_randopt.py
+++ b/tests/experimental/test_randopt.py
@@ -1,0 +1,72 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from trl.experimental.randopt import RandOptConfig, RandOptSearch, majority_vote
+
+
+def test_randopt_run_returns_sorted_candidates_and_restores_parameters():
+    model = torch.nn.Linear(4, 2, bias=False)
+    initial_weight = model.weight.detach().clone()
+
+    def score_fn(current_model: torch.nn.Module) -> float:
+        weight_norm = current_model.weight.norm().item()
+        # Higher score for smaller norm to make ranking deterministic enough.
+        return -weight_norm
+
+    config = RandOptConfig(population_size=8, sigma_values=[1e-4, 5e-4], top_k=3, base_seed=123)
+    search = RandOptSearch(model=model, score_fn=score_fn, config=config)
+    all_candidates, top_candidates = search.run()
+
+    assert len(all_candidates) == 8
+    assert len(top_candidates) == 3
+    assert all_candidates == sorted(all_candidates, key=lambda candidate: candidate.score, reverse=True)
+    assert top_candidates == all_candidates[:3]
+
+    # Model must be restored after search.
+    assert torch.allclose(model.weight, initial_weight)
+
+
+def test_randopt_parameter_filter():
+    model = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 2))
+    config = RandOptConfig(population_size=4, sigma_values=[1e-3], top_k=1, base_seed=0)
+    search = RandOptSearch(
+        model=model,
+        score_fn=lambda _: 0.0,
+        config=config,
+        parameter_filter=lambda name, _: "0.weight" in name,
+    )
+    assert len(search._params) == 1
+    assert search._params[0][0] == "0.weight"
+
+
+def test_majority_vote():
+    answers = [
+        ["a", "x", ""],
+        ["a", "y", ""],
+        ["b", "x", ""],
+    ]
+    assert majority_vote(answers) == ["a", "x", ""]
+    assert majority_vote(answers, k=2) == ["a", "x", ""]
+
+
+def test_majority_vote_rejects_mismatched_lengths():
+    answers = [["a", "b"], ["a"]]
+    try:
+        majority_vote(answers)
+    except ValueError as error:
+        assert "same length" in str(error)
+    else:
+        raise AssertionError("majority_vote should reject ragged input.")

--- a/trl/experimental/randopt/__init__.py
+++ b/trl/experimental/randopt/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .randopt import RandOptCandidate, RandOptConfig, RandOptSearch, majority_vote
+
+__all__ = ["RandOptCandidate", "RandOptConfig", "RandOptSearch", "majority_vote"]

--- a/trl/experimental/randopt/randopt.py
+++ b/trl/experimental/randopt/randopt.py
@@ -1,0 +1,218 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import random
+from typing import Callable
+
+import torch
+
+
+@dataclass(frozen=True)
+class RandOptCandidate:
+    """A single perturbation candidate evaluated by RandOpt."""
+
+    seed: int
+    sigma: float
+    score: float
+
+
+@dataclass
+class RandOptConfig:
+    r"""
+    Configuration for random parameter-space search.
+
+    Args:
+        population_size (`int`, *optional*, defaults to `32`):
+            Number of perturbations to evaluate.
+        sigma_values (`list[float]`, *optional*, defaults to `[1e-4, 5e-4, 1e-3]`):
+            Candidate standard deviations used for Gaussian perturbations.
+        top_k (`int`, *optional*, defaults to `4`):
+            Number of top perturbations kept after evaluation.
+        base_seed (`int`, *optional*, defaults to `0`):
+            Base random seed used to derive perturbation seeds.
+    """
+
+    population_size: int = 32
+    sigma_values: list[float] | None = None
+    top_k: int = 4
+    base_seed: int = 0
+
+    def __post_init__(self):
+        if self.sigma_values is None:
+            self.sigma_values = [1e-4, 5e-4, 1e-3]
+        if self.population_size < 1:
+            raise ValueError("`population_size` must be >= 1.")
+        if not self.sigma_values:
+            raise ValueError("`sigma_values` must contain at least one value.")
+        if any(sigma <= 0 for sigma in self.sigma_values):
+            raise ValueError("All `sigma_values` must be > 0.")
+        if self.top_k < 1:
+            raise ValueError("`top_k` must be >= 1.")
+        if self.top_k > self.population_size:
+            raise ValueError("`top_k` must be <= `population_size`.")
+
+
+class RandOptSearch:
+    r"""
+    Random parameter perturbation search with deterministic restore semantics.
+
+    The algorithm evaluates `population_size` perturbed model copies (in-place perturb, score, restore) and returns the
+    top-k perturbation descriptors.
+
+    Args:
+        model (`torch.nn.Module`):
+            Model whose parameters are perturbed in-place.
+        score_fn (`Callable[[torch.nn.Module], float]`):
+            Scoring function where higher is better.
+        config ([`RandOptConfig`], *optional*):
+            RandOpt configuration.
+        parameter_filter (`Callable[[str, torch.nn.Parameter], bool]`, *optional*):
+            Predicate selecting parameters to perturb. Defaults to all trainable floating-point parameters.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        score_fn: Callable[[torch.nn.Module], float],
+        config: RandOptConfig | None = None,
+        parameter_filter: Callable[[str, torch.nn.Parameter], bool] | None = None,
+    ):
+        self.model = model
+        self.score_fn = score_fn
+        self.config = config or RandOptConfig()
+        self.parameter_filter = parameter_filter
+        self._params = self._collect_params()
+        if not self._params:
+            raise ValueError("No eligible parameters found for perturbation.")
+
+    def _collect_params(self) -> list[tuple[str, torch.nn.Parameter]]:
+        params: list[tuple[str, torch.nn.Parameter]] = []
+        for name, param in self.model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if not torch.is_floating_point(param):
+                continue
+            if self.parameter_filter is not None and not self.parameter_filter(name, param):
+                continue
+            params.append((name, param))
+        return params
+
+    @torch.no_grad()
+    def _apply_noise(self, seed: int, sigma: float):
+        generators: dict[torch.device, torch.Generator] = {}
+        for _, param in self._params:
+            device = param.device
+            if device not in generators:
+                generator = torch.Generator(device=device)
+                generator.manual_seed(seed)
+                generators[device] = generator
+            noise = torch.randn(
+                param.shape,
+                generator=generators[device],
+                device=device,
+                dtype=param.dtype,
+            )
+            param.add_(noise, alpha=sigma)
+
+    @torch.no_grad()
+    def _save_state(self) -> dict[str, torch.Tensor]:
+        return {name: param.detach().clone() for name, param in self._params}
+
+    @torch.no_grad()
+    def _restore_state(self, state: dict[str, torch.Tensor]):
+        for name, param in self._params:
+            param.copy_(state[name])
+
+    def run(
+        self,
+        progress_callback: Callable[[int, int, RandOptCandidate, float], None] | None = None,
+        log_every: int | None = None,
+    ) -> tuple[list[RandOptCandidate], list[RandOptCandidate]]:
+        """
+        Returns:
+            tuple:
+                - all candidates sorted by score (descending)
+                - top-k candidates
+        """
+        rng = random.Random(self.config.base_seed)
+        base_state = self._save_state()
+        candidates: list[RandOptCandidate] = []
+
+        try:
+            for i in range(self.config.population_size):
+                seed = self.config.base_seed + i
+                sigma = rng.choice(self.config.sigma_values)
+                self._apply_noise(seed=seed, sigma=sigma)
+                score = float(self.score_fn(self.model))
+                candidate = RandOptCandidate(seed=seed, sigma=sigma, score=score)
+                candidates.append(candidate)
+                best_score = max(c.score for c in candidates)
+                if progress_callback is not None:
+                    progress_callback(i + 1, self.config.population_size, candidate, best_score)
+                elif log_every is not None and log_every > 0 and (i + 1) % log_every == 0:
+                    print(
+                        f"[RANDOPT] {i + 1}/{self.config.population_size} "
+                        f"seed={seed} sigma={sigma} score={score:.4f} best={best_score:.4f}",
+                        flush=True,
+                    )
+                self._restore_state(base_state)
+        finally:
+            # Defensive restore for exception safety.
+            self._restore_state(base_state)
+
+        candidates.sort(key=lambda candidate: candidate.score, reverse=True)
+        return candidates, candidates[: self.config.top_k]
+
+
+def majority_vote(
+    model_answers: list[list[str]],
+    k: int | None = None,
+    empty_answer: str = "",
+) -> list[str]:
+    """
+    Aggregate answer strings with per-example majority voting.
+
+    Args:
+        model_answers (`list[list[str]]`):
+            `model_answers[m][i]` is answer from model `m` on example `i`.
+        k (`int` or `None`, *optional*, defaults to `None`):
+            Number of leading models to include. Uses all models when `None`.
+        empty_answer (`str`, *optional*, defaults to `""`):
+            Placeholder for missing/invalid answers.
+    """
+    if not model_answers:
+        return []
+    num_examples = len(model_answers[0])
+    if any(len(answers) != num_examples for answers in model_answers):
+        raise ValueError("All model answer lists must have the same length.")
+
+    if k is None:
+        selected = model_answers
+    else:
+        if k < 1:
+            raise ValueError("`k` must be >= 1 when provided.")
+        selected = model_answers[: min(k, len(model_answers))]
+
+    aggregated: list[str] = []
+    for idx in range(num_examples):
+        votes = [answers[idx] for answers in selected if answers[idx] != empty_answer]
+        if not votes:
+            aggregated.append(empty_answer)
+            continue
+        aggregated.append(Counter(votes).most_common(1)[0][0])
+    return aggregated


### PR DESCRIPTION
# What does this PR do?

Add support for the [RandOpt (ICML 2026 Spotlight)](https://arxiv.org/pdf/2603.12228) algorithm based on Gaussian random search and ensembling, along with tests and documentation. Add a reproducible GSM8K evaluation script under examples while keeping library code isolated in trl.experimental.randopt.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.
## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

## Test Results

**Command:**
```bash
python examples/scripts/randopt.py \
  --population_size 100 \
  --top_k 50 \
  --model_name Qwen/Qwen2.5-3B-Instruct \
  --train_samples 50 \
  --test_samples 200 \
  --max_new_tokens 512 \
  --batch_size 128 \
  --seed 42 \
  --output_dir logs \
  --log_every 8 \
  --prompt_style plain \
  --num_workers 8
```

[INFO] loading gsm8k dataset (trl/sdpo format)...
[INFO] eval config: prompt_style=plain max_new_tokens=512 train_samples=50 test_samples=200
[INFO] running RandOpt search in parallel: workers=8 visible_devices=['0', '1', '2', '3', '4', '5', '6', '7']
[INFO] evaluating base model...
[BASE] test_acc=0.7600 (152/200)
[RANDOPT] 1/100 seed=42 sigma=0.0001 train_score=0.9000 best=0.9000 eta=371.9m
...
[RANDOPT] 100/100 seed=141 sigma=0.002 train_score=0.8000 best=0.9200 eta=0.0m
[INFO] search complete. kept top=50
[CANDIDATE 001] seed=54 sigma=0.0005 train_score=0.9200 test_acc=0.7600
...
[CANDIDATE 050] seed=120 sigma=0.002 train_score=0.8800 test_acc=0.7800

[ENSEMBLE K=1] test_acc=0.7600 (152/200)
[ENSEMBLE K=5] test_acc=0.7900 (158/200)
[ENSEMBLE K=10] test_acc=0.8000 (160/200)
[ENSEMBLE K=20] test_acc=0.8050 (161/200)

[DONE] results saved to logs/gsm8k_pop100_top50_20260506_213402/results.json



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are additive and isolated under `trl.experimental` plus docs/examples, with unit tests covering parameter restore and voting behavior.
> 
> **Overview**
> Adds a new experimental `trl.experimental.randopt` module implementing `RandOptSearch` (Gaussian parameter perturbation search with deterministic restore semantics) and a `majority_vote` helper for ensembling model answers.
> 
> Includes a reproducible multi-GPU GSM8K evaluation script (`examples/scripts/randopt.py`), unit tests for candidate ranking/restore behavior and voting edge cases, and wires new `RandOpt` docs into the Experimental docs toctree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe4c809f5b38da2d56d948f358c680ecc79ae6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->