### PR TITLE
fix: scale async grpo aiohttp connection limit

### DIFF
--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -1,0 +1,31 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from trl.experimental.async_grpo.async_rollout_worker import _make_client_session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_inflight_tasks", "expected_limit"),
+    [
+        (32, 100),
+        (100, 100),
+        (256, 256),
+    ],
+)
+async def test_client_session_connector_follows_max_inflight_tasks(max_inflight_tasks, expected_limit):
+    async with _make_client_session(max_inflight_tasks) as session:
+        assert session.connector.limit == expected_limit

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -64,6 +64,11 @@ async def _retry_on_http_error(coro_factory: Callable[[], Awaitable], *, label: 
             await asyncio.sleep(sleep)
 
 
+def _make_client_session(max_inflight_tasks: int) -> aiohttp.ClientSession:
+    connector = aiohttp.TCPConnector(limit=max(100, max_inflight_tasks))
+    return aiohttp.ClientSession(connector=connector)
+
+
 @dataclass(slots=True)
 class RolloutGroup:
     prompt: Messages
@@ -288,7 +293,7 @@ class _AsyncRolloutLoop:
             self._loop.close()
 
     async def _run_loops(self, stop_event: asyncio.Event) -> None:
-        async with aiohttp.ClientSession() as session:
+        async with _make_client_session(self.max_inflight_tasks) as session:
             self.session = session
             logger.info(
                 f"vllm worker started: num_generations={self.num_generations}, "


### PR DESCRIPTION
# What does this PR do?

AsyncGRPO already sizes its rollout scheduler with `max_inflight_tasks`, but the child worker used the default `aiohttp.ClientSession()` connector. `aiohttp` caps total open connections at 100 by default, so runs with `max_inflight_tasks > 100` can still queue requests behind the HTTP connector instead of sending the expected number of concurrent requests to vLLM.

This PR creates the worker session with an explicit `TCPConnector(limit=max(100, max_inflight_tasks))`. Small runs keep aiohttp's default 100-connection floor, while larger AsyncGRPO runs can actually use the concurrency that the trainer configured. The regression test checks representative connector limits without starting vLLM or a training loop.

Fixes #5847.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case: #5847.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

## Local validation

- `python -m pytest tests\experimental\test_async_rollout_worker.py -q`
- `python -m ruff check trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `python -m ruff format --check trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `python -m py_compile trl\experimental\async_grpo\async_rollout_worker.py tests\experimental\test_async_rollout_worker.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to HTTP client setup in the experimental async rollout worker, with a unit test and no auth, data, or training-logic changes.
> 
> **Overview**
> Fixes a mismatch where AsyncGRPO’s rollout worker could schedule more than 100 concurrent vLLM HTTP calls via `max_inflight_tasks`, but **aiohttp** still capped open connections at its default **100**, so extra work queued on the connector instead of hitting vLLM.
> 
> The worker now builds its session through **`_make_client_session`**, which sets **`TCPConnector(limit=max(100, max_inflight_tasks))`**—keeping the 100-connection floor for smaller runs and raising the cap when the trainer configures higher concurrency. A focused async test asserts the connector limit for representative `max_inflight_tasks` values without starting vLLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a60b57f30923a5386b6ccb4b48f9d58d4745a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->