### PR TITLE
Fix ValueError by pinning kernels < 0.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ deepspeed = [
     "transformers!=5.1.0",  # see transformers#43780
 ]
 kernels = [
-    "kernels"
+    "kernels<0.15.1",  # see GH-5878
 ]
 liger = [
     "liger-kernel>=0.8.0"
@@ -104,7 +104,7 @@ dev = [
     # deepspeed
     "deepspeed>=0.14.4",
     # kernels
-    "kernels",
+    "kernels<0.15.1",  # see GH-5878
     # liger
     "liger-kernel>=0.8.0",
     # openreward (requires Python 3.11+)


### PR DESCRIPTION
Fix ValueError by pinning kernels < 0.15.1.

Fix #5878.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint only in pyproject.toml; no application or training logic changes.
> 
> **Overview**
> Pins the optional **`kernels`** dependency to **`<0.15.1`** in both the **`kernels`** extra and the **`dev`** extra in `pyproject.toml`, with a reference to GH-5878.
> 
> This avoids installing **`kernels` 0.15.1+**, which was triggering a **`ValueError`** at install or runtime (per the linked issue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b1be1aa408d6433ce53a05f355638b2da27cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->