### PR TITLE
Add explicit response_schema override for GRPO

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -157,6 +157,34 @@ class TestAddResponseSchema:
         # The correctness of the parsing is tested in TestParseResponse
         tokenizer.parse_response(response)
 
+    def test_add_response_schema_with_explicit_override(self):
+        tokenizer_name = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+
+        baseline_tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        baseline_tokenizer = add_response_schema(baseline_tokenizer)
+        expected_schema = copy.deepcopy(baseline_tokenizer.response_schema)
+
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        tokenizer.chat_template = tokenizer.chat_template + "\n"
+
+        with pytest.raises(ValueError, match="Unrecognized chat template"):
+            add_response_schema(copy.deepcopy(tokenizer))
+
+        tokenizer = add_response_schema(tokenizer, response_schema=expected_schema)
+        assert tokenizer.response_schema == expected_schema
+
+        messages = [
+            {"role": "user", "content": "What is 3*4?"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"type": "function", "function": {"name": "multiply", "arguments": {"a": 3, "b": 4}}}],
+            },
+        ]
+        prefix = tokenizer.apply_chat_template(messages[:1], tokenize=False, add_generation_prompt=True)
+        text = tokenizer.apply_chat_template(messages, tokenize=False)
+        response = text[len(prefix) :]
+        tokenizer.parse_response(response)
+
     @pytest.mark.parametrize(
         "processor_name",
         [
@@ -188,6 +216,27 @@ class TestAddResponseSchema:
         # Here, we just test that the parsing doesn't raise an error.
         # The correctness of the parsing is tested in TestParseResponse
         processor.tokenizer.parse_response(response)
+
+    @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+        strict=True,
+    )
+    def test_add_response_schema_vlm_with_explicit_override(self):
+        processor_name = "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink"
+
+        baseline_processor = AutoProcessor.from_pretrained(processor_name)
+        baseline_processor = add_response_schema(baseline_processor)
+        expected_schema = copy.deepcopy(baseline_processor.tokenizer.response_schema)
+
+        processor = AutoProcessor.from_pretrained(processor_name)
+        processor.chat_template = processor.chat_template + "\n"
+
+        with pytest.raises(ValueError, match="Unrecognized chat template"):
+            add_response_schema(processor)
+
+        processor = add_response_schema(processor, response_schema=expected_schema)
+        assert processor.tokenizer.response_schema == expected_schema
 
 
 class TestSupportsToolCalling:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -19,7 +19,7 @@ from unittest.mock import mock_open, patch
 import pytest
 from datasets import DatasetDict, load_dataset
 
-from trl import DatasetMixtureConfig, TrlParser, get_dataset
+from trl import DatasetMixtureConfig, GRPOConfig, TrlParser, get_dataset
 from trl.scripts.utils import DatasetConfig
 
 from .testing_utils import TrlTestCase
@@ -120,6 +120,28 @@ class TestTrlParser(TrlTestCase):
         assert isinstance(result_args[0], MyDataclass)
         assert result_args[0].arg1 == 2
         assert result_args[0].arg2 == "value"
+
+    def test_grpo_config_parses_response_schema_from_cli(self):
+        parser = TrlParser(dataclass_types=[GRPOConfig])
+        response_schema = '{"type": "json_schema", "json_schema": {"name": "response", "schema": {"type": "object"}}}'
+
+        (args,) = parser.parse_args_and_config(
+            [
+                "--output_dir",
+                self.tmp_dir,
+                "--report_to",
+                "none",
+                "--bf16",
+                "False",
+                "--response_schema",
+                response_schema,
+            ]
+        )
+
+        assert args.response_schema == {
+            "type": "json_schema",
+            "json_schema": {"name": "response", "schema": {"type": "object"}},
+        }
 
     def test_set_defaults_with_config(self):
         """Test set_defaults_with_config updates the defaults."""

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2417,6 +2417,45 @@ class TestGRPOTrainer(TrlTestCase):
         strict=True,
     )
     @require_jmespath
+    def test_init_with_tools_and_explicit_response_schema_overrides_existing_schema(self):
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train[:1]")
+        model_name = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+
+        baseline_tokenizer = AutoTokenizer.from_pretrained(model_name)
+        baseline_tokenizer = add_response_schema(baseline_tokenizer)
+        explicit_response_schema = copy.deepcopy(baseline_tokenizer.response_schema)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer.chat_template = tokenizer.chat_template + "\n"
+        tokenizer.response_schema = {"type": "json_schema", "json_schema": {"name": "stale", "schema": {"type": "object"}}}
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            report_to="none",
+            bf16=False,
+            response_schema=explicit_response_schema,
+        )
+
+        def reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        trainer = GRPOTrainer(
+            model=AutoModelForCausalLM.from_pretrained(model_name),
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+            tools=[multiply_tool],
+        )
+
+        assert trainer._tokenizer.response_schema == explicit_response_schema
+
+    @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.0.0"),
+        reason="Tool parsing is not supported in transformers versions below 5.0.0",
+        strict=True,
+    )
+    @require_jmespath
     @pytest.mark.parametrize("tools", [[multiply_tool], [async_multiply_tool]])
     def test_train_with_tools(self, tools: list[Callable]):
         # In this test, we define a simple tool that multiplies two integers. Regardless of the input prompt,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import gc
 import os
 import warnings
@@ -37,7 +38,7 @@ from transformers import (
 from transformers.testing_utils import backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
-from trl import GRPOConfig, GRPOTrainer
+from trl import GRPOConfig, GRPOTrainer, add_response_schema
 from trl.import_utils import is_liger_kernel_available
 from trl.trainer.utils import get_kbit_device_map
 
@@ -2371,6 +2372,44 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.0.0"),
+        reason="Tool parsing is not supported in transformers versions below 5.0.0",
+        strict=True,
+    )
+    @require_jmespath
+    def test_init_with_tools_and_explicit_response_schema(self):
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train[:1]")
+        model_name = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+
+        baseline_tokenizer = AutoTokenizer.from_pretrained(model_name)
+        baseline_tokenizer = add_response_schema(baseline_tokenizer)
+        explicit_response_schema = copy.deepcopy(baseline_tokenizer.response_schema)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer.chat_template = tokenizer.chat_template + "\n"
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            report_to="none",
+            bf16=False,
+            response_schema=explicit_response_schema,
+        )
+
+        def reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        trainer = GRPOTrainer(
+            model=AutoModelForCausalLM.from_pretrained(model_name),
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+            tools=[multiply_tool],
+        )
+
+        assert trainer._tokenizer.response_schema == explicit_response_schema
 
     @pytest.mark.xfail(
         condition=Version(transformers.__version__) < Version("5.0.0"),

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import warnings
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from jinja2 import TemplateError
 from transformers import AddedToken, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
@@ -349,7 +350,9 @@ qwen3_6_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6.jinja").read_text()
 ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizerBase, ProcessorMixin)
 
 
-def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
+def add_response_schema(
+    processing_class: ProcessingClassT, response_schema: dict[str, Any] | str | None = None
+) -> ProcessingClassT:
     r"""
     Adds the appropriate response schema to the given tokenizer based on its chat template.
 
@@ -363,6 +366,9 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or VLM processor to which the response schema will be added.
+        response_schema (`dict[str, Any]` or `str`, *optional*):
+            Explicit response schema to set on the tokenizer. When provided, this bypasses chat-template identity
+            matching, which is useful for forked templates that remain response-parse compatible.
 
     Returns:
         `PreTrainedTokenizerBase` or `ProcessorMixin`:
@@ -389,6 +395,10 @@ def add_response_schema(processing_class: ProcessingClassT) -> ProcessingClassT:
         tokenizer = processing_class.tokenizer
     else:
         tokenizer = processing_class
+    # Explicit override is opt-in and lets callers skip exact template fingerprinting for forked templates.
+    if response_schema is not None:
+        tokenizer.response_schema = json.loads(response_schema) if isinstance(response_schema, str) else response_schema
+        return processing_class
     if chat_template == glm4moe_chat_template:
         tokenizer.response_schema = glm4moe_schema
     elif chat_template == gptoss_chat_template:

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -2,7 +2,7 @@
 
 Jinja2 chat templates stored here serve two purposes:
 
-1. **Identity comparison**: detecting which model is being used (by comparing `tokenizer.chat_template` against known templates) to add the appropriate response schema (`add_response_schema`) or swap in a training template (`get_training_chat_template`).
+1. **Identity comparison**: detecting which model is being used (by comparing `tokenizer.chat_template` against known templates) to add the appropriate response schema (`add_response_schema`) or swap in a training template (`get_training_chat_template`). `add_response_schema` also accepts an explicit schema override for forked templates that no longer match byte-for-byte.
 2. **Training patches**: modified templates that fix training-specific issues (prefix-preservation for GRPO, `{% generation %}` markers for SFT assistant-only loss).
 
 **Why prefix-preserving?** The GRPO tool call loop extracts tool response formatting tokens by comparing tokenizations with and without tool messages appended (`_get_tool_suffix_ids`). This requires the chat template to be *prefix-preserving*: appending messages must not change how earlier messages are rendered.

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -98,6 +98,9 @@ class GRPOConfig(_BaseConfig):
             with the other generation parameters (like `min_p`, `top_p`, etc.), they will override them.
         chat_template_kwargs (`dict[str, Any]`, *optional*):
             Additional keyword arguments to pass to the `apply_chat_template` function when generating completions.
+        response_schema (`dict[str, Any]` or `str`, *optional*):
+            Explicit response schema to set on the tokenizer when tools are enabled. This bypasses chat-template
+            identity matching and is useful for forked templates that still follow a supported response format.
         repetition_penalty (`float`, *optional*, defaults to `1.0`):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
@@ -346,7 +349,7 @@ class GRPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
-    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs", "response_schema"]
 
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(
@@ -476,6 +479,14 @@ class GRPOConfig(_BaseConfig):
         metadata={
             "help": "Additional keyword arguments to pass to the `apply_chat_template` function when generating "
             "completions."
+        },
+    )
+    response_schema: dict[str, Any] | str | None = field(
+        default=None,
+        metadata={
+            "help": "Explicit response schema to set on the tokenizer when tools are enabled. This bypasses "
+            "chat-template identity matching and is useful for forked templates that still follow a supported "
+            "response format."
         },
     )
     repetition_penalty: float = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -538,7 +538,9 @@ class GRPOTrainer(_BaseTrainer):
         # known chat templates. `response_schema` lives on the (inner) tokenizer, since `parse_response` is a tokenizer
         # method that reads `self.response_schema`. An explicit schema lets users opt out of exact template matching
         # when they are using a forked but response-compatible template.
-        if self.tools and getattr(self._tokenizer, "response_schema", None) is None:
+        if self.tools and (
+            args.response_schema is not None or getattr(self._tokenizer, "response_schema", None) is None
+        ):
             processing_class = add_response_schema(processing_class, response_schema=args.response_schema)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -536,9 +536,10 @@ class GRPOTrainer(_BaseTrainer):
         # At the time of initial implementation, most tokenizers do not have built-in support for response schemas.
         # While waiting for broader adoption, we provide this utility function to manually set the response schema for
         # known chat templates. `response_schema` lives on the (inner) tokenizer, since `parse_response` is a tokenizer
-        # method that reads `self.response_schema`.
+        # method that reads `self.response_schema`. An explicit schema lets users opt out of exact template matching
+        # when they are using a forked but response-compatible template.
         if self.tools and getattr(self._tokenizer, "response_schema", None) is None:
-            processing_class = add_response_schema(processing_class)
+            processing_class = add_response_schema(processing_class, response_schema=args.response_schema)
         # In multi-turn training, the chat template *must* be prefix-preserving. If the tokenizer's original template
         # isn't, we replace it at initialization with a training-safe, prefix-preserving template.
         if self.tools and not is_chat_template_prefix_preserving(processing_class):


### PR DESCRIPTION
# What does this PR do?

Fixes #5724.

This PR adds an explicit `response_schema` override to `add_response_schema` and threads it through `GRPOConfig` / `GRPOTrainer`.

## Root cause

Today, response schema assignment depends on exact chat-template fingerprinting. That works for vendored templates, but it breaks for forked tokenizers whose templates are still response-parse compatible yet no longer match TRL’s stored template byte-for-byte.

## Changes

- add optional `response_schema` to `add_response_schema`
- thread `response_schema` through `GRPOConfig`
- pass `args.response_schema` from `GRPOTrainer`
- document the explicit override behavior in `trl/chat_templates/README.md`
- add regression tests for:
  - tokenizer override
  - VLM processor override
  - CLI/config parsing
  - GRPO trainer init with tools and a modified template

## Why this approach?

This keeps the current exact-match path as the default behavior and makes the new behavior opt-in. Existing supported models keep the same behavior, while users with forked but response-compatible templates can explicitly provide a schema and avoid template fingerprint mismatches.

## Files changed

- `trl/chat_template_utils.py`
- `trl/trainer/grpo_config.py`
- `trl/trainer/grpo_trainer.py`
- `trl/chat_templates/README.md`
- `tests/test_chat_template_utils.py`
- `tests/test_cli_utils.py`
- `tests/test_grpo_trainer.py`

## Tests

TDD / regression coverage added for:
- explicit schema override on tokenizer chat templates
- explicit schema override on VLM processors
- CLI parsing of `--response_schema`
- `GRPOTrainer` initialization with tools when the template is modified but an explicit schema is provided

I also manually validated the runtime path on a remote GPU host:
- the stock `trl grpo` CLI accepts `--response_schema` and trains successfully
- a dedicated tool-calling validation script confirms the actual `#5724` path:
  - modified chat template fails without explicit schema
  - modified chat template parses successfully with explicit schema
  - 100-step GRPO training succeeds with:
    - `tool_call_frequency = 0.5`
    - `tool_failure_frequency = 0.0`

## Before submitting

- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: AI wrote the entire PR, including code, without human review.

## Who can review?

@huggingface/trl-maintainers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GRPO tool-calling initialization and completion parsing, but changes are opt-in and leave default template fingerprinting unchanged for supported models.
> 
> **Overview**
> Adds an **opt-in explicit `response_schema`** path so GRPO tool calling can parse assistant completions when a tokenizer’s chat template is forked and no longer matches TRL’s byte-for-byte template fingerprints.
> 
> `add_response_schema` now accepts an optional schema (dict or JSON string) and applies it directly on the tokenizer, skipping template identity matching. The same knob is exposed on **`GRPOConfig`** / CLI (`--response_schema`) and passed from **`GRPOTrainer`** when tools are enabled—either to supply a schema or to refresh/override an existing one. Default behavior for recognized vendored templates is unchanged.
> 
> Regression tests cover tokenizer and VLM overrides, CLI parsing, and trainer init with modified templates; `trl/chat_templates/README.md` documents the override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92c0935757af43bea9a3103e845cfff2cca333a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->