### PR TITLE
Fix OOM in CI by clearing chained exception tracebacks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,16 +34,21 @@ def pytest_runtest_makereport(item, call):
     yield
     if call.when == "call" and call.excinfo is not None:
         traceback.clear_frames(call.excinfo.tb)
-        # Also clear chained exception tracebacks: when OOM fires inside a try/except in the trainer,
-        # the OOM becomes __context__ of the outer exception and its traceback holds frame locals
-        # (model, tensors) that prevent gc from releasing CUDA memory even after clear_frames above.
-        exc, seen = call.excinfo.value, set()
-        while exc is not None and id(exc) not in seen:
+        # Also clear all reachable chained exception tracebacks (both __context__ and __cause__ at
+        # every node): when OOM fires inside a try/except in the trainer, the OOM becomes __context__
+        # of the outer exception and its traceback holds frame locals (model, tensors) that prevent gc
+        # from releasing CUDA memory even after clear_frames above.
+        stack, seen = [call.excinfo.value], set()
+        while stack:
+            exc = stack.pop()
+            if exc is None or id(exc) in seen:
+                continue
             seen.add(id(exc))
             if exc.__traceback__ is not None:
                 traceback.clear_frames(exc.__traceback__)
                 exc.__traceback__ = None
-            exc = exc.__cause__ if exc.__suppress_context__ else exc.__context__
+            stack.append(exc.__context__)
+            stack.append(exc.__cause__)
 
 
 # ============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,16 @@ def pytest_runtest_makereport(item, call):
     yield
     if call.when == "call" and call.excinfo is not None:
         traceback.clear_frames(call.excinfo.tb)
+        # Also clear chained exception tracebacks: when OOM fires inside a try/except in the trainer,
+        # the OOM becomes __context__ of the outer exception and its traceback holds frame locals
+        # (model, tensors) that prevent gc from releasing CUDA memory even after clear_frames above.
+        exc, seen = call.excinfo.value, set()
+        while exc is not None and id(exc) not in seen:
+            seen.add(id(exc))
+            if exc.__traceback__ is not None:
+                traceback.clear_frames(exc.__traceback__)
+                exc.__traceback__ = None
+            exc = exc.__cause__ if exc.__suppress_context__ else exc.__context__
 
 
 # ============================================================================


### PR DESCRIPTION
Fix OOM in CI by clearing chained exception tracebacks.

This PR improves memory management during test runs by ensuring that all chained exception tracebacks are cleared. This helps prevent memory leaks, especially with CUDA memory, by allowing garbage collection to release resources that would otherwise be held by lingering references in exception tracebacks.

Partial fix for:
- #5750

### Motivation

`traceback.clear_frames(call.excinfo.tb)` only cleared the main traceback. When OOM fires inside a `try/except` in a trainer, the OOM exception becomes `__context__` of the outer exception and its traceback holds strong references to frame locals (model, tensors). `gc.collect()` cannot reclaim memory still reachable through a live traceback, so CUDA memory accumulates across reruns (~2 GiB per rerun, reaching ~12 GiB after 5 reruns, exactly what was observed in CI). The fix walks the full `__context__`/`__cause__` chain, clears every traceback's frame locals, and nulls `__traceback__` so `cleanup_gpu` can actually reclaim the memory before the next test.

### Changes

Exception and traceback handling improvements:

* Enhanced the `pytest_runtest_makereport` hook in `tests/conftest.py` to recursively clear all chained exception tracebacks (including those from `__context__` and `__cause__`). This prevents objects (like models and tensors) referenced in exception locals from blocking garbage collection and releasing CUDA memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that broadens traceback cleanup on failures; main risk is masking some debugging context by nulling chained exception tracebacks.
> 
> **Overview**
> Improves CI test memory cleanup by extending `pytest_runtest_makereport` to clear frame locals for *all* exceptions in the `__context__`/`__cause__` chain, not just the primary traceback.
> 
> After clearing each traceback’s frames, it also sets `exc.__traceback__ = None` to break lingering references that can keep CUDA tensors/models alive across reruns and lead to accumulated OOMs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620d4f3441b67e47b1eff107ef6d3eaebe0d87a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->