### PR TITLE
Remove non-existent params from tiny Qwen2-VL model

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/qwen2_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen2_vl_for_conditional_generation.py
@@ -36,10 +36,8 @@ text_config = {
     "rope_scaling": {"type": "default", "mrope_section": [1, 1], "rope_type": "default"},
 }
 vision_config = {
-    "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_heads": 4,
-    "num_key_value_heads": 2,
     "embed_dim": 64,
     "depth": 2,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration": "refs/pr/6",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration": "refs/pr/6",
 }
 
 


### PR DESCRIPTION
Remove non-existent params from tiny Qwen2-VL model.

This PR updates to the `vision_config` dictionary in `qwen2_vl_for_conditional_generation.py`, removing two configuration parameters that are nonexistent: `num_hidden_layers` and `num_key_value_heads`.

### Context

While reviewing PR #5792, I realized there are other non-existent params in the generation script of Qwen2-VL model. This PR removes them.

Related to:
- #5792

### Changes

- Removed `num_hidden_layers` and `num_key_value_heads` from the `vision_config` dictionary to simplify the configuration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a tiny-model generation script by removing unused/invalid config fields, with no runtime logic or API changes beyond config creation.
> 
> **Overview**
> Removes the non-existent `num_hidden_layers` and `num_key_value_heads` entries from the `vision_config` passed to `AutoConfig.from_pretrained` in the tiny Qwen2-VL conditional-generation script.
> 
> This simplifies the generated tiny model configuration and avoids setting unsupported vision parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132cfdb203dfd3818089e40a0a939930bdc51378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->