### PR TITLE
[feat] add Dapo prompt level avg

### DIFF
--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -115,6 +115,11 @@ class GRPOTrainer(_GRPOTrainer):
             loss = (per_token_loss * completion_mask).sum() / (per_token_loss.size(0) * self.max_completion_length)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
+        elif self.loss_type == "dapo_prompt_mean":
+            row_token = completion_mask.sum(dim=1).clamp(min=1.0)
+            row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
+            prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
+            loss = prompt_loss.mean()
         elif self.loss_type == "dapo":
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * completion_mask).sum() / normalizer

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -118,7 +118,8 @@ class GRPOTrainer(_GRPOTrainer):
         elif self.loss_type == "dapo_prompt_mean":
             row_token = completion_mask.sum(dim=1).clamp(min=1.0)
             row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
-            prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
+            num_generations = self.num_generations if mode == "train" else self.num_generations_eval
+            prompt_loss = row_loss.view(-1, num_generations).mean(dim=1)
             loss = prompt_loss.mean()
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -120,6 +120,8 @@ class GRPOTrainer(_GRPOTrainer):
             row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
             prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
             loss = prompt_loss.mean()
+            normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
+            loss = loss / normalizer
         elif self.loss_type == "dapo":
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * completion_mask).sum() / normalizer

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2580,6 +2580,8 @@ class GRPOTrainer(_BaseTrainer):
             row_loss = (per_token_loss * mask).sum(dim=1) / row_token
             prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
             loss = prompt_loss.mean()        
+            normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            loss = loss / normalizer
         elif self.loss_type in ["cispo", "dapo", "vespo"]:
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2575,6 +2575,11 @@ class GRPOTrainer(_BaseTrainer):
             loss = (per_token_loss * mask).sum() / (per_token_loss.size(0) * self.max_completion_length)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
+        elif self.loss_type == "dapo_prompt_mean":
+            row_token = completion_mask.sum(dim=1).clamp(min=1.0)
+            row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
+            prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
+            loss = prompt_loss.mean()        
         elif self.loss_type in ["cispo", "dapo", "vespo"]:
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2576,8 +2576,8 @@ class GRPOTrainer(_BaseTrainer):
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
         elif self.loss_type == "dapo_prompt_mean":
-            row_token = completion_mask.sum(dim=1).clamp(min=1.0)
-            row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
+            row_token = mask.sum(dim=1).clamp(min=1.0)
+            row_loss = (per_token_loss * mask).sum(dim=1) / row_token
             prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
             loss = prompt_loss.mean()        
         elif self.loss_type in ["cispo", "dapo", "vespo"]:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2578,9 +2578,10 @@ class GRPOTrainer(_BaseTrainer):
         elif self.loss_type == "dapo_prompt_mean":
             row_token = mask.sum(dim=1).clamp(min=1.0)
             row_loss = (per_token_loss * mask).sum(dim=1) / row_token
-            prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
+            num_generations = self.num_generations if mode == "train" else self.num_generations_eval
+            prompt_loss = row_loss.view(-1, num_generations).mean(dim=1)
             loss = prompt_loss.mean()        
-            normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
         elif self.loss_type in ["cispo", "dapo", "vespo"]:
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2522,7 +2522,7 @@ class GRPOTrainer(_BaseTrainer):
         if self.loss_type == "cispo":
             clamped_ratios = torch.clamp(coef_1, max=self.epsilon_high).detach()
             per_token_loss = -clamped_ratios * advantages * per_token_logps
-        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo", "dapo_prompt_mean"]:
             coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
             # Two-sided clipping
             if self.args.delta is not None:


### PR DESCRIPTION
# What does this PR do?

file changes
- `trl\trainer\grpo_trainer.py` - added `dapo_prompt_mean`
-  ` trl\experimental\gspo_token\grpo_trainer.py` -added `dapo_prompt_mean`

The prompt-level aggregation as mentioned in the issue

average each row over its own tokens
```
row_token = completion_mask.sum(dim=1).clamp(min=1.0)
row_loss = (per_token_loss * completion_mask).sum(dim=1) / row_token
```

group by prompt then average
```
prompt_loss = row_loss.view(-1, self.num_generations).mean(dim=1)
```

average across prompt
```
loss = prompt_loss.mean()
```

Fixes #5375 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new loss variant in the GRPO training loop, changing optimization behavior when selected and relying on correct reshaping by `num_generations`/`num_generations_eval`.
> 
> **Overview**
> Introduces a new `loss_type` option, `dapo_prompt_mean`, for GRPO training that aggregates the clipped per-token loss by **(1) averaging per completion over its valid tokens, (2) averaging across generations per prompt, then (3) averaging across prompts**.
> 
> Wires this loss type into the main `GRPOTrainer` loss computation (including the per-token loss branch selection) and mirrors the same prompt-level averaging logic in the experimental `gspo_token` trainer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980b70be8f129dd7b242c797dbe05a9e06b9bf19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->