### PR TITLE
Create CI workflow to sync TRL skill with huggingface/skills

### DIFF
--- a/.github/workflows/sync-huggingface-skills.yml
+++ b/.github/workflows/sync-huggingface-skills.yml
@@ -1,0 +1,91 @@
+name: Sync TRL skill with huggingface/skills
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!v*rc*'
+  workflow_dispatch:
+
+jobs:
+  sync-skills:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trl repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Determine PR title
+        id: pr_title
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            echo "title=Sync TRL Skill (${{ github.ref_name }})" >> $GITHUB_OUTPUT
+          else
+            echo "title=Sync TRL Skill (manual trigger)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
+          private-key: ${{ secrets.APP_SECRET_PREM_HUB_SKILLS_REPO }}
+          repositories: skills
+
+      - name: Checkout huggingface/skills repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: huggingface/skills
+          token: ${{ steps.app_token.outputs.token }}
+          path: skills-repo
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Copy generated files
+        run: cp trl/skills/trl-training/SKILL.md skills-repo/skills/trl-training/
+
+      - name: Check for TRL skill changes
+        id: check_changes
+        working-directory: skills-repo
+        # git diff returns zero if there is no diff
+        run: |
+          if git diff --quiet -- skills/trl-training/SKILL.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No trl skill changes; skipping PR"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Regenerate skills repo artifacts
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: skills-repo
+        run: |
+          ./scripts/publish.sh
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          path: skills-repo
+          branch: sync/hf-cli-${{ github.run_id }}
+          delete-branch: true
+          title: ${{ steps.pr_title.outputs.title }}
+          body: |
+            Auto-generated from [trl@${{ github.sha }}](https://github.com/huggingface/trl/commit/${{ github.sha }})
+
+            Triggered by changes to `trl/skills/trl-training`
+
+            ---
+            This PR was created automatically by the [sync-huggingface-skills](https://github.com/huggingface/trl/blob/main/.github/workflows/sync-huggingface-skills.yml) workflow.
+          commit-message: "Sync TRL skill from trl@${{ github.sha }}"
+          labels: |
+            automated
+            cli-sync


### PR DESCRIPTION
Create CI workflow to sync TRL skill with huggingface/skills.

This PR adds a new GitHub Actions workflow to automate syncing the TRL skill with the `huggingface/skills` repository. The workflow triggers on new version tags or manual dispatch, checks for changes, and creates a pull request in the `skills` repo if updates are detected.

CC: @burtenshaw 

### Requirement

I have already manually created the TRL skill in the `huggingface/skills`: needs approval and merging
- [ ] https://github.com/huggingface/skills/pull/161

Once this PR merged, users will be able to install the TRL skill using the general Hugging Face procedure:
```shell
hf skills add trl-training
```

See docs: https://huggingface.co/docs/hub/agents-skills

### Changes

**New workflow for syncing TRL skill:**

* Adds `.github/workflows/sync-huggingface-skills.yml` to automate copying `SKILL.md` from `trl/skills/trl-training` to the `huggingface/skills` repository and opening a PR if there are changes.
* Uses a GitHub App for secure authentication and permissions when pushing to the `skills` repo.
* Ensures the workflow only runs on version tags (excluding release candidates) or when manually triggered.
* Automatically regenerates artifacts in the `skills` repo and labels the PR as automated and cli-sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with no runtime or library behavior changes; risk is limited to misconfigured secrets or unintended PRs to the external skills repo.
> 
> **Overview**
> Adds **`.github/workflows/sync-huggingface-skills.yml`** to keep the TRL training skill in sync with **`huggingface/skills`**.
> 
> The workflow runs on **non-RC `v*` tags** or **`workflow_dispatch`**, checks out TRL and **`huggingface/skills`** (via a GitHub App token), copies **`trl/skills/trl-training/SKILL.md`**, and only if that file differs runs **`./scripts/publish.sh`** in the skills repo and opens an automated PR (`automated`, `cli-sync` labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43bd2973ac72ef2f88b9fc13d27c6d71f646052f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->