### PR TITLE
Remove redundant .contiguous() calls in DPOTrainer to reduce peak memory

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1074,9 +1074,9 @@ class DPOTrainer(_BaseTrainer):
 
         input_ids = inputs["input_ids"]
         completion_mask = inputs["completion_mask"]
-        shift_labels = input_ids[..., 1:].contiguous()
-        shift_completion_mask = completion_mask[..., 1:].contiguous()
-        ref_shift_logits = ref_outputs.logits[..., :-1, :].contiguous()
+        shift_labels = input_ids[..., 1:]
+        shift_completion_mask = completion_mask[..., 1:]
+        ref_shift_logits = ref_outputs.logits[..., :-1, :]
         ref_per_token_logps = selective_log_softmax(ref_shift_logits, shift_labels)
         ref_per_token_logps[shift_completion_mask == 0] = 0.0
 
@@ -1182,9 +1182,9 @@ class DPOTrainer(_BaseTrainer):
 
         input_ids = inputs["input_ids"]
         completion_mask = inputs["completion_mask"]
-        shift_logits = outputs.logits[..., :-1, :].contiguous()
-        shift_labels = input_ids[..., 1:].contiguous()
-        shift_completion_mask = completion_mask[..., 1:].contiguous()
+        shift_logits = outputs.logits[..., :-1, :]
+        shift_labels = input_ids[..., 1:]
+        shift_completion_mask = completion_mask[..., 1:]
         per_token_logps = selective_log_softmax(shift_logits, shift_labels)
         per_token_logps[shift_completion_mask == 0] = 0.0  # mask out non-completion tokens
         if self.ld_alpha is None:
@@ -1219,7 +1219,7 @@ class DPOTrainer(_BaseTrainer):
                 else:
                     ref_outputs = self.ref_model(**model_kwargs)
 
-            ref_shift_logits = ref_outputs.logits[..., :-1, :].contiguous()
+            ref_shift_logits = ref_outputs.logits[..., :-1, :]
             ref_per_token_logps = selective_log_softmax(ref_shift_logits, shift_labels)
             ref_per_token_logps[shift_completion_mask == 0] = 0.0  # mask out non-completion tokens
             if self.ld_alpha is None:


### PR DESCRIPTION
## PR Title

`Remove redundant .contiguous() calls in DPOTrainer to reduce peak memory`

## PR Body

**What does this PR do?**

Removes unnecessary `.contiguous()` calls on logits, labels, and completion masks in `DPOTrainer.compute_ref_log_probs` and `DPOTrainer._compute_loss`.

These slicing operations (`[..., :-1, :]`, `[..., 1:]`) produce non-contiguous views. Calling `.contiguous()` forces a full copy — for the logits tensor `[B, S, V]` with Qwen's 151k vocab, each copy is ~580 MB in bf16. In `_compute_loss` without `precompute_ref_log_probs`, both model and ref logits are copied, wasting ~1.16 GB.

The downstream consumer `selective_log_softmax` only uses `torch.gather` and `torch.logsumexp`, neither of which requires contiguous input. The same optimization was already applied to `SFTTrainer` in #5897.

The Liger loss path (`_compute_loss_liger`) is left unchanged since fused Liger kernels may rely on contiguous memory.

**Benchmark** (Qwen2.5-0.5B-Instruct, A100 44GB, bf16, batch\_size=4, max\_length=512, `precompute_ref_log_probs=False`):

| | Before | After | Δ |
|---|---|---|---|
| Peak memory | 18289 MB | 15531 MB | **−2758 MB (−15.1%)** |
| Train time (3 steps) | 2.00 s | 2.00 s | — |
| Loss / metrics | identical | identical | — |

<details>
<summary>Reproduce</summary>

```python
# Save as bench.py, then run:
#   python bench.py                                          # after
#   git stash && python bench.py && git stash pop            # before
import gc, tempfile, time, torch
from datasets import load_dataset
from trl import DPOConfig, DPOTrainer

gc.collect(); torch.cuda.empty_cache(); torch.cuda.reset_peak_memory_stats()
dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train[:100]")
args = DPOConfig(
    output_dir=tempfile.mkdtemp(), save_strategy="no",
    per_device_train_batch_size=4, max_steps=3, max_length=512,
    gradient_checkpointing=True, bf16=True, report_to="none",
    logging_steps=1, precompute_ref_log_probs=False,
)
start = time.perf_counter()
trainer = DPOTrainer(model="Qwen/Qwen2.5-0.5B-Instruct", args=args, train_dataset=dataset)
trainer.train()
peak_mb = torch.cuda.max_memory_allocated() / 1024**2
print(f"Peak: {peak_mb:.0f} MB | Time: {time.perf_counter()-start:.1f}s")
```

</details>

**Before submitting**

- [x] This PR fixes a bug or adds a non-invasive improvement (no new features or API changes)
- [x] A benchmark is included demonstrating the memory reduction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow memory optimization on tensor views with unchanged numerics; Liger path untouched and behavior matches the prior SFTTrainer change.
> 
> **Overview**
> **DPOTrainer** no longer calls `.contiguous()` on shifted `logits`, `input_ids`, and `completion_mask` in `compute_ref_log_probs` and `_compute_loss`. Slicing already yields views; forcing contiguity duplicated large `[B, S, V]` tensors and inflated peak VRAM during reference and policy log-prob computation.
> 
> Downstream `selective_log_softmax` only uses `torch.gather` and `torch.logsumexp`, so contiguity was unnecessary—the same change was already made for **SFTTrainer** in #5897. The **Liger** loss path (`_compute_loss_liger`) is unchanged because fused kernels may still expect contiguous buffers.
> 
> Reported impact: materially lower peak memory with identical loss/metrics and no training-time regression in the included benchmark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528bc898e32466b9164a9f6d9a0f58b9057e782b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->