### PR TITLE
fix(grpo) #5785 : align mm_token_type_ids padding with left-padded prompt_ids

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1973,15 +1973,13 @@ class GRPOTrainer(_BaseTrainer):
             )
         # If mm_token_type_ids are used, extend them with zeros for the completion part
         if "mm_token_type_ids" in forward_kwargs:
-            mm_token_type_ids = forward_kwargs["mm_token_type_ids"]
-            if self.pad_to_multiple_of is not None:
-                # Needed only with pad_to_multiple_of: otherwise prompt_ids and mm_token_type_ids must have equal len
-                padding_size = prompt_ids.size(1) - mm_token_type_ids.size(1)
-                if padding_size > 0:
-                    mm_token_type_ids = torch.cat(
-                        [mm_token_type_ids.new_zeros((mm_token_type_ids.size(0), padding_size)), mm_token_type_ids],
-                        dim=1,
-                    )
+            # [Minimal Fix] Rebuild from the left-padded prompt_ids to ensure padding alignment
+            mm_token_type_ids = torch.zeros_like(prompt_ids)
+            if self._image_pad_token_id is not None:
+                mm_token_type_ids[prompt_ids == self._image_pad_token_id] = 1
+            if self._video_pad_token_id is not None:
+                mm_token_type_ids[prompt_ids == self._video_pad_token_id] = 2
+            
             forward_kwargs["mm_token_type_ids"] = torch.cat(
                 [mm_token_type_ids, mm_token_type_ids.new_zeros(completion_ids.shape)], dim=1
             )


### PR DESCRIPTION
Rebuild mm_token_type_ids for padding alignment using prompt_ids.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #5785 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GRPOTrainer’s multimodal forward-input construction; mistakes here can break VLM training/inference shapes but the change is localized to `mm_token_type_ids` padding/alignment.
> 
> **Overview**
> Fixes multimodal padding alignment in GRPO by **rebuilding `mm_token_type_ids` directly from the left-padded `prompt_ids`** (marking image/video pad tokens) before concatenating the completion zeros. This replaces the prior logic that tried to pad/shift an existing `mm_token_type_ids`, avoiding misalignment when `pad_to_multiple_of` introduces extra left padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12668b6740d8ee37b093069bd479eb9d5a30e367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->