### PR TITLE
Support multimodal config in PPO ValueHead

### DIFF
--- a/trl/experimental/ppo/modeling_value_head.py
+++ b/trl/experimental/ppo/modeling_value_head.py
@@ -610,6 +610,8 @@ class ValueHead(nn.Module):
             hidden_size = config.hidden_size
         if hasattr(config, "word_embed_proj_dim"):
             hidden_size = config.word_embed_proj_dim
+        elif hasattr(config, "text_config") and hasattr(config.text_config, "hidden_size"):
+            hidden_size = config.text_config.hidden_size
         elif hasattr(config, "is_encoder_decoder"):
             if config.is_encoder_decoder and hasattr(config, "decoder"):
                 if hasattr(config.decoder, "hidden_size"):


### PR DESCRIPTION
Support multimodal config (Gemma3, LLaVA,...) with no top-level hidden_size in PPO ValueHead.

Fix #3546, fix #3828.

TODO: First merge
- [ ] #5908

This PR makes a small improvement to the initialization logic of the value head model in `trl/experimental/ppo/modeling_value_head.py`. The change adds an additional check for `hidden_size` in the nested `text_config` attribute of the model configuration, improving compatibility with more model architectures.

### Changes

* Added a check for `hidden_size` under `config.text_config` if it exists, to better support models with nested configuration structures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-branch config lookup change in experimental PPO ValueHead init; no auth, data, or training-loop logic touched.
> 
> **Overview**
> **ValueHead** now resolves the scalar head’s input width from **`config.text_config.hidden_size`** when the top-level config has no `hidden_size` but exposes a nested text config (e.g. Gemma 3, LLaVA-style multimodal models).
> 
> This unblocks PPO value-head setup for architectures that keep language-model dimensions under `text_config` instead of on the root config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0097a8a6edb31e7178b44139c5ec872c5623579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->