### PR TITLE
Improve error message when image tokens are truncated by max_length

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1481,10 +1481,19 @@ class DPOTrainer(_BaseTrainer):
         return (loss, outputs) if return_outputs else loss
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        if self.use_liger_kernel:
-            return self._compute_loss_liger(model, inputs, return_outputs)
-        else:
-            return self._compute_loss(model, inputs, return_outputs)
+        try:
+            if self.use_liger_kernel:
+                return self._compute_loss_liger(model, inputs, return_outputs)
+            else:
+                return self._compute_loss(model, inputs, return_outputs)
+        except ValueError as e:
+            if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:
+                raise ValueError(
+                    f"The current `max_length` ({self.args.max_length}) is too short and causes image placeholder "
+                    f"tokens in `input_ids` to be truncated, while the corresponding image features remain intact. "
+                    f"Please increase `max_length` or set it to `None` to disable truncation."
+                ) from e
+            raise
 
     # Override training step to add activation offloading context.
     def training_step(self, *args, **kwargs):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1600,9 +1600,18 @@ class SFTTrainer(_BaseTrainer):
             inputs["return_token_accuracy"] = True
             inputs["use_token_scaling"] = self.args.loss_type == "dft"
 
-        (loss, outputs) = super().compute_loss(
-            model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
-        )
+        try:
+            (loss, outputs) = super().compute_loss(
+                model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
+            )
+        except ValueError as e:
+            if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:
+                raise ValueError(
+                    f"The current `max_length` ({self.args.max_length}) is too short and causes image placeholder "
+                    f"tokens in `input_ids` to be truncated, while the corresponding image features remain intact. "
+                    f"Please increase `max_length` or set it to `None` to disable truncation."
+                ) from e
+            raise
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":


### PR DESCRIPTION
# What does this PR do?

When training VLMs (e.g., Qwen3.5) with max_length truncation enabled, the tokenizer may truncate image placeholder tokens while the image processor retains all pixel features. This causes a mismatch at model forward time: 

ValueError: Image features and image tokens do not match, tokens: 14650, features: 17152.

This error gives no indication of the root cause, leaving users to debug on their own.

This PR wraps the `compute_loss` call in both `SFTTrainer` and `DPOTrainer` with a try-except that catches this 
specific `ValueError` when `max_length` is set, and re-raises it with a clear, actionable message:

ValueError: The current max_length (self.args.max_length) is too short and causes image placeholder tokens in input_ids
to be truncated, while the corresponding image features remain intact. Please increase max_length or set
it to None to disable truncation.

The original exception is chained via `from e` so the full traceback is preserved.

As discussed in #5904, the maintainer confirmed that the raise-error behavior should be preserved (silently dropping image tokens would change training semantics), but the error message should be improved for better diagnostics.

**Changes:**
- `SFTTrainer.compute_loss`: wrap `super().compute_loss()` with try-except
- `DPOTrainer.compute_loss`: wrap `_compute_loss()` / `_compute_loss_liger()` dispatch with try-except
- Other `ValueError`s are re-raised unchanged

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @kashif

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only change around existing loss computation; no change to truncation behavior or loss math.
> 
> **Overview**
> **SFTTrainer** and **DPOTrainer** now wrap their `compute_loss` paths in a `try`/`except` that intercepts the transformers `ValueError` whose message contains *"Image features and image tokens do not match"* when `max_length` is set.
> 
> Instead of the opaque token/feature count mismatch, users get a message explaining that **`max_length` is truncating image placeholder tokens in `input_ids` while `pixel_values` stay full**, with guidance to raise `max_length` or set it to `None`. The original error is preserved via `from e`. All other `ValueError`s are re-raised unchanged; training semantics are not altered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e4d7e19bf57e66aa6d7d40b245c736a61f005d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->