### PR TITLE
Memory-efficient PEFT/LoRA vLLM weight sync under DeepSpeed ZeRO-3

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -456,43 +456,51 @@ class VLLMGeneration:
             gather_if_zero3 = nullcontext
 
         if is_peft_model(model):
-            # With PEFT and FSDP/DeepSpeed ZeRO Stage 3, we must gather the full model at once before merging, as
-            # merging adapters in a sharded manner is not supported.
-            # TODO: does this work with FSDP?
-            with gather_if_zero3(list(model.parameters())):
-                model.merge_adapter()
-
-                # Update vLLM weights while parameters are gathered
-                if is_fsdp_enabled:  # note if using FSDP, gather_if_zero3 is nullcontext
-                    # Update vLLM weights while parameters are gathered
-                    # For PEFT with FSDP we need to use the memory efficient post-order traversal
+            if is_fsdp_enabled:
+                # For PEFT with FSDP, gather_if_zero3 is nullcontext (FSDP handles sharding).
+                # Merge all adapters, sync via FSDP-aware traversal, then unmerge.
+                with gather_if_zero3(list(model.parameters())):
+                    model.merge_adapter()
                     fsdp_plugin = getattr(accelerator.state, "fsdp_plugin", None)
                     fsdp_version = getattr(fsdp_plugin, "fsdp_version", 1) if fsdp_plugin else 1
                     if fsdp_version == 1:
-                        self._sync_fsdp1_params_to_vllm(model)  # use memory-efficient post-order traversal for FSDP
+                        self._sync_fsdp1_params_to_vllm(model)
                     elif fsdp_version == 2:
                         self._sync_fsdp2_params_to_vllm(model)
-                else:
-                    # DeepSpeed ZeRO-3 with PEFT
-                    for name, param in model.named_parameters():
-                        # When using PEFT, we need to recover the original parameter name
-                        name = name.removeprefix("base_model.model.").replace(".base_layer", "")
-                        # Skip PEFT layers: they don't exist in vLLM, and they are merged already.
-                        if model.prefix in name:
-                            continue
-                        # When module to save, remove its prefix and discard the original module
-                        if "original_module" in name:
-                            continue
-                        name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
+                    model.unmerge_adapter()
+            else:
+                # DeepSpeed ZeRO-3 with PEFT: gather, merge, sync, and unmerge one LoRA module at a time
+                # to avoid materializing the entire model on every rank (which OOMs on large models).
+                from peft.tuners.tuners_utils import BaseTunerLayer, onload_layer
+                from peft.utils.other import ModulesToSaveWrapper
 
-                        if self.mode == "server" and accelerator.is_main_process:
-                            self.vllm_client.update_named_param(name, param.data)
-                        elif self.mode == "colocate":
-                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
-                            llm_model.load_weights([(name, param.data)])
-                # Unmerge adapters while parameters are still gathered
-                model.unmerge_adapter()
-                # Parameters will automatically be repartitioned when exiting the context
+                for module_name, module in model.named_modules():
+                    if not isinstance(module, (BaseTunerLayer, ModulesToSaveWrapper)):
+                        continue
+                    with gather_if_zero3(list(module.parameters())):
+                        if isinstance(module, BaseTunerLayer):
+                            with onload_layer(module):
+                                module.merge()
+                        for name, param in module.named_parameters():
+                            full_name = f"{module_name}.{name}"
+                            name = (
+                                full_name.removeprefix("base_model.model.")
+                                .replace(".base_layer", "")
+                                .replace("base_layer.", "")
+                            )
+                            if model.prefix in name:
+                                continue
+                            if "original_module" in name:
+                                continue
+                            name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
+                            if self.mode == "server" and accelerator.is_main_process:
+                                self.vllm_client.update_named_param(name, param.data)
+                            elif self.mode == "colocate":
+                                llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                                llm_model.load_weights([(name, param.data)])
+                        if isinstance(module, BaseTunerLayer):
+                            with onload_layer(module):
+                                module.unmerge()
         else:
             # For non-PEFT models, simply gather (if needed) and update each parameter individually.
             if is_fsdp_enabled:

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -380,7 +380,13 @@ def llm_worker(
             method_name = command["method"]
             args, kwargs = command.get("args", ()), command.get("kwargs", {})
             method = getattr(llm, method_name)
-            result = method(*args, **kwargs)
+            try:
+                result = method(*args, **kwargs)
+            except Exception as exc:
+                if command["type"] == "call":
+                    connection.send(exc)
+                    continue
+                raise
             if command["type"] == "call":
                 connection.send(result)
         elif command["type"] == "shutdown":
@@ -644,6 +650,9 @@ def main(script_args: ScriptArguments):
 
         # Receive results
         all_outputs = [connection.recv() for connection in connections]
+        for output in all_outputs:
+            if isinstance(output, Exception):
+                raise output
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_prompts, strict=True) if prompts]
@@ -688,6 +697,9 @@ def main(script_args: ScriptArguments):
             kwargs = {"prompts": chunk, "sampling_params": sampling_params}
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
         all_outputs = [connection.recv() for connection in connections]
+        for output in all_outputs:
+            if isinstance(output, Exception):
+                raise output
         all_outputs = [output for output, chunk in zip(all_outputs, chunked_prompts, strict=True) if chunk]
         return list(chain.from_iterable(all_outputs))
 
@@ -1100,6 +1112,9 @@ def main(script_args: ScriptArguments):
 
         # Receive results
         all_outputs = [connection.recv() for connection in connections]
+        for output in all_outputs:
+            if isinstance(output, Exception):
+                raise output
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_messages, strict=True) if prompts]


### PR DESCRIPTION
# What does this PR do?

This PR makes vLLM weight synchronization more memory-efficient for PEFT/LoRA models trained with DeepSpeed ZeRO-3.

Previously, the PEFT weight-sync path gathered all model parameters before merging adapters and syncing weights to vLLM. Under DeepSpeed ZeRO-3, this can materialize the full model on every rank and cause OOMs for large models.

This PR changes the non-FSDP PEFT path to gather, merge, sync, and unmerge one `BaseTunerLayer` module at a time. This avoids a full-model gather while preserving the existing parameter-name normalization and vLLM loading behavior.

It also adds minimal worker exception propagation in [vllm_serve.py](cci:7://file:///home/rakeshramesh/trl/trl/scripts/vllm_serve.py:0:0-0:0), so worker-side failures are sent back through the pipe and surfaced by the parent process instead of hanging.

No new dependencies are added.

## Changes

- Avoid full-model parameter gathering for PEFT/LoRA + DeepSpeed ZeRO-3 vLLM weight sync.
- Keep the FSDP PEFT path unchanged.
- Preserve existing vLLM parameter-name handling for PEFT layers.
- Propagate worker exceptions from [generate()](cci:1://file:///home/rakeshramesh/trl/trl/scripts/vllm_serve.py:539:4-669:9), [chat()](cci:1://file:///home/rakeshramesh/trl/trl/scripts/vllm_serve.py:1002:4-1131:9), and [_run_prompt_logprobs()](cci:1://file:///home/rakeshramesh/trl/trl/scripts/vllm_serve.py:689:4-702:53) calls.

## Testing

- [x] `python -m ruff check trl/generation/vllm_generation.py trl/scripts/vllm_serve.py`
- [x] `python -m ruff format --check trl/generation/vllm_generation.py trl/scripts/vllm_serve.py`
- [x] `python -m pytest tests/test_vllm_client_server.py::TestChunkList tests/test_vllm_client_server.py::TestExtractLogprobs -q`
- [x] `python -m pytest tests/test_vllm_client_server.py -q -m "not slow"`
- [ ] Full vLLM server/GPU tests were not run locally.
- [ ] DeepSpeed ZeRO-3 + PEFT integration test was not run locally.
<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @AmineDiro @kashif @remi-or

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed PEFT/LoRA weight syncing under DeepSpeed ZeRO-3 and changes inter-process error handling; mistakes could cause incorrect weight updates or new runtime failures/hangs during generation.
> 
> **Overview**
> Improves PEFT/LoRA weight synchronization to vLLM under **DeepSpeed ZeRO-3** by switching from a full-model gather/merge to a *module-at-a-time* gather+merge+sync+unmerge flow (using `BaseTunerLayer`/`ModulesToSaveWrapper`) to avoid per-rank full-model materialization and OOMs.
> 
> Keeps the **FSDP** PEFT path as a full merge+sync via existing FSDP-aware traversal, but ensures unmerge happens within the gathered context.
> 
> Updates `vllm_serve.py` so worker-side exceptions during `generate`/`chat` (and prompt-logprob generation) are sent through the pipe and raised in the parent, preventing silent hangs and surfacing failures earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533325d03a3682e72851eb69287fb19db579b4c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->