### PR TITLE
Fix OOM in CI by reducing batch size in GRPO/RLOO VLM tests

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1966,7 +1966,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -2012,7 +2012,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
@@ -2054,7 +2054,7 @@ class TestGRPOTrainer(TrlTestCase):
             output_dir=self.tmp_dir,
             beta=0.1,  # set beta to non-zero value to test the case where the reference model is used
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -2102,7 +2102,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -2146,7 +2146,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             steps_per_generation=2,  # increase the steps per generation to trigger IS
@@ -2200,7 +2200,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             use_liger_kernel=True,  # enable Liger kernel
@@ -2256,7 +2256,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -2297,7 +2297,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -2496,7 +2496,7 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=512,
             report_to="none",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1968,6 +1968,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2014,6 +2015,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
             report_to="none",
@@ -2056,6 +2058,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2104,6 +2107,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2148,6 +2152,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             steps_per_generation=2,  # increase the steps per generation to trigger IS
             report_to="none",
@@ -2202,6 +2207,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             use_liger_kernel=True,  # enable Liger kernel
             report_to="none",
@@ -2258,6 +2264,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
             use_vllm=True,
@@ -2299,6 +2306,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2498,6 +2506,7 @@ class TestGRPOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=512,
             report_to="none",
         )

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1966,8 +1966,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2012,8 +2012,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
             report_to="none",
@@ -2054,8 +2054,8 @@ class TestGRPOTrainer(TrlTestCase):
             output_dir=self.tmp_dir,
             beta=0.1,  # set beta to non-zero value to test the case where the reference model is used
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2102,8 +2102,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2146,8 +2146,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             steps_per_generation=2,  # increase the steps per generation to trigger IS
             report_to="none",
@@ -2200,8 +2200,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             use_liger_kernel=True,  # enable Liger kernel
             report_to="none",
@@ -2256,8 +2256,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
             use_vllm=True,
@@ -2297,8 +2297,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -2496,8 +2496,8 @@ class TestGRPOTrainer(TrlTestCase):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=512,
             report_to="none",
         )

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2512,7 +2512,7 @@ class TestGRPOTrainer(TrlTestCase):
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
         def fake_generate(input_ids, **kwargs):
-            if input_ids.shape[0] == 3:  # first call
+            if input_ids.shape[0] == 2:  # first call: num_generations=2 completions for 1 prompt
                 # fmt: off
                 completion_ids = torch.tensor(
                     [
@@ -2520,17 +2520,13 @@ class TestGRPOTrainer(TrlTestCase):
                         [248058, 198, 27, 1628, 13744, 30091, 22076, 29, 198, 510, 1628, 29, 198, 248059, 248046],
                         # "I don't know any tool<|im_end|>" + padding
                         [40, 1459, 914, 1366, 866, 5224, 248046, 248044, 248044, 248044, 248044, 248044, 248044, 248044, 248044],
-                        # '<tool_call>\n<function=screenshot_tool>\n</function>\n</tool_call><|im_end|>'
-                        [248058, 198, 27, 1628, 13744, 30091, 22076, 29, 198, 510, 1628, 29, 198, 248059, 248046],
                     ],
                     device=input_ids.device,
                 )
                 # fmt: on
-            else:  # second call: 2 tool calls succeeded
+            else:  # second call: 1 tool call succeeded
                 completion_ids = torch.tensor(
                     [
-                        # 'Done!<|im_end|>'
-                        [16936, 0, 248046],
                         # 'Done!<|im_end|>'
                         [16936, 0, 248046],
                     ],
@@ -2542,7 +2538,8 @@ class TestGRPOTrainer(TrlTestCase):
             trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
-        assert trainer.state.log_history[-1]["tools/call_frequency"] == pytest.approx(2 / 3)
+        # With num_generations=2: 1 out of 2 completions is a tool call (1/2), and it succeeds (0 failures).
+        assert trainer.state.log_history[-1]["tools/call_frequency"] == pytest.approx(1 / 2)
         assert trainer.state.log_history[-1]["tools/failure_frequency"] == pytest.approx(0.0)
 
         # Check that the params have changed (skip vision parts, see test_train_vlm)

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1354,6 +1354,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1400,6 +1401,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
             report_to="none",
@@ -1442,6 +1444,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1490,6 +1493,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1544,6 +1548,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
             use_vllm=True,
@@ -1585,6 +1590,7 @@ class TestRLOOTrainer(TrlTestCase):
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1352,7 +1352,7 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -1398,7 +1398,7 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
@@ -1440,7 +1440,7 @@ class TestRLOOTrainer(TrlTestCase):
             output_dir=self.tmp_dir,
             beta=0.1,  # set beta to non-zero value to test the case where the reference model is used
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -1488,7 +1488,7 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -1542,7 +1542,7 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
@@ -1583,7 +1583,7 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1352,8 +1352,8 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1398,8 +1398,8 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             pad_to_multiple_of=7,
             report_to="none",
@@ -1440,8 +1440,8 @@ class TestRLOOTrainer(TrlTestCase):
             output_dir=self.tmp_dir,
             beta=0.1,  # set beta to non-zero value to test the case where the reference model is used
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1488,8 +1488,8 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )
@@ -1542,8 +1542,8 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
             use_vllm=True,
@@ -1583,8 +1583,8 @@ class TestRLOOTrainer(TrlTestCase):
         training_args = RLOOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            num_generations=3,  # reduce the number of generations to reduce memory usage
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             report_to="none",
         )


### PR DESCRIPTION
Fix OOM in CI by reducing batch size in GRPO/RLOO VLM tests.

This PR updates the test configurations for GRPO and RLOO trainers to further reduce memory usage during VLM (Vision-Language Model) training. The primary change is lowering the `per_device_train_batch_size` from 3 to 1 in various test cases, with updated comments to clarify that this is to avoid out-of-memory (OOM) errors due to the memory-intensive nature of VLM training.

Partial fix for:
- #5750

Aligned with:
- #5687

Related to:
- #5760

### Motivation

CI was OOMing because `-n auto` runs 4 xdist workers sharing one 14.74 GiB GPU. When `test_train_vlm[tiny-Gemma4ForConditionalGeneration]` ran in one worker (~9.17 GiB), a concurrent worker attempting to allocate 2.95 GiB found only 2.87 GiB free. Two fixes address this at different levels:
- shrink the Gemma4 model itself: #5760
- and reduce the batch size in all VLM trainer tests: this PR
  - Dropping to per_device_train_batch_size=1 reduces training-phase memory roughly 3×

### Changes

Test configuration updates for memory optimization:

* Reduced `per_device_train_batch_size` from 3 to 1 in all relevant test cases within `tests/test_grpo_trainer.py` to prevent OOM errors during VLM training.
* Made the same batch size reduction in all relevant test cases within `tests/test_rloo_trainer.py` for consistency and to address VLM memory constraints.

These changes ensure that the test suite can run reliably on machines with limited memory resources when training VLMs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only config tweaks to lower GPU memory usage in CI; low functional risk beyond potentially reducing VLM training coverage in tests.
> 
> **Overview**
> Reduces GPU memory pressure in **GRPO** and **RLOO** vision-language training tests by lowering `per_device_train_batch_size` and `num_generations` from `3` to `2`, with updated comments clarifying this is *CI-only* to avoid OOM.
> 
> Updates the GRPO multimodal tools test to reflect the new `num_generations=2` behavior by adjusting the mocked `generate` batch shapes and the expected `tools/call_frequency` assertion (from `2/3` to `1/2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6184460441e5493aadbd086d1b10553fa1e0e7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->