### PR TITLE
Align KTO with DPO: Add activation offloading support

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -73,6 +73,8 @@ class KTOConfig(_BaseConfig):
             Desirable losses are weighed by this factor to counter unequal number of desirable and undesirable pairs.
         undesirable_weight (`float`, *optional*, defaults to `1.0`):
             Undesirable losses are weighed by this factor to counter unequal number of desirable and undesirable pairs.
+        activation_offloading (`bool`, *optional*, defaults to `False`):
+            Whether to offload the activations to the CPU.
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.
@@ -173,4 +175,8 @@ class KTOConfig(_BaseConfig):
             "help": "Undesirable losses are weighed by this factor to counter unequal number of desirable and "
             "undesirable pairs.",
         },
+    )
+    activation_offloading: bool = field(
+        default=False,
+        metadata={"help": "Whether to offload the activations to the CPU."},
     )

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -49,7 +49,8 @@ from ...data_utils import (
     unpair_preference_dataset,
 )
 from ...import_utils import is_liger_kernel_available
-from ...models.utils import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp
+from ...models import get_act_offloading_ctx_manager
+from ...models.utils import prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import (
     create_model_from_path,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1166,6 +1166,11 @@ class KTOTrainer(_BaseTrainer):
                 logits, labels = outputs.logits, inputs["completion_input_ids"]
         return loss, logits, labels
 
+    # Override training step to add activation offloading context.
+    def training_step(self, *args, **kwargs):
+        with self.maybe_activation_offload_context:
+            return super().training_step(*args, **kwargs)
+
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"
         metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}  # average the metrics

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import os
 import textwrap
 from collections import defaultdict
@@ -48,7 +49,7 @@ from ...data_utils import (
     unpair_preference_dataset,
 )
 from ...import_utils import is_liger_kernel_available
-from ...models.utils import prepare_deepspeed, prepare_fsdp
+from ...models.utils import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import (
     create_model_from_path,
@@ -391,6 +392,12 @@ class KTOTrainer(_BaseTrainer):
             callbacks=callbacks,
             optimizers=optimizers,
         )
+
+        # Initialize activation offloading context
+        if self.args.activation_offloading:
+            self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
+        else:
+            self.maybe_activation_offload_context = contextlib.nullcontext()
 
         # Reference model
         if ref_model is None:


### PR DESCRIPTION
Align KTO with DPO: Add activation offloading support.

Part of:
- #4786 

This PRadds support for activation offloading to CPU during training in the KTO Trainer. This feature is controlled via a new configuration parameter and is integrated into the training loop to help manage memory usage for large models.

### Changes

**Activation Offloading Support:**

* Added an `activation_offloading` boolean parameter to the `KTOConfig` class, allowing users to enable or disable activation offloading to CPU.
* Imported and used the `get_act_offloading_ctx_manager` utility to manage activation offloading context in the trainer.
* Initialized the activation offloading context in the `KTOTrainer` constructor, based on the `activation_offloading` config parameter.
* Wrapped the `training_step` method with the activation offloading context to ensure activations are offloaded during training when enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in training memory optimization reusing existing TRL utilities; default behavior unchanged.
> 
> **Overview**
> Adds optional **activation offloading to CPU** for experimental KTO training, matching the existing DPO pattern.
> 
> **`KTOConfig`** gains `activation_offloading` (default `False`) with docs and a dataclass field. **`KTOTrainer`** wires `get_act_offloading_ctx_manager` after init when enabled, otherwise uses `contextlib.nullcontext()`, and wraps **`training_step`** so forward/backward can spill activations to host memory during training only.
> 
> No change to loss, reference model, or eval paths unless users opt in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70360bf6c8cae6034dd5503f5ca8f29541ddbaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->