### PR TITLE
Add Qwen2.5 response schema

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -748,6 +748,7 @@ Tested with:
 - [**GPT-OSS**](https://huggingface.co/collections/openai/gpt-oss) — e.g., `openai/gpt-oss-20b`
 - [**Llama 3.1**](https://huggingface.co/collections/meta-llama/llama-31) — e.g., `meta-llama/Llama-3.1-8B-Instruct`
 - [**Llama 3.2**](https://huggingface.co/collections/meta-llama/llama-32) — e.g., `meta-llama/Llama-3.2-3B-Instruct`
+- [**Qwen2.5**](https://huggingface.co/collections/Qwen/qwen25) — e.g., `Qwen/Qwen2.5-0.5B-Instruct`
 - [**Qwen3**](https://huggingface.co/collections/Qwen/qwen3) — e.g., `Qwen/Qwen3-0.6B`
 - [**Qwen3-VL**](https://huggingface.co/collections/Qwen/qwen3-vl) — e.g., `Qwen/Qwen3-VL-2B-Instruct`
 - [**Qwen3.5**](https://huggingface.co/collections/Qwen/qwen35) — e.g., `Qwen/Qwen3.5-2B`

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -127,6 +127,7 @@ class TestAddResponseSchema:
             pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
+            pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
             pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
             pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
         ],
@@ -668,6 +669,7 @@ class TestGetTrainingChatTemplate:
         pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
+        pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
         pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
@@ -731,6 +733,7 @@ class TestParseResponse:
             "trl-internal-testing/tiny-GptOssForCausalLM",
             "trl-internal-testing/tiny-LlamaForCausalLM-3.1",
             "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
+            "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             "trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507",
             "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration",
         ):

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -393,7 +393,12 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
         tokenizer.response_schema = gptoss_schema
     elif chat_template in [llama3_1_chat_template, llama3_2_chat_template]:
         tokenizer.response_schema = llama3_schema
-    elif chat_template in [qwen3_chat_template, qwen3_instruct_2507_chat_template, qwen3_vl_chat_template]:
+    elif chat_template in [
+        qwen2_5_chat_template,
+        qwen3_chat_template,
+        qwen3_instruct_2507_chat_template,
+        qwen3_vl_chat_template,
+    ]:
         tokenizer.response_schema = qwen3_schema
     elif chat_template in [
         qwen3_5_chat_template_2b_and_below,


### PR DESCRIPTION
# What does this PR do?

Adds Qwen2.5 (text) support to `add_response_schema`.

Qwen2.5 emits tool calls in the same Hermes format as Qwen3
(`<tool_call>\n{json}\n</tool_call><|im_end|>` with `tojson` arguments), so this
extends the existing `qwen3_schema` dispatch arm rather than introducing a new
schema — same reuse pattern as #5469 (Qwen3-VL) and #5574 (Qwen3-Instruct-2507).
The bundled `qwen2_5.jinja` is already in place from #5522.

**Changes:**
- `trl/chat_template_utils.py`: add `qwen2_5_chat_template` to the `qwen3_schema` dispatch arm.
- `tests/test_chat_template_utils.py`: add Qwen2.5 to `TestAddResponseSchema` and `TestParseResponse` parametrize lists; skip the reasoning_content test (no thinking block).
- `docs/source/grpo_trainer.md`: list Qwen2.5 under Agent Training "Tested with".

**Out of scope:** Qwen2-VL / Qwen2.5-VL — these need a tool-capable bundled template authored first (analogous to `qwen3_vl.jinja` from #5469), since the upstream defaults don't render tool calls. Planning a follow-up PR for this.

Part of #5460.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small dispatch/list updates plus test/doc coverage; no changes to core parsing logic beyond enabling an existing schema for an additional template.
> 
> **Overview**
> Adds **Qwen2.5 (text)** support to `add_response_schema` by routing the `qwen2_5_chat_template` through the existing `qwen3_schema` response-parsing path.
> 
> Updates `test_chat_template_utils.py` to include a tiny Qwen2.5 model in `TestAddResponseSchema`/`TestParseResponse` parametrizations (and skips inline `reasoning_content` expectations for it), and documents Qwen2.5 as a tested model in `grpo_trainer.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22729d19f6edfb6b06a68c3e8d713657f240bd51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->