### PR TITLE
feat: add Falcon Mamba training chat templates with generation markers

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -467,6 +467,7 @@ class TestIsChatTemplatePrefixPreserving:
                 reason="Qwen3.5 tokenizer requires transformers>=5.0.0",
             ),
         ),
+        pytest.param("trl-internal-testing/tiny-FalconMambaForCausalLM", id="falconmamba"),
     ],
 )
 class TestGetTrainingChatTemplate:

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -343,6 +343,8 @@ qwen3_5_chat_template_4b_and_above = (_CHAT_TEMPLATES_DIR / "qwen3_5_4b_and_abov
 
 qwen3_6_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6.jinja").read_text()
 
+falconmamba_chat_template = (_CHAT_TEMPLATES_DIR / "falconmamba.jinja").read_text()
+
 
 ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizerBase, ProcessorMixin)
 
@@ -564,6 +566,8 @@ qwen3_instruct_2507_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_instr
 
 qwen3_6_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6_training.jinja").read_text()
 
+falconmamba_training_chat_template = (_CHAT_TEMPLATES_DIR / "falconmamba_training.jinja").read_text()
+
 
 def get_training_chat_template(
     processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
@@ -575,7 +579,7 @@ def get_training_chat_template(
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
     Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Qwen2.5,
-    Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
+    Qwen3 (including the Instruct-2507 variant), Qwen3.6 and Falcon Mamba are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -679,6 +683,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == qwen3_6_chat_template:
         return qwen3_6_training_chat_template
+    
+    if processing_class.chat_template == falconmamba_chat_template:
+        return falconmamba_training_chat_template
 
     raise ValueError(
         "The chat template is not training-compatible (missing prefix-preservation or `{% generation %}` markers) "

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -73,6 +73,10 @@ Original Qwen3.5 chat templates.
 
 Original Qwen3.6 chat template (shared across `Qwen3.6-27B`, `Qwen3.6-35B-A3B`, and their FP8 variants). Differs from `qwen3_5_4b_and_above.jinja` by adding a `preserve_thinking` flag and tweaking how non-string tool-call argument values are stringified.
 
+### `falconmamba.jinja.jinja`
+
+Original Falcon Mamba chat template.
+
 ## Training templates
 
 Patched templates that fix training-specific issues. Swapped in at init when tools are enabled (GRPO) or when `assistant_only_loss=True` (SFT).
@@ -175,3 +179,10 @@ Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so
 ### `qwen3_6_training.jinja`
 
 Patched Qwen3.6 template. Same diff as `qwen3_training.jinja` (require both `<think>` and `</think>` before parsing, drop the `loop.index0 > ns.last_query_index` conditional so the thinking block is always emitted, wrap assistant output in `{% generation %}` / `{% endgeneration %}`), applied to the Qwen3.6 base template.
+
+
+### `falconmamba_training.jinja`
+
+Patched Falcon Mamba template. Diff vs `falconmamba.jinja`:
+
+Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.

--- a/trl/chat_templates/falconmamba.jinja
+++ b/trl/chat_templates/falconmamba.jinja
@@ -1,0 +1,17 @@
+{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = '' %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 %}{{ system_message.strip() }}{% endif %}{% if message['role'] == 'user' %}{{ '
+
+User: ' + message['content'].strip().replace('
+', '
+').replace('
+
+', '
+') }}{% elif message['role'] == 'assistant' %}{{ '
+
+Assistant: ' + message['content'].strip().replace('
+', '
+').replace('
+
+', '
+') }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '
+
+Assistant:' }}{% endif %}

--- a/trl/chat_templates/falconmamba_training.jinja
+++ b/trl/chat_templates/falconmamba_training.jinja
@@ -1,0 +1,16 @@
+{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = '' %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 %}{{ system_message.strip() }}{% endif %}{% if message['role'] == 'user' %}{{ '
+
+User: ' + message['content'].strip().replace('
+', '
+').replace('
+
+', '
+') }}{% elif message['role'] == 'assistant' %}{{'\n'}}{% generation %}{{ '
+Assistant: ' + message['content'].strip().replace('
+', '
+').replace('
+
+', '
+') }}{% endgeneration %}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '
+
+Assistant:' }}{% endif %}


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

contributing to #5471 

Adds a training-compatible variant of the Falcon Mamba chat template with `{% generation %} / {% endgeneration %}` markers, enabling `return_assistant_tokens_mask=True` for assistant-only loss masking in SFT training.

-`falconmamba.jinja`: template from `tiiuae/falcon-7b-instruct`
-`falconmamba_training.jinja`: modified the falconmamba.jinja to turn the training chat template
-`get_training_chat_template`: registered falcon mamba
-`tests/test_chat_template_utils.py`: added param `"trl-internal-testing/tiny-FalconMambaForCausalLM", id="falconmamba"`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? https://github.com/huggingface/trl/issues/5471
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?
@qgallouedec (opened #5471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new model-specific training template and registration path without changing existing template behavior, aside from minor doc updates and expanded test coverage.
> 
> **Overview**
> Adds Falcon Mamba support to `get_training_chat_template` by introducing `falconmamba.jinja` and a patched `falconmamba_training.jinja` that wraps assistant output in `{% generation %}` / `{% endgeneration %}` for correct `return_assistant_tokens_mask` behavior.
> 
> Updates docs to describe the new templates and expands `TestGetTrainingChatTemplate` to include the Falcon Mamba tiny tokenizer in the parameterized suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b4150ace8207ecaa456f2e9640faee239f5974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->