### PR TITLE
Fix `loss_type="chunked_nll"` under DeepSpeed ZeRO-3

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -98,6 +98,42 @@ class TestDistributed(TrlTestCase):
             "fsdp2",
         ],
     )
+    def test_sft_chunked_nll(self, config, get_config_path):
+        # fmt: off
+        run_command(
+            [
+                "accelerate", "launch", "--config_file", get_config_path(config), "trl/scripts/sft.py",
+                "--output_dir", self.tmp_dir,
+                "--model_name_or_path", "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                "--dataset_name", "trl-internal-testing/zen",
+                "--dataset_config", "standard_language_modeling",
+                "--loss_type", "chunked_nll",
+            ],
+            os.environ.copy(),
+        )
+        # fmt: on
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            "ddp",
+            pytest.param(
+                "zero2",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.1.0"),
+                    reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
+                ),
+            ),
+            pytest.param(
+                "zero3",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.1.0"),
+                    reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
+                ),
+            ),
+            "fsdp2",
+        ],
+    )
     def test_dpo(self, config, get_config_path):
         # fmt: off
         run_command(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -86,10 +86,27 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
     aux_loss: torch.Tensor | None = None
 
 
+def _maybe_gather_lm_head_ctx(w, b):
+    # Allgather ZeRO-3 partitioned `lm_head` weight/bias for the chunked matmul. No-op if not ZeRO-3, or if the
+    # param is already gathered (tied embeddings: `embed_tokens` shares the weight and keeps it `AVAILABLE`, so
+    # partitioning on our exit would collide with its active-submodule tracking).
+    params = [w] if b is None else [w, b]
+    if not any(hasattr(p, "ds_id") for p in params):
+        return contextlib.nullcontext()
+    from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+
+    if all(p.ds_status == ZeroParamStatus.AVAILABLE for p in params):
+        return contextlib.nullcontext()
+    import deepspeed
+
+    return deepspeed.zero.GatheredParameters(params)
+
+
 def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
-    logits = h.float() @ w.float().t()
-    if b is not None:
-        logits = logits + b.float()
+    with _maybe_gather_lm_head_ctx(w, b):
+        logits = h.float() @ w.float().t()
+        if b is not None:
+            logits = logits + b.float()
     if logit_scale != 1.0:
         logits = logits * logit_scale
     if final_logit_softcapping is not None:
@@ -179,9 +196,10 @@ def _chunked_cross_entropy_loss(
         # Whole micro-batch masked (e.g. completion-only loss + truncation). Keep the loss connected
         # to the autograd graph through every trainable parameter so `.backward()` succeeds and DDP /
         # FSDP gradient sync doesn't hang on a missing param.
-        loss = (hidden_states.float().sum() + lm_head_weight.float().sum()) * 0.0
-        if lm_head_bias is not None:
-            loss = loss + lm_head_bias.float().sum() * 0.0
+        with _maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+            loss = (hidden_states.float().sum() + lm_head_weight.float().sum()) * 0.0
+            if lm_head_bias is not None:
+                loss = loss + lm_head_bias.float().sum() * 0.0
         return loss, correct, entropy_sum, n_valid_tensor
 
     loss = hidden.new_zeros((), dtype=torch.float32)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -90,15 +90,17 @@ def _maybe_gather_lm_head_ctx(w, b):
     # Allgather ZeRO-3 partitioned `lm_head` weight/bias for the chunked matmul. No-op if not ZeRO-3, or if the
     # param is already gathered (tied embeddings: `embed_tokens` shares the weight and keeps it `AVAILABLE`, so
     # partitioning on our exit would collide with its active-submodule tracking).
-    params = [w] if b is None else [w, b]
-    if not any(hasattr(p, "ds_id") for p in params):
+    from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
+
+    if not is_deepspeed_zero3_enabled():
         return contextlib.nullcontext()
+
+    import deepspeed
     from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
 
+    params = [w] if b is None else [w, b]
     if all(p.ds_status == ZeroParamStatus.AVAILABLE for p in params):
         return contextlib.nullcontext()
-    import deepspeed
-
     return deepspeed.zero.GatheredParameters(params)
 
 


### PR DESCRIPTION
The chunked-CE path in `SFTTrainer` reads `lm_head.weight` (and `lm_head.bias`) directly to do its own per-chunk matmul, bypassing the DeepSpeed pre-forward hooks that normally allgather ZeRO-3 partitioned params. On non-owning ranks the weight is a 0-element shard and the matmul crashes.

To see the traceback, see https://github.com/huggingface/trl/actions/runs/26475700871/job/77960573388?pr=5846#step:9:60

This adds a tiny `_maybe_gather_lm_head_ctx(w, b)` helper that wraps the matmul in `deepspeed.zero.GatheredParameters` when the param is ZeRO-3-partitioned, and is a no-op otherwise (DDP, FSDP2, single-GPU, or when the param is already `AVAILABLE`, e.g. tied embeddings where `embed_tokens` shares the weight). 

With `use_reentrant=False` the checkpoint recompute re-enters the context during backward, so the gather happens on both passes.

Also gathers in the `n_valid == 0` fallback branch which reads `lm_head_weight.float().sum()` for the dummy loss.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed training loss math and DeepSpeed parameter gathering; scope is narrow to chunked_nll but affects multi-GPU ZeRO-3 SFT runs.
> 
> **Overview**
> Fixes **`loss_type="chunked_nll"`** under **DeepSpeed ZeRO-3** by gathering partitioned **`lm_head`** weights before the custom chunked matmul.
> 
> The chunked cross-entropy path reads **`lm_head.weight`** (and bias) directly, so ZeRO-3 ranks can see empty shards and crash. A new **`_maybe_gather_lm_head_ctx`** wraps those reads in **`deepspeed.zero.GatheredParameters`** when needed; it stays a no-op for DDP, FSDP2, single GPU, or params already **`AVAILABLE`** (e.g. tied embeddings).
> 
> The same gather is applied in the **all-masked** dummy-loss branch so backward still touches head params.
> 
> Adds distributed **`test_sft_chunked_nll`** (DDP, ZeRO-2/3, FSDP2) mirroring **`test_sft`** with **`--loss_type chunked_nll`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666c92cb52f4896d1778476424ef473b83ef4e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->