### PR TITLE
Add compute_metrics support to GRPOTrainer

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -386,6 +386,141 @@ class TestGRPOTrainer(TrlTestCase):
         )
         trainer.train()
 
+    def test_train_with_compute_metrics(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        def compute_metrics(eval_pred):
+            return {"custom_accuracy": 1.0}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_custom_accuracy" in logged_keys
+
+    def test_compute_metrics_receives_correct_inputs(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        was_called = [False]
+
+        def compute_metrics(eval_pred):
+            assert isinstance(eval_pred.predictions, list)
+            assert isinstance(eval_pred.predictions[0], str)
+            assert isinstance(eval_pred.label_ids, torch.Tensor)
+            was_called[0] = True
+            return {}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        assert was_called[0] is True
+
+    def test_compute_metrics_none_does_not_break(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=None,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_reward" in logged_keys
+
+    def test_compute_metrics_does_not_break_reward_metrics(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion)) for completion in completions]
+
+        def compute_metrics(eval_pred):
+            return {"custom_accuracy": 0.5}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            per_device_eval_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            eval_strategy="steps",
+            eval_steps=2,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            compute_metrics=compute_metrics,
+        )
+
+        trainer.train()
+
+        logged_keys = {k for entry in trainer.state.log_history for k in entry}
+        assert "eval_custom_accuracy" in logged_keys
+        assert "eval_reward" in logged_keys
+
     def test_train_multiple_iterations(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -218,19 +218,19 @@ class GRPOTrainer(_BaseTrainer):
             are ignored.
         compute_metrics (`Callable[[EvalPrediction], dict]`, *optional*):
             Function called after each evaluation pass to compute additional metrics. It receives an
-            [`~transformers.EvalPrediction`] whose `predictions` field contains the generated text completions
-            as a list of strings (or list of message dicts in conversational format), and whose `label_ids`
-            field contains a `(N, R)` float tensor of per-function reward scores, where `N` is the number of
-            completions and `R` is the number of reward functions. The function must return a `dict` mapping
-            metric names to scalar values. Unlike [`DPOTrainer`], predictions here are raw text, not logit
-            tensors. Example:
+            [`~transformers.EvalPrediction`] whose `predictions` field contains the generated text completions as a
+            list of strings (or list of message dicts in conversational format), and whose `label_ids` field contains a
+            `(N, R)` float tensor of per-function reward scores, where `N` is the number of completions and `R` is the
+            number of reward functions. The function must return a `dict` mapping metric names to scalar values. Unlike
+            [`DPOTrainer`], predictions here are raw text, not logit tensors. Example:
 
             ```python
             def compute_metrics(eval_pred):
                 completions = eval_pred.predictions  # list of strings
-                rewards = eval_pred.label_ids        # tensor of shape (N, R)
+                rewards = eval_pred.label_ids  # tensor of shape (N, R)
                 correct = [1 if "answer" in c else 0 for c in completions]
                 return {"exact_match": sum(correct) / len(correct)}
+
 
             trainer = GRPOTrainer(
                 model=model,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -46,6 +46,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoProcessor,
     AutoTokenizer,
+    EvalPrediction,
     GenerationConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
@@ -215,6 +216,32 @@ class GRPOTrainer(_BaseTrainer):
             [`~transformers.AutoTokenizer.from_pretrained`]. For elements in `reward_funcs` that are custom reward
             functions (not [`~transformers.PreTrainedModel`]), the corresponding entries in `reward_processing_classes`
             are ignored.
+        compute_metrics (`Callable[[EvalPrediction], dict]`, *optional*):
+            Function called after each evaluation pass to compute additional metrics. It receives an
+            [`~transformers.EvalPrediction`] whose `predictions` field contains the generated text completions
+            as a list of strings (or list of message dicts in conversational format), and whose `label_ids`
+            field contains a `(N, R)` float tensor of per-function reward scores, where `N` is the number of
+            completions and `R` is the number of reward functions. The function must return a `dict` mapping
+            metric names to scalar values. Unlike [`DPOTrainer`], predictions here are raw text, not logit
+            tensors. Example:
+
+            ```python
+            def compute_metrics(eval_pred):
+                completions = eval_pred.predictions  # list of strings
+                rewards = eval_pred.label_ids        # tensor of shape (N, R)
+                correct = [1 if "answer" in c else 0 for c in completions]
+                return {"exact_match": sum(correct) / len(correct)}
+
+            trainer = GRPOTrainer(
+                model=model,
+                reward_funcs=reward_func,
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+                compute_metrics=compute_metrics,
+            )
+            trainer.train()
+            ```
         callbacks (list of [`~transformers.TrainerCallback`], *optional*):
             List of callbacks to customize the training loop. Will add those to the list of default callbacks detailed
             in [here](https://huggingface.co/docs/transformers/main_classes/callback).
@@ -276,6 +303,7 @@ class GRPOTrainer(_BaseTrainer):
         eval_dataset: Dataset | IterableDataset | dict[str, Dataset | IterableDataset] | None = None,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
         reward_processing_classes: PreTrainedTokenizerBase | list[PreTrainedTokenizerBase] | None = None,
+        compute_metrics: Callable[[EvalPrediction], dict] | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         peft_config: "PeftConfig | None" = None,
@@ -647,6 +675,7 @@ class GRPOTrainer(_BaseTrainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             processing_class=processing_class,
+            compute_metrics=compute_metrics,
             callbacks=callbacks,
             optimizers=optimizers,
             # In Trainer, `training_step` scales the loss by `gradient_accumulation_steps` only if `compute_loss_func`
@@ -755,6 +784,9 @@ class GRPOTrainer(_BaseTrainer):
         # Buffers for user-logged data from reward functions, flushed after gathering
         self._pending_extra_logs = defaultdict(list)
         self._pending_metrics = defaultdict(list)
+        # Buffers for compute_metrics: accumulated across eval batches, flushed in log()
+        self._completions_for_compute_metrics = []
+        self._rewards_for_compute_metrics = None
 
         # Ensure each process receives a unique seed to prevent duplicate completions when generating with
         # transformers if num_generations exceeds per_device_train_batch_size. We could skip it if we use vLLM, but
@@ -2301,6 +2333,19 @@ class GRPOTrainer(_BaseTrainer):
             output["num_images"] = num_images
         if tool_mask is not None:
             output["tool_mask"] = tool_mask
+
+        # Accumulate completions and per-function rewards for compute_metrics. Each eval batch appends
+        # to the buffers; log() drains them once per eval cycle after all batches have run.
+        if mode == "eval" and self.compute_metrics is not None:
+            local_rewards = rewards_per_func[process_slice]
+            self._completions_for_compute_metrics.extend(completions)
+            if self._rewards_for_compute_metrics is None:
+                self._rewards_for_compute_metrics = local_rewards.cpu()
+            else:
+                self._rewards_for_compute_metrics = torch.cat(
+                    [self._rewards_for_compute_metrics, local_rewards.cpu()], dim=0
+                )
+
         return output
 
     def compute_liger_loss(self, unwrapped_model, inputs):
@@ -2658,6 +2703,17 @@ class GRPOTrainer(_BaseTrainer):
         # start with "eval_". We need to add the prefix "eval_" to the keys in `metrics` to match the format.
         if mode == "eval":
             metrics = {f"eval_{key}": val for key, val in metrics.items()}
+
+        # Call compute_metrics with completions and rewards buffered across all eval batches.
+        if mode == "eval" and self.compute_metrics is not None and self._completions_for_compute_metrics:
+            eval_pred = EvalPrediction(
+                predictions=self._completions_for_compute_metrics,
+                label_ids=self._rewards_for_compute_metrics,
+            )
+            custom_metrics = self.compute_metrics(eval_pred)
+            metrics.update({f"eval_{key}": val for key, val in custom_metrics.items()})
+            self._completions_for_compute_metrics = []
+            self._rewards_for_compute_metrics = None
 
         logs = {**logs, **metrics}
         super().log(logs, start_time)


### PR DESCRIPTION
# What does this PR do?

Adds `compute_metrics` support to `GRPOTrainer` so users can compute 
custom evaluation metrics on held-out eval datasets, in addition to 
reward-based metrics.

Currently, `GRPOTrainer` only logs reward-based metrics during evaluation 
(`eval_reward`, `eval_reward_std`, etc.). Users have no way to plug in 
downstream task metrics like exact match, format compliance, or F1 — 
making it impossible to detect reward hacking or use `metric_for_best_model` 
with a meaningful task metric.

This PR adds `compute_metrics` following the same interface as other TRL 
trainers, with one key difference: since GRPO generates text rather than 
producing logits, `EvalPrediction.predictions` contains the generated text 
completions (list of strings) and `EvalPrediction.label_ids` contains the 
per-function reward scores (tensor of shape `[N, R]`).

Because the standard `Trainer` evaluation loop expects tensors from 
`prediction_step`, completions and rewards are instead buffered across eval 
batches in `_generate_and_score_completions` and `compute_metrics` is called 
directly in `log()`, following the same pattern GRPO already uses for its 
internal metrics accumulation.

Fixes #2959

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #2959
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR 
      was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @lewtun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `GRPOTrainer` evaluation/logging flow by buffering completions and rewards across eval batches and invoking user code, which could affect eval memory usage and metric reporting correctness.
> 
> **Overview**
> `GRPOTrainer` now accepts an optional `compute_metrics` callback (Transformers-style) and documents that it receives an `EvalPrediction` where `predictions` are generated completions (raw text) and `label_ids` are per-reward-function scores.
> 
> During evaluation, the trainer buffers completions and per-function rewards across eval batches, then calls `compute_metrics` from `log()` once per eval cycle and merges returned values into the usual `eval_*` logs without breaking existing reward metrics.
> 
> Adds targeted tests to ensure `compute_metrics` is called, receives the expected inputs, logs custom metrics (e.g. `eval_custom_accuracy`), and behaves correctly when `compute_metrics=None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073b5c2e3007185db8c57956052881b544948975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->