### PR TITLE
async grpo native weight sync with vllm>=0.22.0

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -442,7 +442,6 @@ class AsyncGRPOTrainer(_BaseTrainer):
                         "dtype_names": weight_dtype_names,
                         "shapes": weight_shapes,
                         "packed": True,
-                        "is_checkpoint_format": True,
                     },
                 )
                 self.rollout_worker = AsyncRolloutWorker(

--- a/trl/experimental/async_grpo/weight_transfer.py
+++ b/trl/experimental/async_grpo/weight_transfer.py
@@ -21,7 +21,7 @@ from accelerate.logging import get_logger
 from trl.import_utils import is_vllm_available
 
 
-if is_vllm_available(min_version="0.17.1"):
+if is_vllm_available(min_version="0.22.0"):
     from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerSendWeightsArgs, NCCLWeightTransferEngine
     from vllm.utils.network_utils import get_ip, get_open_port
 
@@ -37,9 +37,9 @@ class WeightTransferClient:
         server_timeout: float = 240.0,
         init_weight_transfer_timeout: int = 1800,
     ):
-        if not is_vllm_available(min_version="0.17.1"):
+        if not is_vllm_available(min_version="0.22.0"):
             raise ImportError(
-                "vLLM >= 0.17.1 is required to use WeightTransferClient. Install it with: pip install 'vllm>=0.17.1'"
+                "vLLM >= 0.22.0 is required to use WeightTransferClient. Install it with: pip install 'vllm>=0.22.0'"
             )
         self.vllm_server_url = vllm_server_url.rstrip("/")
         self.server_timeout = server_timeout
@@ -103,25 +103,27 @@ class WeightTransferClient:
         if self.model_update_group is None:
             return
         t0 = time.time()
+        # Prepare the workers for the reload; must complete before any weights are sent.
+        requests.post(
+            f"{self.vllm_server_url}/start_weight_update",
+            json={"is_checkpoint_format": True},
+            timeout=1800,
+        )
+        # The /update_weights POST drives the workers' blocking NCCL recv, so it runs on a thread
+        # concurrently with the trainer-side broadcast.
         t_update = threading.Thread(
             target=requests.post,
             args=(f"{self.vllm_server_url}/update_weights",),
             kwargs={"json": {"update_info": self._weight_update_info}, "timeout": 1800},
         )
         t_update.start()
-        logger.debug(f"[weight_sync] /update_weights POST sent ({time.time() - t0:.1f}s)")
-        t_nccl = time.time()
         NCCLWeightTransferEngine.trainer_send_weights(
             iterator=iterator,
             trainer_args=NCCLTrainerSendWeightsArgs(group=self.model_update_group, packed=True),
         )
-        logger.debug(f"[weight_sync] NCCL transfer took {time.time() - t_nccl:.1f}s")
-        t_join = time.time()
         t_update.join()
-        logger.debug(
-            f"[weight_sync] /update_weights join took {time.time() - t_join:.1f}s "
-            f"(total send_weights: {time.time() - t0:.1f}s)"
-        )
+        requests.post(f"{self.vllm_server_url}/finish_weight_update", timeout=1800)
+        logger.debug(f"[weight_sync] send_weights took {time.time() - t0:.1f}s")
 
     def pause(self) -> None:
         t0 = time.time()


### PR DESCRIPTION
### What this implements

Wires AsyncGRPO's WeightTransferClient to vLLM's native RL weight-transfer API (the 4-phase protocol from the 2026-05-28 native RL APIs post
(https://vllm.ai/blog/2026-05-28-native-rl-apis)), replacing the previous 2-call flow.

Per weight sync, WeightTransferClient.send_weights() now drives the full lifecycle:

```bash
pause(mode="keep")
→ start_weight_update(is_checkpoint_format=True)   # workers run initialize_layerwise_reload
→ update_weights(update_info)                      # threaded; concurrent with the trainer NCCL broadcast
→ finish_weight_update()                           # workers run finalize_layerwise_reload
→ resume()
```

### Reference implementations

- vLLM weight-transfer docs: https://docs.vllm.ai/en/latest/training/weight_transfer/
- vLLM RL examples (HTTP + NCCL): https://github.com/vllm-project/vllm/tree/main/examples/rl  in particular rlhf_http_nccl.py (same 4-phase order an concurrent update_weights/broadcast) and rlhf_async_new_apis.py (pause(mode="keep")).

## Validation

End-to-end on H100 (Qwen3-0.6B, GSM8K) at three scales, all completing with healthy GRPO metrics; server logs show paired start/finish bracketing every `update_weights`:

| Scale | Layout | weight_sync_time |
|-------|--------|-----------------|
| 1 node | trainer×1 + vLLM TP=1 | ~0.18s |
| 1 node | trainer FSDP2×4 + vLLM TP=4 | ~0.24s |
| 2 nodes | trainer FSDP2×4 + vLLM DP=2×TP=4 | ~0.8s (cross-node) |

> **Runtime note:** vLLM ≥0.22 ships CUDA-13 wheels by default; on a CUDA-12.9 driver use the `+cu129` vLLM release wheel + `torch==2.11.0+cu128`.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot path that pushes trainer weights to the vLLM rollout server; mis-ordering or version skew would break training sync, though it follows vLLM’s documented RL API.
> 
> **Overview**
> Updates **Async GRPO** weight sync to match vLLM **≥0.22.0**’s native RL weight-transfer lifecycle instead of the older two-endpoint flow.
> 
> `WeightTransferClient.send_weights()` now calls **`start_weight_update`** (`is_checkpoint_format: true`) before weights, then the existing threaded **`update_weights`** + NCCL broadcast, then **`finish_weight_update`**. Checkpoint-format is no longer passed in the static `weight_update_info` built in `AsyncGRPOTrainer`. The minimum vLLM version for `WeightTransferClient` is raised from **0.17.1** to **0.22.0** (imports and error messages updated). Per-phase debug timing logs in `send_weights` are collapsed to a single total timing line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e828e149b65c286f0982173a266fccfcd56ac2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->