### PR TITLE
Align KTO with DPO: Decouple KL dataset generation

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -19,7 +19,7 @@ from datasets import Dataset, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
-from trl.experimental.kto.kto_trainer import _get_kl_dataset
+from trl.experimental.kto.kto_trainer import _get_kl_completion_ids
 
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
 
@@ -146,7 +146,7 @@ class TestKTOTrainer(TrlTestCase):
         assert completion_labels[first_unmasked:] == completion_input_ids[first_unmasked:]
 
         # Test corruption of (prompt, completion) pairs for KL dataset.
-        # _get_kl_dataset shifts completion_ids by one within each batch; prompt_ids are unchanged.
+        # _get_kl_completion_ids shifts completion_ids by one within each batch; prompt_ids are unchanged.
         synthetic = Dataset.from_dict(
             {
                 "prompt_ids": [[1, 2], [3, 4], [5, 6]],
@@ -155,7 +155,7 @@ class TestKTOTrainer(TrlTestCase):
             }
         )
         for batch_size in [2, 3]:
-            rotated = synthetic.map(_get_kl_dataset, batched=True, batch_size=batch_size)
+            rotated = synthetic.map(_get_kl_completion_ids, batched=True, batch_size=batch_size)
 
             # Verify that completion_ids have been rotated (differ from original). When the dataset length
             # modulo batch_size equals 1, the last batch is unaltered: exclude it from the check.

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -535,7 +535,7 @@ class KTOTrainer(_BaseTrainer):
             `Dataset` or `IterableDataset` with a single `KL_completion_ids` column.
         """
         map_kwargs = {}
-        if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
+        if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc or desc
             map_kwargs["num_proc"] = args.dataset_num_proc
             map_kwargs["desc"] = f"Extracting KL {dataset_name} dataset"
         kl_dataset = dataset.map(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -78,7 +78,7 @@ def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
     return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
 
 
-def _get_kl_dataset(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
+def _get_kl_completion_ids(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
     """
     Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of
     completions. For best results, the mismatched outputs y' used to estimate the KL term for a batch should be the

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -514,6 +514,47 @@ class KTOTrainer(_BaseTrainer):
             result = processing_class(text=input)
         return result
 
+    def _get_kl_dataset(
+        self,
+        dataset: Dataset | IterableDataset,
+        dataset_name: str,
+        args: KTOConfig,
+    ) -> Dataset | IterableDataset:
+        """
+        Creates the KL dataset by creating mismatched (prompt, completion) pairs for KL divergence estimation.
+
+        Args:
+            dataset (`Dataset` or `IterableDataset`):
+                Tokenized dataset with `prompt_ids` and `completion_ids` columns.
+            dataset_name (`str`):
+                Name used in progress bar descriptions.
+            args ([`KTOConfig`]):
+                Training arguments providing `per_device_train_batch_size` and `dataset_num_proc`.
+
+        Returns:
+            `Dataset` or `IterableDataset` with a single `KL_completion_ids` column.
+        """
+        map_kwargs = {}
+        if isinstance(dataset, Dataset):  # IterableDataset does not support num_proc
+            map_kwargs["num_proc"] = args.dataset_num_proc
+            map_kwargs["desc"] = f"Extracting KL {dataset_name} dataset"
+        kl_dataset = dataset.map(
+            _get_kl_completion_ids, batched=True, batch_size=args.per_device_train_batch_size, **map_kwargs
+        )
+
+        def rename_kl_fn(example):
+            return {"KL_completion_ids": example["completion_ids"]}
+
+        if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+            map_kwargs["desc"] = f"Assembling KL {dataset_name} dataset"
+        column_names = get_dataset_column_names(dataset)
+        kl_dataset = kl_dataset.map(
+            rename_kl_fn,
+            remove_columns=[c for c in get_dataset_column_names(kl_dataset) if c in column_names],
+            **map_kwargs,
+        )
+        return kl_dataset
+
     def _prepare_dataset(
         self,
         dataset: Dataset | IterableDataset,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -637,28 +637,9 @@ class KTOTrainer(_BaseTrainer):
 
             # Get KL datasets if needed
             if self.calculate_KL:
-
-                def rename_kl_fn(example):
-                    return {"KL_completion_ids": example["completion_ids"]}
-
                 # create pairs for estimating the KL term by flipping the matched pairs in each batch of size total_batch_size
                 # i.e., (x_1, y_1), ..., (x_n, y_n) --> (x_1, y_n), ..., (x_n, y_1) = (x'_1, y'_1), ..., (x'_n, y'_n)
-                if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
-                    map_kwargs["desc"] = f"Extracting KL {dataset_name} dataset"
-                kl_dataset = dataset.map(
-                    _get_kl_dataset, batched=True, batch_size=args.per_device_train_batch_size, **map_kwargs
-                )
-
-                if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
-                    map_kwargs["desc"] = f"Assembling KL {dataset_name} dataset"
-                column_names = get_dataset_column_names(dataset)
-                kl_dataset = kl_dataset.map(
-                    rename_kl_fn,
-                    remove_columns=[c for c in get_dataset_column_names(kl_dataset) if c in column_names],
-                    **map_kwargs,
-                )
-
-                # merge the datasets
+                kl_dataset = self._get_kl_dataset(dataset, dataset_name, args)
                 dataset = concatenate_datasets([dataset, kl_dataset], axis=1)
 
             # Calculate dataset desirability balance


### PR DESCRIPTION
Align KTO with DPO: Decouple KL dataset generation.

Part of:
- #4786

This PR refactors the way KL datasets are created and handled in the KTO training pipeline, focusing on improving code clarity and modularity. The main changes involve renaming and restructuring the KL dataset creation logic, updating references in both the implementation and tests, and encapsulating the KL dataset creation as a method within the trainer class.

### Motivation

Decoupling:
- _prepare_dataset focuses on tokenization;
- _get_kl_dataset is a standalone, overridable method. 

Subclasses can override _get_kl_dataset to customize how KL datasets are built without touching the core preprocessing pipeline.

### Changes

**KL Dataset Creation Refactor:**

* Renamed the function `_get_kl_dataset` to `_get_kl_completion_ids` to better reflect its purpose and updated all references accordingly in both the implementation and tests. 
* Moved and encapsulated the KL dataset creation logic into a new `_get_kl_dataset` method within the trainer class, which handles batching, column renaming, and supports both `Dataset` and `IterableDataset` types.
* Updated the main dataset preparation workflow to use the new `_get_kl_dataset` method, simplifying the code and removing duplicated logic.

These changes improve maintainability and readability by clarifying function responsibilities and centralizing KL dataset creation logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with unchanged KL pairing logic; behavior should match prior inline implementation unless subclasses override `_get_kl_dataset`.
> 
> **Overview**
> Refactors KTO KL-dataset construction to mirror DPO: the batched completion shuffle is renamed from `_get_kl_dataset` to **`_get_kl_completion_ids`**, and the full pipeline (rotate completions per train batch size, rename to `KL_completion_ids`, strip overlapping columns) moves into a new overridable **`KTOTrainer._get_kl_dataset`**.
> 
> **`_prepare_dataset`** now only tokenizes and then calls `self._get_kl_dataset` before `concatenate_datasets`, instead of inlining the same `map` steps. Tests import **`_get_kl_completion_ids`** and keep the same rotation assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee549285803948307bf54eaf304f56e2ca68248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->