### PR TITLE
trainer/grpo_trainer: fix NaN-poisoned group mean/std in sum_then_normalize advantage computation

### DIFF
--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -1075,7 +1075,7 @@ class DPPOTrainer(GRPOTrainer):
             elif self.scale_rewards == "batch":
                 # Compute global std
                 if rewards.numel() > 1:
-                    std_rewards = rewards.std().expand_as(rewards)
+                    std_rewards = nanstd(rewards).expand_as(rewards)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=batch_size=1
                     std_rewards = torch.zeros_like(rewards)
             else:

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -1060,13 +1060,15 @@ class DPPOTrainer(GRPOTrainer):
 
         if self.multi_objective_aggregation == "sum_then_normalize":
             # Apply weights to each reward function's output and sum
-            rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
-            mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1)
+            weighted = rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
+            rewards = weighted.nansum(dim=1)
+            rewards[torch.isnan(weighted).all(dim=1)] = float("nan")
+            mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1)
             mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
                 # If self.scale_rewards = "none", we'll only use std_rewards to check for zero std for logging
                 if num_generations > 1:
-                    std_rewards = rewards.view(-1, num_generations).std(dim=1)
+                    std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
                     std_rewards = std_rewards.repeat_interleave(num_generations, dim=0)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=1
                     std_rewards = torch.zeros_like(rewards)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2142,20 +2142,22 @@ class GRPOTrainer(_BaseTrainer):
 
         if self.multi_objective_aggregation == "sum_then_normalize":
             # Apply weights to each reward function's output and sum
-            rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
-            mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1)
+            weighted = rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
+            rewards = weighted.nansum(dim=1)
+            rewards[torch.isnan(weighted).all(dim=1)] = float("nan")
+            mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1)
             mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
                 # If self.scale_rewards = "none", we'll only use std_rewards to check for zero std for logging
                 if num_generations > 1:
-                    std_rewards = rewards.view(-1, num_generations).std(dim=1)
+                    std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
                     std_rewards = std_rewards.repeat_interleave(num_generations, dim=0)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=1
                     std_rewards = torch.zeros_like(rewards)
             elif self.scale_rewards == "batch":
                 # Compute global std
                 if rewards.numel() > 1:
-                    std_rewards = rewards.std().expand_as(rewards)
+                    std_rewards = nanstd(rewards).expand_as(rewards)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=batch_size=1
                     std_rewards = torch.zeros_like(rewards)
             else:


### PR DESCRIPTION
# What does this PR do?

In the `sum_then_normalize` branch of the advantage computation in `GRPOTrainer`, rewards are aggregated across reward functions using `nansum`. This correctly handles reward functions that return `None` (stored as `torch.nan`) for individual samples. However, `nansum` silently converts an **all-NaN row** — a generation slot where every reward function returned `None` — to `0.0` instead of preserving `NaN`. The warning at line 1268 does not halt execution, so this spurious `0.0` flows forward into the group mean and std calculations.

Two downstream calls are affected:
- `rewards.view(-1, num_generations).mean(dim=1)` includes the fake `0.0` in the group mean, corrupting the advantage baseline for every other generation in the same group.
- `rewards.view(-1, num_generations).std(dim=1)` uses the same fake `0.0`, distorting the scale factor applied to advantages.

This fix:
1. Detects all-NaN rows before `nansum` collapses them and restores `NaN` afterward.
2. Replaces `.mean(dim=1)` with `torch.nanmean(..., dim=1)` and `.std(dim=1)` with `nanstd(..., dim=1)` (already imported), consistent with how the `normalize_then_sum` branch already handles the same situation.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure
- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?
Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core GRPO/DPPO advantage normalization path to treat all-NaN reward rows as NaN and to compute group/batch statistics with NaN-aware reductions; this can materially alter training dynamics but is localized to the `sum_then_normalize` aggregation branch.
> 
> **Overview**
> Fixes NaN handling in the `sum_then_normalize` multi-objective reward aggregation for both `GRPOTrainer` and experimental `DPPOTrainer`.
> 
> Instead of letting `nansum` collapse all-NaN reward rows to `0.0`, the code now restores those rows to `NaN` and computes grouped means and standard deviations with `torch.nanmean`/`nanstd`, preventing invalid rows from contaminating advantage centering/scaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9a0b7bcf6e468c11a3d75f10e9ac379e70d70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->