### PR TITLE
Fix MPS support in experimental empty_cache()

### DIFF
--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -33,6 +33,7 @@ from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.utils import (
     is_peft_available,
     is_torch_mlu_available,
+    is_torch_mps_available,
     is_torch_npu_available,
     is_torch_xpu_available,
 )
@@ -536,8 +537,8 @@ def pad_to_length(tensor: torch.Tensor, length: int, pad_value: int | float, dim
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
 
-    This function checks for the availability of different torch devices (XPU, MLU, NPU, CUDA) and empties the cache of
-    the first available device it finds.
+    This function checks for the availability of different torch devices (XPU, MLU, NPU, MPS, CUDA) and empties the
+    cache of the first available device it finds.
 
     If none of the specific devices are available, it defaults to emptying the CUDA cache.
     """
@@ -547,6 +548,8 @@ def empty_cache() -> None:
         torch.mlu.empty_cache()
     elif is_torch_npu_available():
         torch.npu.empty_cache()
+    elif is_torch_mps_available():
+        torch.mps.empty_cache()
     else:
         torch.cuda.empty_cache()
 

--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -537,19 +537,19 @@ def pad_to_length(tensor: torch.Tensor, length: int, pad_value: int | float, dim
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
 
-    This function checks for the availability of different torch devices (XPU, MLU, NPU, MPS, CUDA) and empties the
+    This function checks for the availability of different torch devices (CUDA, MLU, MPS, NPU, XPU) and empties the
     cache of the first available device it finds.
 
     If none of the specific devices are available, it defaults to emptying the CUDA cache.
     """
-    if is_torch_xpu_available():
-        torch.xpu.empty_cache()
-    elif is_torch_mlu_available():
+    if is_torch_mlu_available():
         torch.mlu.empty_cache()
-    elif is_torch_npu_available():
-        torch.npu.empty_cache()
     elif is_torch_mps_available():
         torch.mps.empty_cache()
+    elif is_torch_npu_available():
+        torch.npu.empty_cache()
+    elif is_torch_xpu_available():
+        torch.xpu.empty_cache()
     else:
         torch.cuda.empty_cache()
 

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -49,19 +49,19 @@ logger = logging.getLogger(__name__)
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
 
-    This function checks for the availability of different torch devices (XPU, MLU, NPU, MPS, CUDA) and empties the
+    This function checks for the availability of different torch devices (CUDA, MLU, MPS, NPU, XPU) and empties the
     cache of the first available device it finds.
 
     If none of the specific devices are available, it defaults to emptying the CUDA cache.
     """
-    if is_torch_xpu_available():
-        torch.xpu.empty_cache()
-    elif is_torch_mlu_available():
+    if is_torch_mlu_available():
         torch.mlu.empty_cache()
-    elif is_torch_npu_available():
-        torch.npu.empty_cache()
     elif is_torch_mps_available():
         torch.mps.empty_cache()
+    elif is_torch_npu_available():
+        torch.npu.empty_cache()
+    elif is_torch_xpu_available():
+        torch.xpu.empty_cache()
     else:
         torch.cuda.empty_cache()
 

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -25,7 +25,12 @@ from accelerate.utils import broadcast_object_list, gather_object, is_peft_model
 from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin, is_bitsandbytes_available
-from transformers.utils import is_torch_mlu_available, is_torch_npu_available, is_torch_xpu_available
+from transformers.utils import (
+    is_torch_mlu_available,
+    is_torch_mps_available,
+    is_torch_npu_available,
+    is_torch_xpu_available,
+)
 
 from ..extras.profiling import ProfilingContext
 from ..import_utils import is_vllm_available
@@ -44,8 +49,8 @@ logger = logging.getLogger(__name__)
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
 
-    This function checks for the availability of different torch devices (XPU, MLU, NPU, CUDA) and empties the cache of
-    the first available device it finds.
+    This function checks for the availability of different torch devices (XPU, MLU, NPU, MPS, CUDA) and empties the
+    cache of the first available device it finds.
 
     If none of the specific devices are available, it defaults to emptying the CUDA cache.
     """
@@ -55,6 +60,8 @@ def empty_cache() -> None:
         torch.mlu.empty_cache()
     elif is_torch_npu_available():
         torch.npu.empty_cache()
+    elif is_torch_mps_available():
+        torch.mps.empty_cache()
     else:
         torch.cuda.empty_cache()
 


### PR DESCRIPTION
# What does this PR do?

Adds MPS (Apple Silicon) support to `empty_cache()` in `trl/experimental/utils.py`. Previously, the function fell through to `torch.cuda.empty_cache()` on MPS devices, which is a no-op. This causes progressive memory pressure and slowdown during training (e.g., GKD) on MPS, as the MPS allocator never releases freed tensors from its pool.

The fix adds an `elif` branch calling `torch.mps.empty_cache()` when `is_torch_mps_available()` is true, consistent with the existing XPU/MLU/NPU branches.

The same fix is propagated to the duplicate `empty_cache()` in `trl/generation/vllm_generation.py` to maintain consistency.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change that only affects device-specific cache clearing behavior and should reduce memory pressure on MPS without impacting CUDA flows.
> 
> **Overview**
> Fixes `empty_cache()` to properly clear Apple Silicon (MPS) allocator caches by importing `is_torch_mps_available()` and calling `torch.mps.empty_cache()` when applicable.
> 
> Applies the same device-detection order and MPS branch in both `trl/experimental/utils.py` and the duplicate helper in `trl/generation/vllm_generation.py`, updating the docstrings to match the new device list/order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5bb591c975ed4ee4707fd2aa35e6bd77e316b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->