### PR TITLE
Hotfix CI param not updated AssertionError: Pin torch < 2.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,8 @@ dev = [
     "num2words==0.5.14",
     # for response parsing (required for training with tools)
     "jmespath",
+    # CI
+    "torch<2.12.0",  # temporary hotfix for #5768
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Hotfix CI AssertionError: Param model.visual.blocks.0.norm1.weight is not updated by temporarily:
- Pin torch < 2.12.0.

Hotfix for:
- #5768



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change, but it can mask issues or create environment drift if developers rely on newer PyTorch features.
> 
> **Overview**
> Adds a temporary CI hotfix by pinning `torch<2.12.0` in the `dev` optional dependency set (with an inline reference to `#5768`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a241d830d7a02857b9a9fa71e92ca178ed4f1645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->