### PR TITLE
Add Entropy Adaptive Fine Tuning

### DIFF
--- a/tests/test_eaft.py
+++ b/tests/test_eaft.py
@@ -1,0 +1,105 @@
+
+import pytest
+import torch
+import torch.nn as nn
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM
+from unittest.mock import MagicMock
+
+from trl import SFTConfig, SFTTrainer
+from .testing_utils import TrlTestCase
+from trl.trainer.sft_trainer import eaft_loss_func
+
+
+class TestEAFTLoss(TrlTestCase):
+    def test_eaft_loss(self):
+        batch_size = 2
+        seq_len = 3
+        vocab_size = 25
+        
+        # Create random logits and labels
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+        
+        # Use a dict for outputs to behave like the model output dict
+        outputs = {"logits": logits}
+        
+        # Calculate loss
+        loss = eaft_loss_func(outputs, labels, alpha=1.0)
+        
+        # Simple assertions
+        assert torch.is_tensor(loss)
+        assert loss.dim() == 0
+
+    def test_eaft_loss_zero_alpha(self):
+        batch_size = 2
+        seq_len = 3
+        vocab_size = 25
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+        
+        # ensure ignore_index handling matches
+        labels[0, 0] = -100
+        
+        outputs = {"logits": logits}
+        
+        # EAFT with alpha=0
+        eaft_loss = eaft_loss_func(outputs, labels, alpha=0.0)
+        
+        # manually replicate the padding and shifting logic from `eaft_loss_func`
+        # in sft_trainer.py because eaft_loss_func performs this
+        # internally before computing the loss. To verify alpha=0.0 matches standard CE,
+        # we apply the same transformations to the labels here
+        labels_padded = torch.nn.functional.pad(labels, (0, 1), value=-100)
+        shift_labels = labels_padded[..., 1:].contiguous()
+        flat_logits = logits.view(-1, vocab_size)
+        flat_labels = shift_labels.view(-1)
+        
+        # standard CE loss check
+        ce_loss = torch.nn.functional.cross_entropy(flat_logits, flat_labels, ignore_index=-100)
+        
+        torch.testing.assert_close(eaft_loss, ce_loss)
+
+
+class TestSFTTrainerEAFT(TrlTestCase):
+    def setup_method(self):
+        self.model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        self.dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:100]")
+        self.model = AutoModelForCausalLM.from_pretrained(self.model_id)
+
+    def test_train_eaft_loss(self):
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="eaft",
+            eaft_alpha=0.5,
+            learning_rate=1e-3,
+            report_to="none",
+            max_steps=3,
+        )
+        trainer = SFTTrainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=self.dataset,
+        )
+        
+        trainer.train()
+        # check that loss is recorded
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        # check that it ran 3 steps
+        assert trainer.state.global_step == 3
+
+    def test_train_eaft_init_error(self):
+        # should raise error if compute_loss_func is provided with loss_type="eaft"
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="eaft",
+            report_to="none",
+        )
+        
+        with pytest.raises(ValueError, match="compute_loss_func"):
+            SFTTrainer(
+                model=self.model,
+                args=training_args,
+                train_dataset=self.dataset,
+                compute_loss_func=lambda x, y: 0.0
+            )

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -264,13 +264,20 @@ class SFTConfig(_BaseConfig):
     loss_type: str = field(
         default="nll",
         metadata={
-            "help": "Type of loss to use. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
-            "(Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), and `'chunked_nll'` (same math as "
-            "`'nll'`, but the `lm_head` projection is computed on non-ignored tokens only and the cross-entropy is "
-            "processed in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`. "
-            "Under FSDP2, set `fsdp_reshard_after_forward false` in the accelerate config — the chunked path "
-            "otherwise re-gathers `lm_head.weight` per chunk during backward, adding noticeable wall-time."
+            "help": (
+                "Type of loss to use. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
+                "(Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), `'eaft'` (Entropy-Adaptive Fine-Tuning, "
+                "https://huggingface.co/papers/2601.02151) and `'chunked_nll'` (same math as "
+                "`'nll'`, but the `lm_head` projection is computed on non-ignored tokens only and the cross-entropy is "
+                "processed in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`. "
+                "Under FSDP2, set `fsdp_reshard_after_forward false` in the accelerate config — the chunked path "
+                "otherwise re-gathers `lm_head.weight` per chunk during backward, adding noticeable wall-time."
+            )
         },
+    )
+    eaft_alpha: float = field(
+        default=1.0,
+        metadata={"help": "The alpha parameter for EAFT loss to control the power of adaptive weight."},
     )
     activation_offloading: bool = field(
         default=False,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import accelerate
 import torch
@@ -807,6 +807,68 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
     loss = (per_token_loss * loss_mask).sum() / num_items_in_batch
     return loss
 
+def eaft_loss_func(outputs, labels, num_items_in_batch=None, alpha=1.0):
+    """
+    EAFT loss function, as presented in [Entropy-Adaptive Fine-Tuning](https://huggingface.co/papers/2601.02151)
+    from https://github.com/ymxyll/LlamaFactory-EAFT/blob/feature/eaft/src/llamafactory/train/trainer_utils.py#L682
+    by ymxyll, 2026, Apache-2.0 license
+    """
+    logits = outputs.get("logits")
+    if logits is None:
+        return outputs.get("loss", torch.tensor(0.0))
+
+    logits = logits.float()
+    vocab_size = logits.size(-1)
+    labels = nn.functional.pad(labels, (0, 1), value=-100)
+    shift_labels = labels[..., 1:].contiguous()
+    logits = logits.view(-1, vocab_size)
+    shift_labels = shift_labels.view(-1)
+    shift_labels = shift_labels.to(logits.device)
+
+    loss = _eaft_cross_entropy(logits, shift_labels, num_items_in_batch, alpha)
+    return loss
+
+def _eaft_cross_entropy(
+    source: torch.Tensor,
+    target: torch.Tensor,
+    num_items_in_batch: Optional[torch.Tensor] = None,
+    alpha: float = 1.0,
+    ignore_index: int = -100,
+) -> torch.Tensor:
+    """
+    EAFT cross-entropy loss function, as presented in [Entropy-Adaptive Fine-Tuning](https://huggingface.co/papers/2601.02151)
+    from https://github.com/ymxyll/LlamaFactory-EAFT/blob/feature/eaft/src/llamafactory/train/trainer_utils.py#L699
+    by ymxyll, 2026, Apache-2.0 license
+    """
+    per_token_loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction="none")
+    valid_mask = target != ignore_index
+    if not valid_mask.any():
+        return torch.tensor(0.0, device=source.device, dtype=source.dtype)
+
+    valid_losses = per_token_loss[valid_mask]
+
+    with torch.no_grad():
+        source_detached = source[valid_mask].detach()
+
+        topk_val, _ = torch.topk(source_detached, k=20, dim=-1)
+        logsumexp_topk = torch.logsumexp(topk_val, dim=-1, keepdim=True)
+        log_probs_topk = topk_val - logsumexp_topk
+        probs_topk = torch.exp(log_probs_topk)
+        entropy_approx = -(probs_topk * log_probs_topk).sum(dim=-1)
+
+        entropy_term = entropy_approx / 3.0
+        adaptive_weight = torch.pow(entropy_term, alpha)
+
+    weighted_losses = valid_losses * adaptive_weight
+
+    if num_items_in_batch is not None:
+        total_loss = weighted_losses.sum()
+        if torch.is_tensor(num_items_in_batch):
+            num_items_in_batch = num_items_in_batch.to(total_loss.device)
+        loss = total_loss / num_items_in_batch
+    else:
+        loss = weighted_losses.mean()
+    return loss
 
 class SFTTrainer(_BaseTrainer):
     """
@@ -1273,9 +1335,19 @@ class SFTTrainer(_BaseTrainer):
                             "https://github.com/huggingface/trl/issues."
                         )
                 _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
+            elif args.loss_type == "eaft":
+                if compute_loss_func is not None:
+                    raise ValueError(
+                        "You passed a `compute_loss_func` together with `loss_type='eaft'` to the `SFTTrainer`. "
+                        "When using `loss_type='eaft'`, the loss function is internally set to the EAFT loss, so "
+                        "passing a `compute_loss_func` is not allowed."
+                    )
+                compute_loss_func = lambda outputs, labels, num_items_in_batch=None: eaft_loss_func(
+                    outputs, labels, num_items_in_batch, args.eaft_alpha
+                )
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', 'eaft' and "
                     "'chunked_nll'."
                 )
         elif args.loss_type == "chunked_nll":


### PR DESCRIPTION
from the paper: https://huggingface.co/papers/2601.02151

the implementation is 100% based on (and credited to):
https://github.com/hiyouga/LlamaFactory/compare/main...ymxyll:LlamaFactory-EAFT:feature/eaft

closes #4795

use like so:

```python
trainer = SFTTrainer(
    args = SFTConfig(
        loss_type = "eaft",
        eaft_alpha = 1.0, # default
    ),
)
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new loss implementation and wires it into `SFTTrainer`, changing training-time loss computation and adding a new config knob; incorrect weighting/shape handling could affect training dynamics and metrics.
> 
> **Overview**
> Adds support for *Entropy-Adaptive Fine-Tuning* by introducing an `eaft` `loss_type` in `SFTTrainer`, including a new `eaft_loss_func` that applies entropy-based per-token weighting (controlled via `SFTConfig.eaft_alpha`) and disallows user-provided `compute_loss_func` when enabled.
> 
> Extends `SFTConfig` to document the new loss type and expose `eaft_alpha`, and adds a new test suite (`tests/test_eaft.py`) covering the standalone EAFT loss (including `alpha=0` equivalence to standard CE) and a short end-to-end training run plus initialization error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97270685beeae100df378c49e8b421d311311e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->