### PR TITLE
Fix CI test to avoid skipping model.visual params

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2529,11 +2529,8 @@ class TestGRPOTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["tools/call_frequency"] == pytest.approx(1 / 2)
         assert trainer.state.log_history[-1]["tools/failure_frequency"] == pytest.approx(0.0)
 
-        # Check that the params have changed (skip vision parts, see test_train_vlm)
-        params_to_skip = ("model.visual.",)
+        # Check that the params have changed
         for n, param in previous_trainable_params.items():
-            if n.startswith(params_to_skip):
-                continue
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 


### PR DESCRIPTION
Fix CI test to avoid skipping `model.visual` params.

This PR simplifies the parameter change verification logic in the `test_train_with_tools_multimodal_response` (`tests/test_grpo_trainer.py`). The main change is the removal of logic that previously skipped parameters related to the model's vision components when checking for updates after training.

### Changes

Test simplification:

* The test no longer skips parameters starting with `model.visual.` when asserting that parameters have changed after training, ensuring all trainable parameters are checked for updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes a unit test, but it may surface previously-hidden training non-updates for vision components and could increase CI failure sensitivity.
> 
> **Overview**
> Updates `test_train_with_tools_multimodal_response` to **no longer skip** parameters under `model.visual.*` when verifying weights changed after `trainer.train()`, ensuring the test validates updates across the full model (including vision parts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79bfbd86a04cb9bbdd0ddf742e50656ceb7afe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->