### PR TITLE
Fix tiny Qwen3-VL `deepstack_visual_indexes` and drop the test skip

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
@@ -40,11 +40,11 @@ text_config = {
     "rope_scaling": {"mrope_interleaved": True, "mrope_section": [2, 2, 2], "rope_type": "default"},
 }
 vision_config = {
-    "num_hidden_layers": 2,
+    # Real Qwen3-VL has depth=24 with deepstack at layers [5, 11, 17]. With depth=2 here, those
+    # indexes are unreachable, so the deepstack mergers were instantiated but never invoked.
+    # Pick an index inside [0, depth).
+    "deepstack_visual_indexes": [1],
     "hidden_size": 16,
-    "num_attention_heads": 4,
-    "num_key_value_heads": 2,
-    "embed_dim": 64,
     "depth": 2,
     "out_hidden_size": 16,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/4",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/7",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/4",
+    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/7",
 }
 
 

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -986,8 +986,7 @@ class TestDPOTrainer(TrlTestCase):
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n  # transformers >= 5.6.0, see #5497
             ):
             # fmt: on
                 continue

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -582,8 +582,7 @@ class TestSFTTrainer(TrlTestCase):
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n  # transformers >= 5.6.0, see #5497
             ):
             # fmt: on
                 continue
@@ -1661,8 +1660,7 @@ class TestSFTTrainer(TrlTestCase):
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.vision_model.post_layernorm" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "vision_tower.vision_model.encoder.layers.1" in n or  # transformers < 5.6.0
                 model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.encoder.layers.1" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n or  # transformers >= 5.6.0, see #5497
-                model_id == "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration" and "model.visual.deepstack_merger_list" in n
+                model_id == "trl-internal-testing/tiny-LlavaNextForConditionalGeneration" and "model.vision_tower.post_layernorm" in n  # transformers >= 5.6.0, see #5497
             ):
             # fmt: on
                 continue


### PR DESCRIPTION
Qwen3-VL has a *deepstack* mechanism: it taps the vision encoder at a few intermediate layer indexes and feeds those features into the language model. The indexes are stored in `vision_config.deepstack_visual_indexes`; for each index, a trainable `Qwen3VLVisionPatchMerger` is instantiated in `deepstack_merger_list`.

The tiny model inherited `deepstack_visual_indexes=[5, 11, 17]` from the full Qwen3-VL config but kept only `depth=2` (vision-encoder layers `0` and `1`). At forward time:

```python
for layer_num, blk in enumerate(self.blocks):       # layer_num ∈ {0, 1}
    hidden_states = blk(...)
    if layer_num in self.deepstack_visual_indexes:  # [5, 11, 17] — never matches
        deepstack_merger_list[...](hidden_states)
```

So the 3 mergers were instantiated but **never called** → no gradient → tests had a `model.visual.deepstack_merger_list` skip with the vague "for some reason, these params are not updated" comment.

To fix: in `scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py`, add to `vision_config`:

```python
"deepstack_visual_indexes": [1],
```
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change to a tiny test model plus tightening of trainer tests; main risk is exposing previously-masked training/test failures if the upstream model behavior changes again.
> 
> **Overview**
> Ensures the generated tiny `Qwen3VLForConditionalGeneration` model uses a reachable `vision_config.deepstack_visual_indexes` (within `depth=2`), so `deepstack_merger_list` modules are invoked and receive gradients.
> 
> Updates DPO/SFT VLM training tests to stop skipping `tiny-Qwen3VLForConditionalGeneration` deepstack merger parameters in the “params updated” assertions, relying on the fixed tiny model config instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8275834bbd10606050c1bae0595ce02d93321296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->