### PR TITLE
Fix OOM in CI by reducing intermediate_size and image token budget for tiny Gemma4

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
@@ -55,7 +55,8 @@ vision_config = {
     "default_output_length": IMAGE_TOKENS,  # 70
 }
 
-processor.image_processor.image_seq_length = IMAGE_TOKENS
+processor.image_seq_length = IMAGE_TOKENS  # top-level Gemma4Processor attribute (serialized to processor_config.json)
+processor.image_processor.image_seq_length = IMAGE_TOKENS  # nested Gemma4ImageProcessor attribute
 processor.image_processor.max_soft_tokens = IMAGE_TOKENS
 
 config = AutoConfig.from_pretrained(MODEL_ID)

--- a/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
@@ -26,9 +26,6 @@ check_transformers_version(TRANSFORMERS_VERSION)
 
 MODEL_ID = "google/gemma-4-E2B-it"
 
-processor = AutoProcessor.from_pretrained(MODEL_ID)
-generation_config = GenerationConfig.from_pretrained(MODEL_ID)
-
 # Gemma4 image processor uses aspect-ratio-preserving resizing, not a fixed image size. max_soft_tokens controls
 # the output token budget and must be one of (70, 140, 280, 560, 1120). The smallest value (70) gives
 # max_patches = 70 × pooling_kernel_size² = 70 × 9 = 630, so position_embedding_size must be at least 630.
@@ -36,6 +33,9 @@ generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 # training activations [batch, patches, intermediate_size] to dominate GPU memory and OOM in CI.
 IMAGE_TOKENS = 70  # minimum supported max_soft_tokens
 MAX_PATCHES = IMAGE_TOKENS * 3**2  # 630
+
+processor = AutoProcessor.from_pretrained(MODEL_ID, image_seq_length=IMAGE_TOKENS, max_soft_tokens=IMAGE_TOKENS)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 
 text_config = {
     "num_hidden_layers": 2,
@@ -54,10 +54,6 @@ vision_config = {
     "position_embedding_size": MAX_PATCHES,  # 630
     "default_output_length": IMAGE_TOKENS,  # 70
 }
-
-processor.image_seq_length = IMAGE_TOKENS  # top-level Gemma4Processor attribute (serialized to processor_config.json)
-processor.image_processor.image_seq_length = IMAGE_TOKENS  # nested Gemma4ImageProcessor attribute
-processor.image_processor.max_soft_tokens = IMAGE_TOKENS
 
 config = AutoConfig.from_pretrained(MODEL_ID)
 for k, v in text_config.items():

--- a/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
@@ -29,11 +29,20 @@ MODEL_ID = "google/gemma-4-E2B-it"
 processor = AutoProcessor.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 
+# Gemma4 image processor uses aspect-ratio-preserving resizing, not a fixed image size. max_soft_tokens controls
+# the output token budget and must be one of (70, 140, 280, 560, 1120). The smallest value (70) gives
+# max_patches = 70 × pooling_kernel_size² = 70 × 9 = 630, so position_embedding_size must be at least 630.
+# intermediate_size mirrors Gemma3: without it the production value (text: 6144, vision: 3072) is inherited, causing
+# training activations [batch, patches, intermediate_size] to dominate GPU memory and OOM in CI.
+IMAGE_TOKENS = 70  # minimum supported max_soft_tokens
+MAX_PATCHES = IMAGE_TOKENS * 3**2  # 630
+
 text_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_attention_heads": 4,
     "num_key_value_heads": 2,
+    "intermediate_size": 32,
 }
 vision_config = {
     "num_hidden_layers": 2,
@@ -41,7 +50,13 @@ vision_config = {
     "num_attention_heads": 4,
     "num_key_value_heads": 2,
     "embed_dim": 64,
+    "intermediate_size": 32,
+    "position_embedding_size": MAX_PATCHES,  # 630
+    "default_output_length": IMAGE_TOKENS,  # 70
 }
+
+processor.image_processor.image_seq_length = IMAGE_TOKENS
+processor.image_processor.max_soft_tokens = IMAGE_TOKENS
 
 config = AutoConfig.from_pretrained(MODEL_ID)
 for k, v in text_config.items():

--- a/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
@@ -26,6 +26,9 @@ check_transformers_version(TRANSFORMERS_VERSION)
 
 MODEL_ID = "google/gemma-4-E2B-it"
 
+processor = AutoProcessor.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+
 # Gemma4 image processor uses aspect-ratio-preserving resizing, not a fixed image size. max_soft_tokens controls
 # the output token budget and must be one of (70, 140, 280, 560, 1120). The smallest value (70) gives
 # max_patches = 70 × pooling_kernel_size² = 70 × 9 = 630, so position_embedding_size must be at least 630.
@@ -33,9 +36,6 @@ MODEL_ID = "google/gemma-4-E2B-it"
 # training activations [batch, patches, intermediate_size] to dominate GPU memory and OOM in CI.
 IMAGE_TOKENS = 70  # minimum supported max_soft_tokens
 MAX_PATCHES = IMAGE_TOKENS * 3**2  # 630
-
-processor = AutoProcessor.from_pretrained(MODEL_ID, image_seq_length=IMAGE_TOKENS, max_soft_tokens=IMAGE_TOKENS)
-generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 
 text_config = {
     "num_hidden_layers": 2,
@@ -54,6 +54,10 @@ vision_config = {
     "position_embedding_size": MAX_PATCHES,  # 630
     "default_output_length": IMAGE_TOKENS,  # 70
 }
+
+processor.image_seq_length = IMAGE_TOKENS  # top-level Gemma4Processor attribute (serialized to processor_config.json)
+processor.image_processor.image_seq_length = IMAGE_TOKENS  # nested Gemma4ImageProcessor attribute
+processor.image_processor.max_soft_tokens = IMAGE_TOKENS
 
 config = AutoConfig.from_pretrained(MODEL_ID)
 for k, v in text_config.items():


### PR DESCRIPTION
Fix OOM in CI by reducing intermediate_size and image token budget for tiny Gemma4.

This pull request updates the configuration for the Gemma4 model to better support conditional generation with images. The main focus is on ensuring compatibility with the model's image processing requirements and optimizing memory usage during training.

Partial fix for:
- #5750

Aligned with:
- #5680

### Motivation

The tiny Gemma4 model was inheriting production-scale values for `intermediate_size` (text: 6,144, vision: 3,072) and `position_embedding_size` (10,240 patches), because the generation script never overrode them, unlike the Gemma3 script, which explicitly reduces both. This caused training activations of shape `[batch, patches, intermediate_size]` to dominate GPU memory, making `test_train_vlm[tiny-Gemma4ForConditionalGeneration]` use ~9 GiB and OOM other workers in CI.

### Solution
- Set `intermediate_size=32` for both text and vision configs (same as Gemma3).
- Set `max_soft_tokens=70` (the minimum allowed by `Gemma4ImageProcessor`) and update the processor's `image_seq_length` accordingly. This reduces `max_patches` from 10,240 → 630 (`70 × pooling_kernel_size² = 70 × 9`).
- Set `position_embedding_size=630` and `default_output_length=70` in the vision config to match.

### Verification

Smoke test passes (`Gemma4ForConditionalGeneration: OK`). Config diff against `google/gemma-4-E2B-it` shows only the expected reductions.

### Changes

Configuration updates for image and text processing:

* Added new constants (`IMAGE_TOKENS`, `MAX_PATCHES`) to define the minimum supported `max_soft_tokens` and the corresponding maximum number of image patches, aligning with the Gemma4 image processor's requirements.
* Updated `vision_config` to set `intermediate_size` to 32 (mirroring Gemma3), `position_embedding_size` to `MAX_PATCHES` (630), and `default_output_length` to `IMAGE_TOKENS` (70), preventing out-of-memory errors during training.
* Updated `text_config` to set `intermediate_size` to 32 for consistency and improved memory management.
* Explicitly set `image_seq_length` and `max_soft_tokens` on the processor's `image_processor` to the new `IMAGE_TOKENS` value, ensuring correct image sequence handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated tiny Gemma4 processor and model configs (image token budget, patch/position sizing, MLP intermediate sizes), which can affect VLM training/inference behavior and test expectations. Scope is limited to the tiny-model generation script but impacts the produced artifacts used in CI.
> 
> **Overview**
> Reduces the tiny Gemma4 VLM’s memory footprint by explicitly shrinking both text and vision `intermediate_size` and by lowering the image token/patch budget used during preprocessing.
> 
> Updates the vision configuration to match the new maximum patch count via `position_embedding_size` and sets `default_output_length`, while also forcing the processor’s `image_seq_length`/`max_soft_tokens` to the minimum supported value to keep preprocessing and model config aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0971afad5eff18280e56945d9893609386302e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->