### PR TITLE
Fix:OffloadActivations cross-step state to prevent VRAM leak

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -540,8 +540,7 @@ class OffloadActivations(saved_tensors_hooks):
         # Drop stale state from any prior step where saved tensors didn't unpack
         # (e.g. MoE expert paths under torch.compile). is_first_forward_call only
         # resets when tracker empties during backward, so leaked entries pin GPU
-        # memory across iterations -> linear VRAM leak (axolotl #3638). Backward
-        # has completed by the time we re-enter, so anything still here is dead.
+        # memory across iterations -> linear VRAM leak
         self.tracker.clear()
         self.storage_to_tensor_id.clear()
         if self.use_streams:

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -536,6 +536,22 @@ class OffloadActivations(saved_tensors_hooks):
         unpack_tensor = unpack_tensor_with_streams if self.use_streams else unpack_tensor_single_stream
         super().__init__(pack_tensor, unpack_tensor)
 
+    def __enter__(self):
+        # Drop stale state from any prior step where saved tensors didn't unpack
+        # (e.g. MoE expert paths under torch.compile). is_first_forward_call only
+        # resets when tracker empties during backward, so leaked entries pin GPU
+        # memory across iterations -> linear VRAM leak (axolotl #3638). Backward
+        # has completed by the time we re-enter, so anything still here is dead.
+        self.tracker.clear()
+        self.storage_to_tensor_id.clear()
+        if self.use_streams:
+            self.fwd_stash.clear()
+            self.bwd_tensor_stash.clear()
+            self.bwd_ev_stash.clear()
+        self.is_first_forward_call = True
+        self.is_first_backward_call = True
+        return super().__enter__()
+
     def update_model_params(self, model: nn.Module):
         """
         Update the set of parameter storage pointers from the model. This allows filtering out model parameters during


### PR DESCRIPTION
clear `OffloadActivations` cross-step state to prevent VRAM leak

### Problem

`OffloadActivations` keeps mutable state across forward/backward (`tracker`, `storage_to_tensor_id`, `fwd_stash`, `bwd_tensor_stash`, `bwd_ev_stash`, plus `is_first_forward_call` / `is_first_backward_call`). The state-reset path is gated on `tracker` becoming empty during the unpack of the last saved tensor:


If even one saved tensor never unpacks during backward its autograd node never executes — the reset never fires. On the next forward pass:

This reliably triggers under MoE + sample-packing + torch.compile (e.g. Gemma-4 26B-A4B with ScatterMoE), where dynamic expert routing means some saved tensors live on subgraphs that never contribute to the loss, and AOTAutograd-saved metadata can include tensors whose backward path never runs. 


Originally reported in axolotl-ai-cloud/axolotl#3638 with google/gemma-4-26B-A4B + QLoRA.

## Fix
Override __enter__ to clear cross-step state before re-using the same instance:


## Test plan
 Reproduces leak on google/gemma-4-26B-A4B QLoRA config without fix (OOM by step 2 / 9 GiB/step growth).
 With fix: tracker == 0 at the start of every training step over 200+ consecutive steps.
 VRAM steady-state flat (17.73 ↔ 18.76 GiB working-set oscillation, no monotonic growth).
 Loss / grad-norm trajectory unchanged vs. control runs without activation_offloading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activation offloading lifecycle by clearing internal tracking/stash state on `__enter__`, which could affect edge cases relying on persisted state across nested/reused contexts. Impact is localized but touches memory/stream management used during training.
> 
> **Overview**
> Fixes a **cross-step VRAM leak** in `OffloadActivations` when some saved tensors never reach the unpack path (e.g., dynamic MoE routes under `torch.compile`).
> 
> Adds an `__enter__` override that clears stale per-step state (`tracker`, `storage_to_tensor_id`, and stream stashes when enabled) and resets first-call flags before installing `saved_tensors_hooks`, ensuring each training step starts from a clean activation-offload bookkeeping state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c77a2b4b72ca888d1817a5803ce6690401df265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->