### PR TITLE
Fix image features and tokens mismatch when max_length truncation

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -52,6 +52,7 @@ from .base_trainer import _BaseTrainer
 from .callbacks import SyncRefModelCallback
 from .dpo_config import DPOConfig
 from .utils import (
+    _sync_multimodal_after_truncation,
     create_model_from_path,
     disable_dropout_in_model,
     entropy_from_logits,
@@ -390,6 +391,15 @@ class DataCollatorForVisionPreference(DataCollatorMixin):
                 token_type_ids = token_type_ids[:, : self.max_length]
             if "mm_token_type_ids" in processed_prompts:
                 mm_token_type_ids = mm_token_type_ids[:, : self.max_length]
+
+            # After truncation, image placeholder tokens may have been partially removed
+            # while pixel_values still contains features for all images. Synchronise to
+            # prevent "Image features and image tokens do not match" errors.
+            if "pixel_values" in processed_prompts:
+                num_images = [len(img_list) for img_list in images]
+                input_ids, processed_prompts = _sync_multimodal_after_truncation(
+                    input_ids, processed_prompts, self.processor, num_images
+                )
 
         # Build the output dictionary
         output = processed_prompts  # we take processed_prompts because it contains the images

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -60,6 +60,7 @@ from ..models import get_act_offloading_ctx_manager
 from .base_trainer import _BaseTrainer
 from .sft_config import SFTConfig
 from .utils import (
+    _sync_multimodal_after_truncation,
     create_model_from_path,
     entropy_from_logits,
     flush_left,
@@ -243,7 +244,6 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
     final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
     logit_scale = getattr(text_config, "logit_scale", 1.0)
     original_forward = model.forward
-    lm_head = model.get_output_embeddings()
 
     def _chunked_ce_forward(
         self: torch.nn.Module,
@@ -286,14 +286,14 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
 
         loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
             hidden_states,
-            lm_head.weight,
+            self.lm_head.weight,
             chunk_size,
             labels=labels,
             shift_labels=shift_labels,
             num_items_in_batch=num_items_in_batch,
             logit_scale=logit_scale,
             final_logit_softcapping=final_logit_softcapping,
-            lm_head_bias=lm_head.bias,
+            lm_head_bias=self.lm_head.bias,
         )
 
         aux_loss = None
@@ -685,6 +685,17 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
             return_tensors=self.return_tensors,
             add_special_tokens=False,  # to avoid adding the BOS, twice see https://huggingface.co/blog/qgallouedec/gotchas-in-tokenizer-behavior#7-chat-template-and-tokenization-dont-compose-due-to-special-tokens
         )
+
+        # When truncation is enabled, the tokenizer may remove image placeholder tokens while
+        # the image processor retains all pixel features. Synchronise multimodal tensors with
+        # the (possibly truncated) input_ids to prevent "Image features and image tokens do not
+        # match" errors.
+        if self.max_length is not None and "pixel_values" in output:
+            num_images = [len(img_list) for img_list in images]
+            output["input_ids"], output = _sync_multimodal_after_truncation(
+                output["input_ids"], output, self.processor, num_images
+            )
+
         labels = output["input_ids"].clone()
         labels[output["attention_mask"] == 0] = -100
         # We mask only padding tokens (-100) in the labels. Vision tokens are left unchanged because their handling in
@@ -773,6 +784,15 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
                 token_type_ids = token_type_ids[:, : self.max_length]
             if "mm_token_type_ids" in processed_prompts:
                 mm_token_type_ids = mm_token_type_ids[:, : self.max_length]
+
+            # After truncation, image placeholder tokens may have been partially removed
+            # while pixel_values still contains features for all images. Synchronise to
+            # prevent "Image features and image tokens do not match" errors.
+            if "pixel_values" in processed_prompts:
+                num_images = [len(img_list) for img_list in images]
+                input_ids, processed_prompts = _sync_multimodal_after_truncation(
+                    input_ids, processed_prompts, self.processor, num_images
+                )
 
         # Create labels and mask padding tokens
         labels = input_ids.clone()
@@ -1260,17 +1280,18 @@ class SFTTrainer(_BaseTrainer):
                 # `PeftModel.forward`. Prompt-learning variants need `PeftModel.forward` to run first (to inject
                 # virtual tokens), then it delegates into the patched inner forward.
                 target = model.get_base_model() if is_peft_model(model) else model
-                # The chunked path reads the output projection weight directly, which would silently drop the
-                # adapter delta (and starve its parameters of gradients) if the head itself is a PEFT tuner layer.
+                # The chunked path reads `lm_head.weight` directly, which would silently drop the adapter delta
+                # (and starve its parameters of gradients) if `lm_head` itself is a PEFT tuner layer.
                 if is_peft_model(model):
                     from peft.tuners.tuners_utils import BaseTunerLayer
 
-                    if isinstance(target.get_output_embeddings(), BaseTunerLayer):
+                    if isinstance(target.lm_head, BaseTunerLayer):
                         raise ValueError(
-                            "`loss_type='chunked_nll'` is not supported when `lm_head` is wrapped by a PEFT adapter "
-                            "(e.g. `target_modules='all-linear'` or explicitly including `'lm_head'`). Either remove "
-                            "`lm_head` from `target_modules`, or switch to `loss_type='nll'`. If this is a real use "
-                            "case for you, please open an issue at https://github.com/huggingface/trl/issues."
+                            "`loss_type='chunked_nll'` is not supported when `lm_head` is wrapped by a PEFT "
+                            "adapter (e.g. `target_modules='all-linear'` or explicitly including `'lm_head'`). "
+                            "Either remove `lm_head` from `target_modules`, or switch to `loss_type='nll'`. If "
+                            "this is a real use case for you, please open an issue at "
+                            "https://github.com/huggingface/trl/issues."
                         )
                 _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
             else:
@@ -1632,24 +1653,15 @@ class SFTTrainer(_BaseTrainer):
                     shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
 
                 per_token_entropy = entropy_from_logits(shift_logits)
-                predictions = shift_logits.argmax(dim=-1)
                 mask = shift_labels != -100
-
                 entropy_sum = (per_token_entropy * mask).sum()
                 total_tokens = mask.sum()
-                correct_predictions = (predictions == shift_labels) & mask
-                correct_tokens = correct_predictions.sum()
 
                 # Gather counts across ranks and weight-average
                 entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
                 total_tokens = self.accelerator.gather_for_metrics(total_tokens).sum()
-                correct_tokens = self.accelerator.gather_for_metrics(correct_tokens)
                 entropy = (entropy_sum / total_tokens).item() if total_tokens > 0 else 0.0
-
-                total_sum = total_tokens.sum()
-                accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
             self._metrics[mode]["entropy"].append(entropy)
-            self._metrics[mode]["mean_token_accuracy"].append(accuracy)
 
         if mode == "train":
             # When using padding-free, the attention_mask is not present in the inputs, instead we have cu_seq_lens_q,
@@ -1678,6 +1690,46 @@ class SFTTrainer(_BaseTrainer):
                     "not be logged. This is unexpected; please report it to the liger-kernel repository.",
                     stacklevel=2,
                 )
+        else:
+            # Compute accuracy from logits using argmax (traditional method)
+            with torch.no_grad():
+                if "shift_labels" in inputs:
+                    # When using CP or SP, labels are pre-shifted. We must use these (and cannot manually shift) because:
+                    # - The first discarded token from inputs["labels"] actually belongs to process n-1
+                    # - The last logits require the label from process n+1
+                    shift_logits = outputs.logits.contiguous()
+                    shift_labels = inputs["shift_labels"]
+                else:
+                    shift_logits = outputs.logits[..., :-1, :].contiguous()
+                    shift_labels = labels[..., 1:].contiguous()
+
+                # Prompt Tuning and P-Tuning output logits for virtual tokens but Prefix-Tuning does not.
+                if (
+                    self.num_virtual_tokens > 0
+                    and model.peft_config[model.active_adapter].peft_type != PeftType.PREFIX_TUNING
+                ):
+                    shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
+
+                # Get predictions
+                predictions = shift_logits.argmax(dim=-1)
+
+                # Create mask for non-padding tokens (assuming ignore_index is -100)
+                mask = shift_labels != -100
+
+                # Calculate accuracy only on non-padding tokens
+                correct_predictions = (predictions == shift_labels) & mask
+                total_tokens = mask.sum()
+                correct_tokens = correct_predictions.sum()
+
+                # Gather the correct_tokens and total_tokens across all processes
+                correct_tokens = self.accelerator.gather_for_metrics(correct_tokens)
+                total_tokens = self.accelerator.gather_for_metrics(total_tokens)
+
+                # Compute the mean token accuracy and log it
+                total_sum = total_tokens.sum()
+                accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
+                self._metrics[mode]["mean_token_accuracy"].append(accuracy)
+
         # Log auxiliary loss if enabled (applies to both Liger and non-Liger)
         if self.aux_loss_enabled:
             aux_loss = outputs.aux_loss

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -24,7 +24,7 @@ from collections.abc import Mapping, Sequence, Sized
 from contextlib import contextmanager
 from importlib.metadata import version
 from itertools import accumulate
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -940,12 +940,148 @@ def unsplit_pixel_values_by_grid(batch: dict[str, torch.Tensor | list[torch.Tens
     if isinstance(image_position_ids, list):
         merged = torch.cat(image_position_ids, dim=0)
         batch = {**batch, "image_position_ids": merged}
-
     return batch
 
 
-TListOrMapping = TypeVar("TListOrMapping", list, Mapping)
+def _sync_multimodal_after_truncation(
+    input_ids: torch.Tensor,
+    output: dict[str, Any],
+    processor: "ProcessorMixin",
+    num_images_per_sample: list[int],
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """
+    After truncating ``input_ids`` to ``max_length``, ensure that multimodal tensors
+    (``pixel_values``, ``image_grid_thw``, etc.) only contain features for images whose
+    placeholder tokens are **fully** present in the (truncated) ``input_ids``.
 
+    Images whose placeholder tokens were partially or fully removed by truncation are
+    dropped from ``pixel_values`` / ``image_grid_thw``, and any residual partial
+    placeholder tokens in ``input_ids`` are replaced with the pad token to avoid
+    downstream "Image features and image tokens do not match" errors.
+
+    Args:
+        input_ids: Truncated input_ids tensor of shape ``(batch_size, seq_len)``.
+        output: The collator output dict that still holds the *original*
+            ``pixel_values`` / ``image_grid_thw`` / ``image_sizes`` etc.
+        processor: The multimodal processor used to resolve image token IDs and merge size.
+        num_images_per_sample: A list of length ``batch_size`` indicating how many images
+            each sample originally had. Used to correctly map images in ``image_grid_thw``
+            to their respective samples.
+
+    Returns:
+        A ``(input_ids, output)`` tuple with image-related tensors trimmed to match the
+        truncated ``input_ids``.
+    """
+    if "pixel_values" not in output:
+        return input_ids, output
+
+    tokenizer = getattr(processor, "tokenizer", processor)
+
+    # Resolve the image placeholder token id
+    image_token_id = getattr(processor, "image_token_id", None)
+    if image_token_id is None:
+        for candidate in ("<|image_pad|>", "<|image|>"):
+            tid = tokenizer.convert_tokens_to_ids(candidate)
+            if tid != tokenizer.unk_token_id:
+                image_token_id = tid
+                break
+    if image_token_id is None:
+        return input_ids, output
+
+    image_grid_thw = output.get("image_grid_thw")
+    pad_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+
+    if image_grid_thw is not None:
+        # Qwen2-VL style: pixel_values rows are determined by image_grid_thw
+        merge_size = getattr(getattr(processor, "image_processor", None), "merge_size", 2)
+        merge_length = merge_size**2
+        tokens_per_image = (image_grid_thw.prod(dim=-1) // merge_length).tolist()
+        pixel_rows_per_image = image_grid_thw.prod(dim=-1).tolist()
+
+        batch_size = input_ids.shape[0]
+        num_images_total = image_grid_thw.shape[0]
+
+        # Determine how many images belong to each sample
+        sample_image_counts = list(num_images_per_sample)
+
+        keep_grid_indices: list[int] = []
+        keep_pixel_ranges: list[tuple[int, int]] = []
+        num_dropped_images = 0
+
+        img_idx = 0
+        pixel_offset = 0
+        for b in range(batch_size):
+            remaining_image_tokens = (input_ids[b] == image_token_id).sum().item()
+            consumed = 0
+            num_imgs_this_sample = sample_image_counts[b]
+
+            for j in range(num_imgs_this_sample):
+                cur_img = img_idx + j
+                if cur_img >= num_images_total:
+                    break
+                needed = tokens_per_image[cur_img]
+                pix_rows = pixel_rows_per_image[cur_img]
+
+                if consumed + needed <= remaining_image_tokens:
+                    # This image is fully present after truncation
+                    keep_grid_indices.append(cur_img)
+                    keep_pixel_ranges.append((pixel_offset, pixel_offset + pix_rows))
+                    consumed += needed
+                else:
+                    # Partially or fully truncated image
+                    leftover = remaining_image_tokens - consumed
+                    if leftover > 0:
+                        # Replace residual partial placeholder tokens with pad
+                        positions = (input_ids[b] == image_token_id).nonzero(as_tuple=True)[0]
+                        input_ids[b, positions[consumed : consumed + leftover]] = pad_id
+                    num_dropped_images += num_imgs_this_sample - j
+                    # Accumulate pixel_offset for all remaining images in this sample
+                    for skip in range(j, num_imgs_this_sample):
+                        skip_img = img_idx + skip
+                        if skip_img < num_images_total:
+                            pixel_offset += pixel_rows_per_image[skip_img]
+                    break
+
+                pixel_offset += pix_rows
+            else:
+                # All images in this sample were kept
+                pass
+
+            img_idx += num_imgs_this_sample
+
+        if num_dropped_images > 0:
+            logger.warning(
+                f"{num_dropped_images} image(s) were dropped because their placeholder tokens were truncated "
+                f"by max_length. Consider increasing max_length or reducing image resolution to avoid losing "
+                f"image information during training."
+            )
+
+        if keep_grid_indices:
+            output["image_grid_thw"] = image_grid_thw[keep_grid_indices]
+            keep_pixel_indices = []
+            for start, end in keep_pixel_ranges:
+                keep_pixel_indices.extend(range(start, end))
+            output["pixel_values"] = output["pixel_values"][keep_pixel_indices]
+        else:
+            output.pop("pixel_values", None)
+            output.pop("image_grid_thw", None)
+
+    else:
+        # Fallback for non-Qwen models (LLaVA, etc.): if mismatch detected, drop all images
+        total_image_tokens = (input_ids == image_token_id).sum().item()
+        num_features = output["pixel_values"].shape[0]
+        if total_image_tokens != num_features:
+            logger.warning(
+                f"Image features and image tokens do not match after truncation (tokens: {total_image_tokens}, "
+                f"features: {num_features}). All images in this batch have been dropped. Consider increasing "
+                f"max_length or reducing image resolution."
+            )
+            output.pop("pixel_values", None)
+            output.pop("image_sizes", None)
+
+    return input_ids, output
+
+TListOrMapping = TypeVar("TListOrMapping", list, Mapping)
 
 # This function is intentionally not used internally. It is provided as a utility for users whose datasets contain
 # `None` values inserted by tabular backends (e.g., Arrow/Parquet) for missing keys in nested structures. This


### PR DESCRIPTION
# What does this PR do?

When training VLMs (e.g., Qwen3.5) with `max_length` truncation enabled, the tokenizer may truncate image placeholder tokens while the image processor retains all pixel features. This causes a mismatch at model forward time: ValueError: Image features and image tokens do not match, tokens: 14650, features: 17152.

This PR adds a new utility function `_sync_multimodal_after_truncation()` in `trl/trainer/utils.py` and calls it from the SFT and DPO data collators after truncation. The function:

1. Detects which images have been partially or fully truncated by comparing placeholder token counts against expected counts from `image_grid_thw`.
2. Drops truncated images from `pixel_values` and `image_grid_thw`, keeping only fully-present images.
3. Replaces any residual partial placeholder tokens in `input_ids` with `pad_token_id`.
4. Emits a warning when images are dropped, suggesting the user increase `max_length` or reduce image resolution.
5. For non-Qwen models (without `image_grid_thw`), falls back to dropping all images when a mismatch is detected (consistent with GRPO trainer behavior).

### Files changed
- **`trl/trainer/utils.py`**: Added `_sync_multimodal_after_truncation()`.
- **`trl/trainer/sft_trainer.py`**: Call sync function after truncation in `_collate_language_modeling` and `_collate_prompt_completion`.
- **`trl/trainer/dpo_trainer.py`**: Call sync function after truncation in `DataCollatorForVisionPreference.torch_call`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @kashif

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the VLM batching path when max_length is set and may drop images or alter sequences at train time; incorrect sync logic could affect loss without obvious failure modes beyond warnings.
> 
> **Overview**
> Fixes VLM training crashes when **`max_length`** truncation leaves **`input_ids`** out of sync with **`pixel_values`** (the familiar *Image features and image tokens do not match* error).
> 
> Adds **`_sync_multimodal_after_truncation()`** in `trl/trainer/utils.py` and invokes it from **SFT** and **DPO** vision collators after truncation (and after processor truncation in VLM language-modeling collation). For Qwen-style models with **`image_grid_thw`**, it keeps only images whose placeholders are fully present, trims **`pixel_values`**, pads away partial placeholders, and warns when images are dropped; other architectures fall back to dropping all images on mismatch.
> 
> Also adjusts **`chunked_nll`** to use **`self.lm_head`** directly (PEFT check on **`target.lm_head`**) and moves **`mean_token_accuracy`** for the default (non-Liger, non-chunked) path into its own branch so entropy logging no longer bundles accuracy computation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838a6309d4d2c525858637594119a8ac6af0a5d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->