### PR TITLE
Align KTO with DPO: Add disable_gradient_checkpointing to ref model forward passes

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -980,13 +980,14 @@ class KTOTrainer(_BaseTrainer):
         )
 
         # reference model
-        ref_base_model = self.ref_model.get_decoder()
-        ref_outputs = ref_base_model(
-            batch["completion_input_ids"],
-            attention_mask=batch["completion_attention_mask"],
-            use_cache=False,
-            **model_kwargs,
-        )
+        with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
+            ref_base_model = self.ref_model.get_decoder()
+            ref_outputs = ref_base_model(
+                batch["completion_input_ids"],
+                attention_mask=batch["completion_attention_mask"],
+                use_cache=False,
+                **model_kwargs,
+            )
         lm_head = model.get_output_embeddings()
         ref_lm_head = self.ref_model.get_output_embeddings()
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1078,7 +1078,7 @@ class KTOTrainer(_BaseTrainer):
             else:
                 ref_KL_logps = None
         else:
-            with torch.no_grad():
+            with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
                 if is_peft_model(self.model) and self.ref_model is None:
                     model = self.accelerator.unwrap_model(self.model)
                     with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -48,7 +48,7 @@ from ...data_utils import (
     unpair_preference_dataset,
 )
 from ...import_utils import is_liger_kernel_available
-from ...models.utils import prepare_deepspeed, prepare_fsdp
+from ...models.utils import disable_gradient_checkpointing, prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import (
     create_model_from_path,
@@ -713,7 +713,7 @@ class KTOTrainer(_BaseTrainer):
 
     def compute_ref_log_probs(self, inputs):
         """Computes reference log probabilities for a single padded batch."""
-        with torch.no_grad():
+        with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
             if self.ref_model is None:
                 if is_peft_model(self.model):
                     model = self.accelerator.unwrap_model(self.model)


### PR DESCRIPTION
Align KTO with DPO: Add disable_gradient_checkpointing to ref model forward passes.

Part of:
- #4786 

This PR improves the handling of gradient checkpointing during reference log probability computations in the `KTOTrainer` by ensuring gradient checkpointing is disabled when running inference on the reference model. This prevents unnecessary memory usage and potential side effects during evaluation.

### Solution

This PR adds the `disable_gradient_checkpointing` context manager to all reference model forward passes in `KTOTrainer`, matching the pattern already used in `DPOTrainer`.

### Changes

**Gradient checkpointing management:**

* Imported `disable_gradient_checkpointing` from `models.utils` and included it alongside other utility imports in `kto_trainer.py`.
* Wrapped all reference model inference blocks (`compute_ref_log_probs`, `_compute_loss_liger`, and `_compute_loss`) with the `disable_gradient_checkpointing` context manager to ensure checkpointing is turned off during these computations. 
  * For `_compute_loss_liger`, the `torch.no_grad` was missing entirely: the ref hidden states were computed with gradients enabled, which is a bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Training-path correctness and memory behavior for ref inference only; no auth, data, or API surface changes.
> 
> **Overview**
> **KTOTrainer** now matches **DPOTrainer** for reference-policy inference: all reference forward paths run inside `disable_gradient_checkpointing` (using training `gradient_checkpointing_kwargs`) so checkpointing stays off during `no_grad` ref log-prob work—less memory, fewer PyTorch warnings, and behavior consistent with other preference trainers.
> 
> That wrapper is applied in `compute_ref_log_probs`, the on-the-fly ref branch in `_compute_loss`, and the Liger path in `_compute_loss_liger`. On the Liger path, ref decoder forward is also wrapped in `torch.no_grad()` (it was missing before), so ref hidden states are no longer computed with gradients enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d082d3c5fa4d0c22bde9802158561d1f4f2e7029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->