### PR TITLE
Exclude None  reward completions  from GRPO/RLOO advantage baseline

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2139,22 +2139,28 @@ class GRPOTrainer(_BaseTrainer):
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
 
+        # A completion for which every reward function returned None is unscorable. nansum would collapse it to 0,
+        # which both biases the per-group baseline and hands the completion a spurious advantage. Mark these rows NaN
+        # so they're excluded from the (nan-aware) baseline below; their advantage is forced to 0 afterwards.
+        unscorable_mask = torch.isnan(rewards_per_func).all(dim=1)
+
         if self.multi_objective_aggregation == "sum_then_normalize":
             # Apply weights to each reward function's output and sum
             rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
-            mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1)
+            rewards[unscorable_mask] = torch.nan
+            mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1)
             mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
                 # If self.scale_rewards = "none", we'll only use std_rewards to check for zero std for logging
                 if num_generations > 1:
-                    std_rewards = rewards.view(-1, num_generations).std(dim=1)
+                    std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
                     std_rewards = std_rewards.repeat_interleave(num_generations, dim=0)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=1
                     std_rewards = torch.zeros_like(rewards)
             elif self.scale_rewards == "batch":
                 # Compute global std
                 if rewards.numel() > 1:
-                    std_rewards = rewards.std().expand_as(rewards)
+                    std_rewards = nanstd(rewards).expand_as(rewards)
                 else:  # doesn't occur during training, but could occur in eval when num_generations_eval=batch_size=1
                     std_rewards = torch.zeros_like(rewards)
             else:
@@ -2174,8 +2180,9 @@ class GRPOTrainer(_BaseTrainer):
             reward_k = (grouped - mean_k) / (std_k + 1e-4)
             reward_k = reward_k.view(-1, len(self.reward_funcs))
             rewards = (reward_k * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
-            std_rewards = rewards.std().expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
-            advantages = (rewards - rewards.mean()) / (std_rewards + 1e-4)
+            rewards[unscorable_mask] = torch.nan
+            std_rewards = nanstd(rewards).expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
+            advantages = (rewards - torch.nanmean(rewards)) / (std_rewards + 1e-4)
             is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))  # for logging
 
         else:
@@ -2183,6 +2190,10 @@ class GRPOTrainer(_BaseTrainer):
                 f"Invalid multi_objective_aggregation: {self.multi_objective_aggregation}. Must be "
                 "'sum_then_normalize' or 'normalize_then_sum'."
             )
+
+        # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
+        # so zero their advantage to keep them from moving the policy.
+        advantages = torch.nan_to_num(advantages, nan=0.0)
 
         # Slice to keep only the local part of the data
         process_slice = slice(
@@ -2199,8 +2210,9 @@ class GRPOTrainer(_BaseTrainer):
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
         rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
-        self._metrics[mode]["reward"].append(rewards.mean().item())
-        self._metrics[mode]["reward_std"].append(rewards.std().item())
+        rewards[unscorable_mask] = torch.nan  # exclude unscorable rows from the logged reward stats
+        self._metrics[mode]["reward"].append(torch.nanmean(rewards).item())
+        self._metrics[mode]["reward_std"].append(nanstd(rewards).item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())
 
         # Log prompt and completion texts

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1266,8 +1266,14 @@ class RLOOTrainer(_BaseTrainer):
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
         num_generations = self.num_generations if mode == "train" else self.num_generations_eval
 
+        # A completion for which every reward function returned None is unscorable. nansum would collapse it to 0,
+        # which both biases the leave-one-out baseline and hands the completion a spurious advantage. Mark these rows
+        # NaN so they're excluded from the (nan-aware) baseline below; their advantage is forced to 0 afterwards.
+        unscorable_mask = torch.isnan(rewards_per_func).all(dim=1)
+
         # Apply weights to each reward function's output and sum
         rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+        rewards[unscorable_mask] = torch.nan
 
         # Apply reward clipping if specified
         if self.reward_clip_range:
@@ -1282,24 +1288,30 @@ class RLOOTrainer(_BaseTrainer):
             rewards = rewards - self.beta * kl
 
         grouped_rewards = rewards.view(-1, num_generations)
-        mean_grouped_rewards = grouped_rewards.mean(dim=1)
+        mean_grouped_rewards = torch.nanmean(grouped_rewards, dim=1)
         if num_generations > 1:
-            std_rewards = grouped_rewards.std(dim=1)
+            std_rewards = nanstd(grouped_rewards, dim=1)
         else:  # doesn't occur during training, but could occur in eval when num_generations_eval=1
             std_rewards = torch.zeros_like(mean_grouped_rewards)
 
-        # RLOO advantages computation
-        grouped_sum = grouped_rewards.sum(dim=1, keepdim=True)  # (num_prompts, 1)
+        # RLOO advantages computation. The leave-one-out baseline averages over scorable siblings only: nansum drops
+        # unscorable rewards and the divisor is (scorable count − 1). A group with a single scorable completion yields
+        # 0/0 = NaN, and unscorable rows stay NaN; both are zeroed by nan_to_num below.
+        scorable_counts = (~torch.isnan(grouped_rewards)).sum(dim=1, keepdim=True)  # (num_prompts, 1)
+        grouped_sum = torch.nansum(grouped_rewards, dim=1, keepdim=True)  # (num_prompts, 1)
         if num_generations > 1:
-            baselines = (grouped_sum - grouped_rewards) / (num_generations - 1)  # (num_prompts, num_generations)
+            baselines = (grouped_sum - grouped_rewards) / (scorable_counts - 1)  # (num_prompts, num_generations)
             baselines = baselines.view(-1)  # Flatten back to match rewards shape
             advantages = rewards - baselines
         else:  # this case doesn't occur during training, but could in eval when num_generations_eval=1
             advantages = torch.zeros_like(rewards)
 
-        # Normalize advantages
+        # Normalize advantages over the scorable subset only (unscorable advantages are still NaN here).
         if self.normalize_advantages:
-            advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-4)
+            advantages = (advantages - torch.nanmean(advantages)) / (nanstd(advantages) + 1e-4)
+
+        # Unscorable completions carry no learning signal: zero their advantage to keep them from moving the policy.
+        advantages = torch.nan_to_num(advantages, nan=0.0)
 
         is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))  # for logging
 
@@ -1323,8 +1335,9 @@ class RLOOTrainer(_BaseTrainer):
             std_func_rewards = nanstd(rewards_per_func[:, i]).item()
             self._metrics[mode][f"rewards/{reward_func_name}/std"].append(std_func_rewards)
         rewards = (rewards_per_func * self.reward_weights.to(rewards_per_func.device).unsqueeze(0)).nansum(dim=1)
-        self._metrics[mode]["reward"].append(rewards.mean().item())
-        self._metrics[mode]["reward_std"].append(rewards.std().item())
+        rewards[unscorable_mask] = torch.nan  # exclude unscorable rows from the logged reward stats
+        self._metrics[mode]["reward"].append(torch.nanmean(rewards).item())
+        self._metrics[mode]["reward_std"].append(nanstd(rewards).item())
         self._metrics[mode]["frac_reward_zero_std"].append(is_std_zero.float().mean().item())
 
         # Log prompt and completion texts


### PR DESCRIPTION
## What is the problem 

Follow-up to #5749.

When every reward function returns `None` for a completion, the current code collapses an all-NaN row to 0.0. That nan that became 0 biases the per-group baseline for the completion's scorable siblings and hands the unscorable completion itself an uncorrect advantage, training the policy away from text it had no signal on.
The real bug is within-group variation; some completions are unparseable, siblings are not. when all completions are `None` then we can just. 


### Testing

- GRPO + RLOO smoke runs (Qwen3-0.6B, 8×H100): no regression with real accuracy_reward; finite losses 
- Did a specific run with a within-group None reward: the all-None path fires, losses stay finite, reward metrics stay finite (not NaN), unscorable advantages are zeroed.


```python
"""Exercise the all-None (unscorable) advantage path end-to-end.

A single reward func that returns None for ~1/3 of completions (within each group) and a varied value
otherwise. This guarantees both within-group unscorable rows AND scorable siblings with reward variation,
which is exactly the case the GRPO/RLOO fix targets. Asserts: training runs with finite losses, and the
unscorable path actually fired (some rows had every reward func return None).
"""

import sys

import torch
from datasets import load_dataset

from trl import GRPOConfig, GRPOTrainer, RLOOConfig, RLOOTrainer


_saw_unscorable = {"hit": False}


def flaky_reward(completions, **kwargs):
    """Return None for ~1/3 of completions (unscorable), else a varied reward in {0.0, 1.0}."""
    out = []
    for c in completions:
        n = len(c[0]["content"])
        if n % 3 == 0:
            out.append(None)  # unscorable: simulates unparseable / inapplicable
        else:
            out.append(float(n % 2))
    if any(r is None for r in out):
        _saw_unscorable["hit"] = True
    return out


def make_conversation(example):
    return {"prompt": [{"role": "user", "content": example["problem"]}]}


def main():
    algo = sys.argv[1] if len(sys.argv) > 1 else "grpo"
    train_dataset = load_dataset("AI-MO/NuminaMath-TIR", split="train[:5%]")
    train_dataset = train_dataset.map(make_conversation, remove_columns=["messages", "problem"])

    common = dict(
        output_dir=f"/fsx/amine_dirhoussi/scratch_nansum/out-uns-{algo}",
        model_init_kwargs={"dtype": torch.bfloat16},
        learning_rate=1e-6,
        max_completion_length=256,
        num_generations=8,
        per_device_train_batch_size=8,
        gradient_accumulation_steps=1,
        steps_per_generation=1,
        max_steps=5,
        logging_steps=1,
        save_strategy="no",
        report_to="none",
        use_vllm=True,
        vllm_mode="colocate",
        vllm_gpu_memory_utilization=0.3,
    )

    cls_cfg, cls_trainer = (GRPOConfig, GRPOTrainer) if algo == "grpo" else (RLOOConfig, RLOOTrainer)
    trainer = cls_trainer(
        model="Qwen/Qwen3-0.6B", args=cls_cfg(**common), reward_funcs=[flaky_reward], train_dataset=train_datase              t
    )
    trainer.train()

    losses = [h["loss"] for h in trainer.state.log_history if "loss" in h]
    rewards = [h.get("reward") for h in trainer.state.log_history if "reward" in h]
    print(f"[{algo}] logged rewards: {rewards}")
    print(f"[{algo}] logged losses: {losses}")
    assert losses, "no loss logged"
    assert torch.isfinite(torch.tensor(losses)).all(), f"non-finite loss: {losses}"
    assert _saw_unscorable["hit"], "unscorable path never fired (no all-None rows produced)"
    print(f"[{algo}] OK: {len(losses)} steps, all losses finite, unscorable path exercised")


if __name__ == "__main__":
    main()
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RL advantage/reward normalization in GRPO and RLOO; wrong edge-case handling could shift training dynamics when reward functions return None.
> 
> **Overview**
> When every reward function returns `None` for a completion, weighted `nansum` used to treat that row as **0**, skewing per-prompt baselines and giving those completions a non-zero advantage. **GRPO** and **RLOO** now flag all-`None` rows as unscorable, set their aggregated reward to `NaN`, and compute group means/stds with `nanmean` / `nanstd` so only scorable siblings enter the baseline.
> 
> **RLOO** leave-one-out baselines and advantage normalization use scorable counts only (`nansum`, divisor `scorable_count - 1`). Unscorable completions get **zero advantage** via `nan_to_num` so they do not update the policy. Logged aggregate reward mean/std also ignore unscorable rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587f51f14e8518b16b85774586a8413e2a33569d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->