### PR TITLE
Handle empty conversational fields in dataset format checks

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -485,6 +485,11 @@ class TestIsConversational(TrlTestCase):
         {"prompt": "The sky is"},
         {"prompt": "The sky is", "chosen": " blue.", "rejected": " green."},
         {"prompt": "The sky is", "completion": " blue.", "label": True},
+        {"messages": []},
+        {"prompt": []},
+        {"chosen": []},
+        {"rejected": []},
+        {"completion": []},
     ]
 
     @pytest.mark.parametrize("example", conversational_examples)
@@ -517,6 +522,10 @@ class TestIsConversationalFromValue(TrlTestCase):
 
     def test_negative_2(self):
         example = {"text": "The sky is blue."}
+        assert not is_conversational_from_value(example)
+
+    def test_empty_conversations(self):
+        example = {"conversations": []}
         assert not is_conversational_from_value(example)
 
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -189,7 +189,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
         key = example_keys.pop()  # take the first supported key
         maybe_messages = example[key]
         # It must be a list of messages
-        if isinstance(maybe_messages, list):
+        if isinstance(maybe_messages, list) and maybe_messages:
             maybe_message = maybe_messages[0]
             # Each message must a list of dictionaries with keys "role" and "content"
             if isinstance(maybe_message, dict) and "role" in maybe_message:
@@ -910,7 +910,7 @@ def is_conversational_from_value(example: dict[str, Any]) -> bool:
     """
     maybe_messages = example.get("conversations")
     # It must be a list of messages
-    if isinstance(maybe_messages, list):
+    if isinstance(maybe_messages, list) and maybe_messages:
         maybe_message = maybe_messages[0]
         # Each message must a list of dictionaries with keys "from" and "value"
         if isinstance(maybe_message, dict) and "from" in maybe_message and "value" in maybe_message:


### PR DESCRIPTION
# What does this PR do?

This PR prevents dataset format checks from raising an `IndexError` when a supported conversational field is an empty list.

The affected checks are:

- `is_conversational`, for empty `messages`, `prompt`, `chosen`, `rejected`, or `completion` fields
- `is_conversational_from_value`, for an empty `conversations` field

Empty lists are not valid conversational examples, so these functions now return `False` instead of indexing into the first element. Regression tests were added for the empty-list cases.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

## Test

- `python -m pytest tests/test_data_utils.py::TestIsConversational tests/test_data_utils.py::TestIsConversationalFromValue -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in dataset format detection with added unit tests; no auth, training, or API behavior changes.
> 
> **Overview**
> Fixes **`IndexError`** when dataset format helpers inspect examples whose conversational fields are **empty lists** (`messages`, `prompt`, `chosen`, `rejected`, `completion`, or `conversations`).
> 
> **`is_conversational`** and **`is_conversational_from_value`** now require a non-empty list before reading the first element, and return **`False`** for empty lists (treated as non-conversational). Tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76b111fb98c77d4b29ef194820e54ffc3cf651b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->