### PR TITLE
Set kernels optional dependency via transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ deepspeed = [
     "transformers!=5.1.0",  # see transformers#43780
 ]
 kernels = [
-    "kernels<0.15.1",  # see GH-5878
+    "transformers[kernels]",
 ]
 liger = [
     "liger-kernel>=0.8.0"
@@ -104,7 +104,7 @@ dev = [
     # deepspeed
     "deepspeed>=0.14.4",
     # kernels
-    "kernels<0.15.1",  # see GH-5878
+    "transformers[kernels]",
     # liger
     "liger-kernel>=0.8.0",
     # openreward (requires Python 3.11+)


### PR DESCRIPTION
Set `kernels` optional dependency via `transformers[kernels]`.

This PR updates the way the `kernels` dependency is specified in both the main and development dependencies in `pyproject.toml`. Instead of directly depending on the `kernels` package, the project now relies on the `transformers[kernels]` extra, which should simplify dependency management and improve compatibility.

Related to:
- #5878
- #5880

### Motivation

Since TRL does not directly depend on the kernels package itself, the new extra simply re-exports the corresponding transformers extra instead of duplicating its dependency specification. This keeps transformers as the single source of truth for the underlying package requirements and version constraints.

This also ensures we automatically inherit both the lower and upper version bounds defined upstream (and any future updates to them), avoiding duplication in TRL.

### Changes

Dependency management updates:

* Replaced the direct dependency on `kernels<0.15.1` with `transformers[kernels]` in the main dependencies list.
* Updated the development dependencies to use `transformers[kernels]` instead of `kernels<0.15.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime code; install graphs may shift if Transformers' kernels extra differs from the old pin.
> 
> **Overview**
> The **`kernels`** optional extra and the **`dev`** dependency bundle no longer pin **`kernels<0.15.1`** directly. Both now install **`transformers[kernels]`**, so kernel package versions and bounds come from Transformers instead of being duplicated in TRL (related to GH-5878 / #5880).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf88f153082832443bbcd2a67ae8588a34412152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->