### PR TITLE
Fix CI apply_model_revisions by removing _commit_hash kwarg

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,11 @@ def apply_model_revisions(monkeypatch):
             if pretrained_model_name_or_path in MODEL_REVISIONS:
                 if "revision" not in kwargs:
                     kwargs["revision"] = MODEL_REVISIONS[pretrained_model_name_or_path]
+                    # Clear _commit_hash: Auto classes resolve it from the default branch before calling
+                    # sub-loaders, so the cached hash points to main. If we don't clear it, it silently
+                    # overrides the injected revision for the config load while the weight loader uses the
+                    # revision, producing a config/weights shape mismatch.
+                    kwargs.pop("_commit_hash", None)
 
             return original_func(cls, pretrained_model_name_or_path, *args, **kwargs)
 


### PR DESCRIPTION
Fix CI `apply_model_revisions` by removing `_commit_hash` kwarg.

This PR addresses a subtle bug in the model loading process by ensuring that the correct revision is used consistently when loading model configurations and weights. The change prevents mismatches between configuration and weights by clearing a cached commit hash that could override the intended revision.

Related to:
- #5760

### Motivation

`AutoModelForImageTextToText.from_pretrained(model_id)` (no revision) first does a hub lookup to get `_commit_hash` for the default branch (main). It then passes this `_commit_hash` to its internal calls, including the patched `AutoConfig.from_pretrained`. Inside `AutoConfig`, `_commit_hash` takes precedence over `revision`, so despite our fixture injecting `revision="refs/pr/3"`, the config was loaded from main (with old `intermediate_size=6144`). Meanwhile, the weight loader in the patched `PreTrainedModel.from_pretrained` was using the injected `revision="refs/pr/3"` (new weights with `intermediate_size=32`), causing a shape mismatch.
```python
  FAILED tests/test_sft_trainer.py::TestPatchChunkedCELMHead::test_forward_matches_reference_vlm[trl-internal-testing/tiny-Gemma4ForConditionalGeneration] - RuntimeError: You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!
  FAILED tests/test_sft_trainer.py::TestPatchChunkedCELMHead::test_backward_matches_reference_vlm[trl-internal-testing/tiny-Gemma4ForConditionalGeneration] - RuntimeError: You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!
```
```python
  WARNING  transformers.modeling_utils:loading_report.py:269 Gemma4ForConditionalGeneration LOAD REPORT from: trl-internal-testing/tiny-Gemma4ForConditionalGeneration
  Key                                                                  | Status   |                                                                                                 
  ---------------------------------------------------------------------+----------+-------------------------------------------------------------------------------------------------
  model.vision_tower.patch_embedder.position_embedding_table           | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([2, 630, 16]) vs model:torch.Size([2, 10240, 16])
  model.vision_tower.encoder.layers.{0, 1}.mlp.down_proj.linear.weight | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([16, 32]) vs model:torch.Size([16, 3072])        
  model.language_model.layers.{0, 1}.mlp.down_proj.weight              | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([16, 32]) vs model:torch.Size([16, 6144])        
  model.vision_tower.encoder.layers.{0, 1}.mlp.up_proj.linear.weight   | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([32, 16]) vs model:torch.Size([3072, 16])        
  model.language_model.layers.{0, 1}.mlp.gate_proj.weight              | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([32, 16]) vs model:torch.Size([6144, 16])        
  model.language_model.layers.{0, 1}.mlp.up_proj.weight                | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([32, 16]) vs model:torch.Size([6144, 16])        
  model.vision_tower.encoder.layers.{0, 1}.mlp.gate_proj.linear.weight | MISMATCH | Reinit due to size mismatch - ckpt: torch.Size([32, 16]) vs model:torch.Size([3072, 16])        
  
  Notes:
  - MISMATCH:	ckpt weights were loaded, but they did not match the original empty weight shapes.
```

### Solution

In the wrapper, when injecting `revision`, also pop `_commit_hash` from kwargs so the hub resolves the commit for the correct revision rather than the cached main-branch hash.

### Changes

Bug fix for model loading:

* Updated the `wrapper` function in `tests/conftest.py` to clear the `_commit_hash` from `kwargs` when injecting a specific model revision, ensuring that both configuration and weights are loaded from the same revision and preventing shape mismatches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that tweaks patched `from_pretrained` kwargs; main risk is unintended interaction with Transformers internals if they change kwarg behavior.
> 
> **Overview**
> Fixes the test `apply_model_revisions` monkeypatch so that when it injects a `revision` for models in `MODEL_REVISIONS`, it also removes any `_commit_hash` kwarg.
> 
> This prevents Transformers Auto classes from using a cached default-branch commit hash for config loading while weights load from the injected revision, avoiding config/weights mismatches in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44c59d311714ae026626a08025eedeee3e94adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->