### PR TITLE
Align KTO with DPO: Align compute_ref_log_probs

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -712,42 +712,42 @@ class KTOTrainer(_BaseTrainer):
 
         return dataset
 
-    def compute_ref_log_probs(self, padded_batch: dict) -> dict:
+    def compute_ref_log_probs(self, inputs: dict) -> dict:
         """Computes log probabilities of the reference model for a single padded batch of a KTO specific dataset."""
         with torch.no_grad():
             if self.ref_model is None:
                 with self.null_ref_context():
                     completion_logits = self.model(
-                        padded_batch["completion_input_ids"],
-                        attention_mask=padded_batch["completion_attention_mask"],
+                        inputs["completion_input_ids"],
+                        attention_mask=inputs["completion_attention_mask"],
                     ).logits
 
                     if self.calculate_KL:
                         KL_logits = self.model(
-                            padded_batch["KL_completion_input_ids"],
-                            attention_mask=padded_batch["KL_completion_attention_mask"],
+                            inputs["KL_completion_input_ids"],
+                            attention_mask=inputs["KL_completion_attention_mask"],
                         ).logits
             else:
                 completion_logits = self.ref_model(
-                    padded_batch["completion_input_ids"], attention_mask=padded_batch["completion_attention_mask"]
+                    inputs["completion_input_ids"], attention_mask=inputs["completion_attention_mask"]
                 ).logits
 
                 if self.calculate_KL:
                     KL_logits = self.ref_model(
-                        padded_batch["KL_completion_input_ids"],
-                        attention_mask=padded_batch["KL_completion_attention_mask"],
+                        inputs["KL_completion_input_ids"],
+                        attention_mask=inputs["KL_completion_attention_mask"],
                     ).logits
 
         completion_logps = self.get_batch_logps(
             completion_logits,
-            padded_batch["completion_labels"],
+            inputs["completion_labels"],
             average_log_prob=False,
         )
 
         if self.calculate_KL:
             KL_logps = self.get_batch_logps(
                 KL_logits,
-                padded_batch["KL_completion_labels"],
+                inputs["KL_completion_labels"],
                 average_log_prob=False,
             )
         else:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -712,7 +712,7 @@ class KTOTrainer(_BaseTrainer):
 
         return dataset
 
-    def compute_ref_log_probs(self, inputs: dict) -> dict:
+    def compute_ref_log_probs(self, inputs):
         """Computes log probabilities of the reference model for a single padded batch of a KTO specific dataset."""
         with torch.no_grad():
             if self.ref_model is None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -682,7 +682,7 @@ class KTOTrainer(_BaseTrainer):
             reference_logps = []
             reference_KL_logps = []
             for padded_batch in tqdm(iterable=data_loader, desc=f"Computing reference log probs for {name} dataset"):
-                reference_logp, reference_KL_logp = self.compute_reference_log_probs(padded_batch)
+                reference_logp, reference_KL_logp = self.compute_ref_log_probs(padded_batch)
                 if self.calculate_KL:
                     reference_logp, reference_KL_logp = self.accelerator.gather_for_metrics(
                         (reference_logp, reference_KL_logp)
@@ -712,7 +712,7 @@ class KTOTrainer(_BaseTrainer):
 
         return dataset
 
-    def compute_reference_log_probs(self, padded_batch: dict) -> dict:
+    def compute_ref_log_probs(self, padded_batch: dict) -> dict:
         """Computes log probabilities of the reference model for a single padded batch of a KTO specific dataset."""
         with torch.no_grad():
             if self.ref_model is None:

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -713,7 +713,7 @@ class KTOTrainer(_BaseTrainer):
         return dataset
 
     def compute_ref_log_probs(self, inputs):
-        """Computes log probabilities of the reference model for a single padded batch of a KTO specific dataset."""
+        """Computes reference log probabilities for a single padded batch."""
         with torch.no_grad():
             if self.ref_model is None:
                 with self.null_ref_context():


### PR DESCRIPTION
Align KTO with DPO: Align `compute_ref_log_probs`.

Part of:
- #4786

### Changes

Refactoring and Naming Consistency:

* Renamed the method `compute_reference_log_probs` to `compute_ref_log_probs` and updated all internal calls accordingly for clarity and consistency. 

Code Simplification and Parameter Handling:

* Changed the method parameter from `padded_batch` to `inputs` in `compute_ref_log_probs`, and updated all usages from `padded_batch[...]` to `inputs[...]` to streamline the function interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor in experimental KTO with no training or loss logic changes.
> 
> **Overview**
> Renames **`compute_reference_log_probs`** to **`compute_ref_log_probs`** in the experimental KTO trainer and updates the precompute path to call the new name, matching the DPO trainer API.
> 
> The method now takes **`inputs`** instead of **`padded_batch`**; all tensor lookups use `inputs[...]`. Behavior is unchanged—reference completion (and optional KL) forward passes and `get_batch_logps` are the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8959f80b168e0de2bb341339f67bbf5c88a715de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->