### PR TITLE
`[DPOTrainer] Drop images when max_length truncation causes token/feature mismatch`

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -164,6 +164,39 @@ class TestDataCollatorForVisionPreference(TrlTestCase):
             f"input_ids shape {output['input_ids'].shape}"
         )
 
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.3.0"),
+        reason="mm_token_type_ids are returned by default since transformers-5.3.0 (see transformers#43972)",
+    )
+    @require_vision
+    def test_truncation_drops_images_on_mismatch(self):
+        # Regression test: when max_length truncates image tokens, pixel_values must be dropped to
+        # avoid "Image features and image tokens do not match" errors in the model forward.
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        image = Image.new("RGB", (16, 16))
+        examples = [
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "What is this?"}],
+                "chosen": [{"role": "assistant", "content": "A red square."}],
+                "rejected": [{"role": "assistant", "content": "A blue circle."}],
+            }
+        ]
+
+        # Get natural length, then truncate aggressively to cut image tokens
+        full_length = DataCollatorForVisionPreference(processor)(examples)["input_ids"].shape[1]
+        output = DataCollatorForVisionPreference(processor, max_length=full_length // 2)(examples)
+
+        assert output["input_ids"].shape[1] == full_length // 2
+        # Images dropped → mm_token_type_ids all zeros; or images kept → grid present
+        if "pixel_values" not in output:
+            assert (output["mm_token_type_ids"] == 0).all()
+        else:
+            assert "image_grid_thw" in output
+
 
 class TestDPOTrainer(TrlTestCase):
     @pytest.mark.parametrize(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -391,6 +391,19 @@ class DataCollatorForVisionPreference(DataCollatorMixin):
             if "mm_token_type_ids" in processed_prompts:
                 mm_token_type_ids = mm_token_type_ids[:, : self.max_length]
 
+            # Truncation safety (Qwen-style models with image_grid_thw only): if truncation
+            # removed image tokens, drop ALL images to avoid pixel_values/token mismatch.
+            # Consistent with the same fallback in GRPOTrainer.
+            image_grid_thw = processed_prompts.get("image_grid_thw")
+            if image_grid_thw is not None and "mm_token_type_ids" in processed_prompts:
+                merge_length = self.processor.image_processor.merge_size ** 2
+                expected_tokens = image_grid_thw.prod(-1).sum().item() // merge_length
+                actual_tokens = (mm_token_type_ids == 1).sum().item()
+                if actual_tokens != expected_tokens:
+                    processed_prompts.pop("pixel_values", None)
+                    processed_prompts.pop("image_grid_thw", None)
+                    mm_token_type_ids = torch.zeros_like(mm_token_type_ids)
+
         # Build the output dictionary
         output = processed_prompts  # we take processed_prompts because it contains the images
         output["input_ids"] = input_ids


### PR DESCRIPTION
## PR: Fix image token/feature mismatch crash when `max_length` truncates VLM sequences in DPO

### Title

`[DPOTrainer] Drop images when max_length truncation causes token/feature mismatch`

### Description

**Problem**

When using `DPOTrainer` with a vision-language model (e.g., Qwen2.5-VL) and setting `max_length` in `DPOConfig`, truncating `input_ids` can remove image placeholder tokens while the corresponding `pixel_values` remain intact. This causes the model's forward pass to crash with:

```
ValueError: Image features and image tokens do not match, tokens: 14650, features: 17152
```

**Root Cause**

In `DataCollatorForVisionPreference`, the `max_length` truncation branch slices `input_ids`, `attention_mask`, `completion_mask`, and `mm_token_type_ids`, but does **not** synchronize `pixel_values` and `image_grid_thw`, leading to a mismatch.

**Fix**

After truncation, check whether the number of image tokens remaining in `input_ids` (via `mm_token_type_ids == 1`) matches the expected count derived from `image_grid_thw`. If there is a mismatch, drop all images (`pixel_values`, `image_grid_thw`) and zero out `mm_token_type_ids` as a safe fallback. This is consistent with the existing truncation safety logic in `GRPOTrainer` (line ~2011).

**Changes**

- **`trl/trainer/dpo_trainer.py`** (+13 lines): Added truncation safety check in `DataCollatorForVisionPreference` after the `max_length` slicing block.
- **`tests/test_dpo_trainer.py`** (+33 lines): Added regression test `test_truncation_drops_images_on_mismatch` in `TestDataCollatorForVisionPreference`.

**Scope**

- Only affects Qwen-style models with `image_grid_thw` + `mm_token_type_ids` (consistent with GRPOTrainer).
- No behavior change when `max_length=None` or when truncation does not affect image tokens.

**Testing**

- Unit test: `pytest tests/test_dpo_trainer.py::TestDataCollatorForVisionPreference::test_truncation_drops_images_on_mismatch -v`
- End-to-end: verified DPO training with `tiny-Qwen2_5_VLForConditionalGeneration` + `max_length=32` completes without crash:

```python
# End-to-end test script (not included in PR, for manual verification)
import tempfile
from datasets import Dataset
from PIL import Image
from trl import DPOConfig, DPOTrainer

MODEL_ID = "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration"

image = Image.new("RGB", (64, 64), color="red")
dataset = Dataset.from_dict({
    "image": [image] * 4,
    "prompt": [[{"role": "user", "content": "What is this?"}]] * 4,
    "chosen": [[{"role": "assistant", "content": "A red square."}]] * 4,
    "rejected": [[{"role": "assistant", "content": "A blue circle."}]] * 4,
})

with tempfile.TemporaryDirectory() as tmp_dir:
    trainer = DPOTrainer(
        model=MODEL_ID,
        args=DPOConfig(
            max_length=32,  # very small to force truncation of image tokens
            max_steps=2,
            per_device_train_batch_size=2,
            report_to="none",
            output_dir=tmp_dir,
        ),
        train_dataset=dataset,
    )
    trainer.train()
    print(f"Training loss: {trainer.state.log_history[-1].get('train_loss', 'N/A')}")

print("✅ Training completed without crash")
```

<details>
<summary>Full end-to-end test output</summary>

```
Loading weights: 100%|████████████████████████████| 56/56 [00:00<00:00, 5043.50it/s]
Loading weights: 100%|████████████████████████████| 56/56 [00:00<00:00, 5557.21it/s]
Writing model shards: 100%|███████████████████████████| 1/1 [00:00<00:00, 12.56it/s]
{'train_runtime': '1.188', 'train_samples_per_second': '3.368',
 'train_steps_per_second': '1.684', 'train_loss': '0.6891',
 'entropy': '11.93', 'num_tokens': '256',
 'logits/chosen': '0.0002274', 'logits/rejected': '0.0001554',
 'rewards/chosen': '0.006934', 'rewards/rejected': '-0.001111',
 'rewards/accuracies': '1', 'rewards/margins': '0.008045',
 'logps/chosen': '-35.82', 'logps/rejected': '-35.65', 'epoch': '1'}
100%|█████████████████████████████████████████████████| 2/2 [00:01<00:00, 1.68it/s]
Training loss: 0.6891327500343323
✅ Training completed without crash
```

</details>

**Recommendation for users**

For best training quality with VLMs, prefer `max_length=None` and control memory via `min_pixels`/`max_pixels` in the processor, as documented in the [DPO trainer docs](https://huggingface.co/docs/trl/dpo_trainer#vision-language-models).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized collator change for Qwen-style VLM DPO with max_length; falls back to text-only batch on mismatch and aligns with GRPOTrainer.
> 
> **Overview**
> Fixes a crash when **DPO** vision preference batches use **`max_length`** truncation: slicing **`input_ids`** / **`mm_token_type_ids`** could remove image placeholder tokens while **`pixel_values`** and **`image_grid_thw`** stayed unchanged, triggering *"Image features and image tokens do not match"* in the forward pass.
> 
> **`DataCollatorForVisionPreference`** now compares the count of image tokens in truncated **`mm_token_type_ids`** to the count implied by **`image_grid_thw`** (Qwen-style VLMs). On mismatch it drops **`pixel_values`** and **`image_grid_thw`** and zeros **`mm_token_type_ids`**, matching the existing **`GRPOTrainer`** fallback. Behavior is unchanged when truncation does not break image tokens or when **`max_length`** is unset.
> 
> A regression test **`test_truncation_drops_images_on_mismatch`** exercises aggressive truncation on the tiny Qwen2.5-VL fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0439948e179d9decfbbc5c31a26980a2053070d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->