### PR TITLE
Remove obsolete Gemma3 vision-head guard from VLM training tests

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -979,7 +979,6 @@ class TestDPOTrainer(TrlTestCase):
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
             if (
-                model_id == "trl-internal-testing/tiny-Gemma3ForConditionalGeneration" and "model.vision_tower.vision_model.head" in n or
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -575,7 +575,6 @@ class TestSFTTrainer(TrlTestCase):
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
             if (
-                model_id == "trl-internal-testing/tiny-Gemma3ForConditionalGeneration" and "model.vision_tower.vision_model.head" in n or
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
@@ -1655,7 +1654,6 @@ class TestSFTTrainer(TrlTestCase):
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
             if (
-                model_id == "trl-internal-testing/tiny-Gemma3ForConditionalGeneration" and "model.vision_tower.vision_model.head" in n or
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497


### PR DESCRIPTION
Removes a guard line that skipped the "param has changed during training" assertion for `tiny-Gemma3ForConditionalGeneration` parameters matching `"model.vision_tower.vision_model.head"`

The guard is dead code in every transformers version we currently test (`4.56` → `5.8`).

## Why it was added

Added in commit [5c53f4804](https://github.com/huggingface/trl/commit/5c53f4804) (Aug 9 2025). The earliest revisions of the tiny model on the Hub ([`c3156394`](https://huggingface.co/trl-internal-testing/tiny-Gemma3ForConditionalGeneration/commit/c3156394), [`e1f4b051`](https://huggingface.co/trl-internal-testing/tiny-Gemma3ForConditionalGeneration/commit/e1f4b051), Jul 22 2025) did not set `vision_use_head` in `config.json`. `SiglipVisionModel` defaults `use_head=True` when the attribute is missing ([modeling_siglip.py L572](https://github.com/huggingface/transformers/blob/v5.6.0/src/transformers/models/siglip/modeling_siglip.py#L572)), so the `SiglipMultiheadAttentionPoolingHead` was instantiated.

Those head params received no gradient during training because of a dead-code path in transformers' Gemma3 modeling: `SiglipVisionModel.forward` computes `pooler_output = self.head(last_hidden_state)`, but [`Gemma3Model.get_image_features`](https://github.com/huggingface/transformers/blob/3e80155a968c1080f11b2710e8b31741ac5ab0ed/src/transformers/models/gemma3/modeling_gemma3.py#L801-L808) immediately overwrites that field with `multi_modal_projector(last_hidden_state)`. The head's output never reaches the loss → `param.grad is None` → optimizer leaves it untouched → the assertion fails. The guard was the workaround.

## Why it is now dead code

[`ca18b3a`](https://huggingface.co/trl-internal-testing/tiny-Gemma3ForConditionalGeneration/commit/ca18b3adabcdd7259d21b77587061c14726600e8) (Aug 13 2025) the tiny model was re-uploaded with `vision_config.vision_use_head: False` explicitly set. Every revision since carries that flag. So `hasattr(config, "vision_use_head")` is always `True` and `SiglipVisionModel` never instantiates `head`. The guard string matches zero parameter names today.

This also matches every published Gemma3 checkpoint (`google/gemma-3-4b-it`, `google/gemma-3-12b-it`): they all ship with `vision_use_head=False` and zero head/probe/pooler keys in their safetensors.

## Also, on naming

Transformers PR [#44431](https://github.com/huggingface/transformers/pull/44431) ("Refactor CLIP-like models", v5.6.0) flattened `SiglipVisionModel` by removing the inner `SiglipVisionTransformer` wrapper, renaming params from `vision_tower.vision_model.*` → `vision_tower.*`. The removed guard used the pre-5.6.0 naming, which is another reason it cannot match anything in current transformers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that tightens the "parameters changed during training" assertions for Gemma3 VLM cases without affecting library runtime behavior.
> 
> **Overview**
> Removes an obsolete exception in `test_train_vlm` parameter-update assertions for `trl-internal-testing/tiny-Gemma3ForConditionalGeneration`, so the tests no longer skip checking `model.vision_tower.vision_model.head` parameters.
> 
> Applies the same cleanup in both DPO (`test_dpo_trainer.py`) and SFT (`test_sft_trainer.py`) VLM training tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6377a26de0b4d14c34cef45967a7f50dc2dbceeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->