### PR TITLE
feat:  add Phi-3.5 training chat templates with generation markers

### DIFF
--- a/docs/source/chat_templates.md
+++ b/docs/source/chat_templates.md
@@ -20,7 +20,7 @@ TRL ships patched templates under [`trl/chat_templates/`](https://github.com/hug
 
 ## Supported model families
 
-TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Llama 3 / 3.1 / 3.2, Phi-3, Qwen2.5, Qwen3 (including the Instruct-2507 variant), Qwen3.6.
+TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Llama 3 / 3.1 / 3.2, Phi-3, Phi-3.5, Qwen2.5, Qwen3 (including the Instruct-2507 variant), Qwen3.6.
 
 ## Training templates
 
@@ -111,6 +111,12 @@ Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endge
 ### `phi3_training.jinja`
 
 Patched Phi-3 template. Diff vs `phi3.jinja`:
+
+Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `phi3_5_training.jinja`
+
+Patched Phi-3.5 template. Diff vs `phi3_5.jinja`:
 
 Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -457,6 +457,7 @@ class TestIsChatTemplatePrefixPreserving:
         pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3", id="llama3"),
         pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3", id="phi3"),
+        pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", id="phi3.5"),
         pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -329,6 +329,8 @@ llama3_2_chat_template = (_CHAT_TEMPLATES_DIR / "llama3_2.jinja").read_text()
 
 phi3_chat_template = (_CHAT_TEMPLATES_DIR / "phi3.jinja").read_text()
 
+phi3_5_chat_template = (_CHAT_TEMPLATES_DIR / "phi3_5.jinja").read_text()
+
 qwen2_5_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5.jinja").read_text()
 
 qwen3_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3.jinja").read_text()
@@ -561,6 +563,8 @@ llama3_training_chat_template = (_CHAT_TEMPLATES_DIR / "llama3_training.jinja").
 
 phi3_training_chat_template = (_CHAT_TEMPLATES_DIR / "phi3_training.jinja").read_text()
 
+phi3_5_training_chat_template = (_CHAT_TEMPLATES_DIR / "phi3_5_training.jinja").read_text()
+
 qwen2_5_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5_training.jinja").read_text()
 
 qwen3_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_training.jinja").read_text()
@@ -579,7 +583,7 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Qwen2.5,
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5 Qwen2.5,
     Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
 
     Args:
@@ -672,6 +676,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == phi3_chat_template:
         return phi3_training_chat_template
+    
+    if processing_class.chat_template == phi3_5_chat_template:
+        return phi3_5_training_chat_template
 
     if processing_class.chat_template == qwen2_5_chat_template:
         return qwen2_5_training_chat_template

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -583,7 +583,7 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5 Qwen2.5,
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5, Qwen2.5,
     Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
 
     Args:

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -583,8 +583,8 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5, Qwen2.5,
-    Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5,
+    Qwen2.5, Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -676,7 +676,7 @@ def get_training_chat_template(
 
     if processing_class.chat_template == phi3_chat_template:
         return phi3_training_chat_template
-    
+
     if processing_class.chat_template == phi3_5_chat_template:
         return phi3_5_training_chat_template
 

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -53,6 +53,10 @@ Original Llama 3.1 / 3.2 chat templates. Both render tool calls as a single bare
 
 Original Phi-3 chat template.
 
+### `phi3_5.jinja`
+
+Original Phi-3.5 chat template.
+
 ### `qwen2_5.jinja`
 
 Original Qwen2.5 chat template.
@@ -134,6 +138,13 @@ Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so
 ### `phi3_training.jinja`
 
 Patched Phi-3 template. Diff vs `phi3.jinja`:
+
+Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that
+`return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `phi3_5_training.jinja`
+
+Patched Phi-3.5 template. Diff vs `phi3.5.jinja`:
 
 Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that
 `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.

--- a/trl/chat_templates/phi3_5.jinja
+++ b/trl/chat_templates/phi3_5.jinja
@@ -1,0 +1,8 @@
+{% for message in messages %}{% if message['role'] == 'system' and message['content'] %}{{'<|system|>
+' + message['content'] + '<|end|>
+'}}{% elif message['role'] == 'user' %}{{'<|user|>
+' + message['content'] + '<|end|>
+'}}{% elif message['role'] == 'assistant' %}{{'<|assistant|>
+' + message['content'] + '<|end|>
+'}}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>
+' }}{% else %}{{ eos_token }}{% endif %}

--- a/trl/chat_templates/phi3_5_training.jinja
+++ b/trl/chat_templates/phi3_5_training.jinja
@@ -1,0 +1,21 @@
+{%- for message in messages %}
+    {%- if message['role'] == 'system' and message['content'] %}
+        {{- '<|system|>\n' + message['content'] + '<|end|>\n' }}
+    {%- elif message['role'] == 'user' %}
+        {{- '<|user|>\n' + message['content'] + '<|end|>\n'}}
+    {%- elif message['role'] == 'assistant' %}
+        {{- '<|assistant|>\n' }}
+        {%- generation %}
+        {{- message['content'] + '<|end|>\n' }}
+        {%- endgeneration %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|assistant|>\n'}}
+{%- elif messages[-1]['role'] == 'assistant' %}
+    {%- generation %}
+    {{- eos_token }}
+    {%- endgeneration %}
+{%- else %}
+    {{- eos_token }}
+{%- endif %}

--- a/trl/chat_templates/phi3_5_training.jinja
+++ b/trl/chat_templates/phi3_5_training.jinja
@@ -1,3 +1,8 @@
+{#- Training variant of the Phi-3.5 chat template (see phi3_5.jinja for the original).
+    Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around assistant message output to support
+      assistant-only loss masking in SFT training.
+-#}
 {%- for message in messages %}
     {%- if message['role'] == 'system' and message['content'] %}
         {{- '<|system|>\n' + message['content'] + '<|end|>\n' }}


### PR DESCRIPTION
# What does this PR do?

contributing to #5471 

Adds a training-compatible variant of the Phi-3.5 chat template with `{% generation %} / {% endgeneration %}` markers, enabling `return_assistant_tokens_mask=True` for assistant-only loss masking in SFT training.

-`phi3_5.jinja`: template from `microsoft/Phi-3.5-mini-instruct`
-`phi3_5_training.jinja`: modified the phi3_5.jinja to turn the training chat template
-`get_training_chat_template`: registered Phi-3.5
-`tests/test_chat_template_utils.py`: added param `"trl-internal-testing/tiny-Phi3ForCausalLM-3.5", id="phi3.5"`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? https://github.com/huggingface/trl/issues/5471
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?
@qgallouedec (opened #5471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive support for a new model family template plus a small conditional in `get_training_chat_template`, with coverage via existing template utility tests.
> 
> **Overview**
> Adds Phi-3.5 to TRL’s recognized chat-template families and introduces `phi3_5.jinja` plus a training variant `phi3_5_training.jinja` that wraps assistant output in `{% generation %}` / `{% endgeneration %}` for assistant-only loss masking.
> 
> Registers the new Phi-3.5 templates in `get_training_chat_template`, updates docs/README to list the new family and training template, and extends `test_chat_template_utils.py` to exercise the Phi-3.5 tiny model in the existing training-template test matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c1909d59204d42c1dcd4ccf325811fabf1d2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->