### PR TITLE
Align KTO with DPO: Remove null_ref_context

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -16,7 +16,6 @@ import os
 import textwrap
 from collections import defaultdict
 from collections.abc import Callable
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -662,16 +661,6 @@ class KTOTrainer(_BaseTrainer):
                 "ref_logps",
                 "ref_KL_logps",
             ]
-
-    @contextmanager
-    def null_ref_context(self):
-        """Context manager for handling null reference model (that is, peft adapter manipulation)."""
-        if is_peft_model(self.model):
-            model = self.accelerator.unwrap_model(self.model)
-            with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
-                yield
-        else:
-            yield
 
     def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
         model_hash = hash_module(self.ref_model or self.model)

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -726,7 +726,20 @@ class KTOTrainer(_BaseTrainer):
         """Computes reference log probabilities for a single padded batch."""
         with torch.no_grad():
             if self.ref_model is None:
-                with self.null_ref_context():
+                if is_peft_model(self.model):
+                    model = self.accelerator.unwrap_model(self.model)
+                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+                        completion_logits = self.model(
+                            inputs["completion_input_ids"],
+                            attention_mask=inputs["completion_attention_mask"],
+                        ).logits
+
+                        if self.calculate_KL:
+                            KL_logits = self.model(
+                                inputs["KL_completion_input_ids"],
+                                attention_mask=inputs["KL_completion_attention_mask"],
+                            ).logits
+                else:
                     completion_logits = self.model(
                         inputs["completion_input_ids"],
                         attention_mask=inputs["completion_attention_mask"],

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1090,8 +1090,9 @@ class KTOTrainer(_BaseTrainer):
                 ref_KL_logps = None
         else:
             with torch.no_grad():
-                if self.ref_model is None:
-                    with self.null_ref_context():
+                if is_peft_model(self.model) and self.ref_model is None:
+                    model = self.accelerator.unwrap_model(self.model)
+                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
                         ref_chosen_logps, ref_rejected_logps, _, _, ref_KL_logps, _ = self._compute_logps(
                             self.model, batch
                         )


### PR DESCRIPTION
Align KTO with DPO: Remove `null_ref_context`.

This PR refactors how the code handles the case when there is no explicit reference model (`ref_model is None`), especially for PEFT (Parameter-Efficient Fine-Tuning) models. The main change is the removal of the `null_ref_context` context manager in favor of directly inlining its logic where needed. This makes the code more straightforward and localized, reducing indirection.

Part of:
- #4786

### Changes

**Refactoring context management for PEFT models in KTO:**

* Removed the `null_ref_context` context manager and replaced its usage by inlining the adapter-switching logic directly where reference log probabilities are computed.

* Updated the `compute_ref_log_probs` and `_compute_loss` methods to directly check for PEFT models and handle adapter switching inline, improving clarity and reducing unnecessary abstraction.

These changes simplify the codebase and make the handling of reference log probabilities for PEFT models more explicit and easier to follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how KTO selects the reference policy during training and precompute paths; behavior should match prior logic for PEFT/no-ref_model setups, but mistakes here would skew KTO rewards/loss.
> 
> **Overview**
> Removes the **`null_ref_context`** helper from **`KTOTrainer`** and inlines how reference log-probs are computed when there is no separate **`ref_model`**, matching the DPO trainer pattern (#4786).
> 
> In **`compute_ref_log_probs`**, a **`ref_model is None`** path now branches explicitly: PEFT models run completion (and optional KL) forwards under **`use_adapter`** with the **`ref`** adapter when present; non-PEFT models call **`self.model`** directly without the old context wrapper.
> 
> In **`_compute_loss`**, live reference log-probs use the same inlined **`use_adapter`** block only when **`is_peft_model(self.model)`** and **`ref_model is None`**; otherwise they still come from **`self.ref_model`**. Precomputed **`ref_logps`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50009cb33af6fddb0dcbc0cba49fc5ec4faa4616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->