### PR TITLE
🔒 Gate trainer telemetry on an explicit class-name allowlist

### DIFF
--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -27,6 +27,42 @@ if is_wandb_available():
     import wandb
 
 
+# Trainer class names that may appear in telemetry topics. Any class outside this set — internal helpers,
+# in-flight subclasses not yet shipped, user-defined subclasses — is reported as "other" so unreleased or
+# private names never leak. Adding a new trainer requires an explicit entry here.
+_TELEMETRY_TRAINERS = {
+    # Stable
+    "DPOTrainer",
+    "GRPOTrainer",
+    "KTOTrainer",
+    "RewardTrainer",
+    "RLOOTrainer",
+    "SFTTrainer",
+    # Experimental
+    "AsyncGRPOTrainer",
+    "BCOTrainer",
+    "CPOTrainer",
+    "DistillationTrainer",
+    "DPPOTrainer",
+    "GFPOTrainer",
+    "GKDTrainer",
+    "GOLDTrainer",
+    "GRPOWithReplayBufferTrainer",
+    "MiniLLMTrainer",
+    "NashMDTrainer",
+    "OnlineDPOTrainer",
+    "ORPOTrainer",
+    "PAPOTrainer",
+    "PPOTrainer",
+    "PRMTrainer",
+    "SDFTTrainer",
+    "SDPOTrainer",
+    "SSDTrainer",
+    "TPOTrainer",
+    "XPOTrainer",
+}
+
+
 class _BaseTrainer(Trainer):
     _tag_names = []
     _name = "Base"
@@ -68,7 +104,11 @@ class _BaseTrainer(Trainer):
         # transformers `CONFIG_MAPPING`); anything else is reported as "other" so we never leak the names of internal,
         # custom trainer subclasses or private model architectures.
         cls = type(self)
-        trainer = cls.__name__ if cls.__module__.startswith("trl.") else "other"
+        trainer = (
+            cls.__name__
+            if cls.__name__ in _TELEMETRY_TRAINERS and cls.__module__.startswith("trl.")
+            else "other"
+        )
         model_type = self.model.config.model_type
         model_arch = model_type if model_type in CONFIG_MAPPING else "other"
         send_telemetry(

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -105,9 +105,7 @@ class _BaseTrainer(Trainer):
         # custom trainer subclasses or private model architectures.
         cls = type(self)
         trainer = (
-            cls.__name__
-            if cls.__name__ in _TELEMETRY_TRAINERS and cls.__module__.startswith("trl.")
-            else "other"
+            cls.__name__ if cls.__name__ in _TELEMETRY_TRAINERS and cls.__module__.startswith("trl.") else "other"
         )
         model_type = self.model.config.model_type
         model_arch = model_type if model_type in CONFIG_MAPPING else "other"


### PR DESCRIPTION
Replace the `cls.__module__.startswith("trl.")` check in `_BaseTrainer._send_telemetry` with an explicit allowlist of shipping trainer class names (`_TELEMETRY_TRAINERS`). Any class not in the allowlist is reported as `trl/other`.

## Why

The original check was meant as an "upstream allowlist" but it was implemented as a module-path proxy. Any class defined under `trl.*`, including in-flight subclasses, internal helpers, or unreleased experimental trainers, would have its name shipped in the telemetry topic (`trl/<ClassName>`). That defeats the stated goal of not leaking the names of internal classes.

Concrete example: while iterating on a new trainer at `trl/experimental/foo/foo_trainer.py: class FooTrainer(_BaseTrainer)`, every local run would emit `trl/FooTrainer` before the trainer is ready or publicly announced.

## How

- New module-level set `_TELEMETRY_TRAINERS` enumerating the 6 stable + 21 experimental trainers currently shipping.
- Telemetry topic falls back to `trl/other` unless `cls.__name__` is in the set **and** `cls.__module__` lives under `trl.*` (the second check stays as a cheap guard against user code that reuses a public name).
- Adding a new trainer now requires an explicit allowlist entry: **a deliberate review checkpoint**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes anonymized telemetry topic strings in `_send_telemetry`; training behavior is unchanged, with a minor ops need to update the allowlist when adding trainers.
> 
> **Overview**
> Trainer telemetry topics in `_BaseTrainer._send_telemetry` no longer treat every `trl.*` subclass as reportable by class name. A new `_TELEMETRY_TRAINERS` allowlist lists the stable and experimental trainers that may appear in `trl/<ClassName>`; anything else (in-flight trainers, internal helpers, custom subclasses) is sent as **`trl/other`**, still requiring `cls.__module__.startswith("trl.")` when a name is allowlisted.
> 
> Shipping a new public trainer now needs an explicit entry in that set so unreleased or private class names are not leaked via Hub telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018b785c115af3f84e4513ad100281f0ca93a6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->