### PR TITLE
KTO: Support non-sequential train_sampling_strategy for apo_zero_unpaired

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -79,9 +79,10 @@ class KTOConfig(_BaseConfig):
     > - `gradient_checkpointing`: Defaults to `True` instead of `False`.
     > - `bf16`: Defaults to `True` if `fp16` is not set, instead of `False`.
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
-    > - `train_sampling_strategy`: Defaults to `"sequential"` instead of `"random"`. KTO requires
-    >   sequential sampling because the KL completion for each example is precomputed against its
-    >   neighbors in a fixed-order batch; any other strategy breaks that pairing.
+    > - `train_sampling_strategy`: Defaults to `"sequential"` instead of `"random"`. Loss types
+    >   that estimate the KL divergence term (all except `"apo_zero_unpaired"`) require sequential
+    >   sampling because the KL completion for each example is precomputed against its neighbors in
+    >   a fixed-order batch; any other strategy breaks that pairing.
     """
 
     _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
@@ -94,9 +95,10 @@ class KTOConfig(_BaseConfig):
     train_sampling_strategy: str = field(
         default="sequential",
         metadata={
-            "help": "Sampler to use for the training dataloader. KTO requires `'sequential'` because the KL "
-            "completion for each example is precomputed against its neighbors in a fixed-order batch; any other "
-            "strategy breaks that pairing. Possible values are `'random'`, `'sequential'`, and `'group_by_length'`.",
+            "help": "Sampler to use for the training dataloader. Loss types that estimate the KL divergence term "
+            "(all except `'apo_zero_unpaired'`) require `'sequential'` because the KL completion for each example is "
+            "precomputed against its neighbors in a fixed-order batch; any other strategy breaks that pairing. "
+            "Possible values are `'random'`, `'sequential'`, and `'group_by_length'`.",
             "choices": ["random", "sequential", "group_by_length"],
         },
     )

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1138,7 +1138,7 @@ class KTOTrainer(_BaseTrainer):
         return self._compute_loss(model, inputs, return_outputs)
 
     def _get_train_sampler(self, train_dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:
-        if Version(transformers.__version__) < Version("5.2.0"):
+        if self.calculate_KL and Version(transformers.__version__) < Version("5.2.0"):
             if train_dataset is None:
                 train_dataset = self.train_dataset
             if train_dataset is None or not has_length(train_dataset):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -343,10 +343,11 @@ class KTOTrainer(_BaseTrainer):
         self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
         self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         self.calculate_KL = False if self.loss_type in ["apo_zero_unpaired"] else True
-        if args.train_sampling_strategy != "sequential":
+        if self.calculate_KL and args.train_sampling_strategy != "sequential":
             raise ValueError(
-                f"KTO requires `train_sampling_strategy='sequential'` because the KL completion for each example is "
-                f"precomputed against its neighbors in a fixed-order batch; any other strategy breaks that pairing. "
+                f"Loss type `'{args.loss_type}'` estimates the KL divergence term and requires "
+                f"`train_sampling_strategy='sequential'` because the KL completion for each example is precomputed "
+                f"against its neighbors in a fixed-order batch; any other strategy breaks that pairing. "
                 f"Got `train_sampling_strategy='{args.train_sampling_strategy}'`."
             )
         if self.calculate_KL and args.per_device_train_batch_size <= 1:


### PR DESCRIPTION
KTO: Support non-sequential train_sampling_strategy for apo_zero_unpaired.

Follow-up to:
- #5864

This PR refines the handling and documentation of the `train_sampling_strategy` configuration and related KL divergence requirements in the KTO trainer. The main focus is to clarify that only loss types estimating the KL divergence term require sequential sampling, and to enforce this constraint more precisely in both configuration and runtime checks.

### Motivation

The sequential constraint exists because `_get_kl_dataset` precomputes KL completions by rotating within fixed-order batches of size `per_device_train_batch_size`. This only matters when the KL term is actually computed. For `"apo_zero_unpaired"` (`calculate_KL=False`), no such pairing exists and the constraint was never necessary: it was an artifact of the previous unconditional `_get_train_sampler` override.

### Changes

**Runtime Logic Improvements:**

* Changed the runtime check in `KTOTrainer.__init__` to enforce the sequential sampling requirement only when the selected loss type estimates the KL divergence term, instead of unconditionally for all KTO runs. Loss type `"apo_zero_unpaired"` does not estimate a KL divergence term and is therefore not subject to the sequential-order constraint; it may now use any sampling strategy (`"random"`, `"sequential"`, or `"group_by_length"`).
* Updated the version check for the training sampler in `_get_train_sampler` to only apply when KL estimation is required.

**Configuration and Documentation Updates:**

* Updated the docstring and help text for `train_sampling_strategy` in `KTOConfig` to clarify that only loss types estimating the KL divergence term (all except `'apo_zero_unpaired'`) require sequential sampling, rather than all KTO runs. This is also more forward-compatible: any future loss type that skips the KL term will automatically be documented and handled correctly.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training dataloader behavior for `apo_zero_unpaired` (non-sequential sampling allowed); incorrect gating could break KL pairing for standard KTO loss.
> 
> **Overview**
> **Sequential sampling is now required only when the KTO trainer actually estimates the KL term**, not for every KTO run.
> 
> `KTOConfig` docs and `train_sampling_strategy` help text now state that **all loss types except `apo_zero_unpaired`** need sequential batches (neighbor-based KL completions). **`KTOTrainer`** gates the init-time `ValueError` and the transformers &lt;5.2.0 **`SequentialSampler` override** in `_get_train_sampler` on `calculate_KL`, so **`apo_zero_unpaired` can use `random` or `group_by_length`** without tripping those checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03f02fb4c5564b20f92a0fc5156e0e1e46b49f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->