### PR TITLE
Fix partial reward margins in collator

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,28 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    def test_collate_with_margin_missing_from_first_example(self):
+        collator = DataCollatorForPreference(pad_token_id=0)
+        examples = [
+            {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5]},
+            {"chosen_ids": [6, 7], "rejected_ids": [8], "margin": 0.2},
+        ]
+
+        result = collator(examples)
+
+        torch.testing.assert_close(result["margin"], torch.tensor([0.0, 0.2]))
+
+    def test_collate_with_margin_missing_from_later_example(self):
+        collator = DataCollatorForPreference(pad_token_id=0)
+        examples = [
+            {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5], "margin": 0.1},
+            {"chosen_ids": [6, 7], "rejected_ids": [8]},
+        ]
+
+        result = collator(examples)
+
+        torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.0]))
+
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,8 +201,9 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
-            margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
+        margins = None
+        if any("margin" in example for example in examples):
+            margins = torch.tensor([example.get("margin", 0.0) for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
 
@@ -221,7 +222,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if margins is not None:
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
﻿# What does this PR do?

Fixes #5539.

`DataCollatorForPreference` currently decides whether to emit a `margin` tensor by checking only `examples[0]`. That makes the result depend on batch order:

- if the first example has no `margin`, later margins are silently dropped
- if the first example has `margin` but a later example does not, collation raises `KeyError`

This PR checks the whole batch instead. If any example provides `margin`, the collator emits a margin tensor and defaults missing margins to `0.0`, matching the optional-field behavior documented for this collator.

I added regression tests for both mixed-order cases.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

## Tests

```text
python -m pytest tests/test_reward_trainer.py::TestDataCollatorForPreference -q
python -m ruff check trl\trainer\reward_trainer.py tests\test_reward_trainer.py
python -m py_compile trl\trainer\reward_trainer.py tests\test_reward_trainer.py
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward-training batch collation and can alter loss when batches mix examples with and without margins; scope is small and covered by new tests.
> 
> **Overview**
> Fixes **`DataCollatorForPreference`** so optional **`margin`** values are handled correctly when only some examples in a batch define them.
> 
> Previously, collation keyed off **`examples[0]`** only: margins on later rows could be dropped, or a missing key on a later row could raise **`KeyError`**. The collator now emits a **`margin`** tensor if **any** example has **`margin`**, and fills missing entries with **`0.0`**.
> 
> Two unit tests cover mixed batches (margin missing on the first vs. on a later example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5988fbb8ea7d3b5ea71401b988ce1b0b45dbbc2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->