### PR TITLE
`AsyncGRPOTrainer`: add `model_init_kwargs` support

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -95,6 +95,27 @@ class _StubRolloutWorker:
 
 
 class TestAsyncGRPOTrainer(TrlTestCase):
+    def test_model_init_kwargs(self):
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+
+        training_args = AsyncGRPOConfig(
+            output_dir=self.tmp_dir,
+            model_init_kwargs={"dtype": "bfloat16"},
+            report_to="none",
+        )
+        trainer = AsyncGRPOTrainer(
+            model=model_id,
+            reward_funcs=dummy_reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            rollout_worker=_StubRolloutWorker(AutoTokenizer.from_pretrained(model_id), dataset, num_generations=8),
+        )
+
+        # Verify model was loaded in bfloat16
+        for param in trainer.model.parameters():
+            assert param.dtype == torch.bfloat16, f"Expected bfloat16 but got {param.dtype}"
+
     def test_init_minimal(self):
         # Test that AsyncGRPOTrainer can be instantiated with only model, reward_model and train_dataset
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"

--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from trl.trainer.base_config import _BaseConfig
 
@@ -28,6 +29,12 @@ class AsyncGRPOConfig(_BaseConfig):
     in this class may differ from those in [`~transformers.TrainingArguments`].
 
     Parameters:
+        > Parameters that control the model
+
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
+            Keyword arguments for `from_pretrained`, used when the `model` argument of the [`AsyncGRPOTrainer`] is
+            provided as a string.
+
         > Parameters that control generation
 
         num_generations (`int`, *optional*, defaults to `8`):
@@ -92,6 +99,8 @@ class AsyncGRPOConfig(_BaseConfig):
     > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
+    _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs"]
+
     # Parameters whose default values are overridden from TrainingArguments
     learning_rate: float = field(
         default=1e-6,
@@ -102,6 +111,15 @@ class AsyncGRPOConfig(_BaseConfig):
         metadata={
             "help": "Log every X update steps. Should be an integer or a float in range `[0,1)`. If smaller than 1, "
             "will be interpreted as ratio of total training steps."
+        },
+    )
+
+    # Parameters that control the model
+    model_init_kwargs: dict[str, Any] | str | None = field(
+        default=None,
+        metadata={
+            "help": "Keyword arguments for `from_pretrained`, used when the `model` argument of the "
+            "`AsyncGRPOTrainer` is provided as a string."
         },
     )
 

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -27,11 +27,11 @@ from accelerate.logging import get_logger
 from datasets import Dataset, IterableDataset
 from torch.distributed._tensor import DTensor
 from torch.utils.data import DataLoader
-from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase, TrainerCallback
+from transformers import AutoTokenizer, PreTrainedTokenizerBase, TrainerCallback
 from transformers.data.data_collator import DataCollatorMixin
 
 from trl.trainer.base_trainer import _BaseTrainer
-from trl.trainer.utils import pad, patch_chunked_lm_head
+from trl.trainer.utils import create_model_from_path, pad, patch_chunked_lm_head
 
 from .async_grpo_config import AsyncGRPOConfig
 from .async_rollout_worker import AsyncRolloutWorker
@@ -300,7 +300,10 @@ class AsyncGRPOTrainer(_BaseTrainer):
 
         # Model
         model_name = model
-        model = AutoModelForCausalLM.from_pretrained(model, device_map=None, dtype=torch.float32)
+        model_init_kwargs = self.args.model_init_kwargs or {}
+        # FSDP2 requires device_map=None ("auto" fails)
+        model_init_kwargs["device_map"] = None
+        model = create_model_from_path(model, **model_init_kwargs)
 
         if self.args.use_liger_kernel:
             raise NotImplementedError("`use_liger_kernel` is not supported yet.")


### PR DESCRIPTION

# What does this PR do?

Adds `model_init_kwargs` support to `AsyncGRPOTrainer`, matching the existing behavior in `GRPOTrainer`.

Currently, `AsyncGRPOTrainer` hardcodes `AutoModelForCausalLM.from_pretrained(model, device_map=None, dtype=torch.float32)`, which prevents passing custom kwargs like `attn_implementation` or `dtype`. This PR:

- Adds `model_init_kwargs` field to `AsyncGRPOConfig` (with `_VALID_DICT_FIELDS` for dict serialization support)
- Replaces direct `AutoModelForCausalLM` loading with `create_model_from_path(model, **model_init_kwargs)`, which infers the correct architecture class from the model config (important for models like Qwen3.5 that use `Qwen3_5ForConditionalGeneration` instead of a standard CausalLM)
- Enforces `device_map=None` for FSDP2 compatibility

**Changes:**
- `async_grpo_config.py`: add `model_init_kwargs` field + docstring + `_VALID_DICT_FIELDS`
- `async_grpo_trainer.py`: replace `AutoModelForCausalLM` with `create_model_from_path`, update imports

**Tests:**
- `test_model_init_kwargs`: verifies that `model_init_kwargs={"dtype": "bfloat16"}` results in bfloat16 model parameters

Closes part of https://github.com/huggingface/trl/issues/5831

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to model instantiation with an existing shared helper and a focused unit test; no auth or rollout pipeline logic changes.
> 
> **Overview**
> **`AsyncGRPOTrainer`** can now take optional **`model_init_kwargs`** on **`AsyncGRPOConfig`**, aligned with **`GRPOTrainer`**, so string model IDs accept `from_pretrained` options (e.g. **`dtype`**, **`attn_implementation`**) instead of a fixed **`AutoModelForCausalLM`** load with **`dtype=torch.float32`**.
> 
> Loading goes through **`create_model_from_path`**, which picks the architecture from the hub config (not only causal LM). **`device_map=None`** is always applied for FSDP2. A test asserts **`bfloat16`** parameters when **`model_init_kwargs={"dtype": "bfloat16"}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b925002ba423c480f6fe7abcd704e5f8ddf66c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->