### PR TITLE
cleanup vram

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -540,8 +540,7 @@ class OffloadActivations(saved_tensors_hooks):
         # Drop stale state from any prior step where saved tensors didn't unpack
         # (e.g. MoE expert paths under torch.compile). is_first_forward_call only
         # resets when tracker empties during backward, so leaked entries pin GPU
-        # memory across iterations -> linear VRAM leak (axolotl #3638). Backward
-        # has completed by the time we re-enter, so anything still here is dead.
+        # memory across iterations -> linear VRAM leak
         self.tracker.clear()
         self.storage_to_tensor_id.clear()
         if self.use_streams:

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -536,6 +536,22 @@ class OffloadActivations(saved_tensors_hooks):
         unpack_tensor = unpack_tensor_with_streams if self.use_streams else unpack_tensor_single_stream
         super().__init__(pack_tensor, unpack_tensor)
 
+    def __enter__(self):
+        # Drop stale state from any prior step where saved tensors didn't unpack
+        # (e.g. MoE expert paths under torch.compile). is_first_forward_call only
+        # resets when tracker empties during backward, so leaked entries pin GPU
+        # memory across iterations -> linear VRAM leak (axolotl #3638). Backward
+        # has completed by the time we re-enter, so anything still here is dead.
+        self.tracker.clear()
+        self.storage_to_tensor_id.clear()
+        if self.use_streams:
+            self.fwd_stash.clear()
+            self.bwd_tensor_stash.clear()
+            self.bwd_ev_stash.clear()
+        self.is_first_forward_call = True
+        self.is_first_backward_call = True
+        return super().__enter__()
+
     def update_model_params(self, model: nn.Module):
         """
         Update the set of parameter storage pointers from the model. This allows filtering out model parameters during


### PR DESCRIPTION
# What does this PR do?

`OffloadActivations` keeps mutable state (`tracker`, `storage_to_tensor_id`, `fwd_stash`, `bwd_tensor_stash`, `bwd_ev_stash`, plus `is_first_*` booleans) across forward/backward. The reset is gated on `tracker` becoming empty during the unpack of the last saved tensor — but if any saved tensor never unpacks (its backward node never executes), the reset never fires. Each subsequent step adds more leaked entries, pinning GPU activation references → linear VRAM leak.

Hits reliably on **MoE + sample_packing + torch.compile** (e.g. Gemma‑4 26B‑A4B + ScatterMoE), where dynamic expert routing leaves saved tensors on subgraphs that don't contribute to the loss.

**Fix:** override `__enter__` to clear stale state before re-entering. By the time the next step enters the context, the previous backward has completed (Python is synchronous), so anything still in the dicts is leaked and safe to drop. 16 lines, no other logic touched.

Validated on the failing Gemma‑4 26B‑A4B QLoRA config (axolotl `examples/gemma4/26b-a4b-moe-qlora.yaml`): without the fix, ~60 saved tensors leak per micro‑step and OOM hits by step 2; with the fix, `tracker == 0` at the start of every step and VRAM stays flat across 200+ consecutive steps.

Fixes axolotl-ai-cloud/axolotl#3638

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — axolotl-ai-cloud/axolotl#3638
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches autograd `saved_tensors_hooks` lifecycle by resetting internal tracking on `__enter__`, which could affect activation offloading behavior if any tensors are unexpectedly needed across context boundaries; however the change is small and scoped to state cleanup.
> 
> **Overview**
> Prevents a step-to-step VRAM leak in `OffloadActivations` by overriding `__enter__` to **clear any leftover tracking/stash state** (`tracker`, `storage_to_tensor_id`, and stream stashes) and reset `is_first_*` flags before re-registering hooks.
> 
> This ensures activations that were saved in the forward but never unpacked in backward (e.g., conditional/MoE paths) don’t keep accumulating references and pin GPU memory across iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de13b4568f20ebbdc121df304fb070d430354cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->