### PR TITLE
Add Qwen3-VL training chat template with generation markers

### DIFF
--- a/docs/source/chat_templates.md
+++ b/docs/source/chat_templates.md
@@ -96,6 +96,12 @@ Always include the thinking block regardless of message position. The original c
 
 Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
 
+### `qwen3_vl_training.jinja`
+
+Patched Qwen3-VL template. Diff vs `qwen3_vl.jinja`:
+
+Wrap assistant message output (both `content` and `tool_calls`) with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
 ### `gptoss_training.jinja`
 
 Patched GPT-OSS template. Diff vs `gptoss.jinja`:

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -469,6 +469,7 @@ class TestIsChatTemplatePrefixPreserving:
         pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
+        pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
         pytest.param(
             "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
             id="qwen36",

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -571,6 +571,8 @@ qwen3_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_training.jinja").re
 
 qwen3_instruct_2507_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_instruct_2507_training.jinja").read_text()
 
+qwen3_vl_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_vl_training.jinja").read_text()
+
 qwen3_6_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6_training.jinja").read_text()
 
 
@@ -584,7 +586,7 @@ def get_training_chat_template(
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
     Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5,
-    Qwen2.5, Qwen3 (including the Instruct-2507 variant), and Qwen3.6 are supported.
+    Qwen2.5, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -688,6 +690,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == qwen3_instruct_2507_chat_template:
         return qwen3_instruct_2507_training_chat_template
+
+    if processing_class.chat_template == qwen3_vl_chat_template:
+        return qwen3_vl_training_chat_template
 
     if processing_class.chat_template == qwen3_6_chat_template:
         return qwen3_6_training_chat_template

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -183,6 +183,12 @@ Always include the thinking block regardless of message position. The original c
 
 Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
 
+### `qwen3_vl_training.jinja`
+
+Patched Qwen3-VL template. Diff vs `qwen3_vl.jinja`:
+
+Wrap assistant message output (both `content` and `tool_calls`) with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
 ### `qwen3_6_training.jinja`
 
 Patched Qwen3.6 template. Same diff as `qwen3_training.jinja` (require both `<think>` and `</think>` before parsing, drop the `loop.index0 > ns.last_query_index` conditional so the thinking block is always emitted, wrap assistant output in `{% generation %}` / `{% endgeneration %}`), applied to the Qwen3.6 base template.

--- a/trl/chat_templates/qwen3_vl_training.jinja
+++ b/trl/chat_templates/qwen3_vl_training.jinja
@@ -1,0 +1,127 @@
+{#- Training variant of the Qwen 3 VL chat template (see qwen3_vl.jinja for the original).
+    Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around assistant message content to
+      support assistant-only loss masking in SFT training.
+-#}
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {%- if messages[0].content is string %}
+            {{- messages[0].content }}
+        {%- else %}
+            {%- for content in messages[0].content %}
+                {%- if 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' }}
+        {%- if messages[0].content is string %}
+            {{- messages[0].content }}
+        {%- else %}
+            {%- for content in messages[0].content %}
+                {%- if 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- for message in messages %}
+    {%- if message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- if message.content is string %}
+            {{- message.content }}
+        {%- else %}
+            {%- for content in message.content %}
+                {%- if content.type == 'image' or 'image' in content or 'image_url' in content %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                    {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                    <|vision_start|><|image_pad|><|vision_end|>
+                {%- elif content.type == 'video' or 'video' in content %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                    {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                    <|vision_start|><|video_pad|><|vision_end|>
+                {%- elif 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation -%}
+            {%- if message.content is string %}
+                {{- message.content }}
+            {%- else %}
+                {%- for content_item in message.content %}
+                    {%- if 'text' in content_item %}
+                        {{- content_item.text }}
+                    {%- endif %}
+                {%- endfor %}
+            {%- endif %}
+            {%- if message.tool_calls %}
+                {%- for tool_call in message.tool_calls %}
+                    {%- if (loop.first and message.content) or (not loop.first) %}
+                        {{- '\n' }}
+                    {%- endif %}
+                    {%- if tool_call.function %}
+                        {%- set tool_call = tool_call.function %}
+                    {%- endif %}
+                    {{- '<tool_call>\n{"name": "' }}
+                    {{- tool_call.name }}
+                    {{- '", "arguments": ' }}
+                    {%- if tool_call.arguments is string %}
+                        {{- tool_call.arguments }}
+                    {%- else %}
+                        {{- tool_call.arguments | tojson }}
+                    {%- endif %}
+                    {{- '}\n</tool_call>' }}
+                {%- endfor %}
+            {%- endif %}
+            {{- '<|im_end|>\n' }}
+        {%- endgeneration -%}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {%- if message.content is string %}
+            {{- message.content }}
+        {%- else %}
+            {%- for content in message.content %}
+                {%- if content.type == 'image' or 'image' in content or 'image_url' in content %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                    {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                    <|vision_start|><|image_pad|><|vision_end|>
+                {%- elif content.type == 'video' or 'video' in content %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                    {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                    <|vision_start|><|video_pad|><|vision_end|>
+                {%- elif 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}


### PR DESCRIPTION
## What does this PR do?

Adds a `{% generation %}`-marked training variant of the Qwen3-VL chat template so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.

Diff vs `qwen3_vl.jinja`: wrap the assistant turn body — text content + `tool_calls` + closing `<|im_end|>\n` — with `{% generation %}` / `{% endgeneration %}`. The `<|im_start|>assistant\n` prompt cue stays outside the block; the `tool` and `user` branches are untouched, since tool responses are model input, not output.

### Note: this code path is currently unreachable

`SFTTrainer` raises at `trl/trainer/sft_trainer.py:1006` for any VLM with `assistant_only_loss=True`:

```python
if self._is_vlm and args.assistant_only_loss:
    raise ValueError(
        "Assistant-only loss is not yet supported for vision-language models. ..."
    )
```

So the new template cannot be exercised by a real SFT training run today. **This PR is forward-looking prep**, submitted under the explicit sanction in #5471: *"VLMs currently don't support `assistant_only_loss` in SFT (blocked by a separate check). These should still be tracked so templates are ready when support lands."* When the guard lifts in a separate effort, Qwen3-VL training will work without an additional change here.

Validation surface, in the meantime, is the existing `TestGetTrainingChatTemplate` suite — prefix-preservation, behavior-unchanged, and mask-correctness checks against the rendered template string. No real SFT training was attempted.

### Changes:

- `trl/chat_templates/qwen3_vl_training.jinja`: new training template, identical to `qwen3_vl.jinja` except for the `{% generation %}` / `{% endgeneration %}` markers wrapping the assistant body.
- `trl/chat_template_utils.py`: load the new template and add a dispatch branch in `get_training_chat_template()` for `qwen3_vl_chat_template`. Docstring updated to mention Qwen3-VL.
- `tests/test_chat_template_utils.py`: extend the `TestGetTrainingChatTemplate` parametrize with the `trl-internal-testing/tiny-Qwen3VLForConditionalGeneration` fixture — runs prefix-preservation, behavior-unchanged, and mask-correctness checks against the new template.
- `trl/chat_templates/README.md` and `docs/source/chat_templates.md`: short section describing the training template, mirroring the structure of the existing `qwen3_training.jinja` entries.

Part of #5471.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new opt-in training chat template and selection branch for Qwen3-VL plus associated tests/docs, with minimal impact outside that model family.
> 
> **Overview**
> Adds a new `qwen3_vl_training.jinja` template that wraps Qwen3-VL assistant output (text, `tool_calls`, and the closing `<|im_end|>`) in `{% generation %}` / `{% endgeneration %}` to enable correct assistant-token masking for SFT.
> 
> Updates `get_training_chat_template()` to recognize the Qwen3-VL base template and return this new training variant, extends the existing template utility test matrix to cover a Qwen3-VL processor, and documents the new training template in both the library and Sphinx docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b66bc2f1e48cb93e3d2bcb3c74237cc806c84ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->