### PR TITLE
Don't treat ROCm GPUs as Ampere

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -89,6 +89,11 @@ def is_ampere_or_newer(device_index=0):
     if not torch.cuda.is_available():
         return False
 
+    # "Ampere" is an NVIDIA architecture; an AMD (ROCm) GPU is never Ampere. On ROCm,
+    # torch.cuda.get_device_capability returns the gfx version, which would spuriously compare >= (8, 0).
+    if torch.version.hip is not None:
+        return False
+
     major, minor = torch.cuda.get_device_capability(device_index)
     # Ampere starts at compute capability 8.0 (e.g., A100 = 8.0, RTX 30xx = 8.6)
     return (major, minor) >= (8, 0)


### PR DESCRIPTION
On ROCm, `torch.cuda.get_device_capability()` returns the gfx version, so `is_ampere_or_newer()` was coming back `True` on AMD GPUs. That let the Flash Attention 2 tests run on AMD — where they fail fetching the CUDA-only `kernels-community/flash-attn2` hub kernel — instead of being skipped.

"Ampere" is an NVIDIA architecture, so an AMD GPU is never Ampere-or-newer. This just returns `False` on ROCm so those tests skip cleanly.

Found while bringing TRL up on a ROCm box (Radeon 890M, gfx1150).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only guard change; no production training or inference paths affected.
> 
> **Overview**
> Fixes **`is_ampere_or_newer()`** in `tests/testing_utils.py` so ROCm (HIP) builds always return **`False`**, instead of treating AMD **gfx** capability numbers like NVIDIA Ampere (≥ 8.0).
> 
> Flash Attention 2–related tests that gate on this helper will **skip on AMD GPUs** rather than running and failing on CUDA-only hub kernels (e.g. `kernels-community/flash-attn2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b158bbbcd806e07ebf653cbb62db43df642e071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->