### PR TITLE
Warn when GRPOTrainer use_liger_kernel masks LoRA adapters on lm_head

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -529,6 +529,112 @@ class TestGRPOTrainer(TrlTestCase):
             elif "base_layer" not in n:  # We expect the peft params to be different (except for the base layer)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @require_peft
+    def test_liger_with_lora_targeting_only_lm_head_raises(self):
+        # When `use_liger_kernel=True` and LoRA targets *only* `lm_head`, the Liger fused loss reads `lm_head.weight`
+        # directly from the base model. The LoRA adapter would never receive gradient updates and training would be a
+        # no-op, so we fail fast. See https://github.com/huggingface/trl/issues/4612.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        with pytest.raises(ValueError, match="LoRA adapters that target only `lm_head`"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+                peft_config=LoraConfig(target_modules=["lm_head"]),
+            )
+
+    @require_peft
+    def test_liger_with_lora_targeting_lm_head_and_others_warns(self):
+        # When `use_liger_kernel=True` and LoRA targets `lm_head` alongside other modules, the `lm_head` adapter is
+        # silently ignored by Liger; warn so the user knows that adapter won't train.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        with pytest.warns(UserWarning, match="`lm_head` LoRA adapter will be silently ignored"):
+            try:
+                GRPOTrainer(
+                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                    reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                    args=training_args,
+                    train_dataset=dataset,
+                    peft_config=LoraConfig(target_modules=["lm_head", "q_proj"]),
+                )
+            except ImportError:
+                # Liger kernel may not be installed in the test environment; the warning fires before that check, so
+                # `pytest.warns` will still validate it.
+                pass
+
+    @require_peft
+    def test_liger_with_lora_targeting_only_other_modules_is_silent(self):
+        # When `use_liger_kernel=True` and LoRA does *not* target `lm_head`, no warning or error should fire.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            try:
+                GRPOTrainer(
+                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                    reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                    args=training_args,
+                    train_dataset=dataset,
+                    peft_config=LoraConfig(target_modules=["q_proj"]),
+                )
+            except ImportError:
+                # Liger kernel may not be installed; the lm_head/liger check fires before the import check.
+                pass
+            except UserWarning as exc:
+                # We turned UserWarning into an error so an unexpected warning surfaces clearly.
+                if "lm_head" in str(exc):
+                    raise
+
+    @require_peft
+    def test_lora_targeting_lm_head_without_liger_is_silent(self):
+        # Without `use_liger_kernel`, LoRA on `lm_head` is fine: the standard loss path uses the adapted head normally.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            use_liger_kernel=False,
+            report_to="none",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            try:
+                GRPOTrainer(
+                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                    reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                    args=training_args,
+                    train_dataset=dataset,
+                    peft_config=LoraConfig(target_modules=["lm_head"]),
+                )
+            except UserWarning as exc:
+                if "lm_head" in str(exc) and "Liger" in str(exc):
+                    raise
+
     def test_train_different_reward_model(self):
         # Use a reward model different from the model: different chat template, tokenization, etc.
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -586,6 +586,33 @@ class GRPOTrainer(_BaseTrainer):
                 "Possible values are 'token' and 'sequence'."
             )
 
+        # Liger's fused GRPO loss reads `unwrapped_model.lm_head.weight` directly (see `compute_liger_loss`), which is
+        # the frozen base weight when LoRA wraps `lm_head`. The LoRA adapter on `lm_head` would never reach the kernel
+        # and never receive gradient updates, so the user would silently train a model with a frozen LM head. See
+        # https://github.com/huggingface/trl/issues/4612.
+        if self.use_liger_kernel and is_peft_model(model):
+            target_modules = model.peft_config["default"].target_modules
+            # `target_modules` can be a list, set, str (regex or single name), or None.
+            # We only inspect the cheap explicit cases; a regex string is opaque so we skip it.
+            if isinstance(target_modules, (list, set, tuple)):
+                targeted = set(target_modules)
+                if "lm_head" in targeted:
+                    if targeted == {"lm_head"}:
+                        raise ValueError(
+                            "GRPOTrainer with `use_liger_kernel=True` does not support LoRA adapters that target only "
+                            "`lm_head`. The Liger fused loss reads `lm_head.weight` directly from the base model, so "
+                            "the `lm_head` LoRA adapter never receives gradient updates and training would be a no-op. "
+                            "Either set `use_liger_kernel=False` or include other modules in `target_modules`."
+                        )
+                    warnings.warn(
+                        "GRPOTrainer with `use_liger_kernel=True` is being used with a LoRA config whose "
+                        "`target_modules` includes `lm_head`. The Liger fused loss reads `lm_head.weight` directly "
+                        "from the base model, so the `lm_head` LoRA adapter will be silently ignored and will not "
+                        "receive gradient updates. Remove `lm_head` from `target_modules` or set "
+                        "`use_liger_kernel=False` if you intend to fine-tune the LM head.",
+                        UserWarning,
+                    )
+
         # Datasets
         self.shuffle_dataset = args.shuffle_dataset
 


### PR DESCRIPTION
# What does this PR do?

Fixes #4612.

`GRPOTrainer.compute_liger_loss` passes `unwrapped_model.lm_head.weight` directly to `LigerFusedLinearGRPOLoss`. When LoRA targets `lm_head`, that weight is the frozen base; the LoRA adapters never reach the Liger kernel and never receive gradient updates, so the user silently trains a model where `lm_head` behaves as frozen.

Implements the approach @pramodith proposed in the issue:

- **Error** when `lm_head` is the *only* target of the active PEFT config and `use_liger_kernel=True`. With nothing else in `target_modules`, the run would be a no-op for the head, so it is better to fail fast.
- **Warning** when `lm_head` is one of several targets. The other adapters will still train; we surface that the lm_head adapter is being silently ignored.

No behavior change when `use_liger_kernel=False` or when `lm_head` is not in `target_modules`. The check is cheap: it only reads `model.peft_config["default"].target_modules`, with no module traversal. A regex `target_modules` string is treated as opaque and skipped (no false positives on patterns that may or may not match `lm_head`).

The check lives next to the existing Liger validation block in `GRPOTrainer.__init__` and uses `is_peft_model` to guard the PEFT-only path, matching the surrounding style.

## Tests

Added four cases in `tests/test_grpo_trainer.py`:

1. `use_liger_kernel=True` + LoRA `target_modules=[\"lm_head\"]` raises `ValueError`
2. `use_liger_kernel=True` + LoRA `target_modules=[\"lm_head\", \"q_proj\"]` issues `UserWarning`
3. `use_liger_kernel=True` + LoRA `target_modules=[\"q_proj\"]` is silent
4. `use_liger_kernel=False` + LoRA `target_modules=[\"lm_head\"]` is silent

All four pass locally and existing PEFT/Liger tests remain green.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Pure code change, no docs needed.
- [x] Did you write any new necessary tests?

## Who can review?

@pramodith @qgallouedec @lewtun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new init-time validation that can now raise a `ValueError` or emit a `UserWarning` for certain `use_liger_kernel=True` + LoRA configurations, potentially breaking previously-running training jobs that were silently no-ops for `lm_head`. Logic is narrow and guarded, but impacts a performance-critical training path.
> 
> **Overview**
> Prevents silent no-op fine-tuning when using `GRPOTrainer` with `use_liger_kernel=True` and LoRA targets `lm_head`.
> 
> `GRPOTrainer.__init__` now inspects PEFT `target_modules` and **errors** if LoRA targets *only* `lm_head`, or **warns** if `lm_head` is among other targets (since Liger reads base `lm_head.weight` directly and ignores the adapter). Adds targeted tests covering raise/warn/silent behavior with and without Liger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67dbfe22b2654b4c07f03cf6abac97bcf9944b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->