### PR TITLE
Fix CI AttributeError: 'GptOssConfig' object has no attribute 'num_experts'

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2511,14 +2511,7 @@ class TestPatchChunkedCELMHead:
         "model_id",
         [
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
-            pytest.param(
-                "trl-internal-testing/tiny-GptOssForCausalLM",
-                marks=pytest.mark.xfail(
-                    Version("5.0.0") <= Version(transformers.__version__) < Version("5.6.0"),
-                    reason="Upstream bug AttributeError: 'GptOssConfig' object has no attribute 'num_experts'; see #5754",
-                    strict=True,
-                ),
-            ),
+            "trl-internal-testing/tiny-GptOssForCausalLM",
         ],
     )
     def test_forward_matches_reference_with_aux_loss(self, model_id):

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2511,7 +2511,14 @@ class TestPatchChunkedCELMHead:
         "model_id",
         [
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
-            "trl-internal-testing/tiny-GptOssForCausalLM",
+            pytest.param(
+                "trl-internal-testing/tiny-GptOssForCausalLM",
+                marks=pytest.mark.xfail(
+                    Version("5.0.0") <= Version(transformers.__version__) < Version("5.6.0"),
+                    reason="Upstream bug AttributeError: 'GptOssConfig' object has no attribute 'num_experts'; see #5754",
+                    strict=True,
+                ),
+            ),
         ],
     )
     def test_forward_matches_reference_with_aux_loss(self, model_id):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -308,7 +308,13 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
                 num_experts_per_tok = self.num_experts_per_tok
                 router_aux_loss_coef = self.router_aux_loss_coef
             else:
-                num_experts = text_config.num_experts
+                # Upstream bug AttributeError: 'GptOssConfig' object has no attribute 'num_experts'; see #5754
+                if text_config.model_type == "gpt_oss" and Version("5.0.0") <= Version(
+                    transformers.__version__
+                ) < Version("5.6.0"):
+                    num_experts = self.num_experts
+                else:
+                    num_experts = text_config.num_experts
                 num_experts_per_tok = text_config.num_experts_per_tok
                 router_aux_loss_coef = text_config.router_aux_loss_coef
             aux_loss = load_balancing_loss_func(


### PR DESCRIPTION
Fix CI AttributeError: 'GptOssConfig' object has no attribute 'num_experts'.

This PR addresses an upstream compatibility issue in the `trl/trainer/sft_trainer.py` file related to handling the `GptOssConfig` object when using certain versions of the `transformers` library. The main change is a conditional workaround to avoid an `AttributeError` by using the correct source for expert configuration parameters.

Fix #5754.

### Changes

Bug fix for compatibility with upstream library:

* Added a conditional check to handle cases where `text_config` is a `GptOssConfig` and the `transformers` version is between 5.0.0 (inclusive) and 5.6.0 (exclusive), ensuring `num_experts` is accessed from `self` instead of `text_config` to avoid an `AttributeError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MoE auxiliary-loss computation in `SFTTrainer`’s chunked loss path; while the change is small, it affects training loss for `gpt_oss` models on specific `transformers` versions.
> 
> **Overview**
> Fixes an upstream `transformers` regression affecting `gpt_oss` MoE models by **avoiding `text_config.num_experts` access** for `transformers` versions `>=5.0.0` and `<5.6.0`.
> 
> In `trl/trainer/sft_trainer.py`’s chunked CE forward, the MoE load-balancing loss now falls back to `self.num_experts` for those versions, preventing the `AttributeError` and keeping aux-loss computation working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495d3fd5339fe6176104ae725b7e70d1d31efde0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->