### PR TITLE
Fix tiny Qwen2.5-VL fullatt_block_indexes out of range for depth=2

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py
@@ -40,6 +40,7 @@ vision_config = {
     "hidden_size": 16,
     "num_heads": 4,
     "depth": 2,
+    "fullatt_block_indexes": [1],  # must contain valid layer indices (< depth)
     "out_hidden_size": 16,
 }
 


### PR DESCRIPTION
Fix tiny Qwen2.5-VL `fullatt_block_indexes` out of range for `depth=2`.

Analog to what was done to `deepstack_visual_indexes` for Qwen3-VL:
- #5779

### Motivation

Qwen2.5-VL's vision encoder uses windowed attention by default, with `fullatt_block_indexes` listing the layer indices that switch to full (unwindowed) attention. For each layer, the modeling code does:
```python
for layer_num, blk in enumerate(self.blocks):       # layer_num ∈ {0, 1}
    if layer_num in self.fullatt_block_indexes:     # [7, 15, 23, 31] — never matches
        cu_seqlens_now = cu_seqlens                # full attention — never exercised
    else:
        cu_seqlens_now = cu_window_seqlens         # windowed attention — always used
```
- See: https://github.com/huggingface/transformers/blob/cd74917ffc3e8f84e4a886052c5ab32b7ac623cc/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L321-L325

The tiny model inherited `fullatt_block_indexes=[7, 15, 23, 31]` from the full Qwen2.5-VL-3B config but kept only `depth=2` (vision-encoder layers 0 and 1). None of the four indexes are reachable, so the full-attention path is never exercised by the tiny model.

### Changes

- Add `"fullatt_block_indexes": [1]` to `vision_config` in `scripts/generate_tiny_models/for_conditional_generation/qwen2_5_vl_for_conditional_generation.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single config tweak in a tiny-model generation script; impact is limited to ensuring the full-attention path is exercised and avoids out-of-range/unreachable indices.
> 
> **Overview**
> Updates the tiny Qwen2.5-VL conditional generation model generator to include `vision_config.fullatt_block_indexes=[1]`, ensuring the configured full-attention layer indices are valid for `depth=2` and the full-attention code path can be hit during tiny-model tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d296f8952265ca74a0524cb60ddcc72fc439b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->