### PR TITLE
fix: scale async grpo aiohttp connection limit

### DIFF
--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -1,0 +1,31 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from trl.experimental.async_grpo.async_rollout_worker import _make_client_session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_inflight_tasks", "expected_limit"),
+    [
+        (32, 100),
+        (100, 100),
+        (256, 256),
+    ],
+)
+async def test_client_session_connector_follows_max_inflight_tasks(max_inflight_tasks, expected_limit):
+    async with _make_client_session(max_inflight_tasks) as session:
+        assert session.connector.limit == expected_limit

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -64,6 +64,11 @@ async def _retry_on_http_error(coro_factory: Callable[[], Awaitable], *, label: 
             await asyncio.sleep(sleep)
 
 
+def _make_client_session(max_inflight_tasks: int) -> aiohttp.ClientSession:
+    connector = aiohttp.TCPConnector(limit=max(100, max_inflight_tasks))
+    return aiohttp.ClientSession(connector=connector)
+
+
 @dataclass(slots=True)
 class RolloutGroup:
     prompt: Messages
@@ -288,7 +293,7 @@ class _AsyncRolloutLoop:
             self._loop.close()
 
     async def _run_loops(self, stop_event: asyncio.Event) -> None:
-        async with aiohttp.ClientSession() as session:
+        async with _make_client_session(self.max_inflight_tasks) as session:
             self.session = session
             logger.info(
                 f"vllm worker started: num_generations={self.num_generations}, "


### PR DESCRIPTION
## Summary
- create the async rollout worker aiohttp session with an explicit TCPConnector
- keep aiohttp's default total connection floor of 100 for small runs
- raise the connector limit to `max_inflight_tasks` when AsyncGRPO schedules more than 100 concurrent rollout requests

Fixes #5847.

## To verify
- `python -m pytest tests\experimental\test_async_rollout_worker.py -q`
- `python -m ruff check trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `python -m ruff format --check trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `python -m py_compile trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to HTTP client pooling in experimental async rollout code, with unit tests and no auth or data-path changes.
> 
> **Overview**
> The async GRPO rollout worker now builds its **aiohttp** session with an explicit **`TCPConnector`** whose total connection limit is **`max(100, max_inflight_tasks)`**, instead of relying on the library default (100). That keeps the default floor for small runs but lets high **`max_inflight_tasks`** (e.g. from AsyncGRPO auto-sizing) open enough parallel connections to vLLM so rollout tasks are not queued behind the connector cap.
> 
> A small **`_make_client_session`** helper centralizes this, and **`_run_loops`** uses it when starting the worker. New async tests assert the connector limit for representative **`max_inflight_tasks`** values (32 → 100, 100 → 100, 256 → 256).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a60b57f30923a5386b6ccb4b48f9d58d4745a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->