### PR TITLE
docs(rloo): clarify KL estimator choice

### DIFF
--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1281,6 +1281,8 @@ class RLOOTrainer(_BaseTrainer):
 
         # Include the KL penalty in the reward
         if self.beta != 0.0:
+            # RLOO follows Ahmadian et al. and uses the sampled log-ratio estimator here.
+            # This differs intentionally from GRPO's Schulman approximation.
             per_token_kl = old_per_token_logps - ref_per_token_logps
             # Apply sequence-level KL penalty to rewards (sum KL across tokens first, then apply to each sequence)
             kl = (per_token_kl * completion_mask).sum(-1)


### PR DESCRIPTION
## Summary
- document that RLOO intentionally uses the sampled log-ratio KL estimator from Ahmadian et al.
- make the divergence from GRPO's Schulman approximation explicit

This follows the maintainer direction in #5889: if the formula is intentional, the code should say so.

## To verify
- `python -m py_compile trl/trainer/rloo_trainer.py`
- `python -m ruff check trl/trainer/rloo_trainer.py`
- `python -m ruff format --check trl/trainer/rloo_trainer.py`

No trainer behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or training behavior impact.
> 
> **Overview**
> Adds inline comments in `rloo_trainer.py` where the KL penalty is applied to rewards, documenting that **RLOO** intentionally uses the **sampled log-ratio** estimator (`old_per_token_logps - ref_per_token_logps`) per Ahmadian et al., and that this is **not** the same as **GRPO**’s Schulman-style KL approximation.
> 
> There are **no** changes to formulas, training logic, or configuration—documentation only, aimed at reviewers comparing RLOO and GRPO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa14d012138973b020f19b988b2140be5cdc42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->