### PR TITLE
ci tests only (no fix)

### DIFF
--- a/tests/experimental/test_tpo_trainer.py
+++ b/tests/experimental/test_tpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from transformers.utils import is_peft_available
 
 from trl.experimental.tpo import TPOConfig, TPOTrainer
@@ -272,6 +272,32 @@ class TestTPOTrainer(TrlTestCase):
                 args=training_args,
                 train_dataset=dataset,
             )
+
+    def test_evaluate_no_nan_when_completions_truncated(self):
+        # Regression test: when max_length is smaller than the prompt length, all completion
+        # tokens are truncated away and shift_completion_mask for the reference branch is
+        # entirely False. Previously, F.cross_entropy on the resulting empty tensor returned
+        # NaN which propagated into eval_loss.
+        prompts = ["Tell me all about the history of computing and its wide impact."] * 4
+        chosen = ["Great."] * 4
+        rejected = ["Bad."] * 4
+        reference = ["Perfect."] * 4
+        dataset = Dataset.from_dict({"prompt": prompts, "chosen": chosen, "rejected": rejected, "reference": reference})
+
+        training_args = TPOConfig(
+            output_dir=self.tmp_dir,
+            max_length=5,  # prompt tokenizes to more than 5 tokens; completions are fully truncated
+            report_to="none",
+        )
+        trainer = TPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset.select(range(2)),
+            eval_dataset=dataset.select(range(2, 4)),
+        )
+
+        results = trainer.evaluate()
+        assert not torch.isnan(torch.tensor(results["eval_loss"])), "eval_loss must be finite when completions are truncated"
 
     def test_missing_reference_column_raises(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from packaging.version import Version
 from packaging.version import parse as parse_version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
@@ -1165,6 +1165,32 @@ class TestDPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
             else:
                 raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
+
+    def test_evaluate_no_nan_when_sft_completions_truncated(self):
+        # Regression test: when max_length is smaller than the prompt length, all completion
+        # tokens are truncated away and chosen_mask is entirely False for the 'sft' loss branch.
+        # Previously, F.cross_entropy on the resulting empty tensor returned NaN which propagated
+        # into eval_loss.
+        prompts = ["Tell me all about the history of computing and its wide impact."] * 4
+        chosen = ["Great."] * 4
+        rejected = ["Bad."] * 4
+        dataset = Dataset.from_dict({"prompt": prompts, "chosen": chosen, "rejected": rejected})
+
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="sft",
+            max_length=5,  # prompt tokenizes to more than 5 tokens; completions are fully truncated
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset.select(range(2)),
+            eval_dataset=dataset.select(range(2, 4)),
+        )
+
+        results = trainer.evaluate()
+        assert not torch.isnan(torch.tensor(results["eval_loss"])), "eval_loss must be finite when completions are truncated"
 
     @require_vision
     def test_train_vlm_keep_end_raises(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes that add new regression cases around evaluation loss stability; no production code paths are modified.
> 
> **Overview**
> Adds regression tests for `TPOTrainer` and `DPOTrainer` evaluation to ensure `eval_loss` stays finite when `max_length` truncates away all completion tokens (resulting in an empty completion mask and previously NaN `F.cross_entropy`).
> 
> Updates both test modules to build small in-memory `datasets.Dataset` fixtures for these edge cases instead of relying solely on `load_dataset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05dd33d39c1fc87195b26d9e1f0da35467f47ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->