### PR TITLE
Fix reward function name fallback for callable objects

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -602,6 +602,33 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_init_reward_func_without_name(self):
+        # Test if trainer can handle callable reward functions without a __name__ attribute
+        dataset = Dataset.from_dict({"prompt": ["Hello", "World", "Goodbye"]})
+
+        class RewardFunc:
+            def __call__(self, completions, **kwargs):
+                return [float(len(completion)) for completion in completions]
+
+            def __str__(self):
+                return "custom_reward_func"
+
+        reward_func = RewardFunc()
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert trainer.reward_func_names == ["custom_reward_func"]
+
     def test_train_reward_func_conversational(self):
         # Test if trainer can handle reward function with conversational format
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from packaging.version import Version
 from transformers import (
     AutoModelForCausalLM,
@@ -338,6 +338,33 @@ class TestRLOOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_init_reward_func_without_name(self):
+        # Test if trainer can handle callable reward functions without a __name__ attribute
+        dataset = Dataset.from_dict({"prompt": ["Hello", "World", "Goodbye"]})
+
+        class RewardFunc:
+            def __call__(self, completions, **kwargs):
+                return [float(len(completion)) for completion in completions]
+
+            def __str__(self):
+                return "custom_reward_func"
+
+        reward_func = RewardFunc()
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            report_to="none",
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert trainer.reward_func_names == ["custom_reward_func"]
 
     def test_train_reward_func_conversational(self):
         # Test if trainer can handle reward function with conversational format

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -204,7 +204,13 @@ class _AsyncRolloutLoop:
         self.dataset = dataset
         self._dataset_iter = iter(dataset)
         self.reward_funcs = reward_funcs
-        self.reward_func_names = [f.__name__ for f in reward_funcs]
+        self.reward_func_names = []
+        for reward_func in reward_funcs:
+            try:
+                reward_func_name = reward_func.__name__
+            except AttributeError:
+                reward_func_name = str(reward_func)
+            self.reward_func_names.append(reward_func_name)
         self.tokenizer = add_response_schema(processing_class)
         self.rollout_buffer = rollout_buffer  # shared mp.Queue
         self._model_version_value = model_version_value  # shared mp.Value

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -213,7 +213,11 @@ class OnlineDPOTrainer(_BaseTrainer):
             if isinstance(reward_funcs[i], nn.Module):
                 self.reward_func_names.append(get_config_model_id(reward_funcs[i].config).split("/")[-1])
             else:
-                self.reward_func_names.append(reward_funcs[i].__name__)
+                try:
+                    reward_func_name = reward_funcs[i].__name__
+                except AttributeError:
+                    reward_func_name = str(reward_funcs[i])
+                self.reward_func_names.append(reward_func_name)
         self.reward_funcs = reward_funcs
 
         # Handle reward processing classes for reward_funcs

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -538,7 +538,11 @@ class SDPOTrainer(_BaseTrainer):
             if isinstance(reward_funcs[i], nn.Module):
                 self.reward_func_names.append(get_config_model_id(reward_funcs[i].config).split("/")[-1])
             else:
-                self.reward_func_names.append(reward_funcs[i].__name__)
+                try:
+                    reward_func_name = reward_funcs[i].__name__
+                except AttributeError:
+                    reward_func_name = str(reward_funcs[i])
+                self.reward_func_names.append(reward_func_name)
         self.reward_funcs = reward_funcs
 
         if args.reward_weights is not None:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -406,7 +406,11 @@ class GRPOTrainer(_BaseTrainer):
             if isinstance(reward_funcs[i], nn.Module):  # Use Module over PretrainedModel for compat w/ compiled models
                 self.reward_func_names.append(get_config_model_id(reward_funcs[i].config).split("/")[-1])
             else:
-                self.reward_func_names.append(reward_funcs[i].__name__)
+                try:
+                    reward_func_name = reward_funcs[i].__name__
+                except AttributeError:
+                    reward_func_name = str(reward_funcs[i])
+                self.reward_func_names.append(reward_func_name)
         self.reward_funcs = reward_funcs
 
         # Reward weights

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -338,7 +338,11 @@ class RLOOTrainer(_BaseTrainer):
             if isinstance(reward_funcs[i], nn.Module):  # Use Module over PretrainedModel for compat w/ compiled models
                 self.reward_func_names.append(get_config_model_id(reward_funcs[i].config).split("/")[-1])
             else:
-                self.reward_func_names.append(reward_funcs[i].__name__)
+                try:
+                    reward_func_name = reward_funcs[i].__name__
+                except AttributeError:
+                    reward_func_name = str(reward_funcs[i])
+                self.reward_func_names.append(reward_func_name)
         self.reward_funcs = reward_funcs
 
         self._has_async_funcs = any(inspect.iscoroutinefunction(func) for func in self.reward_funcs)


### PR DESCRIPTION
# What does this PR do?

Fixes #3049 

`GRPOTrainer` assumed custom reward callables always define `__name__`, but callable objects such as mocks or class instances may not. This can make trainer initialization fail with `AttributeError`.

This PR falls back to `str(reward_func)` when `__name__` is unavailable. The same duplicated reward-function naming pattern is updated consistently across the affected trainers.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

Docs were not updated because this is a narrow bug fix with no public API or behavior documentation change.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow init-time naming change for custom callables; behavior for normal functions and reward models is unchanged.
> 
> **Overview**
> Fixes trainer initialization when custom **reward callables** lack `__name__` (e.g. class instances or mocks), which previously raised `AttributeError` during `reward_func_names` setup.
> 
> For non-`nn.Module` rewards, trainers now use `__name__` when present and **fall back to `str(reward_func)`** on `AttributeError`. The same pattern is applied in `GRPOTrainer`, `RLOOTrainer`, async GRPO rollout worker, `OnlineDPOTrainer`, and `SDPOTrainer`.
> 
> **Tests** assert `GRPOTrainer` / `RLOOTrainer` accept a callable class with `__str__` and set `reward_func_names` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14df39a3dd511ae80157454c1ca7a211f1e5c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->