### PR TITLE
feat(sft): add loss_type='weighted_nll' for per-sample loss scaling

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -42,6 +42,7 @@ from trl.trainer.sft_trainer import (
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
+    weighted_nll_loss,
 )
 
 from .testing_utils import (
@@ -69,6 +70,100 @@ if is_peft_available():
         TaskType,
         get_peft_model,
     )
+
+
+class TestWeightedNLLLoss(TrlTestCase):
+    def _make_outputs_labels(self, batch_size=2, seq_len=4, vocab_size=8, seed=0):
+        torch.manual_seed(seed)
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        outputs = MagicMock()
+        outputs.logits = logits
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+        return outputs, labels
+
+    def test_unit_weights_equals_nll(self):
+        """weighted_nll_loss with all-ones weights must match standard NLL."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.ones(2)
+
+        wloss = weighted_nll_loss(outputs, labels, weights)
+
+        # Reference: mean NLL over all valid tokens
+        shift_logits = outputs.logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+        ref = F.cross_entropy(
+            shift_logits.reshape(-1, shift_logits.size(-1)),
+            shift_labels.reshape(-1),
+            ignore_index=-100,
+            reduction="mean",
+        )
+        torch.testing.assert_close(wloss, ref, atol=1e-5, rtol=1e-5)
+
+    def test_zero_weight_suppresses_sample(self):
+        """A sample with weight=0.0 should not contribute to the loss."""
+        outputs, labels = self._make_outputs_labels(batch_size=2)
+        # Keep only second sample (weight 0 for first, 1 for second)
+        weights_zero_first = torch.tensor([0.0, 1.0])
+        weights_second_only = torch.tensor([0.0, 1.0])
+
+        loss_a = weighted_nll_loss(outputs, labels, weights_zero_first)
+        loss_b = weighted_nll_loss(outputs, labels, weights_second_only)
+        torch.testing.assert_close(loss_a, loss_b, atol=1e-6, rtol=1e-6)
+
+    def test_negative_weight_inverts_gradient(self):
+        """Negative weights should produce negative loss (gradient inversion)."""
+        outputs, labels = self._make_outputs_labels(batch_size=1)
+        weights_pos = torch.tensor([1.0])
+        weights_neg = torch.tensor([-1.0])
+
+        loss_pos = weighted_nll_loss(outputs, labels, weights_pos)
+        loss_neg = weighted_nll_loss(outputs, labels, weights_neg)
+        torch.testing.assert_close(loss_pos, -loss_neg, atol=1e-6, rtol=1e-6)
+
+    def test_masked_tokens_excluded(self):
+        """Positions with label=-100 must not affect the loss."""
+        batch_size, seq_len, vocab_size = 1, 5, 4
+        torch.manual_seed(7)
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        outputs = MagicMock()
+        outputs.logits = logits
+
+        # Labels with and without masking — same valid tokens
+        labels_full = torch.tensor([[0, 1, 2, 1, 3]])
+        labels_masked = torch.tensor([[0, 1, 2, 1, -100]])  # last token masked
+        weights = torch.ones(batch_size)
+
+        loss_full = weighted_nll_loss(outputs, labels_full, weights)
+        loss_masked = weighted_nll_loss(outputs, labels_masked, weights)
+        # Masking one token changes the per-sample mean; they should differ
+        assert not torch.isclose(loss_full, loss_masked)
+
+    def test_num_items_in_batch_normalisation(self):
+        """When num_items_in_batch is provided the normalisation denominator changes."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.ones(2)
+        n_tokens = 6
+
+        loss_no_nib = weighted_nll_loss(outputs, labels, weights)
+        loss_with_nib = weighted_nll_loss(outputs, labels, weights, num_items_in_batch=n_tokens)
+
+        # They should differ (different normalization denominators)
+        assert not torch.isclose(loss_no_nib, loss_with_nib)
+        # Both should be finite scalars
+        assert loss_no_nib.isfinite()
+        assert loss_with_nib.isfinite()
+
+    def test_weight_scaling_proportional(self):
+        """Doubling all weights (and dividing by 2) should give the same loss."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.tensor([0.5, 1.5])
+
+        loss_ref = weighted_nll_loss(outputs, labels, weights)
+        loss_2x = weighted_nll_loss(outputs, labels, weights * 2)
+
+        # With default normalisation (/ sum_abs_weights), scaling all weights by 2
+        # cancels: (2w · loss) / (2 * sum|w|) == (w · loss) / sum|w|
+        torch.testing.assert_close(loss_ref, loss_2x, atol=1e-5, rtol=1e-5)
 
 
 class TestDFTLoss(TrlTestCase):
@@ -455,6 +550,38 @@ class TestSFTTrainer(TrlTestCase):
             args=training_args,
             train_dataset=dataset["train"],
             eval_dataset=dataset["test"],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_weighted_nll_loss(self):
+        from datasets import Dataset
+
+        # Build a small dataset with a float 'weight' column
+        raw = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+        weights = [1.0 if i % 2 == 0 else 0.5 for i in range(len(raw))]
+        dataset = raw.add_column("weight", weights)
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="weighted_nll",
+            report_to="none",
+            eval_strategy="steps",
+            eval_steps=3,
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
         )
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -104,6 +104,11 @@ class SFTConfig(_BaseConfig):
             - `"nll"`: standard negative log-likelihood (default).
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
+            - `"weighted_nll"`: per-sample weighted NLL. The dataset must contain a float ``"weight"`` column.
+              Positive weights reinforce the response proportionally; negative weights invert the gradient direction
+              (gently pushing the model away from the completion); zero suppresses the sample entirely. When all
+              weights are ``1.0`` the loss is numerically identical to ``"nll"``. Useful for mixed-quality datasets,
+              curriculum learning, or soft preference signals without a separate RL loop.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`. Under

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -812,6 +812,66 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
         return output
 
 
+def weighted_nll_loss(outputs, labels, weights, num_items_in_batch=None):
+    """
+    Per-sample weighted NLL loss for SFT.
+
+    Computes per-sample mean cross-entropy and scales each sample's contribution by
+    a scalar weight supplied by the dataset. Positive weights reinforce the response;
+    negative weights invert the gradient (gently pushing the model away from it);
+    zero weights mask the sample entirely.
+
+    When ``weights`` are all ``1.0`` the result is numerically identical to
+    ``loss_type="nll"`` (verified by the unit tests).
+
+    Args:
+        outputs:
+            Model outputs. ``outputs.logits`` must have shape ``(B, S, V)``.
+        labels (`torch.Tensor`):
+            Target token ids of shape ``(B, S)``. Positions equal to ``-100``
+            are excluded from the loss.
+        weights (`torch.Tensor`):
+            Per-sample scalar weights of shape ``(B,)``. Passed through the
+            dataset as a ``"weight"`` column.
+        num_items_in_batch (`int` or `torch.Tensor`, *optional*):
+            Global valid-token count supplied by the Trainer for
+            gradient-accumulation-correct normalisation. When ``None``,
+            normalises by ``weights.abs().sum()``.
+
+    Returns:
+        Scalar weighted loss.
+    """
+    shift_logits = outputs.logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+    B = shift_labels.shape[0]
+
+    # Per-token NLL, shape (B, S-1)
+    per_token_loss = nn.functional.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1),
+        ignore_index=-100,
+        reduction="none",
+    ).view(B, -1)
+
+    # Mean over valid tokens within each sample → shape (B,)
+    valid_mask = shift_labels != -100
+    tokens_per_sample = valid_mask.sum(dim=-1).clamp(min=1)
+    per_sample_loss = (per_token_loss * valid_mask).sum(dim=-1) / tokens_per_sample
+
+    # Scale by per-sample weights and reduce
+    weights = weights.to(dtype=per_sample_loss.dtype, device=per_sample_loss.device)
+    weighted_loss = (per_sample_loss * weights).sum()
+
+    if num_items_in_batch is None:
+        denom = weights.abs().sum().clamp(min=1e-8)
+        loss = weighted_loss / denom
+    else:
+        if isinstance(num_items_in_batch, torch.Tensor):
+            num_items_in_batch = num_items_in_batch.to(weighted_loss.device)
+        loss = weighted_loss / num_items_in_batch
+    return loss
+
+
 def dft_loss(outputs, labels, num_items_in_batch=None):
     """
     DFT loss function, as presented in [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward
@@ -1271,6 +1331,14 @@ class SFTTrainer(_BaseTrainer):
                         "passing a `compute_loss_func` is not allowed."
                     )
                 compute_loss_func = dft_loss
+            elif args.loss_type == "weighted_nll":
+                if compute_loss_func is not None:
+                    raise ValueError(
+                        "You passed a `compute_loss_func` together with `loss_type='weighted_nll'` to the "
+                        "`SFTTrainer`. When using `loss_type='weighted_nll'`, the loss function is internally "
+                        "set to the weighted NLL loss, so passing a `compute_loss_func` is not allowed."
+                    )
+                # Actual loss computation is handled in compute_loss; no patch needed here.
             elif args.loss_type == "chunked_nll":
                 # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
                 # chunks of tokens. Implemented by patching the model's forward before `super().__init__` so accelerate
@@ -1295,8 +1363,8 @@ class SFTTrainer(_BaseTrainer):
                 _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
-                    "'chunked_nll'."
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', "
+                    "'weighted_nll', and 'chunked_nll'."
                 )
         elif args.loss_type == "chunked_nll":
             raise ValueError("`loss_type='chunked_nll'` is not compatible with `use_liger_kernel=True`.")
@@ -1584,11 +1652,14 @@ class SFTTrainer(_BaseTrainer):
             if self._is_vision_dataset:
                 self._signature_columns = ["messages", "prompt", "completion", "image", "images"]
             else:
-                self._signature_columns = ["input_ids", "labels", "seq_lengths", "completion_mask", "assistant_masks"]
+                self._signature_columns = ["input_ids", "labels", "seq_lengths", "completion_mask", "assistant_masks", "weight"]
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         mode = "train" if self.model.training else "eval"
         prediction_loss_only = inputs.pop("_prediction_loss_only", None)
+
+        # Pop per-sample weights before forwarding to the model; the model does not expect them.
+        sample_weights = inputs.pop("weight", None)
 
         # Set aside labels as it will be dropped by super().compute_loss() if a custom `compute_loss_func` is used.
         # This can be removed when this issue is fixed.
@@ -1623,6 +1694,16 @@ class SFTTrainer(_BaseTrainer):
         (loss, outputs) = super().compute_loss(
             model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
         )
+
+        # Replace loss with weighted NLL when requested.
+        if self.args.loss_type == "weighted_nll":
+            if sample_weights is None:
+                raise ValueError(
+                    "loss_type='weighted_nll' requires a 'weight' column in the dataset but none was found in "
+                    "the batch. Add a float 'weight' field to each example (positive to reinforce, negative to "
+                    "suppress, zero to ignore)."
+                )
+            loss = weighted_nll_loss(outputs, labels, sample_weights, num_items_in_batch=num_items_in_batch)
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":


### PR DESCRIPTION
## Summary

Adds `loss_type="weighted_nll"` to `SFTTrainer`, letting each training example carry a float `"weight"` column that scales its contribution to the loss.

Closes #5761.

---

## Motivation

Standard SFT treats every assistant token equally. In practice datasets are mixed-quality: a 20-turn conversation where turns 1–18 are mediocre but turns 19–20 contain the behaviour you actually want shouldn't contaminate the gradient equally. Today the only escape hatch is a full RL loop. This adds a **lightweight middle ground**.

---

## Dataset format

```python
# In your dataset (conversational or prompt-completion format):
{"messages": [...], "weight": 1.0}   # full reinforcement (default)
{"messages": [...], "weight": 0.5}   # half reinforcement
{"messages": [...], "weight": -0.1}  # gentle gradient inversion
{"messages": [...], "weight": 0.0}   # masked — contributes nothing
```

```python
from trl import SFTConfig, SFTTrainer

trainer = SFTTrainer(
    model="...",
    args=SFTConfig(loss_type="weighted_nll", ...),
    train_dataset=dataset_with_weight_column,
)
```

---

## How it works

```
per_sample_loss = mean_over_valid_tokens(cross_entropy(logits, labels))
loss = Σ (per_sample_loss_i × weight_i) / Σ |weight_i|
```

- **`weight=1.0` everywhere** → numerically identical to `loss_type="nll"` (unit-tested)
- **`weight=0.0`** → sample contributes zero gradient
- **Negative weight** → gradient inversion (the sign flips; useful for soft DPO-like pushback)
- Normalisation by `Σ|w|` keeps the effective learning rate stable regardless of weight distribution

When `num_items_in_batch` is provided (gradient accumulation path) the denominator switches to the global token count, matching the existing NLL behaviour.

---

## Changes

| File | Change |
|------|--------|
| `trl/trainer/sft_trainer.py` | New `weighted_nll_loss()` function; `compute_loss` pops `"weight"` from inputs and routes to it when `loss_type="weighted_nll"` |
| `trl/trainer/sft_config.py` | Docstring updated with new `loss_type` option |
| `tests/test_sft_trainer.py` | `TestWeightedNLLLoss` (6 unit tests) + `test_train_weighted_nll_loss` integration test |

---

## Tests

**Unit tests (`TestWeightedNLLLoss`):**
- `test_unit_weights_equals_nll` — weight=1.0 everywhere produces identical result to standard NLL
- `test_zero_weight_suppresses_sample` — weight=0.0 contributes zero
- `test_negative_weight_inverts_gradient` — loss flips sign
- `test_masked_tokens_excluded` — label=-100 positions don't affect loss
- `test_num_items_in_batch_normalisation` — GA-correct path differs from default
- `test_weight_scaling_proportional` — doubling all weights cancels in normalisation

**Integration test (`test_train_weighted_nll_loss`):**
- Loads `trl-internal-testing/zen`, adds alternating weights `[1.0, 0.5, ...]`, trains, verifies params change and loss is logged.

---

## Non-goals

- No token-level weights (per-token scaling is a separate, more invasive change)
- Not compatible with `use_liger_kernel=True` (liger bypasses the `compute_loss` path; raises a clear error)
- Not compatible with `loss_type="chunked_nll"` (the chunked path skips logit materialisation; combining both would require significant changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in training loss path changes how gradients are aggregated (including negative weights); mistakes in dataset weights or normalization could skew updates, though behavior is covered by new unit and integration tests.
> 
> **Overview**
> Adds **`loss_type="weighted_nll"`** to `SFTTrainer` so each example can supply a float **`weight`** column that scales its contribution to the training loss (positive reinforce, negative invert gradient, zero skip).
> 
> A new **`weighted_nll_loss()`** computes per-sample mean CE over valid tokens, multiplies by weights, and normalizes by **Σ|weight|** (or by **`num_items_in_batch`** under gradient accumulation). **`compute_loss`** pops **`weight`** before the forward pass and swaps in this loss after the standard forward; **`weight`** is kept in signature columns when **`remove_unused_columns`** is on. **`SFTConfig`** documents the option and disallows a custom **`compute_loss_func`** alongside it.
> 
> **Tests:** **`TestWeightedNLLLoss`** (unit parity with NLL, masking, negative weights, normalization) and **`test_train_weighted_nll_loss`** (end-to-end training with a weighted dataset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6f095f453737466830f3c6065a183ca11a5464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->