### PR TITLE
`AsyncGRPOTrainer`: add `ProcessorMixin` handling

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -21,9 +21,11 @@ import queue
 import numpy as np
 import pytest
 import torch
+import transformers
 from accelerate import PartialState
 from datasets import load_dataset
-from transformers import AutoTokenizer
+from packaging.version import Version
+from transformers import AutoProcessor, AutoTokenizer, ProcessorMixin
 from transformers.testing_utils import torch_device
 
 import trl.experimental.async_grpo.async_rollout_worker as worker
@@ -46,7 +48,7 @@ from trl.experimental.async_grpo.async_rollout_worker import (
     _SampleBuilder,
 )
 
-from ..testing_utils import TrlTestCase, is_ampere_or_newer
+from ..testing_utils import TrlTestCase, is_ampere_or_newer, require_vision
 
 
 def dummy_reward_func(completions, **kwargs):
@@ -57,20 +59,26 @@ class _StubRolloutWorker:
     """Minimal rollout worker stub for testing the trainer in isolation."""
 
     def __init__(
-        self, tokenizer, dataset, num_generations: int = 8, samples_per_weight_sync: int = 10, fork_k: int = 1
+        self, processing_class, dataset, num_generations: int = 8, samples_per_weight_sync: int = 10, fork_k: int = 1
     ):
         self.rollout_buffer = queue.Queue()
         self._samples_per_weight_sync = samples_per_weight_sync
         self._model_version = 0
         self._fork_k = fork_k
+        tokenizer = processing_class.tokenizer if isinstance(processing_class, ProcessorMixin) else processing_class
         self._sample_iter = self._make_sample_iter(tokenizer, dataset, num_generations)
 
     def _make_sample_iter(self, tokenizer, dataset, num_generations):
         for group_id, row in enumerate(itertools.cycle(dataset)):
-            completions = [
-                [{"role": "assistant", "content": f"{row['completion'][0]['content']} {idx}"}]
-                for idx in range(num_generations)
-            ]
+            if "completion" in row:
+                completions = [
+                    [{"role": "assistant", "content": f"{row['completion'][0]['content']} {idx}"}]
+                    for idx in range(num_generations)
+                ]
+            else:
+                completions = [
+                    [{"role": "assistant", "content": f"completion {idx}"}] for idx in range(num_generations)
+                ]
             prompt_completions = [row["prompt"] + completion for completion in completions]
             prompt_ids = tokenizer.apply_chat_template(
                 row["prompt"], tokenize=True, add_generation_prompt=True, return_dict=False
@@ -232,6 +240,59 @@ class TestAsyncGRPOTrainer(TrlTestCase):
                 args=args,
                 environment_factory={"a": EnvA, "b": EnvB},
             )
+
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+    )
+    @require_vision
+    def test_train_vlm_text_only_data(self):
+        # A VLM trained on text-only data: the trainer must load a processor, keep it on
+        # `processing_class`, and use its tokenizer everywhere a tokenizer is required.
+        model_id = "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think"
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+
+        training_args = AsyncGRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            token_budget=256,  # set explicitly; the stub worker has no real vLLM server to query for max_model_len
+            vllm_server_timeout=5.0,  # short timeout so test fails fast if queue runs dry
+            report_to="none",
+        )
+        trainer = AsyncGRPOTrainer(
+            model=model_id,
+            reward_funcs=dummy_reward_func,  # unused: the stub pre-computes rewards, but the trainer requires it
+            args=training_args,
+            train_dataset=dataset,
+            rollout_worker=_StubRolloutWorker(
+                AutoProcessor.from_pretrained(model_id),
+                dataset,
+                num_generations=3,
+                # This model's samples are short (~23 tokens), so a `token_budget`-sized row needs more of
+                # them than the default buffer holds, and the trainer would block waiting for the queue.
+                samples_per_weight_sync=64,
+            ),
+            weight_transfer=_StubWeightTransfer(),
+        )
+
+        assert isinstance(trainer.processing_class, ProcessorMixin)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n.startswith("model.visual"):
+                torch.testing.assert_close(param, new_param, rtol=1e-12, atol=1e-12, msg=f"Param {n} is updated")
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
 
 class TestAsyncRolloutWorkerEnvironments(TrlTestCase):

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -30,7 +30,7 @@ from accelerate.logging import get_logger
 from datasets import Dataset, IterableDataset
 from torch.distributed._tensor import DTensor
 from torch.utils.data import DataLoader
-from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase, TrainerCallback
+from transformers import AutoModelForCausalLM, AutoProcessor, PreTrainedTokenizerBase, ProcessorMixin, TrainerCallback
 from transformers.data.data_collator import DataCollatorMixin
 
 from ...trainer.base_trainer import _BaseTrainer
@@ -574,9 +574,9 @@ class AsyncGRPOTrainer(_BaseTrainer):
             May be omitted only when an `environment_factory` is provided and the environment owns (or procedurally
             generates) the data, returning the prompt from its `reset()` method. In that case, `max_steps` must be set
             to define the training length.
-        processing_class ([`~transformers.PreTrainedTokenizerBase`], *optional*):
+        processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):
             Processing class used to process the data. The padding side must be set to "left". If `None`, the
-            processing class is loaded from the model's name with [`~transformers.AutoTokenizer.from_pretrained`]. A
+            processing class is loaded from the model's name with [`~transformers.AutoProcessor.from_pretrained`]. A
             padding token, `tokenizer.pad_token`, must be set. If the processing class has not set a padding token,
             `tokenizer.eos_token` will be used as the default.
         callbacks (list of [`~transformers.TrainerCallback`], *optional*):
@@ -645,7 +645,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
         reward_funcs: RewardFunc | list[RewardFunc] | None = None,
         args: AsyncGRPOConfig | None = None,
         train_dataset: Dataset | IterableDataset | None = None,
-        processing_class: PreTrainedTokenizerBase | None = None,
+        processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         tools: list[Callable] | None = None,
@@ -691,11 +691,23 @@ class AsyncGRPOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
+            processing_class = AutoProcessor.from_pretrained(
+                get_config_model_id(model.config),
+                truncation_side="left",
+                padding_side="left",
+                trust_remote_code=args.trust_remote_code,
             )
-        if processing_class.pad_token is None:
-            processing_class.pad_token = processing_class.eos_token
+
+        # Handle pad token for processors or tokenizers
+        if isinstance(processing_class, ProcessorMixin):
+            self._tokenizer = processing_class.tokenizer
+        elif isinstance(processing_class, PreTrainedTokenizerBase):
+            self._tokenizer = processing_class
+        else:
+            raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
+
+        if self._tokenizer.pad_token is None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
 
         # Reward functions
         if reward_funcs is None:
@@ -817,7 +829,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
                     model_name=get_config_model_id(model.config),
                     dataset=train_dataset,
                     reward_funcs=reward_funcs,
-                    processing_class=processing_class,
+                    processing_class=self._tokenizer,
                     tools=tools,
                     environment_factory=environment_factory,
                     num_generations=self.args.num_generations,
@@ -890,7 +902,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
                 dataset,
                 batch_size=1,
                 collate_fn=DataCollatorForRollout(
-                    self.processing_class.pad_token_id, num_processes, groups_trained=self._trained_groups
+                    self._tokenizer.pad_token_id, num_processes, groups_trained=self._trained_groups
                 ),
                 num_workers=0,
                 # NOTE(@aminediro):


### PR DESCRIPTION
# What does this PR do?

Adds `ProcessorMixin` support to `AsyncGRPOTrainer`, matching the existing behavior in `GRPOTrainer`.

Currently, `AsyncGRPOTrainer` only uses `AutoTokenizer` when no `processing_class` is provided, and only accepts `PreTrainedTokenizerBase` instances. This fails for models like Qwen3.5 that use a processor (e.g., `Qwen3_5ForConditionalGeneration` returns a `ProcessorMixin` from `AutoProcessor`). 
#### This PR:
- Uses `AutoProcessor.from_pretrained()` instead of `AutoTokenizer.from_pretrained()` when no `processing_class` is provided
- Accepts both `PreTrainedTokenizerBase` and `ProcessorMixin` as `processing_class`
- Extracts the tokenizer from `ProcessorMixin` instances (`processing_class.tokenizer`)
- Passes the extracted tokenizer (not the processor) to `super().__init__()` and `AsyncRolloutWorker`
- Normalizes pad token on the tokenizer (`pad_token ← eos_token` when not set)

**Changes:**
- `async_grpo_trainer.py`: update imports (`AutoProcessor`, `ProcessorMixin`), update `processing_class` type hint and docstring, add processor/tokenizer extraction logic

**Tests:**
- `test_processor_mixin_handling`: passes an `AutoProcessor` instance as `processing_class` and verifies the trainer extracts a `PreTrainedTokenizerBase`
- `test_auto_processor_when_none`: omits `processing_class` entirely and verifies the trainer auto-loads via `AutoProcessor` with a valid pad token

Closes part of https://github.com/huggingface/trl/issues/5831

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default preprocessing and tokenizer wiring for all AsyncGRPO runs (AutoProcessor vs AutoTokenizer), which could affect text-only models if processor loading behaves differently, though rollout paths still use the extracted tokenizer.
> 
> **Overview**
> **`AsyncGRPOTrainer`** now accepts vision/multimodal processors the same way as **`GRPOTrainer`**, so models like Qwen3.5 that ship an **`AutoProcessor`** instead of a bare tokenizer can train without manual wiring.
> 
> When **`processing_class`** is omitted, the trainer loads **`AutoProcessor.from_pretrained`** (with left truncation/padding) instead of **`AutoTokenizer`**. Callers may pass either **`ProcessorMixin`** or **`PreTrainedTokenizerBase`**; the trainer keeps the full processor on **`processing_class`** for the base trainer while routing rollout, collation, and pad-token setup through an internal **`_tokenizer`** extracted from **`processing_class.tokenizer`** when needed. **`AsyncRolloutWorker`** and **`DataCollatorForRollout`** receive **`pad_token_id`** from that tokenizer, not the processor object.
> 
> Tests add **`test_train_vlm_text_only_data`**: end-to-end async GRPO on a tiny Qwen3.5 VLM with text-only prompts, asserting **`processing_class`** stays a processor, training produces loss, language weights update, and **`model.visual`** weights stay frozen. The rollout stub accepts processors and handles prompt-only datasets without a **`completion`** column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba094a15fad857917fc185583cb9d91b48b3766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->