### PR TITLE
docs: set max_completion_length=1024 in GRPO quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,21 @@ trainer.train()
 
 ```python
 from datasets import load_dataset
-from trl import GRPOTrainer
+from trl import GRPOConfig, GRPOTrainer
 from trl.rewards import accuracy_reward
 
 dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
+
+training_args = GRPOConfig(
+    output_dir="Qwen2.5-0.5B-Instruct-GRPO",
+    max_completion_length=1024,
+)
 
 trainer = GRPOTrainer(
     model="Qwen/Qwen2.5-0.5B-Instruct",
     reward_funcs=accuracy_reward,
     train_dataset=dataset,
+    args=training_args,
 )
 trainer.train()
 ```

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -28,15 +28,21 @@ Below is the script to train the model.
 ```python
 # train_grpo.py
 from datasets import load_dataset
-from trl import GRPOTrainer
+from trl import GRPOConfig, GRPOTrainer
 from trl.rewards import accuracy_reward
 
 dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
+
+training_args = GRPOConfig(
+    output_dir="Qwen2.5-0.5B-Instruct-GRPO",
+    max_completion_length=1024,
+)
 
 trainer = GRPOTrainer(
     model="Qwen/Qwen2.5-0.5B-Instruct",
     reward_funcs=accuracy_reward,
     train_dataset=dataset,
+    args=training_args,
 )
 trainer.train()
 ```
@@ -47,7 +53,7 @@ Execute the script using the following command:
 accelerate launch train_grpo.py
 ```
 
-Distributed across 8 GPUs, the training takes approximately 1 day.
+Distributed across 8 GPUs, the training takes approximately 1 day. On a single A100 80GB, training takes approximately 5 days with a peak memory usage of ~32 GB.
 
 ![GRPO curves](https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/grpo_curves.png)
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -22,14 +22,20 @@ trainer.train()
 ### Group Relative Policy Optimization
 
 ```python
-from trl import GRPOTrainer
 from datasets import load_dataset
+from trl import GRPOConfig, GRPOTrainer
 from trl.rewards import accuracy_reward
+
+training_args = GRPOConfig(
+    output_dir="Qwen2.5-0.5B-Instruct-GRPO",
+    max_completion_length=1024,
+)
 
 trainer = GRPOTrainer(
     model="Qwen/Qwen2.5-0.5B-Instruct",
     train_dataset=load_dataset("trl-lib/DeepMath-103K", split="train"),
     reward_funcs=accuracy_reward,
+    args=training_args,
 )
 trainer.train()
 ```


### PR DESCRIPTION

# What does this PR do?

The default `max_completion_length=256` truncates 97-99% of completions on DeepMath-103K before the model can emit `\boxed{...}`, so `accuracy_reward` scores everything 0. Training runs silently with zero reward, zero loss, and zero gradient updates for most steps without errors. A user following the quickstart will watch flat metrics for hours with no indication that anything is wrong.

This PR sets `max_completion_length=1024` in all three quickstart GRPO examples (README, `quickstart.md`, `grpo_trainer.md`). At 1024, truncation drops to ~14%, and the reward signal appears within the first few steps. Verified on actual runs on a single A100. Details in #5697. 

Also adds single-GPU timing and memory guidance (A100 80GB: ~5 days, ~32 GB peak). Quickstart users are most likely to run on a single GPU, so setting realistic hardware expectations upfront prevents wasted compute.

Fixes #5697

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only changes updating GRPO example configuration; no runtime/library behavior is modified.
> 
> **Overview**
> Updates the GRPO quickstart examples in `README.md`, `docs/source/quickstart.md`, and `docs/source/grpo_trainer.md` to construct a `GRPOConfig` and pass it via `args`, explicitly setting `max_completion_length=1024` (and `output_dir`).
> 
> Adds an additional note in the GRPO trainer docs with expected single-GPU (A100 80GB) training time and peak memory usage alongside the existing 8-GPU estimate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d2f04c3f2ce254c164fe71308580245c427b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->