### PR TITLE
Fix SFTTrainer failing to provide token_type_ids for Gemma 3 text-only training

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -242,6 +242,34 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
         torch.testing.assert_close(result["attention_mask"], torch.tensor([[1, 1, 1], [1, 1, 0]]))
         torch.testing.assert_close(result["labels"], torch.tensor([[1, 2, 3], [4, 5, -100]]))
 
+    def test_add_token_type_ids(self):
+        """Test that `add_token_type_ids=True` emits zero `token_type_ids` matching `input_ids` shape.
+
+        Regression test for https://github.com/huggingface/trl/issues/5807: Gemma 3
+        (`Gemma3ForConditionalGeneration`) requires `token_type_ids` as a model input during training, even
+        for text-only batches.
+        """
+        collator = DataCollatorForLanguageModeling(pad_token_id=0, add_token_type_ids=True)
+        examples = [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5]}]
+
+        result = collator(examples)
+
+        assert set(result.keys()) == {"input_ids", "attention_mask", "labels", "token_type_ids"}
+        torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
+        torch.testing.assert_close(result["token_type_ids"], torch.zeros((2, 3), dtype=result["input_ids"].dtype))
+        assert result["token_type_ids"].dtype == result["input_ids"].dtype
+
+    def test_add_token_type_ids_padding_free(self):
+        """Test that `add_token_type_ids=True` works in `padding_free=True` mode."""
+        collator = DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True, add_token_type_ids=True)
+        examples = [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5]}]
+
+        result = collator(examples)
+
+        assert set(result.keys()) == {"input_ids", "position_ids", "labels", "token_type_ids"}
+        torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3, 4, 5]]))
+        torch.testing.assert_close(result["token_type_ids"], torch.zeros((1, 5), dtype=result["input_ids"].dtype))
+
     def test_assistant_masks(self):
         """Test handling of assistant masks in examples."""
         collator = DataCollatorForLanguageModeling(pad_token_id=0)
@@ -1056,6 +1084,29 @@ class TestSFTTrainer(TrlTestCase):
         assert isinstance(trainer.data_collator, DataCollatorForLanguageModeling)
         assert trainer.data_collator.max_length == 16
         assert trainer.data_collator.truncation_mode == "keep_end"
+
+    def test_text_only_gemma3_collator_adds_token_type_ids(self):
+        """Regression test for https://github.com/huggingface/trl/issues/5807.
+
+        Gemma 3 (`Gemma3ForConditionalGeneration`) requires `token_type_ids` as a model input during training,
+        even for text-only batches. When `SFTTrainer` auto-creates its data collator for a text-only dataset, it
+        should detect Gemma 3 and emit zero `token_type_ids` matching `input_ids`.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:2]")
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert isinstance(trainer.data_collator, DataCollatorForLanguageModeling)
+        assert trainer.data_collator.add_token_type_ids is True
+
+        batch = next(iter(trainer.get_train_dataloader()))
+        assert "token_type_ids" in batch
+        assert batch["token_type_ids"].shape == batch["input_ids"].shape
+        assert torch.all(batch["token_type_ids"] == 0)
 
     def test_padding_free_without_packing_and_max_length_raises(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:2]")

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1175,7 +1175,7 @@ class SFTTrainer(_BaseTrainer):
             # Some models (currently Gemma 3's `Gemma3ForConditionalGeneration`) require `token_type_ids` as a model
             # input during training. The default text-only language modeling collator does not produce them, so we
             # opt in here when we detect such a model. See https://github.com/huggingface/trl/issues/5807.
-            add_token_type_ids = getattr(model.config, "model_type", None) == "gemma3"
+            add_token_type_ids = model.config.model_type == "gemma3"
             data_collator = DataCollatorForLanguageModeling(
                 pad_token_id=self._tokenizer.pad_token_id,
                 max_length=None if self.padding_free else args.max_length,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -390,6 +390,10 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
             If set, the sequences will be padded to a multiple of this value.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             Type of Tensor to return. Only `"pt"` is currently supported.
+        add_token_type_ids (`bool`, *optional*, defaults to `False`):
+            If set to `True`, the returned batch will include a `"token_type_ids"` tensor of zeros matching the shape
+            of `"input_ids"`. This is required by some models, such as Gemma 3 (`Gemma3ForConditionalGeneration`),
+            which expect `token_type_ids` as a model input during text-only training.
 
     Examples:
     ```python
@@ -434,6 +438,7 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
     padding_free: bool = False
     pad_to_multiple_of: int | None = None
     return_tensors: str = "pt"
+    add_token_type_ids: bool = False
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
         input_ids = [example["input_ids"] for example in examples]
@@ -523,6 +528,11 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
                 assistant_masks, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
             )
             output["labels"][assistant_masks == 0] = -100
+        if self.add_token_type_ids:
+            # Some models (e.g. Gemma 3's `Gemma3ForConditionalGeneration`) require `token_type_ids` as a model input
+            # during training, even for text-only batches. Zero values are the standard "text token" type and match
+            # the workaround documented in https://github.com/huggingface/trl/issues/5807.
+            output["token_type_ids"] = output["input_ids"].new_zeros(output["input_ids"].shape)
         return output
 
     @staticmethod
@@ -1162,6 +1172,10 @@ class SFTTrainer(_BaseTrainer):
                     "in the vocabulary before using it as a padding token."
                 )
             self._tokenizer.pad_token = pad_token
+            # Some models (currently Gemma 3's `Gemma3ForConditionalGeneration`) require `token_type_ids` as a model
+            # input during training. The default text-only language modeling collator does not produce them, so we
+            # opt in here when we detect such a model. See https://github.com/huggingface/trl/issues/5807.
+            add_token_type_ids = getattr(model.config, "model_type", None) == "gemma3"
             data_collator = DataCollatorForLanguageModeling(
                 pad_token_id=self._tokenizer.pad_token_id,
                 max_length=None if self.padding_free else args.max_length,
@@ -1169,6 +1183,7 @@ class SFTTrainer(_BaseTrainer):
                 completion_only_loss=self.completion_only_loss,
                 padding_free=self.padding_free,
                 pad_to_multiple_of=args.pad_to_multiple_of,
+                add_token_type_ids=add_token_type_ids,
             )
         elif data_collator is None and self._is_vision_dataset:
             data_collator = DataCollatorForVisionLanguageModeling(


### PR DESCRIPTION
# What does this PR do?

Fixes #5807.

Gemma 3's `transformers` implementation requires `token_type_ids` as a model input during training, but the auto-created `DataCollatorForLanguageModeling` for text-only SFT batches only emits `input_ids` / `attention_mask` / `labels`. Training then fails with:

```
ValueError: `token_type_ids` is required as a model input when training
```

raised from `transformers.models.gemma3.modeling_gemma3.create_causal_mask_mapping`.

This PR detects the Gemma 3 model type when `SFTTrainer` auto-creates the collator and wraps it so a missing `token_type_ids` key gets filled with zeros matching the `input_ids` shape (mirrors the workaround the reporter shared in the issue). Behavior for non-Gemma3 models is unchanged.

Concretely:

- `DataCollatorForLanguageModeling` gains an opt-in `add_token_type_ids: bool = False` flag. When set, the collator emits a zero `token_type_ids` tensor matching `input_ids` (in both padding and padding-free modes).
- `SFTTrainer` enables the flag when `model.config.model_type == "gemma3"` (i.e. `Gemma3ForConditionalGeneration`). The text-only `Gemma3ForCausalLM` (`gemma3_text`) is unaffected because it does not require `token_type_ids`. Other model families are unchanged.

The related earlier prompt-completion fix in #5032 is still in place; this PR covers the residual SFT data-collator path for text-only Gemma 3.

## Tests

Added three regression tests in `tests/test_sft_trainer.py`:

- `TestDataCollatorForLanguageModeling::test_add_token_type_ids` and `::test_add_token_type_ids_padding_free` verify the collator emits zero `token_type_ids` matching `input_ids` in both padding and padding-free modes.
- `TestSFTTrainer::test_text_only_gemma3_collator_adds_token_type_ids` exercises the full `SFTTrainer` setup with `trl-internal-testing/tiny-Gemma3ForConditionalGeneration` and a text-only dataset, asserting the auto-created collator opts in and the produced batch contains a zero `token_type_ids` tensor.

Targeted run on the affected paths (collator unit tests + Gemma 3 trainer-level tests) passes locally:

```
33 passed, 9 skipped
```

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case). (no — bug fix)
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Yes — #5807.
- [ ] Did you make sure to update the documentation with your changes? (no doc surface changes; new option is documented in the `DataCollatorForLanguageModeling` docstring)
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@qgallouedec @lewtun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `SFTTrainer` batching by conditionally adding a new `token_type_ids` field; while gated to Gemma 3 or explicit opt-in, it can affect model inputs and downstream training behavior if mis-detected.
> 
> **Overview**
> Fixes Gemma 3 text-only SFT runs by teaching `DataCollatorForLanguageModeling` to optionally emit zero `token_type_ids` matching `input_ids` (including in `padding_free` mode).
> 
> Updates `SFTTrainer`’s auto-collator creation to enable this flag when `model.config.model_type == "gemma3"`, and adds regression tests covering the collator output and an end-to-end Gemma3 trainer dataloader batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79de83592a81d0803e68781e8547cbb2ff35cf81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->