### PR TITLE
Handle empty conversational examples in is_conversational

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -485,6 +485,11 @@ class TestIsConversational(TrlTestCase):
         {"prompt": "The sky is"},
         {"prompt": "The sky is", "chosen": " blue.", "rejected": " green."},
         {"prompt": "The sky is", "completion": " blue.", "label": True},
+        {"messages": []},
+        {"prompt": []},
+        {"chosen": []},
+        {"rejected": []},
+        {"completion": []},
     ]
 
     @pytest.mark.parametrize("example", conversational_examples)

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -189,7 +189,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
         key = example_keys.pop()  # take the first supported key
         maybe_messages = example[key]
         # It must be a list of messages
-        if isinstance(maybe_messages, list):
+        if isinstance(maybe_messages, list) and maybe_messages:
             maybe_message = maybe_messages[0]
             # Each message must a list of dictionaries with keys "role" and "content"
             if isinstance(maybe_message, dict) and "role" in maybe_message:


### PR DESCRIPTION
This PR prevents `is_conversational` from raising an `IndexError` when a supported conversational field is an empty list, such as `messages`, `prompt`, `chosen`, `rejected`, or `completion`.

Empty lists are not valid conversational examples, so the function now returns `False`.

Regression tests were added for each supported empty conversational field.

Test:
- `python -m pytest tests/test_data_utils.py::TestIsConversational -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in dataset format detection with no auth, security, or training-path behavior changes beyond avoiding crashes on bad rows.
> 
> **Overview**
> **`is_conversational`** no longer treats an empty list on a supported field (`messages`, `prompt`, `chosen`, `rejected`, `completion`) as conversational. It now requires the list to be non-empty before inspecting the first message, so malformed rows return **`False`** instead of raising **`IndexError`**.
> 
> Regression tests cover each supported key with an empty list in **`TestIsConversational`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1520a0e9ae98b5c2586c9eda84176ebfa20b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->