### PR TITLE
Migrate tests to Qwen3.5 Think/NoThink fixtures

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -161,7 +161,8 @@ class TestAddResponseSchema:
         "processor_name",
         [
             pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
-            pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration", id="qwen35"),
+            pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink", id="qwen35-nothink"),
+            pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think", id="qwen35-think"),
             pytest.param("trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6", id="qwen36"),
         ],
     )
@@ -227,8 +228,16 @@ class TestSupportsToolCalling:
                 ),
             ),
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
-                id="qwen35",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                id="qwen35-nothink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.0.0"),
+                    reason="Qwen3.5 tokenizer requires transformers>=5.0.0",
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think",
+                id="qwen35-think",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.0.0"),
                     reason="Qwen3.5 tokenizer requires transformers>=5.0.0",
@@ -683,7 +692,8 @@ class TestGetTrainingChatTemplate:
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
         pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
-        pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration", id="qwen35"),
+        pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink", id="qwen35-nothink"),
+        pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think", id="qwen35-think"),
         pytest.param("trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6", id="qwen36"),
         pytest.param(
             "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
@@ -760,8 +770,8 @@ class TestParseResponse:
         ]
         expected = messages[-1]
         messages = prepare_multimodal_messages(messages) if self.is_vlm else messages
-        # enable_thinking=True is required here because for Qwen3.5, the thinking is disabled by default for the
-        # generation prompt.
+        # enable_thinking=True is required here because the Qwen3.5 NoThink fixture disables thinking by default
+        # for the generation prompt.
         prefix = processing_class.apply_chat_template(
             messages[:1], add_generation_prompt=True, enable_thinking=True, tokenize=True, return_dict=True
         ).input_ids

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -548,7 +548,7 @@ class TestApplyChatTemplate(TrlTestCase):
         "trl-internal-testing/tiny-Qwen3ForCausalLM",
         "trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507",
         pytest.param(
-            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
             marks=pytest.mark.skipif(
                 Version(transformers.__version__) < Version("5.0.0"),
                 reason="Qwen3.5 tokenizer requires transformers>=5.0.0",

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -941,7 +941,7 @@ class TestDPOTrainer(TrlTestCase):
                 ],
             ),
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1939,7 +1939,7 @@ class TestGRPOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -2495,7 +2495,7 @@ class TestGRPOTrainer(TrlTestCase):
             report_to="none",
         )
         trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+            model="trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
             reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
             args=training_args,
             train_dataset=dataset,

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -1325,7 +1325,7 @@ class TestRLOOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -535,7 +535,7 @@ class TestSFTTrainer(TrlTestCase):
                 ],
             ),
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -1638,7 +1638,7 @@ class TestSFTTrainer(TrlTestCase):
                 ],
             ),
             pytest.param(
-                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -2302,7 +2302,7 @@ _CHUNKED_CE_VLM_MODEL_IDS = [
         ),
     ),
     pytest.param(
-        "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration",
+        "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
         marks=pytest.mark.skipif(
             Version(transformers.__version__) < Version("5.2.0"),
             reason="Qwen3.5 models were introduced in transformers-5.2.0",


### PR DESCRIPTION
# What does this PR do?

Migrates the test suite from the legacy `tiny-Qwen3_5ForConditionalGeneration` fixture to the sibling `-Think` / `-NoThink` variants introduced in #5819. 

Chat-template tests now exercise both variants (so the `qwen3_5_4b_and_above.jinja` template gains coverage it didn't have before — no fixture was sourced from the 4B checkpoint until now). Trainer/utility tests, which only need a tiny Qwen3.5 model and don't care about default thinking behavior, are mechanically pointed at `-NoThink` (matching the 0.8B source of the legacy fixture, so behavior is unchanged for those tests).

### Note: legacy Hub repo can be deleted

After this PR merges, `trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration` (the unsuffixed repo) will have no remaining references in the codebase and can be gracefully deleted by a maintainer if needed.

### Changes

**`tests/test_chat_template_utils.py`** — three parametrize sites split into `qwen35-nothink` + `qwen35-think` pairs:

- `TestAddResponseSchema.test_add_response_schema_vlm`
- `TestSupportsToolCalling.test_supports_tool_calling` — `transformers>=5.0.0` `skipif` mark duplicated onto the Think entry
- `TestParseResponse` class-level parameterize

**Mechanical rename** `tiny-Qwen3_5ForConditionalGeneration`to `tiny-Qwen3_5ForConditionalGeneration-NoThink` at 8 sites:

- `tests/test_sft_trainer.py`
- `tests/test_grpo_trainer.py`
- `tests/test_rloo_trainer.py`
- `tests/test_dpo_trainer.py`
- `tests/test_data_utils.py`

These trainer tests don't exercise thinking behavior — they need a small Qwen3.5 checkpoint. `-NoThink` preserves the original 0.8B sourcing, so test behavior is unchanged.

Part of #5471
Follows #5819

cc: @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test fixture/model IDs and parametrization, with no production code or training logic modifications.
> 
> **Overview**
> Updates the test suite to stop using the legacy `tiny-Qwen3_5ForConditionalGeneration` fixture and instead target the new Qwen3.5 `-NoThink` and `-Think` variants.
> 
> Chat-template/response-parsing coverage is expanded to run against both Qwen3.5 variants (including duplicating `transformers>=5.0.0` skip marks where needed), while trainer/data utility tests are mechanically switched to `-NoThink` to preserve prior default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1544c50ef95263fe177e8bb11a7992441bdba671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->