### PR TITLE
fix(grpo,rloo): apply generation_config override in use_transformers_paged path

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+import transformers
+from packaging.version import Version
 from transformers import AutoModelForCausalLM
 
-from trl.models.utils import disable_gradient_checkpointing
+from trl.models.utils import _override_model_generation_config, disable_gradient_checkpointing
 
 
 class TestDisableGradientCheckpointing:
@@ -32,3 +35,56 @@ class TestDisableGradientCheckpointing:
         with disable_gradient_checkpointing(model):
             assert model.is_gradient_checkpointing is False
         assert model.is_gradient_checkpointing is True
+
+
+class TestOverrideModelGenerationConfig:
+    """Tests for _override_model_generation_config (workaround for transformers#42762).
+
+    Qwen2.5 models ship with a model-specific generation_config that sets temperature
+    close to 0 (near-greedy). On transformers < 5.0, passing generation_config to
+    model.generate() merges model defaults on top, silently overriding training kwargs
+    such as temperature=1.0. _override_model_generation_config temporarily replaces the
+    model's generation_config with the training kwargs so the merge is a no-op.
+    """
+
+    def test_overrides_model_generation_config_during_context(self):
+        """Inside the context, model.generation_config reflects the training kwargs.
+
+        Only applies to transformers < 5.0; on v5+ the upstream bug is fixed and
+        the context manager is a no-op.
+        """
+        if Version(transformers.__version__) >= Version("5.0.0"):
+            pytest.skip("transformers >= 5.0 fixes the upstream bug; context manager is a no-op")
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        training_kwargs = {"temperature": 1.0, "do_sample": True}
+        with _override_model_generation_config(model, generation_kwargs=training_kwargs):
+            assert model.generation_config.temperature == 1.0
+            assert model.generation_config.do_sample is True
+
+    def test_restores_original_generation_config_after_context(self):
+        """After the context, model.generation_config is restored to its original value."""
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        original_temperature = model.generation_config.temperature
+        original_config_id = id(model.generation_config)
+        training_kwargs = {"temperature": 1.0, "do_sample": True}
+        with _override_model_generation_config(model, generation_kwargs=training_kwargs):
+            pass
+        assert model.generation_config.temperature == original_temperature
+        assert id(model.generation_config) == original_config_id
+
+    def test_no_op_when_generation_kwargs_is_none(self):
+        """When generation_kwargs is None, the context manager yields without modifying the model."""
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        original_config_id = id(model.generation_config)
+        with _override_model_generation_config(model, generation_kwargs=None):
+            assert id(model.generation_config) == original_config_id
+
+    def test_no_op_on_transformers_v5(self):
+        """On transformers >= 5.0 the upstream bug is fixed; the context manager is a no-op."""
+        if Version(transformers.__version__) < Version("5.0.0"):
+            return  # only meaningful on transformers v5+
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        original_config_id = id(model.generation_config)
+        training_kwargs = {"temperature": 1.0}
+        with _override_model_generation_config(model, generation_kwargs=training_kwargs):
+            assert id(model.generation_config) == original_config_id

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1362,7 +1362,10 @@ class GRPOTrainer(_BaseTrainer):
             with (
                 profiling_context(self, "transformers.generate_batch"),
                 unwrap_model_for_generation(
-                    self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
+                    self.model_wrapped,
+                    self.accelerator,
+                    gather_deepspeed3_params=self.args.ds3_gather_for_generation,
+                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model,
                 torch.no_grad(),
                 FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -981,7 +981,10 @@ class RLOOTrainer(_BaseTrainer):
             with (
                 profiling_context(self, "transformers.generate_batch"),
                 unwrap_model_for_generation(
-                    self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
+                    self.model_wrapped,
+                    self.accelerator,
+                    gather_deepspeed3_params=self.args.ds3_gather_for_generation,
+                    generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model,
                 torch.no_grad(),
                 FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),


### PR DESCRIPTION
# What does this PR do?

The `use_transformers_paged` generation path in both `GRPOTrainer` and `RLOOTrainer` was missing the `generation_kwargs` override that the regular path already applies via `_override_model_generation_config`.

On transformers < 5.0, model-specific `generation_config` values (e.g. Qwen2.5 ships with `temperature=0.7`) are silently merged on top of training kwargs during `model.generate()` — see transformers#42762. The regular generation path was already fixed (after the v0.24.0 tag) by passing `generation_kwargs=self.generation_kwargs` to `unwrap_model_for_generation`. The `use_transformers_paged` branch called `unwrap_model_for_generation` without `generation_kwargs`, leaving the same silent bug active: rollouts collapse to near-duplicates, advantage variance → 0, and GRPO/RLOO training silently fails with no error or warning.

Fix: pass `generation_kwargs=self.generation_kwargs` in the `use_transformers_paged` branch of both trainers, matching the comment and pattern already on the regular path. Also adds unit tests for `_override_model_generation_config` (none existed before).

Fixes #5783

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — #5783
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@lewtun @kashif — this touches the GRPO and RLOO generation paths. Happy to make any adjustments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted parity fix in rollout generation plus unit tests; no new APIs or auth/data paths.
> 
> **Overview**
> **Paged Transformers rollout generation** in `GRPOTrainer` and `RLOOTrainer` now passes `generation_kwargs=self.generation_kwargs` into `unwrap_model_for_generation`, matching the non-paged path. That applies the existing `_override_model_generation_config` workaround for [transformers#42762](https://github.com/huggingface/transformers/issues/42762) on transformers &lt; 5.0, so model-shipped defaults (e.g. low temperature on Qwen2.5) no longer override training sampling during `generate_batch`.
> 
> **Tests** add `TestOverrideModelGenerationConfig` in `tests/test_model_utils.py` covering temporary override, restore after context, no-op when kwargs are `None`, and no-op on transformers ≥ 5.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209ac8cb85ecda1e2981519dbf7407bd7dbc05df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->