### PR TITLE
SFTTrainer: merge entropy and accuracy computation to eliminate redundant logits copy

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1631,16 +1631,26 @@ class SFTTrainer(_BaseTrainer):
                 ):
                     shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
 
+                # Compute entropy and accuracy together to avoid a second .contiguous() copy of logits
                 per_token_entropy = entropy_from_logits(shift_logits)
+                predictions = shift_logits.argmax(dim=-1)
                 mask = shift_labels != -100
+
                 entropy_sum = (per_token_entropy * mask).sum()
                 total_tokens = mask.sum()
+                correct_predictions = (predictions == shift_labels) & mask
+                correct_tokens = correct_predictions.sum()
 
                 # Gather counts across ranks and weight-average
                 entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
                 total_tokens = self.accelerator.gather_for_metrics(total_tokens).sum()
+                correct_tokens = self.accelerator.gather_for_metrics(correct_tokens)
                 entropy = (entropy_sum / total_tokens).item() if total_tokens > 0 else 0.0
+
+                total_sum = total_tokens.sum()
+                accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
             self._metrics[mode]["entropy"].append(entropy)
+            self._metrics[mode]["mean_token_accuracy"].append(accuracy)
 
         if mode == "train":
             # When using padding-free, the attention_mask is not present in the inputs, instead we have cu_seq_lens_q,
@@ -1669,46 +1679,6 @@ class SFTTrainer(_BaseTrainer):
                     "not be logged. This is unexpected; please report it to the liger-kernel repository.",
                     stacklevel=2,
                 )
-        else:
-            # Compute accuracy from logits using argmax (traditional method)
-            with torch.no_grad():
-                if "shift_labels" in inputs:
-                    # When using CP or SP, labels are pre-shifted. We must use these (and cannot manually shift) because:
-                    # - The first discarded token from inputs["labels"] actually belongs to process n-1
-                    # - The last logits require the label from process n+1
-                    shift_logits = outputs.logits.contiguous()
-                    shift_labels = inputs["shift_labels"]
-                else:
-                    shift_logits = outputs.logits[..., :-1, :].contiguous()
-                    shift_labels = labels[..., 1:].contiguous()
-
-                # Prompt Tuning and P-Tuning output logits for virtual tokens but Prefix-Tuning does not.
-                if (
-                    self.num_virtual_tokens > 0
-                    and model.peft_config[model.active_adapter].peft_type != PeftType.PREFIX_TUNING
-                ):
-                    shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
-
-                # Get predictions
-                predictions = shift_logits.argmax(dim=-1)
-
-                # Create mask for non-padding tokens (assuming ignore_index is -100)
-                mask = shift_labels != -100
-
-                # Calculate accuracy only on non-padding tokens
-                correct_predictions = (predictions == shift_labels) & mask
-                total_tokens = mask.sum()
-                correct_tokens = correct_predictions.sum()
-
-                # Gather the correct_tokens and total_tokens across all processes
-                correct_tokens = self.accelerator.gather_for_metrics(correct_tokens)
-                total_tokens = self.accelerator.gather_for_metrics(total_tokens)
-
-                # Compute the mean token accuracy and log it
-                total_sum = total_tokens.sum()
-                accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
-                self._metrics[mode]["mean_token_accuracy"].append(accuracy)
-
         # Log auxiliary loss if enabled (applies to both Liger and non-Liger)
         if self.aux_loss_enabled:
             aux_loss = outputs.aux_loss

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1631,7 +1631,6 @@ class SFTTrainer(_BaseTrainer):
                 ):
                     shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
 
-                # Compute entropy and accuracy together to avoid a second .contiguous() copy of logits
                 per_token_entropy = entropy_from_logits(shift_logits)
                 predictions = shift_logits.argmax(dim=-1)
                 mask = shift_labels != -100


### PR DESCRIPTION
**PR Title**

`SFTTrainer: merge entropy and accuracy computation to eliminate redundant logits copy`

**PR Description**

## What does this PR do?

Merges the entropy and token accuracy computations in `SFTTrainer.compute_loss` into a single `torch.no_grad()` block, eliminating a redundant `.contiguous()` copy of the full logits tensor.

When `loss_type="nll"` (the default) and Liger kernel is not used, `compute_loss` previously materialized `shift_logits = outputs.logits[..., :-1, :].contiguous()` **twice** — once for entropy calculation and once for accuracy calculation. The logits tensor shape is `[batch_size, seq_len, vocab_size]` — for a model with `vocab_size` ~152k (e.g. Qwen2.5), this is one of the largest allocations in `compute_loss`. The second copy is entirely redundant since both metrics operate on the same shifted logits.

### Changes:

- Moved `predictions = shift_logits.argmax(dim=-1)` and accuracy computation into the existing entropy `torch.no_grad()` block, reusing the same `shift_logits` tensor
- Removed the separate accuracy `else` branch that performed a second `.contiguous()` call
- Net reduction of ~20 lines of code

## Memory benchmark

Benchmark script (not included in this PR):

```python
import gc
import torch
from datasets import load_dataset
from trl import SFTConfig, SFTTrainer

if not torch.cuda.is_available():
    print("ERROR: No CUDA GPU available.")
    exit(1)

gc.collect()
torch.cuda.empty_cache()
torch.cuda.reset_peak_memory_stats()

dataset = load_dataset("trl-lib/Capybara", split="train[:200]")

args = SFTConfig(
    output_dir="/tmp/sft_peak_bench",
    per_device_train_batch_size=4,
    max_steps=3,
    max_length=1024,
    gradient_checkpointing=True,
    bf16=True,
    report_to="none",
    logging_steps=1,
    loss_type="nll",
)

trainer = SFTTrainer(model="Qwen/Qwen2.5-0.5B-Instruct", args=args, train_dataset=dataset)
trainer.train()

peak_mb = torch.cuda.max_memory_allocated() / 1024**2
print(f"\nPeak allocated: {peak_mb:.1f} MB")
```

Results (Qwen2.5-0.5B-Instruct, batch\_size=4, max\_length=1024, bf16, gradient\_checkpointing=True):

| | Peak allocated |
|---|---|
| Before | 15799 MB |
| After | 13650 MB |
| **Saved** | **2149 MB (−13.6%)** |

No functional regression — loss, entropy, and accuracy metrics are consistent across both runs:

| Step | Loss (before) | Loss (after) | Accuracy (before) | Accuracy (after) |
|------|--------------|-------------|-------------------|-----------------|
| 1 | 2.481 | 2.481 | 0.5254 | 0.5254 |
| 2 | 2.149 | 2.149 | 0.5424 | 0.5424 |
| 3 | 1.415 | 1.416 | 0.6437 | 0.6441 |

(Minor differences in step 3 are expected due to non-deterministic operations; steps 1–2 are identical, confirming no computational change.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Training-time metric logging only; loss path and Liger/chunked_nll behavior are unchanged aside from deduplicating logits handling for NLL.
> 
> **Overview**
> For default NLL training **without** the Liger kernel, **mean token accuracy** is now computed in the same `torch.no_grad()` block as **entropy**, reusing one shifted, `.contiguous()` logits tensor instead of building it twice.
> 
> The standalone accuracy branch (duplicate shift/mask/argmax/gather logic) is removed. **Liger** still logs accuracy from `outputs.token_accuracy` when present; **chunked_nll** is unchanged.
> 
> This is a memory/throughput optimization for large vocabularies—reported peak CUDA allocation drops on the order of ~10–15% with matching loss/accuracy on benchmark steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f11ac89de52d07d360389f4a6a1b98eef1d464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->