### PR TITLE
fix(tpo): guard against empty ref_mask to prevent NaN eval_loss

### DIFF
--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -676,7 +676,10 @@ class TPOTrainer(_BaseTrainer):
             _, _, ref_labels = shift_labels.chunk(3, dim=0)
             _, _, ref_mask = shift_completion_mask.chunk(3, dim=0)
             ref_mask = ref_mask.bool()
-            nll_loss = F.cross_entropy(ref_logits[ref_mask], ref_labels[ref_mask])
+            if ref_mask.any():
+                nll_loss = F.cross_entropy(ref_logits[ref_mask], ref_labels[ref_mask])
+            else:
+                nll_loss = torch.tensor(0.0, device=loss.device)
             loss = loss + self.tpo_alpha * nll_loss
 
         # Log the metrics


### PR DESCRIPTION
## Problem

Fixes #5662

`TPOTrainer.evaluate()` returns `eval_loss: nan` while training loss is finite. The root cause is in the NLL (reference) loss computation at line 679 of `trl/experimental/tpo/tpo_trainer.py`:

```python
nll_loss = F.cross_entropy(ref_logits[ref_mask], ref_labels[ref_mask])
```

When `max_length` is small relative to the prompt length, all reference completion tokens can be truncated away, making `ref_mask` all-False. `F.cross_entropy` on empty tensors returns `nan`, which propagates to the final `eval_loss`.

Training works fine because the contrastive loss term (chosen vs rejected) doesn't hit this edge case in the same way — the chosen/rejected completions are more likely to survive truncation.

## Fix

Add a guard that checks `ref_mask.any()` before computing the cross-entropy loss. When no reference tokens survive truncation, fall back to a zero loss tensor:

```python
if ref_mask.any():
    nll_loss = F.cross_entropy(ref_logits[ref_mask], ref_labels[ref_mask])
else:
    nll_loss = torch.tensor(0.0, device=loss.device)
```

This is consistent with the defensive coding pattern already used elsewhere in this file (e.g., lines 710-711 for `avg_chosen_logits`).

## Testing

The fix was verified by checking that:
1. When `ref_mask` has valid tokens, behavior is unchanged
2. When `ref_mask` is all-False, loss is 0 instead of NaN
3. The overall training loss remains finite throughout evaluation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small defensive guard in TPO reference NLL computation that only affects an edge case with fully-masked reference tokens during eval/training.
> 
> **Overview**
> Prevents `TPOTrainer` from producing `NaN` `eval_loss` when the reference completion is fully truncated (i.e., `ref_mask` is empty).
> 
> When computing the reference NLL term, the trainer now checks `ref_mask.any()` before calling `F.cross_entropy`, and falls back to a zero `nll_loss` tensor when there are no reference tokens to score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6791cc60e60351a8e18f842ae7abbce22b0127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->