### PR TITLE
Align and simplify the stable training scripts

### DIFF
--- a/examples/scripts/sft_nemotron_3.py
+++ b/examples/scripts/sft_nemotron_3.py
@@ -56,7 +56,6 @@ accelerate launch \
 """
 
 from datasets import load_dataset
-from transformers import AutoModelForCausalLM
 
 from trl import ModelConfig, ScriptArguments, SFTConfig, SFTTrainer, TrlParser, get_peft_config
 
@@ -65,13 +64,11 @@ def main(script_args, training_args, model_args):
     # NemotronH does not support gradient checkpointing
     training_args.gradient_checkpointing = False
 
-    # Load model
-    model_kwargs = dict(
+    training_args.model_init_kwargs = dict(
         revision=model_args.model_revision,
         attn_implementation=model_args.attn_implementation,
         dtype=model_args.dtype,
     )
-    model = AutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, **model_kwargs)
 
     # Load dataset
     dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
@@ -97,7 +94,7 @@ def main(script_args, training_args, model_args):
 
     # Train model
     trainer = SFTTrainer(
-        model=model,
+        model=model_args.model_name_or_path,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=eval_dataset,

--- a/trl/scripts/dpo.py
+++ b/trl/scripts/dpo.py
@@ -62,39 +62,24 @@ import argparse
 
 
 def main(script_args, training_args, model_args, dataset_args):
-    import torch
     from accelerate import logging
     from datasets import load_dataset
-    from transformers import AutoModelForCausalLM
 
     from trl import DPOTrainer, get_dataset, get_kbit_device_map, get_peft_config, get_quantization_config
 
     logger = logging.get_logger(__name__)
 
-    ################
-    # Model
-    ###################
-    dtype = model_args.dtype if model_args.dtype in ["auto", None] else getattr(torch, model_args.dtype)
-    model_kwargs = dict(
+    training_args.model_init_kwargs = dict(
         revision=model_args.model_revision,
+        trust_remote_code=model_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
-        dtype=dtype,
+        dtype=model_args.dtype,
     )
     quantization_config = get_quantization_config(model_args)
     if quantization_config is not None:
         # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
-        model_kwargs["device_map"] = get_kbit_device_map()
-        model_kwargs["quantization_config"] = quantization_config
-
-    model = AutoModelForCausalLM.from_pretrained(
-        model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, **model_kwargs
-    )
-    peft_config = get_peft_config(model_args)
-    if script_args.ignore_bias_buffers:
-        # torch distributed hack
-        model._ddp_params_and_buffers_to_ignore = [
-            name for name, buffer in model.named_buffers() if buffer.dtype == torch.bool
-        ]
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
 
     # Load the dataset
     if dataset_args.datasets and script_args.dataset_name:
@@ -114,23 +99,26 @@ def main(script_args, training_args, model_args, dataset_args):
 
     # Initialize the DPO trainer
     trainer = DPOTrainer(
-        model,
+        model=model_args.model_name_or_path,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
-        peft_config=peft_config,
+        peft_config=get_peft_config(model_args),
     )
+
+    if script_args.ignore_bias_buffers:
+        import torch
+
+        # torch distributed hack
+        trainer.model._ddp_params_and_buffers_to_ignore = [
+            name for name, buffer in trainer.model.named_buffers() if buffer.dtype == torch.bool
+        ]
 
     # Train the model
     trainer.train()
 
     # Log training complete
     trainer.accelerator.print("✅ Training completed.")
-
-    if training_args.eval_strategy != "no":
-        metrics = trainer.evaluate()
-        trainer.log_metrics("eval", metrics)
-        trainer.save_metrics("eval", metrics)
 
     # Save and push to Hub
     trainer.save_model(training_args.output_dir)

--- a/trl/scripts/grpo.py
+++ b/trl/scripts/grpo.py
@@ -66,7 +66,6 @@ class GRPOScriptArguments(ScriptArguments):
 
 
 def main(script_args, training_args, model_args, dataset_args):
-    import torch
     from accelerate import logging
     from datasets import load_dataset
 
@@ -107,21 +106,18 @@ def main(script_args, training_args, model_args, dataset_args):
                     f"Could not load reward function '{func_name}'. Expected one of "
                     f"{list(reward_funcs_registry.keys())} or a valid import path."
                 )
-    dtype = model_args.dtype if model_args.dtype in ["auto", None] else getattr(torch, model_args.dtype)
 
-    model_kwargs = dict(
+    training_args.model_init_kwargs = dict(
         revision=model_args.model_revision,
+        trust_remote_code=model_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
-        dtype=dtype,
+        dtype=model_args.dtype,
     )
     quantization_config = get_quantization_config(model_args)
-
     if quantization_config is not None:
         # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
-        model_kwargs["device_map"] = get_kbit_device_map()
-        model_kwargs["quantization_config"] = quantization_config
-
-    training_args.model_init_kwargs = model_kwargs
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
 
     # Load the dataset
     if dataset_args.datasets and script_args.dataset_name:

--- a/trl/scripts/reward.py
+++ b/trl/scripts/reward.py
@@ -28,9 +28,21 @@ def main(script_args, training_args, model_args, dataset_args):
     from accelerate import logging
     from datasets import load_dataset
 
-    from trl import RewardTrainer, get_dataset, get_peft_config
+    from trl import RewardTrainer, get_dataset, get_kbit_device_map, get_peft_config, get_quantization_config
 
     logger = logging.get_logger(__name__)
+
+    training_args.model_init_kwargs = dict(
+        revision=model_args.model_revision,
+        trust_remote_code=model_args.trust_remote_code,
+        attn_implementation=model_args.attn_implementation,
+        dtype=model_args.dtype,
+    )
+    quantization_config = get_quantization_config(model_args)
+    if quantization_config is not None:
+        # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
 
     # Load the dataset
     if dataset_args.datasets and script_args.dataset_name:
@@ -48,7 +60,7 @@ def main(script_args, training_args, model_args, dataset_args):
     else:
         raise ValueError("Either `datasets` or `dataset_name` must be provided.")
 
-    # Initialize the RewardTrainer
+    # Initialize the reward trainer
     trainer = RewardTrainer(
         model=model_args.model_name_or_path,
         args=training_args,

--- a/trl/scripts/rloo.py
+++ b/trl/scripts/rloo.py
@@ -69,7 +69,7 @@ def main(script_args, training_args, model_args, dataset_args):
     from accelerate import logging
     from datasets import load_dataset
 
-    from trl import RLOOTrainer, get_dataset, get_peft_config
+    from trl import RLOOTrainer, get_dataset, get_kbit_device_map, get_peft_config, get_quantization_config
     from trl.rewards import (
         accuracy_reward,
         get_soft_overlong_punishment,
@@ -106,6 +106,18 @@ def main(script_args, training_args, model_args, dataset_args):
                     f"Could not load reward function '{func_name}'. Expected one of "
                     f"{list(reward_funcs_registry.keys())} or a valid import path."
                 )
+
+    training_args.model_init_kwargs = dict(
+        revision=model_args.model_revision,
+        trust_remote_code=model_args.trust_remote_code,
+        attn_implementation=model_args.attn_implementation,
+        dtype=model_args.dtype,
+    )
+    quantization_config = get_quantization_config(model_args)
+    if quantization_config is not None:
+        # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
 
     # Load the dataset
     if dataset_args.datasets and script_args.dataset_name:

--- a/trl/scripts/sft.py
+++ b/trl/scripts/sft.py
@@ -66,17 +66,12 @@ import argparse
 def main(script_args, training_args, model_args, dataset_args):
     from accelerate import logging
     from datasets import load_dataset
-    from transformers import AutoConfig, AutoModelForCausalLM
-    from transformers.models.auto.modeling_auto import MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
 
     from trl import SFTTrainer, get_dataset, get_kbit_device_map, get_peft_config, get_quantization_config
 
     logger = logging.get_logger(__name__)
 
-    ################
-    # Model init kwargs
-    ################
-    model_kwargs = dict(
+    training_args.model_init_kwargs = dict(
         revision=model_args.model_revision,
         trust_remote_code=model_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
@@ -85,19 +80,8 @@ def main(script_args, training_args, model_args, dataset_args):
     quantization_config = get_quantization_config(model_args)
     if quantization_config is not None:
         # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
-        model_kwargs["device_map"] = get_kbit_device_map()
-        model_kwargs["quantization_config"] = quantization_config
-
-    # Create model
-    config = AutoConfig.from_pretrained(model_args.model_name_or_path)
-    valid_image_text_architectures = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.values()
-
-    if config.architectures and any(arch in valid_image_text_architectures for arch in config.architectures):
-        from transformers import AutoModelForImageTextToText
-
-        model = AutoModelForImageTextToText.from_pretrained(model_args.model_name_or_path, **model_kwargs)
-    else:
-        model = AutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, **model_kwargs)
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
 
     # Load the dataset
     if dataset_args.datasets and script_args.dataset_name:
@@ -117,7 +101,7 @@ def main(script_args, training_args, model_args, dataset_args):
 
     # Initialize the SFT trainer
     trainer = SFTTrainer(
-        model=model,
+        model=model_args.model_name_or_path,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,


### PR DESCRIPTION
The recommended way to instantiate a trainer is to pass a model id string and let the trainer call `from_pretrained` itself (via `model_init_kwargs`). The CLI scripts under `trl/scripts/` were not following this — most loaded the model manually, and they had drifted apart in how they built `model_init_kwargs`.

This PR moves `sft`, `dpo`, `grpo`, `rloo`, `reward` to the same pattern:

```python
training_args.model_init_kwargs = dict(revision=..., trust_remote_code=..., attn_implementation=..., dtype=...)
quantization_config = get_quantization_config(model_args)
if quantization_config is not None:
    training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
    training_args.model_init_kwargs["quantization_config"] = quantization_config
...
trainer = XxxTrainer(model=model_args.model_name_or_path, ...)
```

Along the way:

- **sft**: drops the manual `AutoModelForImageTextToText` branch (the trainer resolves it from `config.architectures[0]`).
- **dpo**: drops a redundant post-train `trainer.evaluate()` block; `ignore_bias_buffers` now operates on `trainer.model`.
- **grpo**: drops a redundant manual `getattr(torch, dtype)` and forwards `trust_remote_code`.
- **rloo** / **reward**: add the missing `model_init_kwargs` block — previously `--dtype` / `--load_in_4bit` / `--attn_implementation` were silently ignored.
- **examples/scripts/sft_nemotron_3.py**: same simplification (direct replica of the old SFT pattern).

`grpo.py` and `rloo.py` are now byte-identical except for class names. Other examples (`cpo`, `orpo`, `bco`, `kto`, `nash_md`, `xpo`, `online_dpo`, `sft_gpt_oss`, `sft_video_llm`, `sft_tiny_aya_tool_calling`) are left alone — each has a twist (multi-model load, custom processor, custom quantization) that doesn't fit cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because multiple CLI training entrypoints change how models are instantiated (and how dtype/quantization/trust_remote_code are applied), which can affect runtime behavior across common workflows.
> 
> **Overview**
> **Unifies model instantiation across the “stable” training CLIs.** The `sft`, `dpo`, `grpo`, `rloo`, `reward`, and `examples/scripts/sft_nemotron_3.py` scripts now set `training_args.model_init_kwargs` (revision/`trust_remote_code`/attention impl/dtype, plus k-bit `device_map` + `quantization_config` when enabled) and pass `model=model_args.model_name_or_path` into the trainer, rather than pre-loading the model themselves.
> 
> This removes divergent/duplicated logic (notably the manual `AutoModelForImageTextToText` branch in `sft.py`), ensures `reward.py`/`rloo.py` actually honor dtype/quantization-related flags, and simplifies `dpo.py` by dropping an extra post-train eval block and applying `ignore_bias_buffers` on `trainer.model`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0441d1eaa810e8b031062a4d6499ab4bd4f67d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->