### PR TITLE
Align KTO with DPO: Align compute_loss flow

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1166,14 +1166,9 @@ class KTOTrainer(_BaseTrainer):
             if prediction_loss_only:
                 logits, labels = None, None
             else:
-                # logits for the chosen and rejected samples from model
-                logits_dict = {}
-                if self._metrics["eval"]["logits/chosen_sum"]:
-                    logits_dict["eval_logits/chosen"] = self._metrics["eval"]["logits/chosen_sum"][-1]
-                if self._metrics["eval"]["logits/rejected_sum"]:
-                    logits_dict["eval_logits/rejected"] = self._metrics["eval"]["logits/rejected_sum"][-1]
-                logits = torch.tensor(list(logits_dict.values()), device=self.accelerator.device)
-                labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
+                # Return dummy tensors so the Trainer calls compute_metrics. Real logits require refactoring forward()
+                logits = torch.zeros(1, device=self.accelerator.device)
+                labels = torch.zeros(1, device=self.accelerator.device)
         return loss, logits, labels
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1163,7 +1163,17 @@ class KTOTrainer(_BaseTrainer):
         inputs = self._prepare_inputs(inputs)
         with torch.no_grad(), self.compute_loss_context_manager():
             loss = self.compute_loss(model, inputs)
-            logits, labels = None, None
+            if prediction_loss_only:
+                logits, labels = None, None
+            else:
+                # logits for the chosen and rejected samples from model
+                logits_dict = {}
+                if self._metrics["eval"]["logits/chosen_sum"]:
+                    logits_dict["eval_logits/chosen"] = self._metrics["eval"]["logits/chosen_sum"][-1]
+                if self._metrics["eval"]["logits/rejected_sum"]:
+                    logits_dict["eval_logits/rejected"] = self._metrics["eval"]["logits/rejected_sum"][-1]
+                logits = torch.tensor(list(logits_dict.values()), device=self.accelerator.device)
+                labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
         return loss, logits, labels
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1148,6 +1148,8 @@ class KTOTrainer(_BaseTrainer):
         return loss
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        # return_outputs is not forwarded: _compute_loss delegates to forward(), which hides the raw model outputs
+        # Returning real outputs requires refactoring forward(), which is deferred.
         return self._compute_loss(model, inputs)
 
     def _get_train_sampler(self, dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1035,7 +1035,6 @@ class KTOTrainer(_BaseTrainer):
         self,
         model,
         inputs: dict[str, list | torch.LongTensor],
-        return_outputs: bool = False,
     ):
         """Compute the KTO loss and other metrics for the given batch of inputs for train or test."""
         mode = "train" if self.model.training else "eval"
@@ -1149,7 +1148,7 @@ class KTOTrainer(_BaseTrainer):
         return loss
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        return self._compute_loss(model, inputs, return_outputs)
+        return self._compute_loss(model, inputs)
 
     def _get_train_sampler(self, dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:
         if dataset is None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1038,7 +1038,7 @@ class KTOTrainer(_BaseTrainer):
         return_outputs: bool = False,
     ):
         """Compute the KTO loss and other metrics for the given batch of inputs for train or test."""
-        metrics = {}
+        mode = "train" if self.model.training else "eval"
         batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
 
         labels = torch.tensor(batch["label"])
@@ -1113,40 +1113,40 @@ class KTOTrainer(_BaseTrainer):
                 reference_KL_logps,
             )
 
-        metrics["kl"] = kl.item()
+        self._metrics[mode]["kl"].append(kl.item())
 
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()
 
         if all_num_chosen > 0:
-            metrics["rewards/chosen_sum"] = (
+            self._metrics[mode]["rewards/chosen_sum"].append(
                 self.accelerator.gather_for_metrics(chosen_rewards.nansum()).nansum().item()
             )
-            metrics["logps/chosen_sum"] = (
+            self._metrics[mode]["logps/chosen_sum"].append(
                 self.accelerator.gather_for_metrics(policy_chosen_logps.nansum()).nansum().item()
             )
-            metrics["logits/chosen_sum"] = (
+            self._metrics[mode]["logits/chosen_sum"].append(
                 self.accelerator.gather_for_metrics(policy_chosen_logits.nansum()).nansum().item()
             )
-            metrics["count/chosen"] = all_num_chosen
+            self._metrics[mode]["count/chosen"].append(all_num_chosen)
 
         if all_num_rejected > 0:
-            metrics["rewards/rejected_sum"] = (
+            self._metrics[mode]["rewards/rejected_sum"].append(
                 self.accelerator.gather_for_metrics(rejected_rewards.nansum()).nansum().item()
             )
-            metrics["logps/rejected_sum"] = (
+            self._metrics[mode]["logps/rejected_sum"].append(
                 self.accelerator.gather_for_metrics(policy_rejected_logps.nansum()).nansum().item()
             )
-            metrics["logits/rejected_sum"] = (
+            self._metrics[mode]["logits/rejected_sum"].append(
                 self.accelerator.gather_for_metrics(policy_rejected_logits.nansum()).nansum().item()
             )
-            metrics["count/rejected"] = all_num_rejected
+            self._metrics[mode]["count/rejected"].append(all_num_rejected)
 
         loss = losses.nanmean()
         if self.aux_loss_enabled:
             loss += self.aux_loss_coef * aux_loss
 
-        return loss, metrics
+        return loss
 
     def compute_loss(
         self,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1148,24 +1148,8 @@ class KTOTrainer(_BaseTrainer):
 
         return loss
 
-    def compute_loss(
-        self,
-        model: PreTrainedModel | nn.Module,
-        inputs: dict[str, torch.Tensor | Any],
-        return_outputs=False,
-        num_items_in_batch=None,
-    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor]]:
-        loss, metrics = self._compute_loss(model, inputs)
-
-        # Make sure to move the loss to the device the original accumulating loss is at back in the `Trainer` class:
-        loss = loss.to(self.args.device)
-        # force log the metrics
-        if self.accelerator.is_main_process:
-            self.store_metrics(metrics, train_eval="train")
-
-        if return_outputs:
-            return (loss, metrics)
-        return loss
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        return self._compute_loss(model, inputs, return_outputs)
 
     def store_metrics(self, metrics: dict[str, float], train_eval: Literal["train", "eval"] = "train") -> None:
         for key, value in metrics.items():

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -19,7 +19,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import torch
@@ -1150,10 +1150,6 @@ class KTOTrainer(_BaseTrainer):
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         return self._compute_loss(model, inputs, return_outputs)
-
-    def store_metrics(self, metrics: dict[str, float], train_eval: Literal["train", "eval"] = "train") -> None:
-        for key, value in metrics.items():
-            self._metrics[train_eval][key].append(value)
 
     def _get_train_sampler(self, dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:
         if dataset is None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1162,40 +1162,14 @@ class KTOTrainer(_BaseTrainer):
             return None
         return SequentialSampler(dataset)
 
-    def prediction_step(
-        self,
-        model: PreTrainedModel | nn.Module,
-        inputs: dict[str, torch.Tensor | Any],
-        prediction_loss_only: bool,
-        ignore_keys: list[str] | None = None,
-    ):
-        if ignore_keys is None:
-            if hasattr(model, "config"):
-                ignore_keys = getattr(model.config, "keys_to_ignore_at_inference", [])
-            else:
-                ignore_keys = []
-
-        with torch.no_grad():
-            loss, metrics = self._compute_loss(model, inputs)
-
-        # force log the metrics
-        if self.accelerator.is_main_process:
-            self.store_metrics(metrics, train_eval="eval")
-
-        if prediction_loss_only:
-            return (loss.detach(), None, None)
-
-        # logits for the chosen and rejected samples from model
-        logits_dict = {}
-        if "logits/chosen_sum" in metrics:
-            logits_dict["eval_logits/chosen"] = metrics["logits/chosen_sum"]
-        if "logits/rejected_sum" in metrics:
-            logits_dict["eval_logits/rejected"] = metrics["logits/rejected_sum"]
-        logits = [v for k, v in logits_dict.items() if k not in ignore_keys]
-        logits = torch.tensor(logits, device=self.accelerator.device)
-        labels = torch.zeros(logits.shape[0], device=self.accelerator.device)
-
-        return (loss.detach(), logits, labels)
+    # During eval, Trainer calls prediction_step. If no labels are present in the inputs, it only runs forward and
+    # returns logits. We override prediction_step to force compute_loss, because this trainer doesn't involve labels.
+    def prediction_step(self, model, inputs, prediction_loss_only, ignore_keys=None):
+        inputs = self._prepare_inputs(inputs)
+        with torch.no_grad(), self.compute_loss_context_manager():
+            loss = self.compute_loss(model, inputs)
+            logits, labels = None, None
+        return loss, logits, labels
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         """

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1031,14 +1031,15 @@ class KTOTrainer(_BaseTrainer):
 
         return output
 
-    def get_batch_loss_metrics(
+    def _compute_loss(
         self,
         model,
-        batch: dict[str, list | torch.LongTensor],
+        inputs: dict[str, list | torch.LongTensor],
+        return_outputs: bool = False,
     ):
         """Compute the KTO loss and other metrics for the given batch of inputs for train or test."""
         metrics = {}
-        batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
+        batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
 
         labels = torch.tensor(batch["label"])
         num_chosen = labels.sum().to(self.accelerator.device)
@@ -1154,7 +1155,7 @@ class KTOTrainer(_BaseTrainer):
         return_outputs=False,
         num_items_in_batch=None,
     ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor]]:
-        loss, metrics = self.get_batch_loss_metrics(model, inputs)
+        loss, metrics = self._compute_loss(model, inputs)
 
         # Make sure to move the loss to the device the original accumulating loss is at back in the `Trainer` class:
         loss = loss.to(self.args.device)
@@ -1191,7 +1192,7 @@ class KTOTrainer(_BaseTrainer):
                 ignore_keys = []
 
         with torch.no_grad():
-            loss, metrics = self.get_batch_loss_metrics(model, inputs)
+            loss, metrics = self._compute_loss(model, inputs)
 
         # force log the metrics
         if self.accelerator.is_main_process:


### PR DESCRIPTION
Align KTO with DPO: Align compute_loss flow.

This PR aligns KTOTrainer's metric storage and compute-loss architecture with DPOTrainer: to simplify loss computation and metrics handling, and to streamline evaluation logic. The main changes focus on consolidating loss and metrics calculation, updating how metrics are stored, and simplifying the prediction step.

Part of:
- #4786

### Motivation

DPOTrainer appends metrics directly to self._metrics[mode] inside _compute_loss / _compute_loss_liger, with no intermediate dict and no helper method.

KTOTrainer used a different pattern (get_batch_loss_metrics → store_metrics) that also included an is_main_process guard absent from DPO. The is_main_process guard was unnecessary: gather_for_metrics already produces the same aggregated scalar on every rank, so appending unconditionally (as DPO does) gives identical results.

### Solution

- Rename get_batch_loss_metrics → _compute_loss(model, inputs, return_outputs) to match DPO's naming convention.
- Move metric appending inside _compute_loss: instead of building a metrics dict and returning it to the caller, append directly to self._metrics[mode], exactly as DPO does in its _compute_loss.
- Simplify compute_loss to a one-liner that delegates to _compute_loss.
- Simplify prediction_step to call compute_loss and return (loss, None, None), matching DPO's pattern (the previous implementation returned fake logits derived from intermediate metric sums).
- Remove store_metrics (no longer needed) and its now-unused Literal import.


### Changes

**Refactoring and Simplification:**

* The methods `get_batch_loss_metrics` and `compute_loss` have been merged and refactored into `_compute_loss` and a new, simplified `compute_loss` method, reducing code duplication and clarifying responsibilities.
* The `prediction_step` method is rewritten to always use `compute_loss`, ensuring consistent loss computation for both training and evaluation, and removing custom metrics/logit handling in favor of a simpler interface.

**Metrics Handling Improvements:**

* Metrics are now directly appended to the internal `_metrics` dictionary within `_compute_loss`, removing the need for a separate `store_metrics` method and streamlining metrics collection.

**Type and Import Cleanups:**

* The unused `Literal` import was removed from the type imports, reflecting updates to function signatures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Trainer` integration points (`compute_loss`/`prediction_step`) and changes how/when metrics are recorded during train/eval, which can affect evaluation outputs and logging behavior.
> 
> **Overview**
> Refactors `KTOTrainer` to compute loss via a single `_compute_loss` path and **append metrics directly into `self._metrics[train|eval]`**, removing the prior `get_batch_loss_metrics` + `store_metrics` pattern and associated main-process guard.
> 
> Simplifies `compute_loss` to delegate to `_compute_loss`, and rewrites `prediction_step` to always run loss computation during eval (returning dummy logits/labels when needed so `compute_metrics` still runs). Also removes the now-unused `Literal` import and tightens some method signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8264c7df5cd78525dc6c24c2ba0d2151e64a44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->