### PR TITLE
Add compute_metrics support to GRPOTrainer

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -386,6 +386,141 @@ class TestGRPOTrainer(TrlTestCase):
         )
         trainer.train()
 
+    def test_train_with_compute_metrics(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        def compute_metrics(eval_pred):
+            return {"custom_accuracy": 1.0}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_custom_accuracy" in logged_keys
+
+    def test_compute_metrics_receives_correct_inputs(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        was_called = [False]
+
+        def compute_metrics(eval_pred):
+            assert isinstance(eval_pred.predictions, list)
+            assert isinstance(eval_pred.predictions[0], str)
+            assert isinstance(eval_pred.label_ids, torch.Tensor)
+            was_called[0] = True
+            return {}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        assert was_called[0] is True
+
+    def test_compute_metrics_none_does_not_break(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=None,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_reward" in logged_keys
+
+    def test_compute_metrics_does_not_break_reward_metrics(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        def compute_metrics(eval_pred):
+            return {"custom_accuracy": 0.5}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_custom_accuracy" in logged_keys
+        assert "eval_reward" in logged_keys
+
     def test_train_multiple_iterations(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -46,6 +46,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoProcessor,
     AutoTokenizer,
+    EvalPrediction,
     GenerationConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
@@ -215,6 +216,32 @@ class GRPOTrainer(_BaseTrainer):
             [`~transformers.AutoTokenizer.from_pretrained`]. For elements in `reward_funcs` that are custom reward
             functions (not [`~transformers.PreTrainedModel`]), the corresponding entries in `reward_processing_classes`
             are ignored.
+        compute_metrics (`Callable[[EvalPrediction], dict]`, *optional*):
+            Function called after each evaluation pass to compute additional metrics. It receives an
+            [`~transformers.EvalPrediction`] whose `predictions` field contains the generated text completions
+            as a list of strings (or list of message dicts in conversational format), and whose `label_ids`
+            field contains a `(N, R)` float tensor of per-function reward scores, where `N` is the number of
+            completions and `R` is the number of reward functions. The function must return a `dict` mapping
+            metric names to scalar values. Unlike [`DPOTrainer`], predictions here are raw text, not logit
+            tensors. Example:
+
+            ```python
+            def compute_metrics(eval_pred):
+                completions = eval_pred.predictions  # list of strings
+                rewards = eval_pred.label_ids        # tensor of shape (N, R)
+                correct = [1 if "answer" in c else 0 for c in completions]
+                return {"exact_match": sum(correct) / len(correct)}
+
+            trainer = GRPOTrainer(
+                model=model,
+                reward_funcs=reward_func,
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+                compute_metrics=compute_metrics,
+            )
+            trainer.train()
+            ```
         callbacks (list of [`~transformers.TrainerCallback`], *optional*):
             List of callbacks to customize the training loop. Will add those to the list of default callbacks detailed
             in [here](https://huggingface.co/docs/transformers/main_classes/callback).
@@ -276,6 +303,7 @@ class GRPOTrainer(_BaseTrainer):
         eval_dataset: Dataset | IterableDataset | dict[str, Dataset | IterableDataset] | None = None,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
         reward_processing_classes: PreTrainedTokenizerBase | list[PreTrainedTokenizerBase] | None = None,
+        compute_metrics: Callable[[EvalPrediction], dict] | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         peft_config: "PeftConfig | None" = None,
@@ -647,6 +675,7 @@ class GRPOTrainer(_BaseTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
+            compute_metrics=compute_metrics,
             callbacks=callbacks,
             optimizers=optimizers,
             # In Trainer, `training_step` scales the loss by `gradient_accumulation_steps` only if `compute_loss_func`
@@ -755,6 +784,9 @@ class GRPOTrainer(_BaseTrainer):
         # Buffers for user-logged data from reward functions, flushed after gathering
         self._pending_extra_logs = defaultdict(list)
         self._pending_metrics = defaultdict(list)
+        # Buffers for compute_metrics: accumulated across eval batches, flushed in log()
+        self._completions_for_compute_metrics = []
+        self._rewards_for_compute_metrics = None
 
         # Ensure each process receives a unique seed to prevent duplicate completions when generating with
         # transformers if num_generations exceeds per_device_train_batch_size. We could skip it if we use vLLM, but
@@ -2301,6 +2333,19 @@ class GRPOTrainer(_BaseTrainer):
             output["num_images"] = num_images
         if tool_mask is not None:
             output["tool_mask"] = tool_mask
+
+        # Accumulate completions and per-function rewards for compute_metrics. Each eval batch appends
+        # to the buffers; log() drains them once per eval cycle after all batches have run.
+        if mode == "eval" and self.compute_metrics is not None:
+            local_rewards = rewards_per_func[process_slice]
+            self._completions_for_compute_metrics.extend(completions)
+            if self._rewards_for_compute_metrics is None:
+                self._rewards_for_compute_metrics = local_rewards.cpu()
+            else:
+                self._rewards_for_compute_metrics = torch.cat(
+                    [self._rewards_for_compute_metrics, local_rewards.cpu()], dim=0
+                )
+
         return output
 
     def compute_liger_loss(self, unwrapped_model, inputs):
@@ -2658,6 +2703,17 @@ class GRPOTrainer(_BaseTrainer):
         # start with "eval_". We need to add the prefix "eval_" to the keys in `metrics` to match the format.
         if mode == "eval":
             metrics = {f"eval_{key}": val for key, val in metrics.items()}
+
+        # Call compute_metrics with completions and rewards buffered across all eval batches.
+        if mode == "eval" and self.compute_metrics is not None and self._completions_for_compute_metrics:
+            eval_pred = EvalPrediction(
+                predictions=self._completions_for_compute_metrics,
+                label_ids=self._rewards_for_compute_metrics,
+            )
+            custom_metrics = self.compute_metrics(eval_pred)
+            metrics.update({f"eval_{key}": val for key, val in custom_metrics.items()})
+            self._completions_for_compute_metrics = []
+            self._rewards_for_compute_metrics = None
 
         logs = {**logs, **metrics}
         super().log(logs, start_time)


### PR DESCRIPTION
## What this PR does
Adds `compute_metrics` support to `GRPOTrainer` so users can compute 
custom evaluation metrics on held-out eval datasets, in addition to 
reward-based metrics.

## Why
GRPO users often need to track downstream task metrics during evaluation, 
not only reward values. This is useful for debugging, model selection, 
and verifying that reward optimization corresponds to actual task improvement.
Closes #2959

## Changes
- Adds `compute_metrics` argument to `GRPOTrainer`
- Buffers completions and rewards across eval batches in 
  `_generate_and_score_completions`
- Calls `compute_metrics` in `log()` after all eval batches complete,
  following the same pattern GRPO already uses for its internal metrics
- Logs returned metrics with `eval_` prefix
- Adds 4 tests
- Adds docstring documentation with usage example

## Note on design
Unlike `DPOTrainer`, predictions here are raw text strings not logit 
tensors, so the standard Trainer `evaluation_loop` gather path cannot 
be used. Completions and rewards are buffered in 
`_generate_and_score_completions` and `compute_metrics` is called 
directly in `log()`.

## Tests
pytest tests/test_grpo_trainer.py -v -k "compute_metrics"
4 passed in 164s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new evaluation-time buffering and metric logging paths in `GRPOTrainer`, which could affect eval memory usage and metric reporting behavior across distributed/batched evaluation.
> 
> **Overview**
> `GRPOTrainer` now accepts a `compute_metrics` callback and invokes it after each evaluation cycle, allowing custom eval metrics to be computed from generated completions (raw text) and per-reward-function scores.
> 
> Evaluation batches now buffer completions and reward tensors, then `log()` constructs an `EvalPrediction`, merges returned metrics under the `eval_` prefix, and clears the buffers. Tests were added to validate callback invocation, input types, metric logging, and that reward metrics continue to be reported when `compute_metrics` is used or `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4786e9964cd8019d85799902233f5f49930def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->