### PR TITLE
Fix OOM in CI by reducing batch size and sequence length for toolcall tests

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -789,6 +789,8 @@ class TestDPOTrainer(TrlTestCase):
         training_args = DPOConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=2,  # toolcall sequences are longer than standard data, reduce batch size to avoid OOM
+            max_length=512,  # toolcall sequences are longer than standard data, limit length to avoid OOM
             report_to="none",
         )
         trainer = DPOTrainer(

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -601,7 +601,12 @@ class TestRewardTrainer(TrlTestCase):
     def test_train_toolcall_data(self):
         dataset = load_dataset("trl-internal-testing/toolcall", "preference", split="train")
 
-        training_args = RewardConfig(output_dir=self.tmp_dir, report_to="none")
+        training_args = RewardConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # toolcall sequences are longer than standard data, reduce batch size to avoid OOM
+            max_length=512,  # toolcall sequences are longer than standard data, limit length to avoid OOM
+            report_to="none",
+        )
         trainer = RewardTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             args=training_args,
@@ -631,7 +636,12 @@ class TestRewardTrainer(TrlTestCase):
 
         dataset = dataset.map(convert_to_json)
 
-        training_args = RewardConfig(output_dir=self.tmp_dir, report_to="none")
+        training_args = RewardConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # toolcall sequences are longer than standard data, reduce batch size to avoid OOM
+            max_length=512,  # toolcall sequences are longer than standard data, limit length to avoid OOM
+            report_to="none",
+        )
         trainer = RewardTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             args=training_args,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1417,7 +1417,12 @@ class TestSFTTrainer(TrlTestCase):
     def test_train_toolcall_data(self):
         dataset = load_dataset("trl-internal-testing/toolcall", "language_modeling", split="train")
 
-        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # toolcall sequences are longer than standard data, reduce batch size to avoid OOM
+            max_length=512,  # toolcall sequences are longer than standard data, limit length to avoid OOM
+            report_to="none",
+        )
         trainer = SFTTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
         )
@@ -1445,7 +1450,12 @@ class TestSFTTrainer(TrlTestCase):
 
         dataset = dataset.map(convert_to_json)
 
-        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # toolcall sequences are longer than standard data, reduce batch size to avoid OOM
+            max_length=512,  # toolcall sequences are longer than standard data, limit length to avoid OOM
+            report_to="none",
+        )
         trainer = SFTTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
         )


### PR DESCRIPTION
Fix OOM in CI by reducing batch size and sequence length for toolcall tests.

This PR updates the test configurations for SFT, DPO, and Reward trainers to better handle toolcall data: reduce the per-device training batch size and limiting the maximum sequence length to prevent out-of-memory (OOM) errors, since toolcall sequences are longer than standard data.

Partial fix to:
- #5750

### Motivation

CI runs 4 pytest-xdist workers sharing one 14.74 GiB GPU. The toolcall dataset contains tool definitions and structured JSON payloads that produce significantly longer sequences than the standard `zen` test data. With the default `per_device_train_batch_size=8` and `max_length=1024`, the trainer materializes full logit tensors of shape `[16, 1024, 152064]` (Qwen2's vocabulary) for both model and reference model simultaneously (roughly 10–13 GiB) exhausting the GPU and causing concurrent workers to OOM.

This was confirmed by instrumenting `conftest.py` to track per-test GPU memory: `test_train_toolcall_data_as_json` (SFT) was observed holding **13.44 GiB** during its training step.

With `per_device_train_batch_size=2` and `max_length=512` the peak allocation for the toolcall tests drops to roughly 1–3 GiB, consistent with all other non-VLM training tests.

### Solution

Add `per_device_train_batch_size=2` and `max_length=512` to all five toolcall training tests (DPO, SFT ×2, Reward ×2).

### Changes

**Test configuration improvements for toolcall data:**

* All test cases that train on toolcall data now set `per_device_train_batch_size=2` to reduce memory usage and avoid OOM errors.
* All test cases that train on toolcall data now set `max_length=512` to limit sequence length and further reduce the risk of OOM errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust test `TrainingArguments` for toolcall datasets to avoid CI OOM, without touching trainer/library logic.
> 
> **Overview**
> Fixes CI OOMs in toolcall training tests by lowering memory pressure across `DPOTrainer`, `RewardTrainer`, and `SFTTrainer` test cases.
> 
> Toolcall tests now explicitly set **smaller `per_device_train_batch_size` (2)** and **cap `max_length` (512)** to account for longer toolcall sequences while keeping the same training assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c7e78816919306354f89fd698c7be106430fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->