### PR TITLE
[AsyncGRPO] Fix missing tool gates in worker init (fixes #5742)

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -14,20 +14,26 @@
 
 import itertools
 import queue
+from unittest.mock import patch
 
 import numpy as np
+import pytest
 import torch
 from datasets import load_dataset
 from transformers import AutoTokenizer
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
-from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
+from trl.experimental.async_grpo.async_rollout_worker import AsyncRolloutWorker, RolloutSample
 
 from ..testing_utils import TrlTestCase
 
 
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
+
+
+def dummy_tool(x: int) -> int:
+    return x
 
 
 class _StubRolloutWorker:
@@ -137,3 +143,53 @@ class TestAsyncGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+
+class TestAsyncRolloutWorker(TrlTestCase):
+    def test_init_with_unsupported_template_and_no_tools(self):
+        """tools=None + unrecognized template must NOT call add_response_schema."""
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokenizer.chat_template = None
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+
+        with (
+            patch(
+                "trl.experimental.async_grpo.async_rollout_worker.is_vllm_available",
+                return_value=True,
+            ),
+            patch.object(AsyncRolloutWorker, "_wait_for_server_ready_sync"),
+            patch.object(AsyncRolloutWorker, "_init_weight_transfer"),
+        ):
+            # Must not raise ValueError
+            # The gate before add_response_schema must skip it when tools is None.
+            AsyncRolloutWorker(
+                model_name=model_id,
+                dataset=dataset,
+                reward_funcs=[dummy_reward_func],
+                processing_class=tokenizer,
+                tools=None,
+            )
+
+    def test_init_with_unsupported_template_and_tools_fails_at_init(self):
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokenizer.chat_template = None
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+
+        with (
+            patch(
+                "trl.experimental.async_grpo.async_rollout_worker.is_vllm_available",
+                return_value=True,
+            ),
+            patch.object(AsyncRolloutWorker, "_wait_for_server_ready_sync"),
+            patch.object(AsyncRolloutWorker, "_init_weight_transfer"),
+            pytest.raises(ValueError, match="does not support tool calling"),
+        ):
+            AsyncRolloutWorker(
+                model_name=model_id,
+                dataset=dataset,
+                reward_funcs=[dummy_reward_func],
+                processing_class=tokenizer,
+                tools=[dummy_tool],
+            )

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -33,8 +33,9 @@ from trl.chat_template_utils import (
     get_training_chat_template,
     is_chat_template_prefix_preserving,
     parse_response,
+    supports_tool_calling,
 )
-from trl.import_utils import is_vllm_available
+from trl.import_utils import is_jmespath_available, is_vllm_available
 from trl.trainer.utils import print_prompt_completions_sample
 
 
@@ -132,6 +133,20 @@ class AsyncRolloutWorker:
         self.reward_func_names = [f.__name__ for f in reward_funcs]
         self.num_generations = num_generations
         self.max_inflight_tasks = max_inflight_tasks
+
+        # Tools
+        if tools or environment_factory:
+            if not is_jmespath_available():
+                raise ImportError(
+                    "Using tools with GRPOTrainer requires the jmespath library for response parsing. Please install "
+                    "it with `pip install jmespath` to use this feature."
+                )
+            if not supports_tool_calling(processing_class):
+                raise ValueError(
+                    "The provided chat template does not support tool calling. The template must be able to render a "
+                    "full tool-calling conversation (user -> assistant with tool_calls -> tool)."
+                )
+
         self.environments = None
         environment_methods = [[] for _ in range(self.max_inflight_tasks)]
         if environment_factory is not None:
@@ -167,7 +182,12 @@ class AsyncRolloutWorker:
         self.log_completions = log_completions
         self.num_completions_to_print = num_completions_to_print
         self.tokenizer = processing_class
-        self.tokenizer = add_response_schema(self.tokenizer)
+        # At the time of initial implementation, most tokenizers do not have built-in support for response schemas.
+        # While waiting for broader adoption, we provide this utility function to manually set the response schema for
+        # known chat templates. `response_schema` lives on the (inner) tokenizer, since `parse_response` is a tokenizer
+        # method that reads `self.response_schema`.
+        if self.tools and getattr(self.tokenizer, "response_schema", None) is None:
+            self.tokenizer = add_response_schema(self.tokenizer)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.
         if self.tools and not is_chat_template_prefix_preserving(self.tokenizer):

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -138,7 +138,7 @@ class AsyncRolloutWorker:
         if tools or environment_factory:
             if not is_jmespath_available():
                 raise ImportError(
-                    "Using tools with GRPOTrainer requires the jmespath library for response parsing. Please install "
+                    "Using tools with AsyncRolloutWorker requires the jmespath library for response parsing. Please install "
                     "it with `pip install jmespath` to use this feature."
                 )
             if not supports_tool_calling(processing_class):


### PR DESCRIPTION
# What does this PR do?

Mirrors the tool-related init gates from `GRPOTrainer.__init__` to `AsyncRolloutWorker.__init__`, fixing a `ValueError` at init for users on non-bundled tokenizers.

`AsyncRolloutWorker.__init__` called `add_response_schema` unconditionally and lacked the `supports_tool_calling` precheck that `GRPOTrainer.__init__` runs — gates dropped during the original port. 

Result: any user with a tokenizer whose template isn't in TRL's dispatch arms (anything with `chat_template=None`) hits the unguarded `add_response_schema` call at the very first init step, even when passing `tools=None`. The same setup on `GRPOTrainer` succeeds.

#5538 fixed a related symptom (worker reloading the tokenizer from `model_name`), but the schema call itself remained ungated.

**Changes:**

- `trl/experimental/async_grpo/async_rollout_worker.py`: gate `add_response_schema` on `self.tools` (the original bug), add `supports_tool_calling` precheck, add `is_jmespath_available` check. 
- `tests/experimental/test_async_grpo_trainer.py`: new `TestAsyncRolloutWorker` class with two negative-path tests — the issue's exact repro (`tools=None` + `chat_template=None`) and the `supports_tool_calling` precheck (`tools=[...]` + `chat_template=None`). 


Fixes #5742


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental async GRPO init-only guards and tests; no change to training loops when tools are unused.
> 
> **Overview**
> **AsyncGRPO rollout worker init** now matches **GRPOTrainer** tool setup: `add_response_schema` runs only when tools are configured and no schema exists yet, so `tools=None` with a missing/unknown chat template no longer fails at init.
> 
> When **tools** or an **environment factory** is used, init also requires **jmespath** and validates the tokenizer with **`supports_tool_calling`** before proceeding.
> 
> New **`TestAsyncRolloutWorker`** cases cover the no-tools success path and the tools + unsupported-template **`ValueError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b406cf115dc38484f228166d3d678d7f685764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->