### PR TITLE
Fix transformers min version for tiny gemma4 as 5.5.0

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma4_for_conditional_generation.py
@@ -21,7 +21,7 @@ from transformers import AutoConfig, AutoProcessor, Gemma4ForConditionalGenerati
 from .._common import check_dtype_pattern, check_transformers_version, print_config_diff, push_to_hub, smoke_test
 
 
-TRANSFORMERS_VERSION = "5.6.0"
+TRANSFORMERS_VERSION = "5.5.0"  # PR transformers#45192 was backported to 5.5.0 with commit 5135e5e
 check_transformers_version(TRANSFORMERS_VERSION)
 
 MODEL_ID = "google/gemma-4-E2B-it"


### PR DESCRIPTION
Fix transformers min version for tiny gemma4 as 5.5.0.

This PR makes a minor update to the `TRANSFORMERS_VERSION` in the `gemma4_for_conditional_generation.py` script, setting it to "5.5.0" to reflect that a required change was backported to this version.

Related to:
- #5760

### Changes

- Dependency version update:
  * Changed `TRANSFORMERS_VERSION` from "5.6.0" to "5.5.0" in `gemma4_for_conditional_generation.py` to align with the backport of PR transformers#45192.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `check_transformers_version` floor in a model-generation script, with no runtime or model-architecture changes.
> 
> **Overview**
> Updates the Gemma4 tiny-model generation script to require `transformers==5.5.0` (down from `5.6.0`), noting that the needed Gemma4 fix was backported (transformers#45192).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e782982cfb46fca6f96fb59340cfd23fb587c6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->