### PR TITLE
Support `'None'` as CLI value for `Optional[T]` fields

### DIFF
--- a/trl/scripts/_hf_argparser.py
+++ b/trl/scripts/_hf_argparser.py
@@ -51,17 +51,18 @@ def string_to_bool(v):
 
 
 def _accept_none(inner: Callable[[str], Any]) -> Callable[[str], Any]:
-    """Wrap a type converter so the literal string `'None'` parses to Python `None`.
+    """Wrap a type converter so `'none'` and `'null'` (case-insensitive) parse to Python `None`.
 
-    Used for `T | None` fields so they can be set to `None` from the CLI (argparse's `type=int` rejects `'None'`). Only
-    the exact spelling `'None'` is recognized.
+    Used for `T | None` fields so they can be set to `None` from the CLI (argparse's `type=int` rejects `'None'`).
+    Mirrors the case-insensitive convention of [`string_to_bool`].
     """
 
     def parse(v: str) -> Any:
-        if v == "None":
+        if v.lower() in ("none", "null"):
             return None
         return inner(v)
 
+    parse.__name__ = getattr(inner, "__name__", "value")  # so argparse error messages keep the inner type name
     return parse
 
 
@@ -205,7 +206,10 @@ class HfArgumentParser(ArgumentParser):
                     field.type.__args__[0] if isinstance(None, field.type.__args__[1]) else field.type.__args__[1]
                 )
                 origin_type = getattr(field.type, "__origin__", field.type)
-                accepts_none = True
+                # Enable the `'none'`/`'null'` sentinel only when the inner type can't possibly accept those as
+                # legitimate string values (i.e. anything non-str). For str-typed fields, `'none'` may be a real
+                # value — e.g. `report_to`, whose CLI string `'none'` means "no integrations" downstream.
+                accepts_none = field.type is not str
 
         # A variable to store kwargs for a boolean field, if needed
         # so that we can init a `no_*` complement argument (see below)

--- a/trl/scripts/_hf_argparser.py
+++ b/trl/scripts/_hf_argparser.py
@@ -50,6 +50,21 @@ def string_to_bool(v):
         )
 
 
+def _accept_none(inner: Callable[[str], Any]) -> Callable[[str], Any]:
+    """Wrap a type converter so the literal string `'None'` parses to Python `None`.
+
+    Used for `T | None` fields so they can be set to `None` from the CLI (argparse's `type=int` rejects `'None'`). Only
+    the exact spelling `'None'` is recognized.
+    """
+
+    def parse(v: str) -> Any:
+        if v == "None":
+            return None
+        return inner(v)
+
+    return parse
+
+
 def make_choice_type_function(choices: list) -> Callable[[str], Any]:
     """
     Creates a mapping function from each choices string representation to the actual value. Used to support multiple
@@ -170,6 +185,7 @@ class HfArgumentParser(ArgumentParser):
             aliases = [aliases]
 
         origin_type = getattr(field.type, "__origin__", field.type)
+        accepts_none = False
         if origin_type is Union or (hasattr(types, "UnionType") and isinstance(origin_type, types.UnionType)):
             if str not in field.type.__args__ and (
                 len(field.type.__args__) != 2 or type(None) not in field.type.__args__
@@ -189,6 +205,7 @@ class HfArgumentParser(ArgumentParser):
                     field.type.__args__[0] if isinstance(None, field.type.__args__[1]) else field.type.__args__[1]
                 )
                 origin_type = getattr(field.type, "__origin__", field.type)
+                accepts_none = True
 
         # A variable to store kwargs for a boolean field, if needed
         # so that we can init a `no_*` complement argument (see below)
@@ -229,7 +246,7 @@ class HfArgumentParser(ArgumentParser):
             elif field.default is dataclasses.MISSING:
                 kwargs["required"] = True
         else:
-            kwargs["type"] = field.type
+            kwargs["type"] = _accept_none(field.type) if accepts_none else field.type
             if field.default is not dataclasses.MISSING:
                 kwargs["default"] = field.default
             elif field.default_factory is not dataclasses.MISSING:


### PR DESCRIPTION
## Summary
HfArgumentParser strips NoneType from `Optional[T]` unions and binds `type=int` (or whatever the inner type is), so `--max_length None` was rejected at argparse with `invalid int value: 'None'`.

This adds a thin wrapper `_accept_none` around the type converter so the literal string `'None'` parses to Python `None`. Only `Optional[T]` (2-arg union with NoneType) gets the wrapper; other unions are unchanged.

Only the exact spelling `'None'` is recognized — keeps the sentinel tight so it doesn't shadow legitimate string values like `'none'` or `'null'` in fields that happen to accept them (e.g. `report_to=none`).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to TRL’s vendored argument parser; main behavioral nuance is skipping the sentinel for optional strings.
> 
> **Overview**
> `HfArgumentParser` in `trl/scripts/_hf_argparser.py` now lets CLI flags for **`Optional[T]`** (non-`str`) accept **`none`** / **`null`** (case-insensitive) and map them to Python **`None`**, instead of failing when the inner `argparse` type (e.g. `int`) tries to parse those strings.
> 
> A new **`_accept_none`** wrapper is applied only when an optional field’s inner type is **not** `str`, so string options like **`report_to=none`** can still use **`none`** as a normal string value rather than being forced to `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2328643af1a9a70d43f2beeb907db273ddecc729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->