### PR TITLE
Add SmolVLM original and training chat template with generation markers

### DIFF
--- a/docs/source/chat_templates.md
+++ b/docs/source/chat_templates.md
@@ -20,7 +20,7 @@ TRL ships patched templates under [`trl/chat_templates/`](https://github.com/hug
 
 ## Supported model families
 
-TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Idefics3, Llama 3 / 3.1 / 3.2, Llava-Next, Nemotron 3 (Nano, Super, Ultra), Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, Qwen3.6.
+TRL stores reference copies of the original templates so it can identify supported models at init and swap in a training template when needed. The following families are recognized: Cohere, Cohere2, DeepSeek-V3, Gemma, Gemma3, GLM-4-MoE, GPT-OSS, Idefics3, Llama 3 / 3.1 / 3.2, Llava-Next, Nemotron 3 (Nano, Super, Ultra), Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, Qwen3.6, SmolVLM (including SmolVLM2).
 
 ## Training templates
 
@@ -175,6 +175,12 @@ Patched Qwen3.5 templates, shared logic across both flavors (they differ only in
 ### `qwen3_6_training.jinja`
 
 Patched Qwen3.6 template. Diff vs `qwen3_6.jinja`: same set of changes as `qwen3_training.jinja` — require both `<think>` and `</think>` to be present before parsing, drop the `loop.index0 > ns.last_query_index` conditional so the thinking block is always emitted (prefix-preservation), and wrap assistant output with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` markers for SFT assistant-only loss.
+
+### `smolvlm_training.jinja`
+
+Patched SmolVLM template (also used for SmolVLM2, which ships a byte-identical template). Diff vs `smolvlm.jinja`:
+
+Split the assistant message into its own branch so the `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;` markers wrap the assistant content. This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.
 
 ## Related utilities
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -664,7 +664,7 @@ class TestIsChatTemplateStopTokenTrained:
                 ),
             ],
         ),
-        pytest.param("trl-internal-testing/tiny-SmolVLMForConditionalGeneration", id="smolvlm"),
+        pytest.param("trl-internal-testing/tiny-SmolVLMForConditionalGeneration", id="smolvlm", marks=require_vision),
     ],
 )
 class TestGetTrainingChatTemplate:

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -664,6 +664,7 @@ class TestIsChatTemplateStopTokenTrained:
                 ),
             ],
         ),
+        pytest.param("trl-internal-testing/tiny-SmolVLMForConditionalGeneration", id="smolvlm"),
     ],
 )
 class TestGetTrainingChatTemplate:

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -367,6 +367,9 @@ qwen3_5_think_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_5_think.jinja").read
 
 qwen3_6_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6.jinja").read_text(encoding="utf-8")
 
+# Also matches SmolVLM2, which ships a byte-identical chat template.
+smolvlm_chat_template = (_CHAT_TEMPLATES_DIR / "smolvlm.jinja").read_text(encoding="utf-8")
+
 
 ProcessingClassT = TypeVar("ProcessingClassT", PreTrainedTokenizerBase, ProcessorMixin)
 
@@ -701,6 +704,8 @@ qwen3_5_think_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_5_think_tra
 
 qwen3_6_training_chat_template = (_CHAT_TEMPLATES_DIR / "qwen3_6_training.jinja").read_text(encoding="utf-8")
 
+smolvlm_training_chat_template = (_CHAT_TEMPLATES_DIR / "smolvlm_training.jinja").read_text(encoding="utf-8")
+
 
 def get_training_chat_template(
     processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
@@ -711,9 +716,9 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LLaMA 3, Phi-3,
-    Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and Qwen3.6
-    are supported.
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LLaMA 3, Phi-3, Phi-3.5,
+    Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and Qwen3.6, and SmolVLM
+    (including SmolVLM2) are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -847,6 +852,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == qwen3_6_chat_template:
         return qwen3_6_training_chat_template
+
+    if processing_class.chat_template == smolvlm_chat_template:
+        return smolvlm_training_chat_template
 
     raise ValueError(
         "The chat template is not training-compatible (missing prefix-preservation or `{% generation %}` markers) "

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -716,9 +716,9 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LLaMA 3, Phi-3, Phi-3.5,
-    Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and Qwen3.6, and SmolVLM
-    (including SmolVLM2) are supported.
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LLaMA 3, Phi-3,
+    Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and
+    Qwen3.6, and SmolVLM (including SmolVLM2) are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -104,6 +104,10 @@ Original Qwen3.5 chat templates. The two differ only in the default value of the
 
 Original Qwen3.6 chat template (shared across `Qwen3.6-27B`, `Qwen3.6-35B-A3B`, and their FP8 variants). Differs from `qwen3_5_think.jinja` by adding a `preserve_thinking` flag and tweaking how non-string tool-call argument values are stringified.
 
+### `smolvlm.jinja`
+
+Original SmolVLM chat template. Also matches SmolVLM2, which ships a byte-identical template. Does not support tool calling.
+
 ## Training templates
 
 Patched templates that fix training-specific issues. Swapped in at init when tools are enabled (GRPO) or when `assistant_only_loss=True` (SFT).
@@ -262,3 +266,9 @@ Patched Qwen3.5 templates. Same diff as `qwen3_training.jinja` (require both `<t
 ### `qwen3_6_training.jinja`
 
 Patched Qwen3.6 template. Same diff as `qwen3_training.jinja` (require both `<think>` and `</think>` before parsing, drop the `loop.index0 > ns.last_query_index` conditional so the thinking block is always emitted, wrap assistant output in `{% generation %}` / `{% endgeneration %}`), applied to the Qwen3.6 base template.
+
+### `smolvlm_training.jinja`
+
+Patched SmolVLM template (also used for SmolVLM2, which ships a byte-identical template). Diff vs `smolvlm.jinja`:
+
+Split the assistant message into its own branch so the `{% generation %}` / `{% endgeneration %}` markers wrap the assistant content. This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.

--- a/trl/chat_templates/smolvlm.jinja
+++ b/trl/chat_templates/smolvlm.jinja
@@ -1,0 +1,2 @@
+<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
+{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

--- a/trl/chat_templates/smolvlm_training.jinja
+++ b/trl/chat_templates/smolvlm_training.jinja
@@ -1,0 +1,11 @@
+{#- Training variant of the SmolVLM chat template (see smolvlm.jinja for the original).
+    Also used for SmolVLM2, which ships a byte-identical chat template.
+    Modifications vs the original:
+    - Split the assistant message into its own branch so the {% generation %} / {% endgeneration %}
+      markers wrap the assistant content (everything after the 'Assistant:' prompt cue, up to and
+      including the trailing '<end_of_utterance>\n'). This enables assistant-only loss masking in
+      SFT training.
+-#}
+<|im_start|>{% for message in messages %}{% if message['role'] == 'assistant' %}Assistant:{% generation %}{% if message['content'][0]['type'] != 'image' %} {% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
+{% endgeneration %}{% else %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
+{% endif %}{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}


### PR DESCRIPTION
# What does this PR do?

Adds a training chat template for SmolVLM (also matches SmolVLM2, which ships a byte-identical template), wiring it into `get_training_chat_template`.

The new template patches `smolvlm.jinja` with a single modification: split the assistant message into its own branch so the `{% generation %}` / `{% endgeneration %}` markers wrap the assistant content (everything after the `Assistant:` prompt cue, up to and including the trailing `<end_of_utterance>\n`). The vision-content rendering inside the assistant branch is duplicated from the original non-assistant branch unchanged. This enables `return_assistant_tokens_mask=True` to produce correct masks for SFT assistant-only loss.

SmolVLM does not ship tool-calling support, so no prefix-preservation changes are needed.

### Changes

**`trl/chat_templates/`**:

- `smolvlm.jinja` – new original template
- `smolvlm_training.jinja` – new training template

**`trl/chat_template_utils.py`**:

- Module-level template variable: `smolvlm_chat_template`, used for identity comparison.
- One new branch in `get_training_chat_template()` mapping the source template to its training variant.

**`tests/test_chat_template_utils.py`** — one new entry in `TestGetTrainingChatTemplate`'s parametrize block (`smolvlm`).

**Docs** — SmolVLM (including SmolVLM2) added to the supported-families list, training-template section added in:

- `docs/source/chat_templates.md`
- `trl/chat_templates/README.md`

Part of #5471

cc: @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive template wiring and tests only; no auth, data, or core training logic changes. Risk is mainly incorrect assistant loss masks if the Jinja patch diverges from the official template.
> 
> **Overview**
> Adds **SmolVLM** and **SmolVLM2** to TRL’s bundled chat-template support so SFT with `assistant_only_loss=True` can swap in a training template automatically.
> 
> New `smolvlm.jinja` (reference copy for identity matching) and `smolvlm_training.jinja` (assistant branch split with `{% generation %}` / `{% endgeneration %}` around assistant text and `<end_of_utterance>`). `get_training_chat_template()` maps the shipped template to the training variant when it matches byte-for-byte (SmolVLM2 included). Docs list the family; `TestGetTrainingChatTemplate` gains the tiny SmolVLM VLM fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febf43f153befc5cb1d9dd8cfabbc14d048f5946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->