### PR TITLE
Make the LLaVA / LLaVA-Next test guard explicit

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/llava_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/llava_for_conditional_generation.py
@@ -36,8 +36,6 @@ vision_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_attention_heads": 4,
-    "num_key_value_heads": 2,
-    "embed_dim": 64,
 }
 
 config = AutoConfig.from_pretrained(MODEL_ID, text_config=text_config, vision_config=vision_config)

--- a/scripts/generate_tiny_models/for_conditional_generation/llava_next_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/llava_next_for_conditional_generation.py
@@ -42,8 +42,6 @@ vision_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_attention_heads": 4,
-    "num_key_value_heads": 2,
-    "embed_dim": 64,
 }
 
 config = AutoConfig.from_pretrained(MODEL_ID, text_config=text_config, vision_config=vision_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-LlavaForConditionalGeneration": "refs/pr/4",
-    "trl-internal-testing/tiny-LlavaNextForConditionalGeneration": "refs/pr/7",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,9 @@ def pytest_runtest_makereport(item, call):
 # ============================================================================
 
 MODEL_REVISIONS = {
-    # Add model_id: revision mappings here to test PRs
+    # Add model_id: revision mappings here to test PRs        
+    "trl-internal-testing/tiny-LlavaForConditionalGeneration": "refs/pr/4",
+    "trl-internal-testing/tiny-LlavaNextForConditionalGeneration": "refs/pr/7",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def pytest_runtest_makereport(item, call):
 # ============================================================================
 
 MODEL_REVISIONS = {
-    # Add model_id: revision mappings here to test PRs        
+    # Add model_id: revision mappings here to test PRs
     "trl-internal-testing/tiny-LlavaForConditionalGeneration": "refs/pr/4",
     "trl-internal-testing/tiny-LlavaNextForConditionalGeneration": "refs/pr/7",
 }

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -977,9 +977,9 @@ class TestDPOTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
-            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
-            # plumbing has likely regressed.
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -975,23 +975,25 @@ class TestDPOTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
+            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
+            # plumbing has likely regressed.
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
-            if (
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
+            elif (
                 model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
             ):
             # fmt: on
                 continue
-            assert not torch.equal(param, new_param), f"Param {n} is not updated"
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
     @pytest.mark.parametrize(
         "model_id",

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -983,7 +983,6 @@ class TestDPOTrainer(TrlTestCase):
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             ) and ("encoder.layers.1" in n or "post_layernorm" in n):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
-                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             elif (

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -986,11 +986,10 @@ class TestDPOTrainer(TrlTestCase):
                 continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
-            # fmt: off
             elif (
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration"
+                and "model.visual.deepstack_merger_list" in n
             ):
-            # fmt: on
                 continue
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1988,7 +1988,8 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
-            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen.
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1985,10 +1985,7 @@ class TestGRPOTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
         # Check that the params have changed
-        # Because of the way the tiny models are initialized, the gradient does not flow properly through the
-        # vision parts of the model, so we skip them. Ideally, we should fix the init of these models.
         params_to_skip = (
-            "model.vision_tower.",
             "model.multi_modal_projector.",
             "model.visual.",
             "model.image_newline",
@@ -1997,7 +1994,15 @@ class TestGRPOTrainer(TrlTestCase):
             if n.startswith(params_to_skip):
                 continue
             new_param = trainer.model.get_parameter(n)
-            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen.
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+            else:
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_vision
     def test_train_vlm_with_pad_to_multiple_of(self):

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1374,7 +1374,8 @@ class TestRLOOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
-            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen.
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1371,10 +1371,7 @@ class TestRLOOTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
         # Check that the params have changed
-        # Because of the way the tiny models are initialized, the gradient does not flow properly through the
-        # vision parts of the model, so we skip them. Ideally, we should fix the init of these models.
         params_to_skip = (
-            "model.vision_tower.",
             "model.multi_modal_projector.",
             "model.visual.",
             "model.image_newline",
@@ -1383,7 +1380,15 @@ class TestRLOOTrainer(TrlTestCase):
             if n.startswith(params_to_skip):
                 continue
             new_param = trainer.model.get_parameter(n)
-            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen.
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+            else:
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_vision
     def test_train_vlm_with_pad_to_multiple_of(self):

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -571,23 +571,25 @@ class TestSFTTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
+            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
+            # plumbing has likely regressed.
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
-            if (
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
+            elif (
                 model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
             ):
             # fmt: on
                 continue
-            assert not torch.equal(param, new_param), f"Param {n} is not updated"
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
     def test_train_moe_model_with_aux_loss(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
@@ -1650,23 +1652,25 @@ class TestSFTTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
+            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
+            # plumbing has likely regressed.
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             # fmt: off
-            if (
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
+            elif (
                 model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
             ):
             # fmt: on
                 continue
-            assert not torch.equal(param, new_param), f"Param {n} is not updated"
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
     @pytest.mark.parametrize(
         "model_id",

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -579,7 +579,6 @@ class TestSFTTrainer(TrlTestCase):
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             ) and ("encoder.layers.1" in n or "post_layernorm" in n):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
-                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             elif (
@@ -1659,7 +1658,6 @@ class TestSFTTrainer(TrlTestCase):
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             ) and ("encoder.layers.1" in n or "post_layernorm" in n):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
-                continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
             elif (

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -571,9 +571,9 @@ class TestSFTTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
-            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
-            # plumbing has likely regressed.
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
@@ -1660,9 +1660,9 @@ class TestSFTTrainer(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1 and post_layernorm
-            # without gradient by design. Assert they stay frozen — if they ever start training, the feature-selection
-            # plumbing has likely regressed.
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -582,11 +582,10 @@ class TestSFTTrainer(TrlTestCase):
                 continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
-            # fmt: off
             elif (
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration"
+                and "model.visual.deepstack_merger_list" in n
             ):
-            # fmt: on
                 continue
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
@@ -1663,11 +1662,10 @@ class TestSFTTrainer(TrlTestCase):
                 continue
             # For some reason, these params are not updated. This is probably not related to TRL, but to
             # the model itself. We should investigate this further, but for now we just skip these params.
-            # fmt: off
             elif (
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration"
+                and "model.visual.deepstack_merger_list" in n
             ):
-            # fmt: on
                 continue
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1661,8 +1661,6 @@ class TestSFTTrainer(TrlTestCase):
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
             ) and ("encoder.layers.1" in n or "post_layernorm" in n):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
-            ):
-                continue
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
 


### PR DESCRIPTION
The VLM trainer tests assert every trainable parameter changes after `trainer.train()`. For LLaVA / LLaVA-Next some params are skipped with a vague:

> `# For some reason, these params are not updated. … We should investigate this further, but for now we just skip these params.`

We investigated. Those params are not bugs: they are unreachable from the loss **by design**.

This PR turns the skip into a positive assertion that they stay frozen, and cleans up two spurious keys in the tiny-model generation scripts.

## Why those params are frozen

LLaVA stitches three off-the-shelf pieces together:

1. **Vision tower**: a frozen, pretrained CLIP vision transformer (24 encoder layers in real LLaVA, 2 in our tiny version).
2. **Multi-modal projector**: two small `Linear` layers that map vision features into the LM's embedding dim.
3. **Language model**: a pretrained LLM (Vicuna for LLaVA-1.5, Mistral for LLaVA-Next).

At forward time: image → CLIP → pick **one intermediate encoder layer's** hidden states (`vision_feature_layer=-2`, the second-to-last) → drop the CLS token → projector → splice the result into the LM's input embeddings at the `<image>` placeholder.

Taking features from an intermediate layer rather than the final one is the reason the last encoder layer (and `post_layernorm`) never reach the loss.

```mermaid
flowchart LR
    img[Image] --> pe[patch_embed]
    pe --> l0[layers.0]
    l0 --> l1[layers.1]
    l1 --> dots["…"]
    dots --> l22[layers.22]
    l22 --> l23[layers.23]
    l23 --> pln[post_layernorm]
    pln -.->|"pooler_output<br/>(unused)"| X([ ])

    l22 ==>|"hidden_states[-2]"| drop["drop CLS token"]
    drop ==> proj[multi_modal_projector]
    proj ==> lm

    text[Text tokens] --> lm[Language Model]
    lm --> out[Output]

    subgraph vt[Vision tower — CLIP-ViT-Large, 24 layers]
        pe
        l0
        l1
        dots
        l22
        l23
        pln
    end

    style l23 stroke:#c33,stroke-dasharray:4 3
    style pln stroke:#c33,stroke-dasharray:4 3
    style X stroke:#c33,stroke-dasharray:4 3
```

**Bold arrows** = the actual path features take to the LLM.
**Red dashed** = computed every forward, but the result never reaches the loss (`vision_feature_layer = -2`, pooler unused).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test expectations and tiny-model generation configs, with no production training logic modifications; primary risk is making CI stricter around LLaVA parameter-freezing behavior.
> 
> **Overview**
> Makes the LLaVA/LLaVA-Next VLM trainer tests *explicitly* validate expected frozen vision-tower parameters: instead of skipping certain vision params, `DPO`/`SFT`/`GRPO`/`RLOO` tests now assert that `encoder.layers.1` and `post_layernorm` **do not change** while all other parameters must update after `trainer.train()`.
> 
> Cleans up the LLaVA tiny-model generation scripts by removing unused/incorrect `vision_config` keys (`num_key_value_heads`, `embed_dim`) for both `llava` and `llava_next` generators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164b4718aef330aabe99f5be384a81634ab159cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->