### PR TITLE
Fix generate_batch: inference tensors block inplace ops in background thread

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1374,12 +1374,11 @@ class GRPOTrainer(_BaseTrainer):
                     unwrapped_model.to(torch.float16)
                 if self.args.cast_lm_head_to_fp32:
                     unwrapped_model.lm_head.to(torch.float32)
-                with torch.inference_mode():
-                    # Continuous batching API expects 'inputs' arg only
-                    all_outputs = unwrapped_model.generate_batch(
-                        prompt_ids, generation_config=self.generation_config, progress_bar=False
-                    )
-                    unwrapped_model.train()  # restore training mode, as generate_batch forces eval mode
+                # Continuous batching API expects 'inputs' arg only
+                all_outputs = unwrapped_model.generate_batch(
+                    prompt_ids, generation_config=self.generation_config, progress_bar=False
+                )
+                unwrapped_model.train()  # restore training mode, as generate_batch forces eval mode
             completion_ids = [output.generated_tokens for output in all_outputs.values()]
             logprobs = None  # not used in this case
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -991,12 +991,11 @@ class RLOOTrainer(_BaseTrainer):
                     unwrapped_model.to(torch.bfloat16)
                 elif self.args.fp16:
                     unwrapped_model.to(torch.float16)
-                with torch.inference_mode():
-                    # Continuous batching API expects 'inputs' arg only
-                    all_outputs = unwrapped_model.generate_batch(
-                        prompt_ids, generation_config=self.generation_config, progress_bar=False
-                    )
-                    unwrapped_model.train()  # restore training mode, as generate_batch forces eval mode
+                # Continuous batching API expects 'inputs' arg only
+                all_outputs = unwrapped_model.generate_batch(
+                    prompt_ids, generation_config=self.generation_config, progress_bar=False
+                )
+                unwrapped_model.train()  # restore training mode, as generate_batch forces eval mode
             completion_ids = [output.generated_tokens for output in all_outputs.values()]
 
         else:


### PR DESCRIPTION
Fix generate_batch: inference tensors block inplace ops in background thread:
- Remove `torch.inference_mode` context manager from `generate_batch`.

Fix #5817.

CC: @sergiopaniego 

### Motivation

In `transformers` PR huggingface/transformers#45943, the `_run_generation_loop` background thread was changed from `@torch.inference_mode()` to `@torch.no_grad()`. Background threads don't inherit torch.inference_mode() context from the parent thread, so this change was meant to be explicit about the thread's context.

However, `trl` wraps `generate_batch()` in `with torch.inference_mode():`, which makes the static tensors created during `warmup()` become "inference tensors". The background thread then crashes trying to do inplace ops (`.zero_()`) on those inference tensors outside inference mode.

Cascade:
- trl wraps `generate_batch()` with `with torch.inference_mode():` in the main thread
- `generate_batch()` calls `warmup()` synchronously, which creates the static tensor `_bulk_input_tensor` inside trl's inference mode context → it becomes an **inference tensor**
- Then `manager.start()` launches the background generation thread
- The background thread runs under `@torch.no_grad()` (not inference mode, and threads don't inherit it from the parent)
- The background thread calls `_reset_static_tensors()` which does `self._bulk_input_tensor[...].zero_()`: **inplace op on an inference tensor outside inference mode → crash**
- Generation fails, `generate_batch()` returns partial/empty results
- trl's `agg_completion_lengths.min()` is called on the empty tensor → the reported error

### Solution

Remove `with torch.inference_mode():` from around `generate_batch()`. The `generate_batch()` method already has its own `@torch.no_grad()` decorator (sufficient to prevent gradient computation during generation), so trl's wrapper was always redundant.

Without it, _bulk_input_tensor is created as a plain no-grad tensor instead of an inference tensor, allowing the background thread's inplace ops to succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the generation path used during training for `use_transformers_paged`, which can affect rollout correctness/performance across distributed/FSDP setups. The change is small and intended to prevent `generate_batch` background-thread crashes caused by inference tensors.
> 
> **Overview**
> Removes the outer `torch.inference_mode()` context around `unwrapped_model.generate_batch()` in `GRPOTrainer` and `RLOOTrainer` when using the continuous batching (`use_transformers_paged`) generation path.
> 
> Generation remains under `torch.no_grad()`, avoiding creation of inference tensors during `generate_batch` warmup and preventing downstream failures from background threads performing in-place ops on those tensors; training mode is still restored via `unwrapped_model.train()` after generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b76d771c1a33b5c7dfd8e8b83ac3f5a5d0357fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->