### PR TITLE
Fix catch-all empty string in Makefile pytest --only-rerun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples tests trl
 ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
 
 test:
-	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01|OutOfMemoryError)' tests
+	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|OutOfMemoryError)' tests
 
 precommit:
 	python scripts/add_copyrights.py

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples tests trl
 ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
 
 test:
-	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' tests
+	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01|OutOfMemoryError)' tests
 
 precommit:
 	python scripts/add_copyrights.py

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples tests trl
 ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
 
 test:
-	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504||not less than or equal to 0.01)' tests
+	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)' tests
 
 precommit:
 	python scripts/add_copyrights.py


### PR DESCRIPTION
Fix catch-all empty string in Makefile pytest --only-rerun.

This PR fixes a typo in the  `Makefile` `pytest` command used for running tests. The change ensures that the `--only-rerun` regex is correctly formed, which should improve test rerun behavior.

### Changes

- Remove accidental `||` (double pipe) in the `--only-rerun` regex pattern in `Makefile`, which introduced an empty alternation that matched every test failure, causing all failing tests to be retried rather than only the intended transient errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the local/CI test runner command and should reduce unnecessary reruns without affecting product code.
> 
> **Overview**
> Fixes the `Makefile` `test` target’s `pytest --only-rerun` pattern by removing an empty alternation and tightening the regex to match only the intended transient errors (including `OutOfMemoryError`) instead of effectively matching everything.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2207deabaed627d87894fbab98807267533973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->