### PR TITLE
Fix vision config num_heads key in Qwen VL tiny model scripts and revert torch pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,6 @@ dev = [
     "num2words==0.5.14",
     # for response parsing (required for training with tools)
     "jmespath",
-    # CI
-    "torch<2.12.0",  # temporary hotfix for #5768
 ]
 
 [tool.setuptools]

--- a/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
@@ -39,7 +39,7 @@ text_config = {
 vision_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
-    "num_attention_heads": 4,
+    "num_heads": 4,
     "num_key_value_heads": 2,
     "embed_dim": 64,
     "depth": 2,

--- a/scripts/generate_tiny_models/for_conditional_generation/qwen2_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen2_vl_for_conditional_generation.py
@@ -38,7 +38,7 @@ text_config = {
 vision_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
-    "num_attention_heads": 4,
+    "num_heads": 4,
     "num_key_value_heads": 2,
     "embed_dim": 64,
     "depth": 2,

--- a/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
@@ -42,7 +42,7 @@ text_config = {
 vision_config = {
     "num_hidden_layers": 2,
     "hidden_size": 16,
-    "num_attention_heads": 4,
+    "num_heads": 4,
     "num_key_value_heads": 2,
     "embed_dim": 64,
     "depth": 2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration": "refs/pr/5",
-    "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration": "refs/pr/12",
-    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/5",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,9 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration": "refs/pr/5",
+    "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration": "refs/pr/12",
+    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/5",
 }
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #5768
Reverts #5769

The three Qwen VL tiny model generation scripts were passing `num_attention_heads` in `vision_config`, but the vision config class (`Qwen2_5_VLVisionConfig`, `Qwen2VLVisionConfig`, `Qwen3VLVisionConfig`) expects `num_heads`. The wrong key is silently ignored, `num_heads` stays at its default of 16, which with `hidden_size=16` gives `head_dim=1` and `rotary_dim=0`. PyTorch's SDPA then returns all-zeros for the attention output, causing zero gradients on all visual encoder parameters.

The torch pin added in #5769 is not needed.

Note: a maintainer with write access to `trl-internal-testing` on the Hub will need to rerun the generation scripts to upload the fixed tiny models before CI passes.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure
- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@albertvillanova since you opened #5768 and #5769.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Qwen VL tiny test models are generated (affecting CI artifacts) and removes a previously-added `torch` version constraint that could re-expose version-specific failures.
> 
> **Overview**
> Fixes the Qwen VL tiny-model generation scripts to pass the correct vision-config field (`num_heads` instead of `num_attention_heads`) for Qwen2-VL, Qwen2.5-VL, and Qwen3-VL, ensuring the intended attention head count is used during tiny model creation.
> 
> Also removes the temporary `torch<2.12.0` dev-dependency pin from `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0365e1e7b891bb75a2a04d4d6dfeba29f864ee52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->