### PR TITLE
Fix CI errors in response parsing for gptoss/llama with transformers v5

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -124,7 +124,15 @@ class TestAddResponseSchema:
         "tokenizer_name",
         [
             pytest.param("trl-internal-testing/tiny-Glm4MoeForCausalLM", id="glm4moe"),
-            pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
+            pytest.param(
+                "trl-internal-testing/tiny-GptOssForCausalLM",
+                id="gptoss",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Upstream bug in response parsing (see #5753; fixed in transformers#45166)",
+                    strict=True,
+                ),
+            ),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.1", id="llama3.1"),
             pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3.2", id="llama3.2"),
             pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
@@ -709,6 +717,10 @@ class TestParseResponse:
         return processing_class
 
     def test_parse_response(self, model_name):
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+            transformers.__version__
+        ) < Version("5.5.0"):
+            pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
         processing_class = self._load(model_name)
         messages = [
             {"role": "user", "content": "What is 3*4?"},
@@ -762,6 +774,12 @@ class TestParseResponse:
         assert parsed == expected
 
     def test_parse_response_tool_call(self, model_name):
+        if model_name in (
+            "trl-internal-testing/tiny-GptOssForCausalLM",
+            "trl-internal-testing/tiny-LlamaForCausalLM-3.1",
+            "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
+        ) and Version(transformers.__version__) < Version("5.5.0"):
+            pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
         processing_class = self._load(model_name)
         tool_calls = [{"type": "function", "function": {"name": "multiply", "arguments": {"a": 3, "b": 4}}}]
         messages = [
@@ -794,6 +812,10 @@ class TestParseResponse:
             "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
         ):
             pytest.skip("Llama 3.1 / 3.2 templates only allow a single tool call per assistant turn, with no content.")
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+            transformers.__version__
+        ) < Version("5.5.0"):
+            pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
         processing_class = self._load(model_name)
         tool_calls = [{"type": "function", "function": {"name": "multiply", "arguments": {"a": 3, "b": 4}}}]
         messages = [
@@ -815,6 +837,10 @@ class TestParseResponse:
         assert parsed == expected
 
     def test_parse_response_tool_call_without_arguments(self, model_name):
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+            transformers.__version__
+        ) < Version("5.5.0"):
+            pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
         processing_class = self._load(model_name)
         tool_calls = [{"type": "function", "function": {"name": "ping", "arguments": {}}}]
         messages = [

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -717,7 +717,7 @@ class TestParseResponse:
         return processing_class
 
     def test_parse_response(self, model_name):
-        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM",) and Version(
             transformers.__version__
         ) < Version("5.5.0"):
             pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
@@ -812,7 +812,7 @@ class TestParseResponse:
             "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
         ):
             pytest.skip("Llama 3.1 / 3.2 templates only allow a single tool call per assistant turn, with no content.")
-        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM",) and Version(
             transformers.__version__
         ) < Version("5.5.0"):
             pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")
@@ -837,7 +837,7 @@ class TestParseResponse:
         assert parsed == expected
 
     def test_parse_response_tool_call_without_arguments(self, model_name):
-        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM") and Version(
+        if model_name in ("trl-internal-testing/tiny-GptOssForCausalLM",) and Version(
             transformers.__version__
         ) < Version("5.5.0"):
             pytest.skip("Upstream bug in response parsing (see #5753; fixed in transformers#45166)")


### PR DESCRIPTION
Fix CI errors in response parsing for gptoss/llama with transformers v5.

This PR improves the reliability of tests in `tests/test_chat_template_utils.py` by adding conditional skips for certain test cases when running with versions of the `transformers` library older than 5.5.0. These skips address a known upstream bug in response parsing for specific models, ensuring that test failures are not triggered by external issues.

Fix #5753.

### Changes

Test robustness improvements:

* Marked the `trl-internal-testing/tiny-GptOssForCausalLM` test parameter with `pytest.mark.xfail` for `transformers` versions below 5.5.0, providing a clear reason and making failures expected due to the upstream bug.
* Added conditional `pytest.skip` statements to several test methods (`test_parse_response`, `test_parse_response_tool_call`, `test_parse_response_tool_call_with_content`, `test_parse_response_tool_call_without_arguments`) to skip tests for affected models when using an older `transformers` version, preventing spurious test failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test gating (xfail/skip) to avoid known upstream `transformers` response-parsing bugs; production code paths are untouched.
> 
> **Overview**
> Improves CI stability for response-parsing tests by conditioning failures on upstream `transformers` behavior.
> 
> Marks the `tiny-GptOssForCausalLM` `add_response_schema` parameter as `xfail` on `transformers<5.5.0`, and adds targeted `pytest.skip` guards in `TestParseResponse` tool-calling/parse cases for GPT-OSS (and Llama 3.1/3.2 tool-call parsing) when running on affected `transformers` versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4dea7236b894a1b17cf4d59a5b5eb9c8c99f4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->