### PR TITLE
Replace custom numpy cache in precompute_ref_logps with native datasets

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -29,7 +29,7 @@ import transformers
 from accelerate import PartialState
 from accelerate.logging import get_logger
 from accelerate.utils import is_peft_model, tqdm
-from datasets import Dataset, IterableDataset, IterableDatasetDict
+from datasets import Dataset, IterableDataset, IterableDatasetDict, concatenate_datasets
 from datasets.fingerprint import Hasher
 from packaging.version import Version
 from torch.utils.data import DataLoader
@@ -1007,44 +1007,53 @@ class DPOTrainer(_BaseTrainer):
     def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash))
-        cache_file = dataset._get_cache_file_path(fingerprint).removesuffix(".arrow") + ".npz"
+        cache_file = dataset._get_cache_file_path(fingerprint)
+
         if os.path.exists(cache_file):
-            loaded = np.load(cache_file)
-            ref_chosen_logps = loaded["ref_chosen_logps"]
-            ref_rejected_logps = loaded["ref_rejected_logps"]
-        else:
-            dataloader = DataLoader(
-                dataset,
-                batch_size=batch_size,
-                collate_fn=self.data_collator,
-                num_workers=self.args.dataloader_num_workers,
-                pin_memory=self.args.dataloader_pin_memory,
-                shuffle=False,
+            return concatenate_datasets([dataset, Dataset.from_file(cache_file)], axis=1)
+
+        dataloader = DataLoader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=self.data_collator,
+            num_workers=self.args.dataloader_num_workers,
+            pin_memory=self.args.dataloader_pin_memory,
+            shuffle=False,
+        )
+        data_loader = self.accelerator.prepare(dataloader)
+        ref_chosen_logps = []
+        ref_rejected_logps = []
+        for padded_batch in tqdm(iterable=data_loader, desc=f"Computing reference log probs for {name} dataset"):
+            ref_chosen_logp, ref_rejected_logp = self.compute_ref_log_probs(padded_batch)
+            ref_chosen_logp, ref_rejected_logp = self.accelerator.gather_for_metrics(
+                (ref_chosen_logp, ref_rejected_logp)
             )
-            data_loader = self.accelerator.prepare(dataloader)
-            ref_chosen_logps = []
-            ref_rejected_logps = []
-            for padded_batch in tqdm(iterable=data_loader, desc=f"Computing reference log probs for {name} dataset"):
-                ref_chosen_logp, ref_rejected_logp = self.compute_ref_log_probs(padded_batch)
-                ref_chosen_logp, ref_rejected_logp = self.accelerator.gather_for_metrics(
-                    (ref_chosen_logp, ref_rejected_logp)
-                )
-                ref_chosen_logps.append(ref_chosen_logp.cpu())
-                ref_rejected_logps.append(ref_rejected_logp.cpu())
+            ref_chosen_logps.append(ref_chosen_logp.cpu())
+            ref_rejected_logps.append(ref_rejected_logp.cpu())
 
-            # Save the reference log probabilities to cache. We need .float() because bf16 is not supported by numpy
-            ref_chosen_logps = torch.cat(ref_chosen_logps).float().numpy()
-            ref_rejected_logps = torch.cat(ref_rejected_logps).float().numpy()
-            if self.accelerator.is_main_process:
-                np.savez_compressed(
-                    cache_file, ref_chosen_logps=ref_chosen_logps, ref_rejected_logps=ref_rejected_logps
-                )
-            self.accelerator.wait_for_everyone()
+        # We need .float() because bf16 is not supported by numpy
+        ref_chosen_logps = torch.cat(ref_chosen_logps).float().numpy()
+        ref_rejected_logps = torch.cat(ref_rejected_logps).float().numpy()
 
-        dataset = dataset.add_column(name="ref_chosen_logps", column=ref_chosen_logps)
-        dataset = dataset.add_column(name="ref_rejected_logps", column=ref_rejected_logps, new_fingerprint=fingerprint)
+        if self.accelerator.is_main_process:
 
-        return dataset
+            def add_ref_logps(batch, indices):
+                return {
+                    "ref_chosen_logps": ref_chosen_logps[indices],
+                    "ref_rejected_logps": ref_rejected_logps[indices],
+                }
+
+            dataset.map(
+                add_ref_logps,
+                with_indices=True,
+                batched=True,
+                remove_columns=dataset.column_names,
+                new_fingerprint=fingerprint,
+                desc=f"Caching reference log probs for {name} dataset",
+            )
+        self.accelerator.wait_for_everyone()
+
+        return concatenate_datasets([dataset, Dataset.from_file(cache_file)], axis=1)
 
     def compute_ref_log_probs(self, inputs):
         """Computes reference log probabilities for a single padded batch."""

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 import transformers
@@ -1031,9 +1030,8 @@ class DPOTrainer(_BaseTrainer):
             ref_chosen_logps.append(ref_chosen_logp.cpu())
             ref_rejected_logps.append(ref_rejected_logp.cpu())
 
-        # We need .float() because bf16 is not supported by numpy
-        ref_chosen_logps = torch.cat(ref_chosen_logps).float().numpy()
-        ref_rejected_logps = torch.cat(ref_rejected_logps).float().numpy()
+        ref_chosen_logps = torch.cat(ref_chosen_logps)
+        ref_rejected_logps = torch.cat(ref_rejected_logps)
 
         if self.accelerator.is_main_process:
 


### PR DESCRIPTION
Replace custom numpy cache in precompute_ref_logps with native datasets.


This PR updates the caching mechanism for reference log probabilities in the `DPOTrainer` class to store and load cached data using the HuggingFace `datasets` library, rather than using NumPy `.npz` files. This improves compatibility and simplifies cache management.

### Motivation

`DPOTrainer._precompute_ref_logps` had a hand-rolled cache mechanism: a custom fingerprint → `.npz` path derived by stripping the `.arrow` suffix from `_get_cache_file_path` and appending `.npz`, then saving and loading the two logp arrays with `numpy`.

This reimplemented what `datasets` already does natively. This PR replaces it with the standard `Dataset.map` caching.

### Changes

**Caching and Loading Improvements:**

* Changed the cache file handling in `_precompute_ref_logps` to use HuggingFace dataset serialization instead of NumPy `.npz` files, allowing for seamless integration with the rest of the dataset pipeline.
* When loading cached reference log probabilities, the code now uses `concatenate_datasets` to merge the original and cached datasets along columns, rather than loading NumPy arrays. 
* When saving reference log probabilities, the code now uses the `map` function to add columns directly to the dataset and writes the result to disk, instead of saving NumPy arrays.

**Dependency Updates:**

* Added the `concatenate_datasets` import from `datasets` and removed the unused `numpy` import, reflecting the switch away from NumPy-based caching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DPO training data preparation and invalidates prior .npz caches; multi-GPU cache write still relies on main-process map plus barrier before load.
> 
> **Overview**
> **`DPOTrainer._precompute_ref_logps`** no longer uses a custom NumPy `.npz` sidecar. Reference log-prob caches now use Hugging Face **`datasets`** Arrow files at the fingerprint path from `_get_cache_file_path`, written via **`Dataset.map`** and read with **`Dataset.from_file`**.
> 
> On a cache hit or after writing, the method returns **`concatenate_datasets([dataset, cached], axis=1)`** so `ref_chosen_logps` / `ref_rejected_logps` are merged as columns instead of **`add_column`** from in-memory NumPy arrays. The **`numpy`** import is removed; **`concatenate_datasets`** is added.
> 
> Existing **`.npz`** caches from the old path suffix hack will not be picked up automatically; the first run after upgrade may recompute reference log probs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0208544700c992414b33e639ca82b768edef19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->