### PR TITLE
Add Qwen2.5-VL original and training chat template with generation markers

### DIFF
--- a/docs/source/chat_templates.md
+++ b/docs/source/chat_templates.md
@@ -20,7 +20,7 @@ TRL ships patched templates under [`trl/chat_templates/`](https://github.com/hug
 
 ## Supported model families
 
-TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Llama 3 / 3.1 / 3.2, Phi-3, Phi-3.5, Qwen2.5, Qwen3 (including the Instruct-2507 variant), Qwen3.5, Qwen3.6.
+TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Llama 3 / 3.1 / 3.2, Phi-3, Phi-3.5, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, Qwen3.6.
 
 ## Training templates
 
@@ -131,6 +131,12 @@ Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endge
 Patched Qwen2.5 template. Diff vs `qwen2_5.jinja`:
 
 Wrap assistant message output with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `qwen2_5_vl_training.jinja`
+
+Patched Qwen2.5-VL template. Diff vs `qwen2_5_vl.jinja`:
+
+Split the assistant message into its own branch so the `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` markers wrap the assistant content.  This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.
 
 ### `qwen3_instruct_2507_training.jinja`
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -476,6 +476,7 @@ class TestIsChatTemplatePrefixPreserving:
         pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3", id="phi3"),
         pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", id="phi3.5"),
         pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
+        pytest.param("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", id="qwen2.5_vl"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
         pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -333,6 +333,8 @@ phi3_5_chat_template = (_CHAT_TEMPLATES_DIR / "phi3_5.jinja").read_text()
 
 qwen2_5_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5.jinja").read_text()
 
+qwen2_5_vl_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5_vl.jinja").read_text()
+
 qwen3_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3.jinja").read_text()
 
 qwen3_instruct_2507_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_instruct_2507.jinja").read_text()
@@ -567,6 +569,8 @@ phi3_5_training_chat_template = (_CHAT_TEMPLATES_DIR / "phi3_5_training.jinja").
 
 qwen2_5_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5_training.jinja").read_text()
 
+qwen2_5_vl_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen2_5_vl_training.jinja").read_text()
+
 qwen3_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_training.jinja").read_text()
 
 qwen3_instruct_2507_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_instruct_2507_training.jinja").read_text()
@@ -590,7 +594,7 @@ def get_training_chat_template(
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
     Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, LLaMA 3, Phi-3, Phi-3.5,
-    Qwen2.5, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and Qwen3.6 are supported.
+    Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -688,6 +692,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == qwen2_5_chat_template:
         return qwen2_5_training_chat_template
+
+    if processing_class.chat_template == qwen2_5_vl_chat_template:
+        return qwen2_5_vl_training_chat_template
 
     if processing_class.chat_template == qwen3_chat_template:
         return qwen3_training_chat_template

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -61,6 +61,10 @@ Original Phi-3.5 chat template.
 
 Original Qwen2.5 chat template.
 
+### `qwen2_5_vl.jinja`
+
+Original Qwen2.5-VL chat template. Does not support tool calling.
+
 ### `qwen3.jinja`
 
 Original Qwen3 chat template.
@@ -157,6 +161,12 @@ Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so
 Patched Qwen2.5 template. Diff vs `qwen2_5.jinja`:
 
 Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `qwen2_5_vl_training.jinja`
+
+Patched Qwen2.5-VL template. Diff vs `qwen2_5_vl.jinja`:
+
+Split the assistant message into its own branch so the `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` markers wrap the assistant content.  This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.
 
 ### `qwen3_training.jinja`
 

--- a/trl/chat_templates/qwen2_5_vl.jinja
+++ b/trl/chat_templates/qwen2_5_vl.jinja
@@ -1,0 +1,7 @@
+{% set image_count = namespace(value=0) %}{% set video_count = namespace(value=0) %}{% for message in messages %}{% if loop.first and message['role'] != 'system' %}<|im_start|>system
+You are a helpful assistant.<|im_end|>
+{% endif %}<|im_start|>{{ message['role'] }}
+{% if message['content'] is string %}{{ message['content'] }}<|im_end|>
+{% else %}{% for content in message['content'] %}{% if content['type'] == 'image' or 'image' in content or 'image_url' in content %}{% set image_count.value = image_count.value + 1 %}{% if add_vision_id %}Picture {{ image_count.value }}: {% endif %}<|vision_start|><|image_pad|><|vision_end|>{% elif content['type'] == 'video' or 'video' in content %}{% set video_count.value = video_count.value + 1 %}{% if add_vision_id %}Video {{ video_count.value }}: {% endif %}<|vision_start|><|video_pad|><|vision_end|>{% elif 'text' in content %}{{ content['text'] }}{% endif %}{% endfor %}<|im_end|>
+{% endif %}{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant
+{% endif %}

--- a/trl/chat_templates/qwen2_5_vl_training.jinja
+++ b/trl/chat_templates/qwen2_5_vl_training.jinja
@@ -1,0 +1,62 @@
+{#- Training variant of the Qwen 2.5 VL chat template (see qwen2_5_vl.jinja for the original).
+    Modifications vs the original:
+    - Split the assistant message into its own branch so the {% generation %} / {% endgeneration %}
+      markers wrap the assistant content (everything after the '<|im_start|>assistant\n' prompt
+      cue, up to and including the trailing '<|im_end|>\n'). This enables assistant-only loss
+      masking in SFT training.
+-#}
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- for message in messages %}
+    {%- if loop.first and message['role'] != 'system' %}
+        {{- '<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+    {%- if message['role'] == 'assistant' %}
+        {{- '<|im_start|>assistant\n' }}
+        {%- generation -%}
+            {%- if message['content'] is string %}
+                {{- message['content'] }}
+                {{- '<|im_end|>\n' }}
+            {%- else %}
+                {%- for content in message['content'] %}
+                    {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content %}
+                        {%- set image_count.value = image_count.value + 1 %}
+                        {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                        <|vision_start|><|image_pad|><|vision_end|>
+                    {%- elif content['type'] == 'video' or 'video' in content %}
+                        {%- set video_count.value = video_count.value + 1 %}
+                        {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                        <|vision_start|><|video_pad|><|vision_end|>
+                    {%- elif 'text' in content %}
+                        {{- content['text'] }}
+                    {%- endif %}
+                {%- endfor %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endgeneration -%}
+    {%- else %}
+        {{- '<|im_start|>' + message['role'] + '\n' }}
+        {%- if message['content'] is string %}
+            {{- message['content'] }}
+            {{- '<|im_end|>\n' }}
+        {%- else %}
+            {%- for content in message['content'] %}
+                {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                    {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                    <|vision_start|><|image_pad|><|vision_end|>
+                {%- elif content['type'] == 'video' or 'video' in content %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                    {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                    <|vision_start|><|video_pad|><|vision_end|>
+                {%- elif 'text' in content %}
+                    {{- content['text'] }}
+                {%- endif %}
+            {%- endfor %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}


### PR DESCRIPTION
# What does this PR do?

Adds a training chat template for Qwen2.5-VL, wiring it into `get_training_chat_template`.

The new template patches `qwen2_5_vl.jinja` with a single modification: split the assistant message into its own branch so the `{% generation %}` / `{% endgeneration %}` markers wrap the assistant content (everything after the `<|im_start|>assistant\n` prompt cue, up to and including the trailing `<|im_end|>\n`). The vision-content rendering inside the assistant branch is duplicated from the original non-assistant branch unchanged. This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.

Qwen2.5-VL does not ship tool-calling support, so no prefix-preservation changes are needed.

### Changes

**`trl/chat_templates/`**:

- `qwen2_5_vl.jinja` – new original template
- `qwen2_5_vl_training.jinja` – new training template

**`trl/chat_template_utils.py`**:

- Module-level template variable: `qwen2_5_vl_chat_template`, used for identity comparison.
- One new branch in `get_training_chat_template()` mapping the source template to its training variant.

**`tests/test_chat_template_utils.py`** — one new entry in `TestGetTrainingChatTemplate`'s parametrize block (`qwen2_5-vl`).

**Docs** — Qwen2.5-VL added to the supported-families list, training-template section added in:

- `docs/source/chat_templates.md`
- `trl/chat_templates/README.md`

Part of #5471

cc: @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Jinja templates and identity mapping only; behavior follows existing Qwen-VL patterns and is covered by parametrized chat-template tests.
> 
> **Overview**
> Adds **Qwen2.5-VL** to TRL’s bundled chat-template set so SFT with `assistant_only_loss=True` can auto-swap a training template.
> 
> New `qwen2_5_vl.jinja` (reference) and `qwen2_5_vl_training.jinja` split assistant turns and wrap assistant text/vision blocks in `{% generation %}` / `{% endgeneration %}` for correct `return_assistant_tokens_mask`—no tool-calling or prefix-preservation changes. `get_training_chat_template` maps the stock template to the training variant; docs and `TestGetTrainingChatTemplate` include the tiny Qwen2.5-VL fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f4b3b598a5f3dde26a5356d37015cf9047e3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->