### PR TITLE
Add loss_type='weighted_nll' for per-sample loss scaling in SFT

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -41,6 +41,7 @@ from trl.trainer.sft_trainer import (
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
+    weighted_nll_loss,
 )
 
 from .testing_utils import (
@@ -68,6 +69,100 @@ if is_peft_available():
         TaskType,
         get_peft_model,
     )
+
+
+class TestWeightedNLLLoss(TrlTestCase):
+    def _make_outputs_labels(self, batch_size=2, seq_len=4, vocab_size=8, seed=0):
+        torch.manual_seed(seed)
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        outputs = MagicMock()
+        outputs.logits = logits
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len))
+        return outputs, labels
+
+    def test_unit_weights_equals_nll(self):
+        """weighted_nll_loss with all-ones weights must match standard NLL."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.ones(2)
+
+        wloss = weighted_nll_loss(outputs, labels, weights)
+
+        # Reference: mean NLL over all valid tokens
+        shift_logits = outputs.logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+        ref = F.cross_entropy(
+            shift_logits.reshape(-1, shift_logits.size(-1)),
+            shift_labels.reshape(-1),
+            ignore_index=-100,
+            reduction="mean",
+        )
+        torch.testing.assert_close(wloss, ref, atol=1e-5, rtol=1e-5)
+
+    def test_zero_weight_suppresses_sample(self):
+        """A sample with weight=0.0 should not contribute to the loss."""
+        outputs, labels = self._make_outputs_labels(batch_size=2)
+        # Keep only second sample (weight 0 for first, 1 for second)
+        weights_zero_first = torch.tensor([0.0, 1.0])
+        weights_second_only = torch.tensor([0.0, 1.0])
+
+        loss_a = weighted_nll_loss(outputs, labels, weights_zero_first)
+        loss_b = weighted_nll_loss(outputs, labels, weights_second_only)
+        torch.testing.assert_close(loss_a, loss_b, atol=1e-6, rtol=1e-6)
+
+    def test_negative_weight_inverts_gradient(self):
+        """Negative weights should produce negative loss (gradient inversion)."""
+        outputs, labels = self._make_outputs_labels(batch_size=1)
+        weights_pos = torch.tensor([1.0])
+        weights_neg = torch.tensor([-1.0])
+
+        loss_pos = weighted_nll_loss(outputs, labels, weights_pos)
+        loss_neg = weighted_nll_loss(outputs, labels, weights_neg)
+        torch.testing.assert_close(loss_pos, -loss_neg, atol=1e-6, rtol=1e-6)
+
+    def test_masked_tokens_excluded(self):
+        """Positions with label=-100 must not affect the loss."""
+        batch_size, seq_len, vocab_size = 1, 5, 4
+        torch.manual_seed(7)
+        logits = torch.randn(batch_size, seq_len, vocab_size)
+        outputs = MagicMock()
+        outputs.logits = logits
+
+        # Labels with and without masking — same valid tokens
+        labels_full = torch.tensor([[0, 1, 2, 1, 3]])
+        labels_masked = torch.tensor([[0, 1, 2, 1, -100]])  # last token masked
+        weights = torch.ones(batch_size)
+
+        loss_full = weighted_nll_loss(outputs, labels_full, weights)
+        loss_masked = weighted_nll_loss(outputs, labels_masked, weights)
+        # Masking one token changes the per-sample mean; they should differ
+        assert not torch.isclose(loss_full, loss_masked)
+
+    def test_num_items_in_batch_normalisation(self):
+        """When num_items_in_batch is provided the normalisation denominator changes."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.ones(2)
+        n_tokens = 6
+
+        loss_no_nib = weighted_nll_loss(outputs, labels, weights)
+        loss_with_nib = weighted_nll_loss(outputs, labels, weights, num_items_in_batch=n_tokens)
+
+        # They should differ (different normalization denominators)
+        assert not torch.isclose(loss_no_nib, loss_with_nib)
+        # Both should be finite scalars
+        assert loss_no_nib.isfinite()
+        assert loss_with_nib.isfinite()
+
+    def test_weight_scaling_proportional(self):
+        """Doubling all weights (and dividing by 2) should give the same loss."""
+        outputs, labels = self._make_outputs_labels()
+        weights = torch.tensor([0.5, 1.5])
+
+        loss_ref = weighted_nll_loss(outputs, labels, weights)
+        loss_2x = weighted_nll_loss(outputs, labels, weights * 2)
+
+        # With default normalisation (/ sum_abs_weights), scaling all weights by 2
+        # cancels: (2w · loss) / (2 * sum|w|) == (w · loss) / sum|w|
+        torch.testing.assert_close(loss_ref, loss_2x, atol=1e-5, rtol=1e-5)
 
 
 class TestDFTLoss(TrlTestCase):
@@ -485,6 +580,38 @@ class TestSFTTrainer(TrlTestCase):
             args=training_args,
             train_dataset=dataset["train"],
             eval_dataset=dataset["test"],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_weighted_nll_loss(self):
+        from datasets import Dataset
+
+        # Build a small dataset with a float 'weight' column
+        raw = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+        weights = [1.0 if i % 2 == 0 else 0.5 for i in range(len(raw))]
+        dataset = raw.add_column("weight", weights)
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="weighted_nll",
+            report_to="none",
+            eval_strategy="steps",
+            eval_steps=3,
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
         )
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -101,13 +101,19 @@ class TestWeightedNLLLoss(TrlTestCase):
     def test_zero_weight_suppresses_sample(self):
         """A sample with weight=0.0 should not contribute to the loss."""
         outputs, labels = self._make_outputs_labels(batch_size=2)
-        # Keep only second sample (weight 0 for first, 1 for second)
         weights_zero_first = torch.tensor([0.0, 1.0])
-        weights_second_only = torch.tensor([0.0, 1.0])
 
-        loss_a = weighted_nll_loss(outputs, labels, weights_zero_first)
-        loss_b = weighted_nll_loss(outputs, labels, weights_second_only)
-        torch.testing.assert_close(loss_a, loss_b, atol=1e-6, rtol=1e-6)
+        # Loss over the full batch with the first sample zeroed out must equal the
+        # loss computed from the second sample alone (weight 1.0, batch size 1) --
+        # not merely two calls with the same weight tensor, which would pass trivially.
+        second_sample_outputs = MagicMock()
+        second_sample_outputs.logits = outputs.logits[1:2]
+        second_sample_labels = labels[1:2]
+        weight_second_only = torch.tensor([1.0])
+
+        loss_full_batch = weighted_nll_loss(outputs, labels, weights_zero_first)
+        loss_second_alone = weighted_nll_loss(second_sample_outputs, second_sample_labels, weight_second_only)
+        torch.testing.assert_close(loss_full_batch, loss_second_alone, atol=1e-6, rtol=1e-6)
 
     def test_negative_weight_inverts_gradient(self):
         """Negative weights should produce negative loss (gradient inversion)."""

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -111,6 +111,11 @@ class SFTConfig(_BaseConfig):
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
+            - `"weighted_nll"`: per-sample weighted NLL. The dataset must contain a float ``"weight"`` column.
+              Positive weights reinforce the response proportionally; negative weights invert the gradient direction
+              (gently pushing the model away from the completion); zero suppresses the sample entirely. When all
+              weights are ``1.0`` the loss is numerically identical to ``"nll"``. Useful for mixed-quality datasets,
+              curriculum learning, or soft preference signals without a separate RL loop.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1840,6 +1840,14 @@ class SFTTrainer(_BaseTrainer):
                     "parallelism (the `shift_labels` path). Use `loss_type='nll'` instead."
                 )
             loss = weighted_nll_loss(outputs, labels, sample_weights, num_items_in_batch=num_items_in_batch)
+            # Re-add the MoE router aux loss. The model's forward adds
+            # `router_aux_loss_coef * aux_loss` to `outputs.loss`, but we
+            # discard that when we replace loss with weighted_nll_loss. Mirror
+            # the same scaling so MoE models train correctly.
+            if self.aux_loss_enabled and getattr(outputs, "aux_loss", None) is not None:
+                config = getattr(self.model.config, "text_config", self.model.config)
+                coef = getattr(config, "router_aux_loss_coef", 0.0)
+                loss = loss + coef * outputs.aux_loss.to(loss.device)
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -796,6 +796,66 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
         return output
 
 
+def weighted_nll_loss(outputs, labels, weights, num_items_in_batch=None):
+    """
+    Per-sample weighted NLL loss for SFT.
+
+    Computes per-sample mean cross-entropy and scales each sample's contribution by
+    a scalar weight supplied by the dataset. Positive weights reinforce the response;
+    negative weights invert the gradient (gently pushing the model away from it);
+    zero weights mask the sample entirely.
+
+    When ``weights`` are all ``1.0`` the result is numerically identical to
+    ``loss_type="nll"`` (verified by the unit tests).
+
+    Args:
+        outputs:
+            Model outputs. ``outputs.logits`` must have shape ``(B, S, V)``.
+        labels (`torch.Tensor`):
+            Target token ids of shape ``(B, S)``. Positions equal to ``-100``
+            are excluded from the loss.
+        weights (`torch.Tensor`):
+            Per-sample scalar weights of shape ``(B,)``. Passed through the
+            dataset as a ``"weight"`` column.
+        num_items_in_batch (`int` or `torch.Tensor`, *optional*):
+            Global valid-token count supplied by the Trainer for
+            gradient-accumulation-correct normalisation. When ``None``,
+            normalises by ``weights.abs().sum()``.
+
+    Returns:
+        Scalar weighted loss.
+    """
+    shift_logits = outputs.logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+    B = shift_labels.shape[0]
+
+    # Per-token NLL, shape (B, S-1)
+    per_token_loss = nn.functional.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1),
+        ignore_index=-100,
+        reduction="none",
+    ).view(B, -1)
+
+    # Mean over valid tokens within each sample → shape (B,)
+    valid_mask = shift_labels != -100
+    tokens_per_sample = valid_mask.sum(dim=-1).clamp(min=1)
+    per_sample_loss = (per_token_loss * valid_mask).sum(dim=-1) / tokens_per_sample
+
+    # Scale by per-sample weights and reduce
+    weights = weights.to(dtype=per_sample_loss.dtype, device=per_sample_loss.device)
+    weighted_loss = (per_sample_loss * weights).sum()
+
+    if num_items_in_batch is None:
+        denom = weights.abs().sum().clamp(min=1e-8)
+        loss = weighted_loss / denom
+    else:
+        if isinstance(num_items_in_batch, torch.Tensor):
+            num_items_in_batch = num_items_in_batch.to(weighted_loss.device)
+        loss = weighted_loss / num_items_in_batch
+    return loss
+
+
 def dft_loss(outputs, labels, num_items_in_batch=None):
     """
     DFT loss function, as presented in [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward
@@ -1291,6 +1351,14 @@ class SFTTrainer(_BaseTrainer):
                         "passing a `compute_loss_func` is not allowed."
                     )
                 compute_loss_func = dft_loss
+            elif args.loss_type == "weighted_nll":
+                if compute_loss_func is not None:
+                    raise ValueError(
+                        "You passed a `compute_loss_func` together with `loss_type='weighted_nll'` to the "
+                        "`SFTTrainer`. When using `loss_type='weighted_nll'`, the loss function is internally "
+                        "set to the weighted NLL loss, so passing a `compute_loss_func` is not allowed."
+                    )
+                # Actual loss computation is handled in compute_loss; no patch needed here.
             elif args.loss_type == "chunked_nll":
                 # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
                 # chunks of tokens. Implemented by patching the model's forward before `super().__init__` so accelerate
@@ -1315,8 +1383,8 @@ class SFTTrainer(_BaseTrainer):
                 _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
-                    "'chunked_nll'."
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', "
+                    "'weighted_nll', and 'chunked_nll'."
                 )
         elif args.loss_type == "chunked_nll":
             raise ValueError("`loss_type='chunked_nll'` is not compatible with `use_liger_kernel=True`.")
@@ -1622,7 +1690,7 @@ class SFTTrainer(_BaseTrainer):
             if self._is_vision_dataset:
                 self._signature_columns = ["messages", "prompt", "completion", "image", "images"]
             else:
-                self._signature_columns = ["input_ids", "labels", "seq_lengths"]
+                self._signature_columns = ["input_ids", "labels", "seq_lengths", "weight"]
 
     def _reject_skip_prepare_without_labels(self, datasets: dict[str, Dataset], data_collator) -> None:
         # This guard may look defensive, but it covers a behavior change introduced when label building moved from
@@ -1685,6 +1753,9 @@ class SFTTrainer(_BaseTrainer):
         mode = "train" if self.model.training else "eval"
         prediction_loss_only = inputs.pop("_prediction_loss_only", None)
 
+        # Pop per-sample weights before forwarding to the model; the model does not expect them.
+        sample_weights = inputs.pop("weight", None)
+
         # Set aside labels as it will be dropped by super().compute_loss() if a custom `compute_loss_func` is used.
         # This can be removed when this issue is fixed.
         # When using CP or SP, labels are pre-shifted, we must use shift_labels instead.
@@ -1732,6 +1803,16 @@ class SFTTrainer(_BaseTrainer):
                     f"Please increase `max_length` or set it to `None` to disable truncation."
                 ) from e
             raise
+
+        # Replace loss with weighted NLL when requested.
+        if self.args.loss_type == "weighted_nll":
+            if sample_weights is None:
+                raise ValueError(
+                    "loss_type='weighted_nll' requires a 'weight' column in the dataset but none was found in "
+                    "the batch. Add a float 'weight' field to each example (positive to reinforce, negative to "
+                    "suppress, zero to ignore)."
+                )
+            loss = weighted_nll_loss(outputs, labels, sample_weights, num_items_in_batch=num_items_in_batch)
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1844,10 +1844,9 @@ class SFTTrainer(_BaseTrainer):
             # `router_aux_loss_coef * aux_loss` to `outputs.loss`, but we
             # discard that when we replace loss with weighted_nll_loss. Mirror
             # the same scaling so MoE models train correctly.
-            if self.aux_loss_enabled and getattr(outputs, "aux_loss", None) is not None:
-                config = getattr(self.model.config, "text_config", self.model.config)
-                coef = getattr(config, "router_aux_loss_coef", 0.0)
-                loss = loss + coef * outputs.aux_loss.to(loss.device)
+            if self.aux_loss_enabled and outputs.aux_loss is not None:
+                text_config = self.model.config.text_config if self._is_vlm else self.model.config
+                loss = loss + text_config.router_aux_loss_coef * outputs.aux_loss.to(loss.device)
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1369,6 +1369,13 @@ class SFTTrainer(_BaseTrainer):
                         "multiple examples into one sequence, so per-example weights have no well-defined "
                         "meaning. Disable packing or use `loss_type='nll'`."
                     )
+                if self.padding_free:
+                    raise ValueError(
+                        "`loss_type='weighted_nll'` is not compatible with `padding_free=True`. "
+                        "Padding-free mode flattens the batch to a single row, so per-example weights "
+                        "cannot be broadcast to the right tokens. Disable padding-free or use "
+                        "`loss_type='nll'`."
+                    )
                 # Actual loss computation is handled in compute_loss; no patch needed here.
             elif args.loss_type == "chunked_nll":
                 # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -474,6 +474,7 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         input_ids = [example["input_ids"] for example in examples]
         batch_seq_lengths = [example["seq_lengths"] for example in examples] if "seq_lengths" in examples[0] else None
         labels = [example.get("labels", example["input_ids"]) for example in examples]
+        weights = [example["weight"] for example in examples] if "weight" in examples[0] else None
 
         # Truncate per sequence if necessary
         if self.max_length is not None and not self.padding_free:
@@ -528,6 +529,8 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
             output["attention_mask"] = pad(
                 attention_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
             )
+        if weights is not None:
+            output["weight"] = torch.tensor(weights, dtype=torch.float)
         return output
 
     @staticmethod
@@ -837,22 +840,24 @@ def weighted_nll_loss(outputs, labels, weights, num_items_in_batch=None):
         reduction="none",
     ).view(B, -1)
 
-    # Mean over valid tokens within each sample → shape (B,)
     valid_mask = shift_labels != -100
-    tokens_per_sample = valid_mask.sum(dim=-1).clamp(min=1)
-    per_sample_loss = (per_token_loss * valid_mask).sum(dim=-1) / tokens_per_sample
-
-    # Scale by per-sample weights and reduce
-    weights = weights.to(dtype=per_sample_loss.dtype, device=per_sample_loss.device)
-    weighted_loss = (per_sample_loss * weights).sum()
+    weights = weights.to(dtype=per_token_loss.dtype, device=per_token_loss.device)
 
     if num_items_in_batch is None:
+        # Normalise by sum of |weights|: numerically identical to nll when all weights == 1.
+        # Mean over valid tokens per sample, then weight-average across samples.
+        tokens_per_sample = valid_mask.sum(dim=-1).clamp(min=1)
+        per_sample_loss = (per_token_loss * valid_mask).sum(dim=-1) / tokens_per_sample
+        weighted_loss = (per_sample_loss * weights).sum()
         denom = weights.abs().sum().clamp(min=1e-8)
         loss = weighted_loss / denom
     else:
+        # Gradient-accumulation path: broadcast sample weight to every token, then
+        # divide by the global token count — same unit as standard nll.
         if isinstance(num_items_in_batch, torch.Tensor):
-            num_items_in_batch = num_items_in_batch.to(weighted_loss.device)
-        loss = weighted_loss / num_items_in_batch
+            num_items_in_batch = num_items_in_batch.to(per_token_loss.device)
+        weighted_token_loss = per_token_loss * weights.unsqueeze(1) * valid_mask
+        loss = weighted_token_loss.sum() / num_items_in_batch
     return loss
 
 
@@ -1358,6 +1363,12 @@ class SFTTrainer(_BaseTrainer):
                         "`SFTTrainer`. When using `loss_type='weighted_nll'`, the loss function is internally "
                         "set to the weighted NLL loss, so passing a `compute_loss_func` is not allowed."
                     )
+                if args.packing:
+                    raise ValueError(
+                        "`loss_type='weighted_nll'` is not compatible with `packing=True`. Packing merges "
+                        "multiple examples into one sequence, so per-example weights have no well-defined "
+                        "meaning. Disable packing or use `loss_type='nll'`."
+                    )
                 # Actual loss computation is handled in compute_loss; no patch needed here.
             elif args.loss_type == "chunked_nll":
                 # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
@@ -1386,8 +1397,8 @@ class SFTTrainer(_BaseTrainer):
                     f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', "
                     "'weighted_nll', and 'chunked_nll'."
                 )
-        elif args.loss_type == "chunked_nll":
-            raise ValueError("`loss_type='chunked_nll'` is not compatible with `use_liger_kernel=True`.")
+        elif args.loss_type in ("chunked_nll", "weighted_nll"):
+            raise ValueError(f"`loss_type='{args.loss_type}'` is not compatible with `use_liger_kernel=True`.")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream
@@ -1811,6 +1822,11 @@ class SFTTrainer(_BaseTrainer):
                     "loss_type='weighted_nll' requires a 'weight' column in the dataset but none was found in "
                     "the batch. Add a float 'weight' field to each example (positive to reinforce, negative to "
                     "suppress, zero to ignore)."
+                )
+            if labels is None:
+                raise ValueError(
+                    "`loss_type='weighted_nll'` is not supported with context parallelism or sequence "
+                    "parallelism (the `shift_labels` path). Use `loss_type='nll'` instead."
                 )
             loss = weighted_nll_loss(outputs, labels, sample_weights, num_items_in_batch=num_items_in_batch)
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -698,6 +698,8 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
         # loss computation has to be done by the model, and masking them here would be infeasible in practice as vision
         # token definitions vary across architectures.
         output["labels"] = labels
+        if "weight" in examples[0]:
+            output["weight"] = torch.tensor([example["weight"] for example in examples], dtype=torch.float)
         return output
 
     def _collate_prompt_completion(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
@@ -796,6 +798,8 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
             output["token_type_ids"] = token_type_ids
         if "mm_token_type_ids" in processed_prompts:
             output["mm_token_type_ids"] = mm_token_type_ids
+        if "weight" in examples[0]:
+            output["weight"] = torch.tensor([example["weight"] for example in examples], dtype=torch.float)
         return output
 
 
@@ -1706,7 +1710,7 @@ class SFTTrainer(_BaseTrainer):
         # padding-free), so we override the default signature columns to keep it alongside the model inputs.
         if self._signature_columns is None:
             if self._is_vision_dataset:
-                self._signature_columns = ["messages", "prompt", "completion", "image", "images"]
+                self._signature_columns = ["messages", "prompt", "completion", "image", "images", "weight"]
             else:
                 self._signature_columns = ["input_ids", "labels", "seq_lengths", "weight"]
 


### PR DESCRIPTION
# What does this PR do?

Adds `loss_type="weighted_nll"` to `SFTTrainer`, letting each training example carry a float `"weight"` column that scales its contribution to the loss. This is a lightweight middle ground between standard SFT (all samples equal) and a full RL loop.

Fixes #5761

---

## Motivation

Standard SFT treats every assistant token equally. In practice datasets are mixed-quality: a 20-turn conversation where turns 1–18 are mediocre but turns 19–20 contain the behaviour you want shouldn't pollute the gradient equally. With `weighted_nll` you can express this directly in the dataset:

```python
{"messages": [...], "weight":  1.0}   # full reinforcement (default)
{"messages": [...], "weight":  0.5}   # half strength
{"messages": [...], "weight": -0.1}   # gentle gradient inversion
{"messages": [...], "weight":  0.0}   # completely ignored
```

```python
trainer = SFTTrainer(
    model="...",
    args=SFTConfig(loss_type="weighted_nll", ...),
    train_dataset=dataset_with_weight_column,
)
```

**How the loss is computed:**

```
per_sample_loss_i = mean_{valid tokens} CE(logits_i, labels_i)
loss = Σ (per_sample_loss_i × weight_i) / Σ |weight_i|
```

Normalising by `Σ|w|` keeps the effective learning rate stable regardless of weight distribution. When `num_items_in_batch` is provided (gradient accumulation path), the denominator switches to the global token count to match the existing NLL behaviour.

**`weight=1.0` everywhere is numerically identical to `loss_type="nll"` — unit-tested.**

---

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. → #5761
- [x] Did you make sure to update the documentation with your changes? (docstring in `SFTConfig`)
- [x] Did you write any new necessary tests? (`TestWeightedNLLLoss` with 6 unit tests + integration test `test_train_weighted_nll_loss`)

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @lewtun — this directly addresses the request in #5761.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SFT loss computation and training gradients; negative weights invert updates, but behavior is guarded, documented, and covered by tests.
> 
> **Overview**
> Adds **`loss_type="weighted_nll"`** to `SFTTrainer` so each example can supply a float **`weight`** column that scales its contribution to the training loss (positive reinforce, negative invert gradient, zero skip). Loss is per-sample mean CE, aggregated as **Σ(wᵢ × lossᵢ) / Σ|wᵢ|** (or token-normalized when `num_items_in_batch` is set for gradient accumulation).
> 
> **`weighted_nll_loss`** is wired in **`compute_loss`** (weights are popped before the model forward). Data collators pass **`weight`** through batches; **`weight`** is kept in signature columns when `remove_unused_columns` is on. **`SFTConfig`** documents the new option.
> 
> **Guards:** incompatible with **`packing`**, **`padding_free`**, **`use_liger_kernel`**, custom **`compute_loss_func`**, and CP/SP **`shift_labels`** paths; missing **`weight`** in the batch raises a clear error. MoE **router aux loss** is re-added after replacing the default loss.
> 
> Tests add **`TestWeightedNLLLoss`** (six unit tests) and **`test_train_weighted_nll_loss`** integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349a4cb2fe5185b916fddc652e71dcfe001c76d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->