### PR TITLE
[GKD] Fix seq kd wasted teacher forward

### DIFF
--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -280,6 +280,48 @@ class TestGKDTrainer(TrlTestCase):
         assert trainer.generation_config.temperature == training_args.temperature
         assert trainer.generation_config.top_k == 0
 
+    def test_seq_kd_does_not_waste_teacher_generation_when_lmbda_is_one(self):
+        """
+        With `seq_kd=True` and `lmbda=1.0`, the student-generation branch fires every step, so the teacher
+        generation must never run (otherwise it would be silently overwritten by the student output).
+        """
+        training_args = GKDConfig(
+            output_dir=self.tmp_dir,
+            dataloader_drop_last=True,
+            max_steps=2,
+            per_device_train_batch_size=2,
+            report_to="none",
+            seq_kd=True,
+            lmbda=1.0,
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+
+        trainer = GKDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+
+        teacher_calls = 0
+        student_calls = 0
+        original = trainer.generate_on_policy_outputs
+
+        def counting_generate(unwrapped_model, *args, **kwargs):
+            nonlocal teacher_calls, student_calls
+            if unwrapped_model is trainer.teacher_model:
+                teacher_calls += 1
+            else:
+                student_calls += 1
+            return original(unwrapped_model, *args, **kwargs)
+
+        trainer.generate_on_policy_outputs = counting_generate
+        trainer.train()
+
+        assert teacher_calls == 0, "teacher generation must not run when student branch fires (lmbda=1.0)"
+        assert student_calls > 0, "student generation should run on every step at lmbda=1.0"
+
     @require_liger_kernel
     def test_compute_loss_return_outputs_with_liger(self):
         """Test that return_outputs=True works correctly with Liger kernel path."""

--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -280,48 +280,6 @@ class TestGKDTrainer(TrlTestCase):
         assert trainer.generation_config.temperature == training_args.temperature
         assert trainer.generation_config.top_k == 0
 
-    def test_seq_kd_does_not_waste_teacher_generation_when_lmbda_is_one(self):
-        """
-        With `seq_kd=True` and `lmbda=1.0`, the student-generation branch fires every step, so the teacher
-        generation must never run (otherwise it would be silently overwritten by the student output).
-        """
-        training_args = GKDConfig(
-            output_dir=self.tmp_dir,
-            dataloader_drop_last=True,
-            max_steps=2,
-            per_device_train_batch_size=2,
-            report_to="none",
-            seq_kd=True,
-            lmbda=1.0,
-        )
-        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
-
-        trainer = GKDTrainer(
-            model=self.model_id,
-            teacher_model=self.model_id,
-            args=training_args,
-            train_dataset=dataset,
-            processing_class=self.tokenizer,
-        )
-
-        teacher_calls = 0
-        student_calls = 0
-        original = trainer.generate_on_policy_outputs
-
-        def counting_generate(unwrapped_model, *args, **kwargs):
-            nonlocal teacher_calls, student_calls
-            if unwrapped_model is trainer.teacher_model:
-                teacher_calls += 1
-            else:
-                student_calls += 1
-            return original(unwrapped_model, *args, **kwargs)
-
-        trainer.generate_on_policy_outputs = counting_generate
-        trainer.train()
-
-        assert teacher_calls == 0, "teacher generation must not run when student branch fires (lmbda=1.0)"
-        assert student_calls > 0, "student generation should run on every step at lmbda=1.0"
-
     @require_liger_kernel
     def test_compute_loss_return_outputs_with_liger(self):
         """Test that return_outputs=True works correctly with Liger kernel path."""

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -426,8 +426,7 @@ class GKDTrainer(SFTTrainer):
 
         This method implements the on-policy learning approach described in the GKD paper. With probability
         `self.lmbda`, it generates new responses using the student model, which are then used for training instead of
-        the original inputs. Otherwise, when `self.seq_kd` is enabled, it falls back to teacher-generated sequences
-        (sequence-level KD); without `seq_kd`, the original dataset inputs are kept.
+        the original inputs.
         """
         if random.random() <= self.lmbda:
             with (

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -426,12 +426,13 @@ class GKDTrainer(SFTTrainer):
 
         This method implements the on-policy learning approach described in the GKD paper. With probability
         `self.lmbda`, it generates new responses using the student model, which are then used for training instead of
-        the original inputs.
+        the original inputs. Otherwise, when `self.seq_kd` is enabled, it falls back to teacher-generated sequences
+        (sequence-level KD); without `seq_kd`, the original dataset inputs are kept.
         """
-        if self.seq_kd:
+        if random.random() <= self.lmbda:
             with (
                 unwrap_model_for_generation(
-                    self.teacher_model,
+                    model,
                     self.accelerator,
                     generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model
@@ -442,10 +443,10 @@ class GKDTrainer(SFTTrainer):
             inputs["input_ids"] = new_input_ids
             inputs["attention_mask"] = new_attention_mask
             inputs["labels"] = new_labels
-        if random.random() <= self.lmbda:
+        elif self.seq_kd:
             with (
                 unwrap_model_for_generation(
-                    model,
+                    self.teacher_model,
                     self.accelerator,
                     generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model


### PR DESCRIPTION
# What does this PR do?

When `seq_kd=True`, GKDTrainer always ran teacher generation, then the student-generation overwrote it. With `lmbda=1.0` the teacher's output was 100% wasted. With the default `lmbda=0.5`, ~50% wasted

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@kashif @qgallouedec @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the control flow in `GKDTrainer.training_step`, which affects which model generates training targets and when; a mistake here could silently alter training data and convergence behavior.
> 
> **Overview**
> Fixes `GKDTrainer.training_step` so on-policy generation is prioritized: when `random.random() <= lmbda`, the **student** generates new sequences; otherwise, if `seq_kd` is enabled, the **teacher** generates them.
> 
> This replaces the previous ordering where `seq_kd` generation could run and then be overwritten by the on-policy path, avoiding wasted teacher generation compute (especially when `lmbda` is high).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36198426a3b18b743a2b929d1438551f2f64915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->