### PR TITLE
docs(grpo): align model to Qwen2.5 and add GRPO OOM tab in quickstart

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -14,7 +14,7 @@ This post-training method was contributed by [Quentin Gallouédec](https://huggi
 
 ## Quick start
 
-This example demonstrates how to train a model using the GRPO method. We train a [Qwen 0.5B Instruct model](https://huggingface.co/Qwen/Qwen2-0.5B-Instruct) with the prompts from the [DeepMath-103K dataset](https://huggingface.co/datasets/trl-lib/DeepMath-103K). You can view the data in the dataset here:
+This example demonstrates how to train a model using the GRPO method. We train a [Qwen2.5 0.5B Instruct model](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct) with the prompts from the [DeepMath-103K dataset](https://huggingface.co/datasets/trl-lib/DeepMath-103K). You can view the data in the dataset here:
 
 <iframe
   src="https://huggingface.co/datasets/trl-lib/DeepMath-103K/embed/viewer/default/train?row=0"
@@ -34,7 +34,7 @@ from trl.rewards import accuracy_reward
 dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
 
 trainer = GRPOTrainer(
-    model="Qwen/Qwen2-0.5B-Instruct",
+    model="Qwen/Qwen2.5-0.5B-Instruct",
     reward_funcs=accuracy_reward,
     train_dataset=dataset,
 )
@@ -50,6 +50,8 @@ accelerate launch train_grpo.py
 Distributed across 8 GPUs, the training takes approximately 1 day.
 
 ![GRPO curves](https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/grpo_curves.png)
+
+> **Note:** The reward curves above were generated with `Qwen/Qwen2-0.5B-Instruct`. Results with `Qwen/Qwen2.5-0.5B-Instruct` will be qualitatively similar.
 
 ## Looking deeper into the GRPO method
 
@@ -533,7 +535,7 @@ def coding_reward_func(prompts, completions, task, **kwargs):
 
 # Use both task-specific reward functions
 trainer = GRPOTrainer(
-    model="Qwen/Qwen2-0.5B-Instruct",
+    model="Qwen/Qwen2.5-0.5B-Instruct",
     reward_funcs=[math_reward_func, coding_reward_func],
     train_dataset=dataset,
 )

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -126,6 +126,18 @@ training_args = DPOConfig(
 ```
 
 </hfoption>
+<hfoption id="GRPO">
+
+```python
+training_args = GRPOConfig(
+    per_device_train_batch_size=1,  # Start small
+    gradient_accumulation_steps=8,  # Maintain effective batch size
+    num_generations=4,              # Reduce from default 8 (GRPO generates num_generations completions per prompt)
+    max_completion_length=256,      # Tune based on task; longer sequences cost more memory
+)
+```
+
+</hfoption>
 </hfoptions>
 
 ### Loss not decreasing?


### PR DESCRIPTION
# What does this PR do?

Two documentation inconsistencies in the GRPO quickstart experience are fixed here.

**1. Model name mismatch in `grpo_trainer.md`** — PR #4803 (2026-01-16) updated `README.md` and `quickstart.md` to use `Qwen/Qwen2.5-0.5B-Instruct` but missed `grpo_trainer.md`, which still referenced the older `Qwen/Qwen2-0.5B-Instruct` in two code examples and in the introductory text. A user following the README or quickstart gets a different model than shown in the GRPO trainer guide, so the reward curves cannot be reproduced exactly. This PR aligns all occurrences to `Qwen/Qwen2.5-0.5B-Instruct` and adds a one-line note below the existing reward-curve screenshot explaining it was generated with the older checkpoint.

**2. Missing GRPO tab in the "Out of Memory?" troubleshooting section of `quickstart.md`** — The `<hfoptions>` block had tabs for SFT and DPO but nothing for GRPO, even though GRPO is the most memory-intensive trainer: it generates `num_generations` completions per prompt (default 8), so the effective sequences per step is `per_device_train_batch_size × num_generations` — 64 with defaults — compared to 8 for SFT/DPO. A new GRPO tab is added with a reduced `per_device_train_batch_size`, `gradient_accumulation_steps`, and `num_generations` to give users a working single-GPU starting point.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

Fixes #5611

## Local verification

```
$ cd /tmp/trl
$ pre-commit run --files docs/source/grpo_trainer.md docs/source/quickstart.md
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Check style with doc-builder.............................................Passed
=== LOCAL_TEST_PASSED ===
```

## AI writing disclosure

- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with TRL documentation is welcome to review. The changes are docs-only (two `.md` files, no Python code touched).

## Risk

Docs-only change; no runtime behaviour is affected. The reward-curve screenshot stays unchanged — the note clarifies it was produced with the older Qwen2 checkpoint so users are not confused when their Qwen2.5 run produces slightly different numbers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that don’t affect runtime behavior. Main risk is minor user confusion if the new GRPOConfig snippet diverges from actual defaults, but it’s guidance-only.
> 
> **Overview**
> Updates the GRPO documentation to consistently use `Qwen/Qwen2.5-0.5B-Instruct` in the quickstart narrative and code examples, and adds a note clarifying the included reward-curve plot was generated with the older `Qwen/Qwen2-0.5B-Instruct` checkpoint.
> 
> Extends the Quickstart *Out of Memory* troubleshooting section with a new `GRPO` tab recommending smaller, more memory-friendly `GRPOConfig` settings (notably reduced `num_generations` and tuned `max_completion_length`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3feaf2939aff8c4553e3df54b93d5f09315b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->