### PR TITLE
Align KTO with DPO: Replace completion_labels/get_batch_logps with completion_mask

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -138,17 +138,13 @@ class TestKTOTrainer(TrlTestCase):
         batch = trainer.data_collator([example])
         # completion_input_ids ends with EOS
         assert batch["completion_input_ids"][0, -1].item() == self.tokenizer.eos_token_id
-        # completion_labels: prompt prefix masked with -100, answer+EOS unmasked and matching input_ids
-        completion_input_ids = batch["completion_input_ids"][0].tolist()
-        completion_labels = batch["completion_labels"][0].tolist()
-        first_unmasked = next(i for i, lbl in enumerate(completion_labels) if lbl != -100)
-        assert first_unmasked > 0  # at least the prompt is masked
-        assert completion_labels[first_unmasked:] == completion_input_ids[first_unmasked:]
-        # completion_mask: binary mask consistent with completion_labels (-100 ↔ 0, non-(-100) ↔ 1)
+        # completion_mask: prompt tokens are 0, completion tokens are 1; at least the prompt is masked
         assert "completion_mask" in batch
         completion_mask = batch["completion_mask"][0].tolist()
-        expected_mask = [0 if lbl == -100 else 1 for lbl in completion_labels]
-        assert completion_mask == expected_mask
+        assert 0 in completion_mask and 1 in completion_mask
+        first_completion = next(i for i, m in enumerate(completion_mask) if m == 1)
+        assert first_completion > 0  # at least the prompt is masked
+        assert all(m == 0 for m in completion_mask[:first_completion])
 
         # Test corruption of (prompt, completion) pairs for KL dataset.
         # _get_kl_completion_ids shifts completion_ids by one within each batch; prompt_ids are unchanged.

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -144,6 +144,11 @@ class TestKTOTrainer(TrlTestCase):
         first_unmasked = next(i for i, lbl in enumerate(completion_labels) if lbl != -100)
         assert first_unmasked > 0  # at least the prompt is masked
         assert completion_labels[first_unmasked:] == completion_input_ids[first_unmasked:]
+        # completion_mask: binary mask consistent with completion_labels (-100 ↔ 0, non-(-100) ↔ 1)
+        assert "completion_mask" in batch
+        completion_mask = batch["completion_mask"][0].tolist()
+        expected_mask = [0 if lbl == -100 else 1 for lbl in completion_labels]
+        assert completion_mask == expected_mask
 
         # Test corruption of (prompt, completion) pairs for KL dataset.
         # _get_kl_completion_ids shifts completion_ids by one within each batch; prompt_ids are unchanged.

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -149,11 +149,6 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
                 padding_value=0,
                 padding_side="right",
             )
-            batch[f"{prefix}_labels"] = pad(
-                [torch.tensor(lbl, dtype=torch.int64) for lbl in labels_list],
-                padding_value=-100,
-                padding_side="right",
-            )
             batch[f"{prefix}_mask"] = pad(
                 [torch.tensor(m, dtype=torch.int64) for m in completion_mask_list],
                 padding_value=0,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -815,47 +815,6 @@ class KTOTrainer(_BaseTrainer):
 
         return completion_logps, KL_logps
 
-    @staticmethod
-    def get_batch_logps(
-        logits: torch.FloatTensor,
-        labels: torch.LongTensor,
-        average_log_prob: bool = False,
-    ) -> torch.FloatTensor:
-        """Compute the log probabilities of the given labels under the given logits.
-
-        Args:
-            logits:
-                Logits of the model (unnormalized). Shape: (batch_size, sequence_length, vocab_size)
-            labels:
-                Labels for which to compute the log probabilities. Label tokens with a value of `-100` are ignored.
-                Shape: (batch_size, sequence_length)
-            average_log_prob:
-                If True, return the average log probability per (non-masked) token. Otherwise, return the sum of the
-                log probabilities of the (non-masked) tokens.
-
-        Returns:
-            A tensor of shape (batch_size,) containing the average/sum log probabilities of the given labels under the
-            given logits.
-        """
-        if logits.shape[:-1] != labels.shape:
-            raise ValueError("Logits (batch and sequence length dim) and labels must have the same shape.")
-
-        # For causal LM, shift labels and logits by one position
-        labels = labels[:, 1:].clone()
-        logits = logits[:, :-1, :]
-
-        loss_mask = labels != -100
-
-        # dummy token; we'll ignore the losses on these tokens later
-        labels[labels == -100] = 0
-
-        per_token_logps = selective_log_softmax(logits, labels)
-
-        if average_log_prob:
-            return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
-        else:
-            return (per_token_logps * loss_mask).sum(-1)
-
     def _compute_logps(self, model, batch):
         KL_logps = self._compute_kl_logps(model, batch)
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -95,6 +95,14 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
     Data collator for unpaired preference data. Assembles completions from raw token IDs and pads sequences to the
     maximum length of the batch.
 
+    Each example is expected to contain `"prompt_ids"`, `"completion_ids"` (and optionally `"KL_completion_ids"`) keys.
+    The collator returns a dictionary with the following keys for each prefix (`"completion"` and, if present,
+    `"KL_completion"`):
+    - `"{prefix}_input_ids"`: full prompt + completion token IDs, padded to the batch maximum length.
+    - `"{prefix}_attention_mask"`: attention mask, padded with 0s.
+    - `"{prefix}_labels"`: labels with prompt tokens masked as `-100`, padded with `-100`.
+    - `"{prefix}_mask"`: binary mask where 1 marks completion tokens and 0 marks prompt or padding tokens.
+
     Args:
         pad_token_id (`int`):
             Token ID to use for padding `input_ids` sequences.
@@ -116,16 +124,20 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
 
             full_ids_list = []
             labels_list = []
+            completion_mask_list = []
             for ex in examples:
                 prompt_ids = ex["prompt_ids"]
                 answer_ids = ex[ids_key]
                 full_ids = prompt_ids + answer_ids
                 labels = [-100] * len(prompt_ids) + answer_ids
+                completion_mask = [0] * len(prompt_ids) + [1] * len(answer_ids)
                 if self.max_length is not None:
                     full_ids = full_ids[: self.max_length]
                     labels = labels[: self.max_length]
+                    completion_mask = completion_mask[: self.max_length]
                 full_ids_list.append(full_ids)
                 labels_list.append(labels)
+                completion_mask_list.append(completion_mask)
 
             batch[f"{prefix}_input_ids"] = pad(
                 [torch.tensor(ids, dtype=torch.int64) for ids in full_ids_list],
@@ -140,6 +152,11 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
             batch[f"{prefix}_labels"] = pad(
                 [torch.tensor(lbl, dtype=torch.int64) for lbl in labels_list],
                 padding_value=-100,
+                padding_side="right",
+            )
+            batch[f"{prefix}_mask"] = pad(
+                [torch.tensor(m, dtype=torch.int64) for m in completion_mask_list],
+                padding_value=0,
                 padding_side="right",
             )
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -798,18 +798,18 @@ class KTOTrainer(_BaseTrainer):
                         attention_mask=inputs["KL_completion_attention_mask"],
                     ).logits
 
-        completion_logps = self.get_batch_logps(
-            completion_logits,
-            inputs["completion_labels"],
-            average_log_prob=False,
-        )
+        shift_logits = completion_logits[:, :-1, :].contiguous()
+        per_token_logps = selective_log_softmax(shift_logits, inputs["completion_input_ids"][:, 1:].contiguous())
+        per_token_logps[inputs["completion_mask"][:, 1:] == 0] = 0.0
+        completion_logps = per_token_logps.sum(-1)
 
         if self.calculate_KL:
-            KL_logps = self.get_batch_logps(
-                KL_logits,
-                inputs["KL_completion_labels"],
-                average_log_prob=False,
+            shift_KL_logits = KL_logits[:, :-1, :].contiguous()
+            KL_per_token_logps = selective_log_softmax(
+                shift_KL_logits, inputs["KL_completion_input_ids"][:, 1:].contiguous()
             )
+            KL_per_token_logps[inputs["KL_completion_mask"][:, 1:] == 0] = 0.0
+            KL_logps = KL_per_token_logps.sum(-1)
         else:
             KL_logps = None
 
@@ -870,11 +870,10 @@ class KTOTrainer(_BaseTrainer):
         )
         completion_logits = outputs.logits
 
-        completion_logps = self.get_batch_logps(
-            completion_logits,
-            batch["completion_labels"],
-            average_log_prob=False,
-        )
+        shift_logits = completion_logits[:, :-1, :].contiguous()
+        per_token_logps = selective_log_softmax(shift_logits, batch["completion_input_ids"][:, 1:].contiguous())
+        per_token_logps[batch["completion_mask"][:, 1:] == 0] = 0.0
+        completion_logps = per_token_logps.sum(-1)
 
         if completion_logps.shape[0] != len(batch["label"]):
             raise ValueError(
@@ -986,11 +985,12 @@ class KTOTrainer(_BaseTrainer):
             with torch.no_grad():
                 KL_logits = model(**KL_model_kwargs).logits
 
-            KL_logps = self.get_batch_logps(
-                KL_logits,
-                batch["KL_completion_labels"],
-                average_log_prob=False,
+            shift_KL_logits = KL_logits[:, :-1, :].contiguous()
+            KL_per_token_logps = selective_log_softmax(
+                shift_KL_logits, batch["KL_completion_input_ids"][:, 1:].contiguous()
             )
+            KL_per_token_logps[batch["KL_completion_mask"][:, 1:] == 0] = 0.0
+            KL_logps = KL_per_token_logps.sum(-1)
         return KL_logps
 
     def _compute_loss_liger(self, model, inputs, return_outputs):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -123,20 +123,16 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
                 continue
 
             full_ids_list = []
-            labels_list = []
             completion_mask_list = []
             for ex in examples:
                 prompt_ids = ex["prompt_ids"]
                 answer_ids = ex[ids_key]
                 full_ids = prompt_ids + answer_ids
-                labels = [-100] * len(prompt_ids) + answer_ids
                 completion_mask = [0] * len(prompt_ids) + [1] * len(answer_ids)
                 if self.max_length is not None:
                     full_ids = full_ids[: self.max_length]
-                    labels = labels[: self.max_length]
                     completion_mask = completion_mask[: self.max_length]
                 full_ids_list.append(full_ids)
-                labels_list.append(labels)
                 completion_mask_list.append(completion_mask)
 
             batch[f"{prefix}_input_ids"] = pad(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -998,6 +998,10 @@ class KTOTrainer(_BaseTrainer):
         lm_head = model.get_output_embeddings()
         ref_lm_head = self.ref_model.get_output_embeddings()
 
+        shift_completion_mask = batch["completion_mask"][:, 1:].contiguous()
+        target = batch["completion_input_ids"][:, 1:].clone()
+        target[shift_completion_mask == 0] = -100
+
         (
             loss,
             (
@@ -1011,7 +1015,7 @@ class KTOTrainer(_BaseTrainer):
         ) = self.kto_loss_fn(
             _input=outputs.last_hidden_state[:, :-1],
             lin_weight=lm_head.weight,
-            target=batch["completion_labels"][:, 1:],
+            target=target,
             bias=lm_head.bias if hasattr(lm_head, "bias") else None,
             preference_labels=torch.tensor(batch["label"], dtype=torch.bool).to(self.accelerator.device),
             ref_input=ref_outputs.last_hidden_state[:, :-1],

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -100,7 +100,6 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
     `"KL_completion"`):
     - `"{prefix}_input_ids"`: full prompt + completion token IDs, padded to the batch maximum length.
     - `"{prefix}_attention_mask"`: attention mask, padded with 0s.
-    - `"{prefix}_labels"`: labels with prompt tokens masked as `-100`, padded with `-100`.
     - `"{prefix}_mask"`: binary mask where 1 marks completion tokens and 0 marks prompt or padding tokens.
 
     Args:


### PR DESCRIPTION
Align KTO with DPO: Replace completion_labels/get_batch_logps with completion_mask.

Part of:
- #4786

This PR refactors how prompt and completion tokens are masked and processed in the KTO trainer and data collator. The main change is replacing the use of label masking (`-100` for prompt tokens) with an explicit binary `completion_mask` to distinguish prompt and completion tokens. This leads to more consistent handling of masked tokens throughout the codebase and simplifies log probability computations.

### Solution

This PR replaces KTO's `-100`-based logprob masking approach with the `completion_mask` binary tensor pattern used by DPO, eliminating the `get_batch_logps` static method.

- **Before:** The collator emitted `completion_labels` (prompt tokens masked with `-100`, completion tokens as actual IDs). Logprobs were computed via a dedicated static method `get_batch_logps` that derived the mask by testing `labels != -100`.

- **After:** The collator emits `completion_mask` (0 for prompt/padding, 1 for completion tokens), matching DPO's `DataCollatorForPreference`. Logprob computation is inlined at each call site using `selective_log_softmax` + `per_token_logps[mask == 0] = 0.0`, exactly as DPO does.

### Changes

**Data Collator and Batch Preparation:**
- The data collator now generates a binary `"{prefix}_mask"` (e.g., `completion_mask`) that marks completion tokens with `1` and prompt/padding tokens with `0`, instead of using label masking with `-100`. 
- The test for tokenization and processing is updated to check the correctness of the new `completion_mask` instead of label masking.

**Log Probability and Loss Computation:**
- All log probability computations now use the new `completion_mask` to select completion tokens, setting non-completion token log-probs to zero before summing. The old `get_batch_logps` method (which relied on `-100` label masking) is removed.
- The loss computation for Liger uses the shifted `completion_mask` to set the target tensor, masking out prompt and padding tokens with `-100`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sequence log-probabilities are aggregated for KTO training and reference precomputation; behavior should match prior masking intent but any mask/shift mismatch would affect rewards and loss.
> 
> **Overview**
> KTO’s unpaired preference collator and trainer now follow the same **completion masking** pattern as DPO: batches expose binary `completion_mask` / `KL_completion_mask` (0 for prompt and padding, 1 for completion tokens) instead of `completion_labels` with `-100` on the prompt.
> 
> **Collator:** `DataCollatorForUnpairedPreference` builds and pads `{prefix}_mask` tensors and documents the new batch keys; `completion_labels` padding is removed.
> 
> **Log-probs:** Reference, policy, and KL log-probability paths no longer call the removed static `get_batch_logps`. They use causal shifting, `selective_log_softmax`, zero out non-completion positions via the shifted mask, then sum per sequence—matching DPO’s inline style.
> 
> **Liger path:** Targets for the fused KTO loss are built from shifted `completion_input_ids` with prompt/padding positions set to `-100` using the shifted `completion_mask`, instead of slicing `completion_labels`.
> 
> **Tests:** `test_tokenize_and_process_tokens` asserts mask structure (zeros before first one, both 0 and 1 present) rather than label alignment with `input_ids`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845858d75b92fcf771f6bf0470903b36bb5819b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->