### PR TITLE
Add telemetry to trainers

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -5,6 +5,8 @@
     title: Installation
   - local: quickstart
     title: Quickstart
+  - local: usage_stats
+    title: Usage Stats Collection
   title: Getting started
 - sections:
   - local: chat_templates

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -40,3 +40,7 @@ If you want the development install you can replace the pip install with the fol
 ```bash
 pip install -e ".[dev]"
 ```
+
+## Telemetry
+
+TRL sends one anonymous ping per trainer instantiation (rank 0 only, skipped when `CI` is set) containing the trainer class, TRL version, model architecture, PEFT usage, and distributed backend. No user data, paths, or hyperparameters are sent. Opt out with `HF_HUB_DISABLE_TELEMETRY=1` or `HF_HUB_OFFLINE=1`.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -43,4 +43,4 @@ pip install -e ".[dev]"
 
 ## Telemetry
 
-TRL sends one anonymous ping per trainer instantiation (rank 0 only, skipped when `CI` is set) containing the trainer class, TRL version, model architecture, PEFT usage, and distributed backend. No user data, paths, or hyperparameters are sent. Opt out with `HF_HUB_DISABLE_TELEMETRY=1` or `HF_HUB_OFFLINE=1`.
+TRL sends usage telemetry to help prioritize features. Disable with `HF_HUB_DISABLE_TELEMETRY=1` or `HF_HUB_OFFLINE=1`.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -40,7 +40,3 @@ If you want the development install you can replace the pip install with the fol
 ```bash
 pip install -e ".[dev]"
 ```
-
-## Telemetry
-
-TRL sends usage telemetry to help prioritize features. Disable with `HF_HUB_DISABLE_TELEMETRY=1` or `HF_HUB_OFFLINE=1`.

--- a/docs/source/usage_stats.md
+++ b/docs/source/usage_stats.md
@@ -7,8 +7,8 @@ TRL collects anonymous usage statistics to help the maintainers understand which
 A single ping is sent each time a trainer is instantiated. The payload contains:
 
 - TRL version (e.g. `1.5.0`)
-- Trainer class name (e.g. `SFTTrainer`, `GRPOTrainer`)
-- Model architecture (`model.config.model_type`, e.g. `llama`, `qwen3`)
+- Trainer class name, reported only if it is a TRL-defined trainer (e.g. `SFTTrainer`, `GRPOTrainer`). Custom user subclasses are reported as `other`.
+- Model architecture, reported only if it is a model type known to [`transformers`](https://github.com/huggingface/transformers) (e.g. `llama`, `qwen3`). Custom or private architectures are reported as `other`.
 - Whether [PEFT](https://github.com/huggingface/peft) is in use
 - Distributed backend (`deepspeed`, `fsdp`, `ddp`, or `none`)
 - World size, bucketed (`1`, `2-8`, `9-64`, `65+`)

--- a/docs/source/usage_stats.md
+++ b/docs/source/usage_stats.md
@@ -1,0 +1,39 @@
+# Usage Stats Collection
+
+TRL collects anonymous usage statistics to help the maintainers understand which trainers, model architectures, and hardware configurations are used in the wild. This data informs prioritization decisions about which features to invest in and which to deprecate.
+
+## What is collected
+
+A single ping is sent each time a trainer is instantiated. The payload contains:
+
+- TRL version (e.g. `1.5.0`)
+- Trainer class name (e.g. `SFTTrainer`, `GRPOTrainer`)
+- Model architecture (`model.config.model_type`, e.g. `llama`, `qwen3`)
+- Whether [PEFT](https://github.com/huggingface/peft) is in use
+- Distributed backend (`deepspeed`, `fsdp`, `ddp`, or `none`)
+- World size, bucketed (`1`, `2-8`, `9-64`, `65+`)
+- Accelerator type (`cuda`, `xpu`, `npu`, `mlu`, `mps`, `cpu`)
+- GPU model name (e.g. `NVIDIA H100 80GB HBM3`), when available
+
+No dataset names, file paths, model identifiers, hyperparameter values, or any other user-provided data are collected. As with any HTTP request, the source IP and standard HTTP headers are visible to the server.
+
+Telemetry is not sent in CI environments (i.e. when the `CI` environment variable is set), nor in offline mode.
+
+## How to opt out
+
+Set either of the following environment variables to disable telemetry:
+
+```bash
+export HF_HUB_DISABLE_TELEMETRY=1   # disables telemetry for all HF libraries
+export HF_HUB_OFFLINE=1             # disables all network calls to the Hub
+```
+
+## Why this helps
+
+Without usage data, the maintainers have no way to know which parts of the library matter to users. Telemetry lets us answer questions like:
+
+- Which trainers are widely adopted, and which can be deprecated safely?
+- Which model architectures are most often fine-tuned with TRL, so we can prioritize their support?
+- What hardware configurations are users running on, so we can test and optimize for them?
+
+If you find TRL useful, leaving telemetry enabled is a low-cost way to help us make it better.

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -528,7 +528,6 @@ class DistillationTrainer(_BaseTrainer):
         # Trainer does not need to remove unused columns — the collator handles raw data
         args.remove_unused_columns = False
 
-        # ── Call _BaseTrainer.__init__ (which is transformers.Trainer.__init__) ──
         super().__init__(
             model=model,
             args=args,

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -51,12 +51,16 @@ class _BaseTrainer(Trainer):
         else:
             distributed = "none"
         device = self.accelerator.device.type
-        # Each accelerator backend (cuda, xpu, npu, mlu, …) exposes its own `torch.<device>.get_device_name`. MPS and
-        # CPU do not, hence the broad except.
-        try:
-            gpu = getattr(torch, device).get_device_name(0)
-        except (AttributeError, RuntimeError):
-            gpu = ""
+        if device == "cuda":
+            gpu = torch.cuda.get_device_name(0)
+        elif device == "xpu":
+            gpu = torch.xpu.get_device_name(0)
+        elif device == "npu":
+            gpu = torch.npu.get_device_name(0)
+        elif device == "mlu":
+            gpu = torch.mlu.get_device_name(0)
+        else:
+            gpu = "other"
         # Bucketed to avoid fingerprinting individual deployments by their exact cluster size.
         n = self.accelerator.num_processes
         world_size = "1" if n == 1 else "2-8" if n <= 8 else "9-64" if n <= 64 else "65+"

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -14,8 +14,11 @@
 
 import os
 
+from accelerate.utils import is_peft_model
+from huggingface_hub.utils import send_telemetry
 from transformers import Trainer, is_wandb_available
 
+from .. import __version__
 from .utils import generate_model_card, get_comet_experiment_url, get_config_model_id, get_trackio_space_url
 
 
@@ -28,6 +31,35 @@ class _BaseTrainer(Trainer):
     _name = "Base"
     _paper = {}
     _template_file = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._send_telemetry()
+
+    def _send_telemetry(self):
+        # Only send from rank 0 to avoid multiplying pings by world size, and skip CI runs so automated tests don't
+        # bias the data. Honors `HF_HUB_DISABLE_TELEMETRY=1` and `HF_HUB_OFFLINE=1` (handled by `send_telemetry`).
+        if not self.accelerator.is_main_process or os.environ.get("CI"):
+            return
+        if self.is_deepspeed_enabled:
+            distributed = "deepspeed"
+        elif self.is_fsdp_enabled:
+            distributed = "fsdp"
+        elif self.accelerator.num_processes > 1:
+            distributed = "ddp"
+        else:
+            distributed = "none"
+        send_telemetry(
+            topic=f"trl/{type(self).__name__}",
+            library_name="trl",
+            library_version=__version__,
+            user_agent={
+                "model_arch": self.model.config.model_type,
+                "peft": str(is_peft_model(self.model)).lower(),
+                "distributed": distributed,
+                "world_size": str(self.accelerator.num_processes),
+            },
+        )
 
     def create_model_card(
         self,

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -17,7 +17,7 @@ import os
 import torch
 from accelerate.utils import is_peft_model
 from huggingface_hub.utils import send_telemetry
-from transformers import Trainer, is_wandb_available
+from transformers import CONFIG_MAPPING, Trainer, is_wandb_available
 
 from .. import __version__
 from .utils import generate_model_card, get_comet_experiment_url, get_config_model_id, get_trackio_space_url
@@ -60,12 +60,19 @@ class _BaseTrainer(Trainer):
         # Bucketed to avoid fingerprinting individual deployments by their exact cluster size.
         n = self.accelerator.num_processes
         world_size = "1" if n == 1 else "2-8" if n <= 8 else "9-64" if n <= 64 else "65+"
+        # Trainer class and model arch are reported only if they come from a known upstream allowlist (TRL trainers,
+        # transformers `CONFIG_MAPPING`); anything else is reported as "other" so we never leak the names of internal,
+        # custom trainer subclasses or private model architectures.
+        cls = type(self)
+        trainer = cls.__name__ if cls.__module__.startswith("trl.") else "other"
+        model_type = self.model.config.model_type
+        model_arch = model_type if model_type in CONFIG_MAPPING else "other"
         send_telemetry(
-            topic=f"trl/{type(self).__name__}",
+            topic=f"trl/{trainer}",
             library_name="trl",
             library_version=__version__,
             user_agent={
-                "model_arch": self.model.config.model_type,
+                "model_arch": model_arch,
                 "peft": str(is_peft_model(self.model)).lower(),
                 "distributed": distributed,
                 "world_size": world_size,

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -14,6 +14,7 @@
 
 import os
 
+import torch
 from accelerate.utils import is_peft_model
 from huggingface_hub.utils import send_telemetry
 from transformers import Trainer, is_wandb_available
@@ -49,6 +50,13 @@ class _BaseTrainer(Trainer):
             distributed = "ddp"
         else:
             distributed = "none"
+        device = self.accelerator.device.type
+        # Each accelerator backend (cuda, xpu, npu, mlu, …) exposes its own `torch.<device>.get_device_name`. MPS and
+        # CPU do not, hence the broad except.
+        try:
+            gpu = getattr(torch, device).get_device_name(0)
+        except (AttributeError, RuntimeError):
+            gpu = ""
         send_telemetry(
             topic=f"trl/{type(self).__name__}",
             library_name="trl",
@@ -58,6 +66,8 @@ class _BaseTrainer(Trainer):
                 "peft": str(is_peft_model(self.model)).lower(),
                 "distributed": distributed,
                 "world_size": str(self.accelerator.num_processes),
+                "device": device,
+                "gpu": gpu,
             },
         )
 

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -57,6 +57,9 @@ class _BaseTrainer(Trainer):
             gpu = getattr(torch, device).get_device_name(0)
         except (AttributeError, RuntimeError):
             gpu = ""
+        # Bucketed to avoid fingerprinting individual deployments by their exact cluster size.
+        n = self.accelerator.num_processes
+        world_size = "1" if n == 1 else "2-8" if n <= 8 else "9-64" if n <= 64 else "65+"
         send_telemetry(
             topic=f"trl/{type(self).__name__}",
             library_name="trl",
@@ -65,7 +68,7 @@ class _BaseTrainer(Trainer):
                 "model_arch": self.model.config.model_type,
                 "peft": str(is_peft_model(self.model)).lower(),
                 "distributed": distributed,
-                "world_size": str(self.accelerator.num_processes),
+                "world_size": world_size,
                 "device": device,
                 "gpu": gpu,
             },


### PR DESCRIPTION
Adds a single anonymous ping per trainer instantiation via `huggingface_hub.send_telemetry`, hooked from `_BaseTrainer.__init__` so it covers every TRL trainer without per-trainer changes.

**Topic:** `trl/<TrainerClassName>` (e.g. `trl/SFTTrainer`, `trl/GRPOTrainer`)

**Payload (user-agent):** `model_arch`, `peft`, `distributed` (`deepspeed`/`fsdp`/`ddp`/`none`), `world_size`, plus `trl` version.

No user data, dataset names, model paths, or hyperparameter values are sent.

## Why

TRL currently emits no telemetry, so we have no signal on which trainers, model families, or distributed backends are actually used. This blocks prioritization decisions.

## Docs

Short opt-out note added to `docs/source/installation.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new outbound network call (`huggingface_hub.send_telemetry`) on every TRL trainer initialization, which could affect privacy expectations and environments with restricted networking if opt-out isn’t set.
> 
> **Overview**
> Adds anonymous usage telemetry across all TRL trainers by hooking a single `send_telemetry` ping into `_BaseTrainer.__init__`, emitted only on the main process and skipped in CI/offline/telemetry-disabled modes.
> 
> The ping reports **bucketed** runtime metadata (TRL version, allowlisted trainer name/model architecture, PEFT usage, distributed backend, world-size bucket, device type, and GPU model when available) and introduces new docs (`usage_stats.md`) plus a toctree entry explaining what’s collected and how to opt out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514a7ae2a65089e933ec297599a4cfa16ec09b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->