### PR TITLE
Remove non-existent params from tiny Qwen2.5-VL model

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
@@ -37,11 +37,8 @@ text_config = {
     "rope_scaling": {"type": "default", "mrope_section": [1, 1], "rope_type": "default"},
 }
 vision_config = {
-    "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_heads": 4,
-    "num_key_value_heads": 2,
-    "embed_dim": 64,
     "depth": 2,
     "out_hidden_size": 16,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration": "refs/pr/13",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration": "refs/pr/13",
 }
 
 


### PR DESCRIPTION
Remove non-existent params from tiny Qwen2.5-VL model.

This PR updates to the `vision_config` dictionary in `qwen2_5_vl_for_conditional_generation.py`, removing three configuration parameters that are nonexistent: `num_hidden_layers`, `num_key_value_heads`, and `embed_dim`.

### Context

While reviewing PR #5792, I realized there are other non-existent params in the generation script of Qwen2.5-VL model. This PR removes them.

Related to:
- #5792

### Changes

- Removed the `num_hidden_layers`, `num_key_value_heads`, and `embed_dim` parameters from the `vision_config` dictionary in `qwen2_5_vl_for_conditional_generation.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes unused/invalid keys from a model-generation script config dict, with no behavioral changes outside tiny model config creation.
> 
> **Overview**
> Cleans up the tiny Qwen2.5-VL conditional-generation script by removing **non-existent `vision_config` parameters** (`num_hidden_layers`, `num_key_value_heads`, `embed_dim`).
> 
> This aligns the generated config with the actual Qwen2.5-VL vision config schema while keeping the remaining vision settings (`hidden_size`, `num_heads`, `depth`, `out_hidden_size`) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d552efd5e9d5cf7fb9558143ed7af5f9ac3412e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->