### PR TITLE
Fix backbone access in GRPO by aligning with SFT

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -997,7 +997,7 @@ class GRPOTrainer(_BaseTrainer):
 
         model_inputs["use_cache"] = False  # only used in generation; set False to suppress warnings
 
-        # `base_model` gives the inner module (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
+        # `base_model` gives the backbone model (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
         # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
         # returns just the text stack and feeds image-placeholder IDs through it.
         # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `base_model is self` (re-runs `lm_head`).

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -997,7 +997,16 @@ class GRPOTrainer(_BaseTrainer):
 
         model_inputs["use_cache"] = False  # only used in generation; set False to suppress warnings
 
-        last_hidden_state = unwrapped_model.model(**model_inputs).last_hidden_state
+        # `base_model` gives the inner module (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
+        # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
+        # returns just the text stack and feeds image-placeholder IDs through it.
+        # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `base_model is self` (re-runs `lm_head`).
+        # Fall back to `.model` there.
+        if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
+            backbone = unwrapped_model.model
+        else:
+            backbone = unwrapped_model.base_model
+        last_hidden_state = backbone(**model_inputs).last_hidden_state
         # Exclude the last value: it corresponds to the next token pred
         last_hidden_state = last_hidden_state[:, :-1, :]  # (B, L-1, H)
         # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -290,7 +290,7 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         decoder_kwargs = {}
         if output_router_logits:
             decoder_kwargs["output_router_logits"] = True
-        # `self.base_model` gives the inner module (skipping `lm_head`) — text decoder for LMs, multimodal wrapper
+        # `base_model` gives the backbone model (skipping `lm_head`) — text decoder for LMs, multimodal wrapper
         # for VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
         # returns just the text stack and feeds image-placeholder IDs through it.
         # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `self.base_model is self` (re-runs `lm_head`).

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -296,10 +296,10 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `self.base_model is self` (re-runs `lm_head`).
         # Fall back to `self.model` there.
         if is_vlm and Version(transformers.__version__) < Version("5.0.0"):
-            decoder = self.model
+            backbone = self.model
         else:
-            decoder = self.base_model
-        outputs: BaseModelOutputWithPast = decoder(
+            backbone = self.base_model
+        outputs: BaseModelOutputWithPast = backbone(
             input_ids=input_ids, attention_mask=attention_mask, use_cache=False, **decoder_kwargs, **kwargs
         )
         hidden_states = outputs.last_hidden_state


### PR DESCRIPTION
Fix backbone access in GRPO aligning with SFT.

This PR aligns `GRPOTrainer` with `SFTTrainer` by fixing how the last hidden state is retrieved from models in the `_get_last_hidden_state` method. This improves compatibility with different versions of the `transformers` library and better handling of vision-language models (VLMs).

Follow-up to this review comment: https://github.com/huggingface/trl/pull/5943#discussion_r3361794937

### Motivation

In `GRPOTrainer._get_last_hidden_state`, the backbone is accessed via `unwrapped_model.model`: a hardcoded attribute name that assumes `base_model_prefix == "model"`. 

`SFTTrainer` uses the more robust `model.base_model`, which is a `PreTrainedModel` property that resolves to `getattr(self, self.base_model_prefix)` and works correctly across all model families.

### Solution

This PR aligns `GRPOTrainer` with `SFTTrainer`'s established pattern:
- Use `unwrapped_model.base_model` in the general case (text LMs and VLMs on transformers ≥ 5.0).
- Fall back to `unwrapped_model.model` only for pre-5.0 VLMs, where `base_model_prefix = ""` makes `base_model is self` (which would re-run `lm_head`).

The comment explaining the choice is taken verbatim from SFTTrainer.

### Changes

Model compatibility and robustness improvements:

* Updated the logic to select the correct model backbone (`base_model` or `model`) depending on whether the model is a VLM and the version of `transformers`, ensuring that the correct module is used for both language models and VLMs, and avoiding issues with pre-5.0 transformers where `base_model_prefix` is set to an empty string.
* Added explanatory comments clarifying why `base_model` or `model` is chosen and the pitfalls of using `get_decoder()` with VLMs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which submodule runs during GRPO/Liger loss hidden-state extraction, so wrong selection would skew policy gradients; scope is limited to backbone routing, not reward or generation logic.
> 
> **Overview**
> **GRPO** `_get_last_hidden_state` no longer hardcodes `unwrapped_model.model` for hidden states. It now picks the backbone the same way as **SFT**: `unwrapped_model.base_model` by default, and `unwrapped_model.model` only for VLMs on **transformers &lt; 5.0** (where `base_model` would alias the full model and re-run `lm_head`). The same inline comment as SFT documents why `get_decoder()` is avoided for VLMs.
> 
> **SFT** only renames the local `decoder` variable to `backbone` and tightens the comment wording—behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9d2efb99f64d71bfe689bd26fd3976858f7460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->