### PR TITLE
Fix GRPO use_liger_kernel under DeepSpeed ZeRO-3

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -21,7 +21,7 @@ import torch
 import transformers
 from packaging.version import Version
 
-from ..testing_utils import TrlTestCase, require_torch_multi_accelerator
+from ..testing_utils import TrlTestCase, require_liger_kernel, require_torch_multi_accelerator
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -302,6 +302,7 @@ class TestDistributed(TrlTestCase):
         )
         # fmt: on
 
+    @require_liger_kernel
     @pytest.mark.parametrize(
         "config",
         [
@@ -325,8 +326,6 @@ class TestDistributed(TrlTestCase):
         ],
     )
     def test_grpo_liger(self, config, get_config_path):
-        # `use_liger_kernel` makes GRPO read `lm_head.weight` outside `model.forward()`; under ZeRO-3 the weight is
-        # partitioned, so without an explicit allgather the fused matmul sees an empty shard (see #3368).
         # fmt: off
         run_command(
             [

--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -301,3 +301,43 @@ class TestDistributed(TrlTestCase):
             os.environ.copy(),
         )
         # fmt: on
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            "ddp",
+            pytest.param(
+                "zero2",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.1.0"),
+                    reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
+                ),
+            ),
+            pytest.param(
+                "zero3",
+                marks=pytest.mark.xfail(
+                    Version("5.0.0") <= Version(transformers.__version__) < Version("5.5.4"),
+                    reason="ZeRO-3 fails with transformers >= 5.0.0 and < 5.5.4 (fixed in transformers#45414), see #4899",
+                    strict=True,
+                ),
+            ),
+            "fsdp2",
+        ],
+    )
+    def test_grpo_liger(self, config, get_config_path):
+        # `use_liger_kernel` makes GRPO read `lm_head.weight` outside `model.forward()`; under ZeRO-3 the weight is
+        # partitioned, so without an explicit allgather the fused matmul sees an empty shard (see #3368).
+        # fmt: off
+        run_command(
+            [
+                "accelerate", "launch", "--config_file", get_config_path(config), "trl/scripts/grpo.py",
+                "--output_dir", self.tmp_dir,
+                "--model_name_or_path", "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                "--dataset_name", "trl-internal-testing/zen",
+                "--dataset_config", "conversational_prompt_only",
+                "--reward_model_name_or_path", "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                "--use_liger_kernel",
+            ],
+            os.environ.copy(),
+        )
+        # fmt: on

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import atexit
-import contextlib
 import copy
 import importlib.resources as pkg_resources
 import inspect
@@ -129,22 +128,6 @@ class _SupportsReset(Protocol):
 
 
 EnvironmentFactory = Callable[[], _SupportsReset]
-
-
-def _maybe_gather_lm_head_ctx(w, b):
-    # Allgather ZeRO-3 partitioned `lm_head` weight/bias for the chunked matmul. No-op if not ZeRO-3, or if the
-    # param is already gathered (tied embeddings: `embed_tokens` shares the weight and keeps it `AVAILABLE`, so
-    # partitioning on our exit would collide with its active-submodule tracking).
-    params = [w] if b is None else [w, b]
-    if not any(hasattr(p, "ds_id") for p in params):
-        return contextlib.nullcontext()
-    from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
-
-    if all(p.ds_status == ZeroParamStatus.AVAILABLE for p in params):
-        return contextlib.nullcontext()
-    import deepspeed
-
-    return deepspeed.zero.GatheredParameters(params)
 
 
 class GRPOTrainer(_BaseTrainer):
@@ -2342,13 +2325,23 @@ class GRPOTrainer(_BaseTrainer):
 
         # Apply tool_mask (from env_mask) for loss computation in multi-turn training scenarios
         loss_mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
-        # Compute loss and metrics using liger grpo loss. Liger reads `lm_head.weight`/`bias` directly (not through
-        # `model.forward()`), so under DeepSpeed ZeRO-3 the gather hooks never fire and the partitioned shards stay
-        # empty, yielding a size mismatch in the fused matmul. Gather them for the call; the grad w.r.t. the weight is
-        # computed eagerly during this forward, so the gathered weight is only needed here, not in the backward.
         lm_head_weight = unwrapped_model.lm_head.weight
         lm_head_bias = unwrapped_model.lm_head.bias
-        with _maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+        # Liger reads `lm_head` directly instead of through `model.forward()`, so its ZeRO-3 gather hook never fires
+        # and the fused matmul gets an empty shard. Gather the weight/bias ourselves for the call (the weight grad is
+        # computed during this forward, so it isn't needed in the backward). Skip it when already gathered: with tied
+        # embeddings `embed_tokens` keeps the weight `AVAILABLE`, and re-partitioning on exit breaks its tracking.
+        deepspeed_plugin = self.accelerator.state.deepspeed_plugin
+        gather_ctx = nullcontext()
+        if deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3:
+            from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+
+            params = [lm_head_weight] if lm_head_bias is None else [lm_head_weight, lm_head_bias]
+            if any(p.ds_status != ZeroParamStatus.AVAILABLE for p in params):
+                import deepspeed
+
+                gather_ctx = deepspeed.zero.GatheredParameters(params)
+        with gather_ctx:
             loss, metrics = self.liger_grpo_loss(
                 _input=last_hidden_state,
                 lin_weight=lm_head_weight,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import atexit
+import contextlib
 import copy
 import importlib.resources as pkg_resources
 import inspect
@@ -128,6 +129,22 @@ class _SupportsReset(Protocol):
 
 
 EnvironmentFactory = Callable[[], _SupportsReset]
+
+
+def _maybe_gather_lm_head_ctx(w, b):
+    # Allgather ZeRO-3 partitioned `lm_head` weight/bias for the chunked matmul. No-op if not ZeRO-3, or if the
+    # param is already gathered (tied embeddings: `embed_tokens` shares the weight and keeps it `AVAILABLE`, so
+    # partitioning on our exit would collide with its active-submodule tracking).
+    params = [w] if b is None else [w, b]
+    if not any(hasattr(p, "ds_id") for p in params):
+        return contextlib.nullcontext()
+    from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+
+    if all(p.ds_status == ZeroParamStatus.AVAILABLE for p in params):
+        return contextlib.nullcontext()
+    import deepspeed
+
+    return deepspeed.zero.GatheredParameters(params)
 
 
 class GRPOTrainer(_BaseTrainer):
@@ -2325,19 +2342,25 @@ class GRPOTrainer(_BaseTrainer):
 
         # Apply tool_mask (from env_mask) for loss computation in multi-turn training scenarios
         loss_mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
-        # Compute loss and metrics using liger grpo loss
-        loss, metrics = self.liger_grpo_loss(
-            _input=last_hidden_state,
-            lin_weight=unwrapped_model.lm_head.weight,
-            selected_token_ids=completion_ids,
-            # The attention_mask parameter in liger loss is actually used as a loss mask (not model attention)
-            attention_mask=loss_mask,
-            advantages=inputs["advantages"],
-            bias=unwrapped_model.lm_head.bias,
-            old_per_token_logps=inputs.get("old_per_token_logps"),
-            ref_per_token_logps=inputs.get("ref_per_token_logps"),
-            vllm_is_ratio=inputs.get("importance_sampling_ratio"),
-        )
+        # Compute loss and metrics using liger grpo loss. Liger reads `lm_head.weight`/`bias` directly (not through
+        # `model.forward()`), so under DeepSpeed ZeRO-3 the gather hooks never fire and the partitioned shards stay
+        # empty, yielding a size mismatch in the fused matmul. Gather them for the call; the grad w.r.t. the weight is
+        # computed eagerly during this forward, so the gathered weight is only needed here, not in the backward.
+        lm_head_weight = unwrapped_model.lm_head.weight
+        lm_head_bias = unwrapped_model.lm_head.bias
+        with _maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+            loss, metrics = self.liger_grpo_loss(
+                _input=last_hidden_state,
+                lin_weight=lm_head_weight,
+                selected_token_ids=completion_ids,
+                # The attention_mask parameter in liger loss is actually used as a loss mask (not model attention)
+                attention_mask=loss_mask,
+                advantages=inputs["advantages"],
+                bias=lm_head_bias,
+                old_per_token_logps=inputs.get("old_per_token_logps"),
+                ref_per_token_logps=inputs.get("ref_per_token_logps"),
+                vllm_is_ratio=inputs.get("importance_sampling_ratio"),
+            )
         # Extract metrics from the liger_grpo_loss output
         # KL divergence is the first metric when beta is non-zero
         mean_kl = metrics[0] if self.beta != 0.0 else None

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2340,7 +2340,7 @@ class GRPOTrainer(_BaseTrainer):
             if any(p.ds_status != ZeroParamStatus.AVAILABLE for p in params):
                 import deepspeed
 
-                gather_ctx = deepspeed.zero.GatheredParameters(params)
+                gather_ctx = deepspeed.zero.GatheredParameters(params, modifier_rank=None)
         with gather_ctx:
             loss, metrics = self.liger_grpo_loss(
                 _input=last_hidden_state,


### PR DESCRIPTION
## What this fixes

`use_liger_kernel=True` + DeepSpeed ZeRO-3 in GRPO crashes with a size mismatch. The matrix below is what people have been hitting (see #3368):

- ✅ liger + zero2
- ✅ no-liger + zero3
- ❌ liger + zero3 → size mismatch

## Why

In `compute_liger_loss` we hand `unwrapped_model.lm_head.weight` straight to the Liger fused loss. Under ZeRO-3 that weight is sharded across ranks, and since Liger reads it by attribute access instead of going through `model.forward()`, DeepSpeed's gather hook never fires. So on the partitioned ranks the fused matmul gets an empty shard and blows up.

## Fix

Wrap the Liger call in a `GatheredParameters` context so the full `lm_head` weight/bias are all-gathered for the matmul, then re-partitioned on exit. This is the same `_maybe_gather_lm_head_ctx` pattern we use for SFT's chunked-NLL path. It's a no-op when not on ZeRO-3, or when the weight is already gathered (tied embeddings keep it `AVAILABLE`).

We only need the gathered weight during the forward: `LigerFusedLinearGRPOLoss` computes the gradient w.r.t. the weight eagerly inside the forward and saves it for backward, so re-partitioning before `backward()` is fine.

## Test

Added `test_grpo_liger` to the distributed suite, parametrized over ddp / zero2 / zero3 / fsdp2 with `--use_liger_kernel` (mirrors the existing `test_grpo`).

Closes #3368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GRPO training loss under ZeRO-3 and tied-embedding edge cases; scope is narrow and covered by new distributed tests.
> 
> **Overview**
> Fixes a crash when **GRPO** runs with **`use_liger_kernel`** under **DeepSpeed ZeRO-3**: Liger reads `lm_head` weights directly, so ZeRO-3 never gathers shards and the fused matmul fails with a size mismatch.
> 
> In **`compute_liger_loss`**, the Liger call is wrapped in **`deepspeed.zero.GatheredParameters`** for `lm_head` weight/bias when ZeRO-3 is active and params are not already `AVAILABLE` (e.g. tied embeddings). Otherwise behavior is unchanged.
> 
> Adds distributed **`test_grpo_liger`** (ddp / zero2 / zero3 / fsdp2) mirroring **`test_grpo`** with **`--use_liger_kernel`**, gated by **`require_liger_kernel`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d345ed1f18e31173889e345b7b6b9aaadf7a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->