### PR TITLE
Fix vllm_importance_sampling_correction sequence-level aggregation: sum → mean

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2067,7 +2067,8 @@ class GRPOTrainer(_BaseTrainer):
 
                 sequence_level_is = self.vllm_importance_sampling_mode in ["sequence_mask", "sequence_truncate"]
                 if sequence_level_is:
-                    per_sequence_logps_diff = per_token_logps_diff.sum(dim=-1, keepdim=True)
+                    seq_len = mask.sum(dim=-1, keepdim=True).clamp(min=1.0)
+                    per_sequence_logps_diff = per_token_logps_diff.sum(dim=-1, keepdim=True) / seq_len
                     logps_diff = per_sequence_logps_diff
                 else:
                     logps_diff = per_token_logps_diff


### PR DESCRIPTION
# What does this PR do?

Fixes #5814.

Sequence-level vLLM importance sampling correction was aggregating per-token log-ratios with `sum` instead of `mean`. This made the IS ratio's variance scale with completion length and, combined with `clamp(max=cap)`, systematically deflated the ratio toward zero even when per-token logprobs from vLLM and the trainer agreed.

The fix divides by the mask sum, matching:

- The GSPO paper formula (Zheng et al., 2025), which has a `1/|y|` factor.
- TRL's own policy-IS aggregation at `importance_sampling_level="sequence"` (`grpo_trainer.py` line ~2501), which already uses `(log_ratio * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)`.

Empirically on a real training run, the IS ratio mean went from **0.569** (with `sum`) to **0.993** (with `mean`) — same checkpoint, same seed, same data, bit-identical per-token logp diffs. Synthetic reproducer in #5814 shows the same effect deterministically in <1s.

The change is one line.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — #5814
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

> The existing test `test_train_vllm_importance_sampling_correction` is marked `@pytest.mark.skip(reason="We should add a mock for the vLLM server.")`, so I have not added a runtime test. Happy to add one if the maintainers point me to the preferred mocking approach.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with GSPO / GRPO importance sampling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the vLLM importance-sampling correction used during GRPO training, which can materially change loss scaling and training dynamics when `vllm_importance_sampling_mode` is sequence-level. Change is localized but affects core RL training behavior.
> 
> **Overview**
> Fixes sequence-level `vllm_importance_sampling_correction` aggregation in `GRPOTrainer` by normalizing the summed per-token log-prob diffs by the masked completion length (sum → mean). This makes the vLLM importance-sampling ratio in `sequence_*` modes independent of completion length before applying the configured cap/masking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0afd3d2fa631f6a1035275ed6147af9b0827c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->