### PR TITLE
Simplify reference model handling in GRPO/RLOO

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -657,28 +657,24 @@ class GRPOTrainer(_BaseTrainer):
             compute_loss_func="non-None value to disable scaling",
         )
 
-        # Reference model
         self.beta = args.beta
-        if self.beta == 0.0:
-            # If beta is 0.0, the reference model is not needed
-            self.ref_model = None
-        elif is_peft_model(model):
-            # If PEFT is used, the reference model is not needed since the adapter can be disabled
-            # to revert to the initial model.
-            self.ref_model = None
-        else:
+        # Reference model: create one from the model path unless:
+        # - beta is 0.0, the reference model is not needed
+        # - or model is PEFT, which recovers the reference by disabling the adapter
+        ref_model = None
+        if self.beta != 0.0 and not is_peft_model(model):
             # For deepspeed, fsdp or non-distributed models, create a reference model from scratch
             model_init_kwargs = args.model_init_kwargs or {}
             # Distributed training requires device_map=None ("auto" fails)
             if self.args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 model_init_kwargs["device_map"] = None
-            self.ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)
+            ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)
 
         # Disable dropout in the models
         if args.disable_dropout:
             disable_dropout_in_model(model)
-            if self.ref_model is not None:
-                disable_dropout_in_model(self.ref_model)
+            if ref_model is not None:
+                disable_dropout_in_model(ref_model)
 
         # Cast LM Head To FP32
         if args.cast_lm_head_to_fp32:
@@ -705,8 +701,8 @@ class GRPOTrainer(_BaseTrainer):
                     target_model.model.embed_tokens.register_forward_hook(cast_outputs_to_original_dtype)
 
             _cast_lm_head_to_fp32(model)
-            if self.ref_model is not None:
-                _cast_lm_head_to_fp32(self.ref_model)
+            if ref_model is not None:
+                _cast_lm_head_to_fp32(ref_model)
 
         # Liger loss
         if self.use_liger_kernel:
@@ -825,13 +821,13 @@ class GRPOTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
-        if self.ref_model is not None:
+        if ref_model is not None:
             if self.is_deepspeed_enabled:
-                self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
+                ref_model = prepare_deepspeed(ref_model, self.accelerator)
             elif self.is_fsdp_enabled:
-                self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)
+                ref_model = prepare_fsdp(ref_model, self.accelerator)
             else:
-                self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
+                ref_model = self.accelerator.prepare_model(ref_model, evaluation_mode=True)
 
         if args.sync_ref_model:
             if self.beta == 0.0:
@@ -849,7 +845,15 @@ class GRPOTrainer(_BaseTrainer):
                     "you need a synced reference model. If you need `sync_ref_model` to work with PEFT, please open a "
                     "feature request at https://github.com/huggingface/trl/issues."
                 )
-            self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
+            self.add_callback(SyncRefModelCallback(ref_model=ref_model, accelerator=self.accelerator))
+
+        # Reference model:
+        # - None if self.beta == 0.0, else
+        # - ref_model
+        # - Or self.model
+        #   - If PEFT, we trigger adapter switching on self.model for the reference forward passes
+        #   - If non-PEFT, self.model is used to precompute_ref_log_probs because no training step has run yet
+        self.ref_model = None if self.beta == 0.0 else (ref_model or self.model)
 
         for i, reward_func in enumerate(self.reward_funcs):
             if isinstance(reward_func, PreTrainedModel):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2096,7 +2096,22 @@ class GRPOTrainer(_BaseTrainer):
 
             # Compute the per-token log probabilities for the reference model
             if self.beta != 0.0:
-                if self.ref_model is not None:
+                if is_peft_model(self.ref_model):
+                    # When training a PEFT adapter, how we obtain the reference depends on the setup:
+                    # - New adapter: disabling adapters yields the base model.
+                    # - Re-training an existing adapter: an initial copy is loaded under the name "ref".
+                    model = self.accelerator.unwrap_model(self.ref_model)
+                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
+                            self.ref_model,
+                            prompt_completion_ids,
+                            attention_mask,
+                            logits_to_keep,
+                            batch_size=batch_size,
+                            num_images=num_images,
+                            **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
+                        )
+                else:
                     ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
                         self.ref_model,
                         prompt_completion_ids,
@@ -2106,21 +2121,6 @@ class GRPOTrainer(_BaseTrainer):
                         num_images=num_images,
                         **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
                     )
-                else:
-                    # When training a PEFT adapter, how we obtain the reference depends on the setup:
-                    # - New adapter: disabling adapters yields the base model.
-                    # - Re-training an existing adapter: an initial copy is loaded under the name "ref".
-                    model = self.accelerator.unwrap_model(self.model)
-                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
-                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
-                            self.model,
-                            prompt_completion_ids,
-                            attention_mask,
-                            logits_to_keep,
-                            batch_size=batch_size,
-                            num_images=num_images,
-                            **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
-                        )
             else:
                 ref_per_token_logps = None
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -454,7 +454,7 @@ class RLOOTrainer(_BaseTrainer):
         )
 
         self.beta = args.beta
-        # Reference model
+        # Reference model: create one from the model path unless:
         # - beta is 0.0, the reference model is not needed
         # - or model is PEFT, which recovers the reference by disabling the adapter
         ref_model = None

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1232,7 +1232,22 @@ class RLOOTrainer(_BaseTrainer):
 
             # Compute the per-token log probabilities for the reference model
             if self.beta != 0.0:
-                if self.ref_model is not None:
+                if is_peft_model(self.ref_model):
+                    # When training a PEFT adapter, how we obtain the reference depends on the setup:
+                    # - New adapter: disabling adapters yields the base model.
+                    # - Re-training an existing adapter: an initial copy is loaded under the name "ref".
+                    model = self.accelerator.unwrap_model(self.ref_model)
+                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
+                            self.ref_model,
+                            prompt_completion_ids,
+                            attention_mask,
+                            logits_to_keep,
+                            batch_size=batch_size,
+                            num_images=num_images,
+                            **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
+                        )
+                else:
                     ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
                         self.ref_model,
                         prompt_completion_ids,
@@ -1242,21 +1257,6 @@ class RLOOTrainer(_BaseTrainer):
                         num_images=num_images,
                         **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
                     )
-                else:
-                    # When training a PEFT adapter, how we obtain the reference depends on the setup:
-                    # - New adapter: disabling adapters yields the base model.
-                    # - Re-training an existing adapter: an initial copy is loaded under the name "ref".
-                    model = self.accelerator.unwrap_model(self.model)
-                    with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
-                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(
-                            self.model,
-                            prompt_completion_ids,
-                            attention_mask,
-                            logits_to_keep,
-                            batch_size=batch_size,
-                            num_images=num_images,
-                            **forward_kwargs,  # may contain pixel_values, image_grid_thw, pixel_attention_mask, image_sizes, image_position_ids
-                        )
             else:
                 ref_per_token_logps = None
 

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -453,28 +453,24 @@ class RLOOTrainer(_BaseTrainer):
             optimizers=optimizers,
         )
 
-        # Reference model
         self.beta = args.beta
-        if self.beta == 0.0:
-            # If beta is 0.0, the reference model is not needed
-            self.ref_model = None
-        elif is_peft_model(model):
-            # If PEFT is used, the reference model is not needed since the adapter can be disabled
-            # to revert to the initial model.
-            self.ref_model = None
-        else:
+        # Reference model
+        # - beta is 0.0, the reference model is not needed
+        # - or model is PEFT, which recovers the reference by disabling the adapter
+        ref_model = None
+        if self.beta != 0.0 and not is_peft_model(model):
             # For deepspeed, fsdp or non-distributed models, create a reference model from scratch
             model_init_kwargs = args.model_init_kwargs or {}
             # Distributed training requires device_map=None ("auto" fails)
             if self.args.distributed_state.distributed_type in ["MULTI_GPU", "DEEPSPEED"]:
                 model_init_kwargs["device_map"] = None
-            self.ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)
+            ref_model = create_model_from_path(get_config_model_id(self.model.config), **model_init_kwargs)
 
         # Disable dropout in the models
         if args.disable_dropout:
             disable_dropout_in_model(model)
-            if self.ref_model is not None:
-                disable_dropout_in_model(self.ref_model)
+            if ref_model is not None:
+                disable_dropout_in_model(ref_model)
 
         # Initialize the metrics
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
@@ -565,13 +561,13 @@ class RLOOTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
-        if self.ref_model is not None:
+        if ref_model is not None:
             if self.is_deepspeed_enabled:
-                self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
+                ref_model = prepare_deepspeed(ref_model, self.accelerator)
             elif self.is_fsdp_enabled:
-                self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)
+                ref_model = prepare_fsdp(ref_model, self.accelerator)
             else:
-                self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
+                ref_model = self.accelerator.prepare_model(ref_model, evaluation_mode=True)
 
         if args.sync_ref_model:
             if self.beta == 0.0:
@@ -589,7 +585,15 @@ class RLOOTrainer(_BaseTrainer):
                     "you need a synced reference model. If you need `sync_ref_model` to work with PEFT, please open a "
                     "feature request at https://github.com/huggingface/trl/issues."
                 )
-            self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
+            self.add_callback(SyncRefModelCallback(ref_model=ref_model, accelerator=self.accelerator))
+
+        # Reference model:
+        # - None if self.beta == 0.0, else
+        # - ref_model
+        # - Or self.model
+        #   - If PEFT, we trigger adapter switching on self.model for the reference forward passes
+        #   - If non-PEFT, self.model is used to precompute_ref_log_probs because no training step has run yet
+        self.ref_model = None if self.beta == 0.0 else (ref_model or self.model)
 
         for i, reward_func in enumerate(self.reward_funcs):
             if isinstance(reward_func, PreTrainedModel):


### PR DESCRIPTION
Simplify reference model handling in GRPO/RLOO.

Follow-up to:
- #5876

This PR refactors how reference models are handled in both `GRPOTrainer` and `RLOOTrainer`, especially to improve support for PEFT (Parameter-Efficient Fine-Tuning) adapters. The main changes clarify and centralize the logic for reference model selection and usage, ensuring consistent behavior across different training setups.

### Changes

**Reference model handling improvements:**

* Refactored the initialization of `self.ref_model` in both `grpo_trainer.py` and `rloo_trainer.py` to:
  * Use a local `ref_model` variable during setup.
  * Assign `self.ref_model` at the end based on whether `beta` is zero, if PEFT is used, or if a reference model needs to be instantiated. This ensures that for PEFT, the base model is used as reference by disabling adapters, and for non-PEFT, an explicit reference model is created if needed.

* Updated all downstream usages to reference the new logic, including dropout disabling, model preparation (e.g., DeepSpeed/FSDP), and callbacks for syncing the reference model.

**PEFT adapter support and scoring logic:**

* Improved the logic in `_generate_and_score_completions` to explicitly check for PEFT models and correctly switch adapters when computing reference log probabilities, covering both new and retrained adapters.

These changes make the code more robust and maintainable when working with different model types and distributed training setups, and clarify how the reference model is selected and used throughout training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which module runs reference KL forwards (PEFT now consistently uses `self.ref_model` with adapter switching) and when a duplicate ref weights copy is loaded; incorrect assignment would skew KL-regularized RL training.
> 
> **Overview**
> **GRPO** and **RLOO** trainers now build a separate reference checkpoint only when `beta != 0` and the policy is not PEFT; setup uses a temporary `ref_model` for dropout, fp32 LM-head casting, and DeepSpeed/FSDP prep, then sets `self.ref_model` in one place: `None` if KL is off, else the prepared duplicate or **`self.model`** for adapter-based reference.
> 
> Reference log-probs no longer branch on `self.ref_model is not None` vs PEFT. They use **`is_peft_model(self.ref_model)`** to run `use_adapter` and forward through **`self.ref_model`** (aligned with the training module for PEFT), with a single non-PEFT path that always calls the dedicated or policy model via `self.ref_model`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e267aa72fc5f665128f17735916c3879c308297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->