### PR TITLE
Align KTO with DPO: Align _compute_loss_liger flow

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1052,73 +1052,60 @@ class KTOTrainer(_BaseTrainer):
         num_chosen = labels.sum().to(self.accelerator.device)
         num_rejected = (len(labels) - num_chosen).to(self.accelerator.device)
 
-        if self.args.use_liger_kernel:
-            model_output = self._compute_loss_liger(model, batch)
-            losses = model_output["loss"]
-            policy_chosen_logits = model_output["chosen_logits_sum"]
-            policy_rejected_logits = model_output["rejected_logits_sum"]
-            policy_chosen_logps = model_output["chosen_logps_sum"]
-            policy_rejected_logps = model_output["rejected_logps_sum"]
-            chosen_rewards = model_output["chosen_rewards_sum"]
-            rejected_rewards = model_output["rejected_rewards_sum"]
-            kl = model_output["kl"]
-            if self.aux_loss_enabled:
-                aux_loss = model_output["aux_loss"]
-        else:
-            forward_output = self.forward(model, batch)
-            (
-                policy_chosen_logps,
-                policy_rejected_logps,
-                policy_chosen_logits,
-                policy_rejected_logits,
-                policy_KL_logps,
-            ) = forward_output[:5]
-            if self.aux_loss_enabled:
-                aux_loss = forward_output[5]
+        forward_output = self.forward(model, batch)
+        (
+            policy_chosen_logps,
+            policy_rejected_logps,
+            policy_chosen_logits,
+            policy_rejected_logits,
+            policy_KL_logps,
+        ) = forward_output[:5]
+        if self.aux_loss_enabled:
+            aux_loss = forward_output[5]
 
-            # if reference_logps in batch use them, otherwise use the reference model
-            if "reference_logps" in batch:
-                # Convert Python lists to tensor indices for efficient CUDA operations
-                device = batch["reference_logps"].device
-                labels = torch.as_tensor(batch["label"], dtype=torch.bool, device=device)
-                chosen_idx = torch.nonzero(labels, as_tuple=False).view(-1)
-                rejected_idx = torch.nonzero(~labels, as_tuple=False).view(-1)
+        # if reference_logps in batch use them, otherwise use the reference model
+        if "reference_logps" in batch:
+            # Convert Python lists to tensor indices for efficient CUDA operations
+            device = batch["reference_logps"].device
+            labels = torch.as_tensor(batch["label"], dtype=torch.bool, device=device)
+            chosen_idx = torch.nonzero(labels, as_tuple=False).view(-1)
+            rejected_idx = torch.nonzero(~labels, as_tuple=False).view(-1)
 
-                # Use index_select for efficient CUDA operations
-                reference_chosen_logps = batch["reference_logps"].index_select(0, chosen_idx)
-                reference_rejected_logps = batch["reference_logps"].index_select(0, rejected_idx)
-                if self.calculate_KL:
-                    reference_KL_logps = batch["reference_KL_logps"]
-                else:
-                    reference_KL_logps = None
+            # Use index_select for efficient CUDA operations
+            reference_chosen_logps = batch["reference_logps"].index_select(0, chosen_idx)
+            reference_rejected_logps = batch["reference_logps"].index_select(0, rejected_idx)
+            if self.calculate_KL:
+                reference_KL_logps = batch["reference_KL_logps"]
             else:
-                with torch.no_grad():
-                    if self.ref_model is None:
-                        with self.null_ref_context():
-                            (
-                                reference_chosen_logps,
-                                reference_rejected_logps,
-                                _,
-                                _,
-                                reference_KL_logps,
-                            ) = self.forward(self.model, batch)[:5]
-                    else:
+                reference_KL_logps = None
+        else:
+            with torch.no_grad():
+                if self.ref_model is None:
+                    with self.null_ref_context():
                         (
                             reference_chosen_logps,
                             reference_rejected_logps,
                             _,
                             _,
                             reference_KL_logps,
-                        ) = self.forward(self.ref_model, batch)[:5]
+                        ) = self.forward(self.model, batch)[:5]
+                else:
+                    (
+                        reference_chosen_logps,
+                        reference_rejected_logps,
+                        _,
+                        _,
+                        reference_KL_logps,
+                    ) = self.forward(self.ref_model, batch)[:5]
 
-            losses, chosen_rewards, rejected_rewards, kl = self.kto_loss(
-                policy_chosen_logps,
-                policy_rejected_logps,
-                policy_KL_logps,
-                reference_chosen_logps,
-                reference_rejected_logps,
-                reference_KL_logps,
-            )
+        losses, chosen_rewards, rejected_rewards, kl = self.kto_loss(
+            policy_chosen_logps,
+            policy_rejected_logps,
+            policy_KL_logps,
+            reference_chosen_logps,
+            reference_rejected_logps,
+            reference_KL_logps,
+        )
 
         self._metrics[mode]["kl"].append(kl.item())
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -939,30 +939,19 @@ class KTOTrainer(_BaseTrainer):
             )
         return KL_logps
 
-    def _compute_loss_liger(self, model, batch):
-        """
-        Compute the KTO loss using the Liger-Kernel's LigerFusedLinearKTOLoss.
+    def _compute_loss_liger(self, model, inputs, return_outputs):
+        if return_outputs:
+            raise RuntimeError(
+                "return_outputs=True is not supported with the Liger KTO loss. The Liger loss computes the loss "
+                "without materializing logits, so outputs cannot be returned."
+            )
+        mode = "train" if self.model.training else "eval"
+        batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
 
-        Args:
-            model:
-                The policy model used for generating log probabilities and outputs. It could be an encoder-decoder
-                model or a regular language model.
-            batch: A dictionary containing the input data and labels for the batch.
+        labels = torch.tensor(batch["label"])
+        num_chosen = labels.sum().to(self.accelerator.device)
+        num_rejected = (len(labels) - num_chosen).to(self.accelerator.device)
 
-        Returns:
-            A dictionary containing the following keys:
-                - "loss": The computed KTO loss for the batch.
-                - "chosen_logits_sum": Sum of the logits for the chosen responses from the policy model.
-                - "rejected_logits_sum": Sum of the logits for the rejected responses from the policy model.
-                - "chosen_logps": Log probabilities of the chosen responses from the policy model.
-                - "rejected_logps": Log probabilities of the rejected responses from the policy model.
-                - "chosen_rewards": Rewards for the chosen responses.
-                - "rejected_rewards": Rewards for the rejected responses.
-                - "kl": The KL divergence between the policy and reference models (detached).
-
-            If auxiliary loss is enabled, the dictionary will also include:
-                - "aux_loss": The auxiliary loss from the model outputs.
-        """
         policy_KL_logps = self._compute_kl_logps(model, batch)
         reference_KL_logps = self._compute_kl_logps(self.ref_model, batch)
         if self.calculate_KL:
@@ -1016,21 +1005,39 @@ class KTOTrainer(_BaseTrainer):
             ref_bias=ref_lm_head.bias if hasattr(lm_head, "bias") else None,
             kl=kl,
         )
-
-        output = {
-            "loss": loss,
-            "chosen_logits_sum": chosen_logits_sum,
-            "rejected_logits_sum": rejected_logits_sum,
-            "chosen_logps_sum": chosen_logps_sum,
-            "rejected_logps_sum": rejected_logps_sum,
-            "chosen_rewards_sum": chosen_rewards_sum,
-            "rejected_rewards_sum": rejected_rewards_sum,
-            "kl": kl,
-        }
         if self.aux_loss_enabled:
-            output["aux_loss"] = outputs.aux_loss
+            loss += self.aux_loss_coef * outputs.aux_loss
 
-        return output
+        self._metrics[mode]["kl"].append(kl.item())
+
+        all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
+        all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()
+
+        if all_num_chosen > 0:
+            self._metrics[mode]["rewards/chosen_sum"].append(
+                self.accelerator.gather_for_metrics(chosen_rewards_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["logps/chosen_sum"].append(
+                self.accelerator.gather_for_metrics(chosen_logps_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["logits/chosen_sum"].append(
+                self.accelerator.gather_for_metrics(chosen_logits_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["count/chosen"].append(all_num_chosen)
+
+        if all_num_rejected > 0:
+            self._metrics[mode]["rewards/rejected_sum"].append(
+                self.accelerator.gather_for_metrics(rejected_rewards_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["logps/rejected_sum"].append(
+                self.accelerator.gather_for_metrics(rejected_logps_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["logits/rejected_sum"].append(
+                self.accelerator.gather_for_metrics(rejected_logits_sum.nansum()).nansum().item()
+            )
+            self._metrics[mode]["count/rejected"].append(all_num_rejected)
+
+        return loss
 
     def _compute_loss(
         self,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1143,6 +1143,8 @@ class KTOTrainer(_BaseTrainer):
         return loss
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        if self.use_liger_kernel:
+            return self._compute_loss_liger(model, inputs, return_outputs)
         # return_outputs is not forwarded: _compute_loss delegates to forward(), which hides the raw model outputs
         # Returning real outputs requires refactoring forward(), which is deferred.
         return self._compute_loss(model, inputs)

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -437,8 +437,9 @@ class KTOTrainer(_BaseTrainer):
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
 
+        self.use_liger_kernel = args.use_liger_kernel
         # Import Liger kernel if enabled
-        if self.args.use_liger_kernel:
+        if self.use_liger_kernel:
             if not is_liger_kernel_available():
                 raise ImportError(
                     "You set `use_liger_kernel=True` but the liger kernel is not available. "


### PR DESCRIPTION
Align KTO with DPO: Align `_compute_loss_liger` flow.

This PR refactors the Liger kernel loss computation in the `KTOTrainer` class to streamline metric tracking, clarify input handling, and simplify the interface. The most significant changes focus on how the Liger loss is computed and integrated, removing the previous dictionary-based output in favor of direct metric accumulation and returning only the loss value.

Part of:
- #4786

### Solution
- Store `self.use_liger_kernel = args.use_liger_kernel` as an instance attribute.
- Rewrite `_compute_loss_liger` as a fully standalone method: new signature `(model, inputs, return_outputs)`, appends directly to `self._metrics[mode]`, returns a scalar loss. 
  - Previously it returned a dict and was called from inside `_compute_loss`.
- Remove the `if self.args.use_liger_kernel` dispatch branch from `_compute_loss`, leaving it as a pure non-liger path.
- Update `compute_loss` to dispatch between the two paths: `if self.use_liger_kernel: return self._compute_loss_liger(...) else: return self._compute_loss(...)`.

### Changes

**Liger Kernel Loss Refactoring and Integration:**

* The `_compute_loss_liger` method is rewritten to:
  - Accept `inputs` and a `return_outputs` flag, raising an error if outputs are requested (since logits are not materialized by the Liger loss).
  - Directly accumulate metrics (such as KL, rewards, and log probabilities) into the trainer's internal `_metrics` dictionary, instead of returning them in a dictionary.
  - Return only the scalar loss value, not a dictionary of outputs.

* The main `_compute_loss` method is updated to:
  - Remove the branching logic that handled dictionary outputs from the Liger loss; now, only the standard loss path remains for non-Liger cases.

**Configuration and Input Handling:**

* The `use_liger_kernel` flag is now stored as an instance variable for consistent access, and the kernel import logic is updated accordingly.
* The `compute_loss` method now directly dispatches to `_compute_loss_liger` if the Liger kernel is enabled, passing through the `return_outputs` flag and enforcing the new interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the Liger-kernel training loss path and metric collection logic; while mostly structural, it affects core training/eval loss computation and logging behavior.
> 
> **Overview**
> Refactors the Liger-kernel KTO loss integration so `compute_loss` dispatches directly to `_compute_loss_liger(model, inputs, return_outputs)`, while `_compute_loss` becomes a single non-Liger path (removing the previous in-method branch and dict-based return handling).
> 
> `_compute_loss_liger` now returns only the scalar loss, explicitly errors on `return_outputs=True`, and records KL/reward/logp/logit metrics by appending directly into `self._metrics` (including auxiliary loss being added into the returned loss), bringing its flow in line with the standard KTO loss computation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a222f282e6d72e3251ca7f5d84c7405b807695b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->