### PR TITLE
Fix SFT padding-free test config

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1095,6 +1095,7 @@ class TestSFTTrainer(TrlTestCase):
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
             padding_free=True,
+            max_length=None,  # padding-free without packing doesn't enforce max_length
             model_init_kwargs={"attn_implementation": "kernels-community/flash-attn2"},
             bf16=True,  # flash_attention_2 only supports bf16 and fp16
             report_to="none",


### PR DESCRIPTION
`test_train_padding_free` builds an `SFTConfig` with `padding_free=True` but leaves `max_length` at its default (1024) and doesn't enable packing. That combination hits the guard added in #5359:

> When `padding_free=True` without packing, `max_length` is not enforced. Either enable packing, provide already truncated inputs, or set `max_length=None`.

so the test raises before it can train. It's gone unnoticed because it's gated behind `is_ampere_or_newer()` and our GPU CI runs on T4s (compute 7.5), where it just skips — it only actually runs on Ampere+/XPU/ROCm.

Fix is the one the error message suggests: set `max_length=None`, which is correct for padding-free without packing (the collator flattens sequences, so there's nothing to truncate). Matches what the VLM tests already do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or training behavior is modified.
> 
> **Overview**
> Sets **`max_length=None`** on the `SFTConfig` in **`test_train_padding_free`** so the test satisfies the trainer guard for **`padding_free=True`** without packing (introduced in #5359). With the default **`max_length=1024`**, **`SFTTrainer`** raises before training; **`max_length=None`** matches padding-free, non-packed training and aligns with existing VLM tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28819804e1c670eb697f37c148ca5a39e0339a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->