### PR TITLE
fix: Add warning for unsupported int4 quantization with device_map

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2298,3 +2298,31 @@ class TestSFTTrainerSlow(TrlTestCase):
             assert not torch.allclose(param, new_param), f"Parameter {n} has not changed"
 
         release_memory(trainer.model, trainer)
+
+    def test_int4_device_map_auto_warning(self):
+        """Test that a warning is raised when using int4 quantization with device_map='auto'."""
+        # Mock a model with is_loaded_in_4bit=True and hf_device_map set
+        mock_model = MagicMock()
+        mock_model.config = MagicMock()
+        mock_model.config.vocab_size = 1000
+        mock_model.config.model_type = "gpt2"
+        mock_model.is_loaded_in_4bit = True
+        mock_model.hf_device_map = {"": 0}
+        mock_model.parameters.return_value = []
+        mock_model.named_parameters.return_value = []
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            report_to="none",
+            per_device_train_batch_size=2,
+            max_steps=2,
+        )
+
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:10]")
+
+        with pytest.warns(UserWarning, match="int4.*device_map.*auto"):
+            SFTTrainer(
+                model=mock_model,
+                args=training_args,
+                train_dataset=dataset,
+            )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -819,6 +819,13 @@ class SFTTrainer(_BaseTrainer):
         # quantized models. See: https://github.com/huggingface/peft/issues/2889
         # Non-quantized models do not have the `is_loaded_in_{8,4}bit` attributes, whereas quantized models do
         if getattr(model, "is_loaded_in_4bit", False) or getattr(model, "is_loaded_in_8bit", False):
+            # Warn about unsupported int4 quantization with device_map auto (see https://github.com/huggingface/trl/issues/4018)
+            if getattr(model, "is_loaded_in_4bit", False) and getattr(model, "hf_device_map", None) is not None:
+                warnings.warn(
+                    "Using 4-bit (int4) quantization with `device_map='auto'` may lead to meta-tensor errors. "
+                    "Consider using 8-bit quantization or manually specifying the device map.",
+                    UserWarning,
+                )
             for param in model.parameters():
                 if param.requires_grad:
                     param.data = param.data.to(torch.bfloat16)


### PR DESCRIPTION
This PR fixes #4018 by adding a warning when the user tries to combine 4-bit quantization with device_map=auto in the SFTTrainer.

4-bit quantization (is_loaded_in_4bit) does not work with device_map, but 8-bit does. We now warn the user and suggest disabling device_map if they want to use 4-bit quantization.

## Changes
- Added a warning in SFTTrainer.__init__ when is_loaded_in_4bit=True and hf_device_map is not None.
- Added a unit test to verify the warning is raised.

## Tests
- test_int4_device_map_auto_warning verifies that the warning is emitted with the correct message.

## PR Checklist
- [x] I have read the CONTRIBUTING.md guide.
- [x] I have written tests for my changes.
- [x] My changes generate no new warnings (except the intended one).
- [x] I have signed all my commits with DCO (git commit -s).

## AI Writing Disclosure
This PR was AI-assisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0ae551a9808dea59d223973caaf869ba69c654b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->