### PR TITLE
Fix CI gradient mismatch AssertionError: Skip test with tiny-Glm4MoeForCausalLM if transformers < 5

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2267,7 +2267,13 @@ _CHUNKED_CE_MODEL_IDS = [
     ),
     "trl-internal-testing/tiny-Gemma2ForCausalLM",
     "trl-internal-testing/tiny-GemmaForCausalLM",
-    "trl-internal-testing/tiny-Glm4MoeForCausalLM",
+    pytest.param(
+        "trl-internal-testing/tiny-Glm4MoeForCausalLM",
+        marks=pytest.mark.skipif(
+            Version(transformers.__version__) < Version("5.0.0"),
+            reason="GLM4 tokenizer requires transformers>=5.0.0",
+        ),
+    ),
     "trl-internal-testing/tiny-GptOssForCausalLM",
     "trl-internal-testing/tiny-LlamaForCausalLM-3.1",
     "trl-internal-testing/tiny-LlamaForCausalLM-3.2",


### PR DESCRIPTION
Skip test with tiny-Glm4MoeForCausalLM if transformers < 5.

Fix #5874.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or training logic is modified.
> 
> **Overview**
> Wraps **`trl-internal-testing/tiny-Glm4MoeForCausalLM`** in the **`_CHUNKED_CE_MODEL_IDS`** list (used by **`TestPatchChunkedCELMHead`**) with **`pytest.mark.skipif`** when **`transformers` &lt; 5.0.0**, because the GLM4 tokenizer is only supported on newer Transformers.
> 
> This mirrors the existing version-gated skips for models like DeepseekV3 and avoids CI failures on older Transformers installs (**#5874**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b15c3f8150d602cd684a7daa6b6b4c343359796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->