### PR TITLE
Update vLLM version support to 0.19.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.21.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.18.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.21.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.18.0",
+    "vllm>=0.12.0,<=0.21.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.21.0",
+    "vllm>=0.12.0,<=0.19.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -109,9 +109,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.18.0")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.21.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.18.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.21.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -109,9 +109,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.21.0")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.21.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
# What does this PR do?

```
 pytest tests/test_vllm_client_server.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.11.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /fsx/sergiopaniego/trl
configfile: pyproject.toml
plugins: rerunfailures-15.1, datadir-1.8.0, anyio-4.12.1, xdist-3.8.0, cov-7.1.0
collected 51 items                                                                                                                                                                                                                        

tests/test_vllm_client_server.py ..................x..................sssssssss.....                                                                                                                                                [100%]

===================================================================================== 41 passed, 9 skipped, 1 xfailed, 1 warning in 531.07s (0:08:51) =====================================================================================
```

https://github.com/vllm-project/vllm/releases/tag/v0.19.0

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @albertvillanova 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version ceiling and messaging only; no trainer or vLLM integration logic changed.
> 
> **Overview**
> **Raises the supported vLLM upper bound from 0.18.0 to 0.19.0** everywhere TRL documents and enforces that range.
> 
> The optional `vllm` extra in `pyproject.toml` now pins `vllm>=0.12.0,<=0.19.0`. `is_vllm_available()` in `trl/import_utils.py` uses the same range for its compatibility warning. The vLLM integration doc warning block matches the new ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04976b5999b0c310609495ca4d60ddb872bac3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->