### PR TITLE
Remove non-existent params from tiny Qwen3-VL model

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen3_vl_for_conditional_generation.py
@@ -40,11 +40,8 @@ text_config = {
     "rope_scaling": {"mrope_interleaved": True, "mrope_section": [2, 2, 2], "rope_type": "default"},
 }
 vision_config = {
-    "num_hidden_layers": 2,
     "hidden_size": 16,
     "num_heads": 4,
-    "num_key_value_heads": 2,
-    "embed_dim": 64,
     "depth": 2,
     "out_hidden_size": 16,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
-    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/6",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def pytest_runtest_makereport(item, call):
 
 MODEL_REVISIONS = {
     # Add model_id: revision mappings here to test PRs
+    "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration": "refs/pr/6",
 }
 
 


### PR DESCRIPTION
Remove non-existent params from tiny Qwen23-VL model.

This PR updates to the `vision_config` dictionary in `qwen3_vl_for_conditional_generation.py`, removing three configuration parameters that are nonexistent: `num_hidden_layers`, `num_key_value_heads`, and `embed_dim`.

### Context

While reviewing PR #5792, I realized there are other non-existent params in the generation script of Qwen2.5-VL model. This PR removes them.

Related to:
- #5792

### Changes

- Removed the `num_hidden_layers`, `num_key_value_heads`, and `embed_dim` parameters from the `vision_config` dictionary in `qwen3_vl_for_conditional_generation.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes unused/non-existent `vision_config` keys in a tiny-model generation script, with no runtime behavior changes beyond avoiding passing invalid config fields.
> 
> **Overview**
> Cleans up the tiny Qwen3-VL conditional-generation model script by removing invalid `vision_config` fields (`num_hidden_layers`, `num_key_value_heads`, `embed_dim`) so only supported vision configuration values are passed into `AutoConfig.from_pretrained`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5ac9b192b98aac62f2ab540c2bb9f73fc69f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->