### PR TITLE
Integrate DPPO into GRPOConfig and GRPOTrainer

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -642,28 +642,18 @@ training_args = GRPOConfig(
 
 **📜 Paper**: https://huggingface.co/papers/2602.04879
 
-DPPO replaces PPO/GRPO's heuristic ratio-clipping with a principled trust region based on direct policy divergence estimates. PPO-style clipping masks tokens based on the probability ratio π/μ, which over-penalizes low-probability tokens and under-penalizes high-probability ones. DPPO instead masks based on direct approximations of policy divergence (TV or KL), ensuring updates stay within a theoretically grounded trust region. Four divergence approximations are supported: `binary_tv`, `binary_kl`, `topk_tv`, and `topk_kl`.
+DPPO replaces PPO/GRPO's heuristic ratio-clipping with a principled trust region based on direct policy divergence estimates. PPO-style clipping masks tokens based on the probability ratio π/μ, which over-penalizes low-probability tokens and under-penalizes high-probability ones. DPPO instead masks based on direct approximations of policy divergence (TV or KL), ensuring updates stay within a theoretically grounded trust region. Two divergence approximations are supported: `dppo_tv` for binary Total Variation, and `dppo_kl` for binary KL-Divergence. The binary approximations are computationally more efficient, introduce no new hyperparameter and have a similar performance compared to the top-K implementation (Section 7 in paper).
 
 ```python
-from trl.experimental.dppo import DPPOConfig, DPPOTrainer
+from trl import GRPOConfig
 
-training_args = DPPOConfig(
-    divergence_type="binary_tv",  # divergence approximation
-    divergence_topk=20,  # K for top-K divergence modes (Section 7 / Appendix G.2 of the paper)
+training_args = GRPOConfig(
+    loss_type="dppo_tv", # or 'dppo_kl' for KL approximation
     epsilon=0.15,  # δ_low threshold (Appendix F of the paper)
     epsilon_high=0.15,  # δ_high threshold (Appendix F of the paper)
-    clip_ratio_c=20.0,  # IS ratio upper bound C (Section 5.4 of the paper)
     beta=0.0,  # KL regularization coefficient
     use_vllm=True,
 )
-
-trainer = DPPOTrainer(
-    model="your-model",
-    reward_funcs=[...],
-    args=training_args,
-    train_dataset=dataset,
-)
-trainer.train()
 ```
 
 The official code [sail-sg/Stable-RL](https://github.com/sail-sg/Stable-RL)

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -15,6 +15,7 @@
 import gc
 import os
 import warnings
+from collections import defaultdict
 from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -157,6 +158,71 @@ class TestGetHighEntropyMask(TrlTestCase):
         entropy_mask = self.get_high_entropy_mask(entropies, mask, threshold=0.5)
         expected_mask = torch.tensor([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]], dtype=torch.bool)
         torch.testing.assert_close(entropy_mask, expected_mask)
+
+
+class TestGRPODPPODivergenceMask:
+    """Unit tests for the GRPO DPPO divergence mask with synthetic inputs."""
+
+    @staticmethod
+    def compute_divergence_mask(
+        current_logps,
+        sampling_logps,
+        advantages,
+        estimator_method,
+        epsilon=0.2,
+        epsilon_high=0.28,
+    ):
+        return GRPOTrainer.get_divergence_mask(
+            advantages=advantages,
+            per_token_logps=current_logps,
+            sampling_per_token_logps=sampling_logps,
+            delta_low=epsilon,
+            delta_high=epsilon_high,
+            estimator_method=estimator_method,
+        )
+
+    def test_tv_no_masking_within_threshold(self):
+        sampling_logps = torch.log(torch.tensor([[0.5, 0.3, 0.7]]))
+        current_logps = torch.log(torch.tensor([[0.51, 0.29, 0.71]]))
+        advantages = torch.tensor([[1.0]])
+
+        mask = self.compute_divergence_mask(current_logps, sampling_logps, advantages, "tv")
+
+        assert mask.shape == (1, 3)
+        assert (mask == 1.0).all()
+
+    def test_tv_masks_positive_advantage_high_divergence(self):
+        sampling_logps = torch.log(torch.tensor([[0.1]]))
+        current_logps = torch.log(torch.tensor([[0.5]]))
+        advantages = torch.tensor([[1.0]])
+
+        mask = self.compute_divergence_mask(
+            current_logps, sampling_logps, advantages, "tv", epsilon=0.01, epsilon_high=0.01
+        )
+
+        assert mask.item() == 0.0
+
+    def test_tv_masks_negative_advantage_low_divergence(self):
+        sampling_logps = torch.log(torch.tensor([[0.5]]))
+        current_logps = torch.log(torch.tensor([[0.1]]))
+        advantages = torch.tensor([[-1.0]])
+
+        mask = self.compute_divergence_mask(
+            current_logps, sampling_logps, advantages, "tv", epsilon=0.01, epsilon_high=0.01
+        )
+
+        assert mask.item() == 0.0
+
+    def test_kl_masks_positive_advantage_high_divergence(self):
+        sampling_logps = torch.log(torch.tensor([[0.1]]))
+        current_logps = torch.log(torch.tensor([[0.5]]))
+        advantages = torch.tensor([[1.0]])
+
+        mask = self.compute_divergence_mask(
+            current_logps, sampling_logps, advantages, "kl", epsilon=0.01, epsilon_high=0.01
+        )
+
+        assert mask.item() == 0.0
 
 
 class TestGRPORolloutDispatch:
@@ -311,6 +377,35 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.parametrize("loss_type", ["dppo_tv", "dppo_kl"])
+    def test_train_dppo_loss_types(self, loss_type):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=32,  # reduce the completion length to reduce memory usage
+            gradient_accumulation_steps=2,  # set to 2 to test than DAPO can operate with accumulated batch
+            loss_type=loss_type,
+            epsilon=0.15,
+            epsilon_high=0.15,
+            beta=0.0,
+            use_liger_kernel=False,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
 
     def test_train_with_eval(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -256,6 +256,12 @@ class GRPOConfig(_BaseConfig):
             - `"vespo"`: Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth,
               asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in
               the [VESPO paper](https://huggingface.co/papers/2602.10693).
+            - `"dppo_tv"`: Divergence Proximal Policy Optimization. Replaces ratio-based clipping with a direct
+              estimate of policy divergence using Total Variation, as introduced in the [Divergence Proximal Policy
+              Paper](https://huggingface.co/papers/2602.04879).
+            - `"dppo_kl"`: Divergence Proximal Policy Optimization. Replaces ratio-based clipping with a direct
+              estimate of policy divergence using KL-Divergence, as introduced in the [Divergence Proximal Policy
+              Paper](https://huggingface.co/papers/2602.04879).
         mask_truncated_completions (`bool`, *optional*, defaults to `False`):
             When enabled, truncated completions are excluded from the loss calculation, preventing them from being
             incorrectly penalized and introducing noise during training. According to the

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2470,6 +2470,32 @@ class GRPOTrainer(_BaseTrainer):
 
         return phi_seq  # (B, 1)
 
+    @staticmethod
+    @torch.no_grad()
+    def get_divergence_mask(
+        advantages,
+        per_token_logps,
+        sampling_per_token_logps,
+        delta_low,
+        delta_high,
+        estimator_method,
+    ):
+        prob = torch.exp(per_token_logps)
+        sampling_prob = torch.exp(sampling_per_token_logps)
+        if estimator_method == "tv":
+            divergence = (prob - sampling_prob).abs()
+        elif estimator_method == "kl":
+            divergence = sampling_prob * (sampling_per_token_logps - per_token_logps) + (1 - sampling_prob) * (
+                torch.log1p(-sampling_prob.clamp(max=1 - 1e-7)) - torch.log1p(-prob.clamp(max=1 - 1e-7))
+            )
+
+        # Mask tokens where divergence > threshold AND policy moves away from trust region
+        invalid_pos = (divergence > delta_high) & (prob > sampling_prob)
+        invalid_neg = (divergence > delta_low) & (prob < sampling_prob)
+        mask = torch.where(advantages > 0, ~invalid_pos, ~invalid_neg)
+
+        return mask
+
     def _compute_loss(self, model, inputs):
         # Compute the per-token log probabilities for the model
         prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
@@ -2584,6 +2610,34 @@ class GRPOTrainer(_BaseTrainer):
                 lambda_neg=self.args.vespo_lambda_neg,
             )
             per_token_loss = -phi_seq * advantages * per_token_logps
+        elif self.loss_type == "dppo_tv":
+            sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
+            divergence_mask = self.get_divergence_mask(
+                advantages=advantages,
+                per_token_logps=per_token_logps,
+                sampling_per_token_logps=sampling_per_token_logps,
+                delta_low=self.epsilon_low,
+                delta_high=self.epsilon_high,
+                estimator_method="tv",
+            )
+            log_ratio_clamped = torch.exp(
+                (per_token_logps - sampling_per_token_logps).clamp(max=math.log(20.0))
+            ).detach()
+            per_token_loss = -advantages * log_ratio_clamped * divergence_mask * per_token_logps
+        elif self.loss_type == "dppo_kl":
+            sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
+            divergence_mask = self.get_divergence_mask(
+                advantages=advantages,
+                per_token_logps=per_token_logps,
+                sampling_per_token_logps=sampling_per_token_logps,
+                delta_low=self.epsilon_low,
+                delta_high=self.epsilon_high,
+                estimator_method="kl",
+            )
+            log_ratio_clamped = torch.exp(
+                (per_token_logps - sampling_per_token_logps).clamp(max=math.log(20.0))
+            ).detach()
+            per_token_loss = -advantages * log_ratio_clamped * divergence_mask * per_token_logps
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}")
 
@@ -2593,7 +2647,11 @@ class GRPOTrainer(_BaseTrainer):
         if entropy_mask is not None:
             per_token_loss = per_token_loss * entropy_mask
 
-        if self.use_vllm and self.vllm_importance_sampling_correction and self.loss_type != "vespo":
+        if (
+            self.use_vllm
+            and self.vllm_importance_sampling_correction
+            and self.loss_type not in ["vespo", "dppo_tv", "dppo_kl"]
+        ):
             per_token_loss = per_token_loss * inputs["importance_sampling_ratio"]
 
         if self.beta != 0.0:
@@ -2612,7 +2670,7 @@ class GRPOTrainer(_BaseTrainer):
             loss = (per_token_loss * mask).sum() / (per_token_loss.size(0) * self.max_completion_length)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
-        elif self.loss_type in ["cispo", "dapo", "vespo"]:
+        elif self.loss_type in ["cispo", "dapo", "vespo", "dppo_tv", "dppo_kl"]:
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer
         elif self.loss_type == "luspo":


### PR DESCRIPTION
# What does this PR do?

This PR adds support for DPPO in `GRPOConfig` and `GRPOTrainer` as described in #4998 
The implementation is close to the experimental implementation (see [trl/experimental/dppo/dppo_config.py](../blob/main/trl/experimental/dppo/dppo_config.py) and [trl/experimental/dppo/dppo_trainer.py](../blob/main/trl/experimental/dppo/dppo_trainer.py)) but integrates DPPO as new `loss_type` as suggested by @albertvillanova 

Some thoughts:
- DPPO is getting a lot of attention recently, e.g., it is the standard loss in [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/docs/algorithms.md#default-loss), was used in recent model releases (ZAYA1: https://arxiv.org/abs/2605.05365, very similar in Kimi-K2.5: https://arxiv.org/abs/2602.02276)
- I only implemented the binary approximations, not the top-K ones. Those would introduce a new hyperparameter, are computationally more expansive, and according to the paper similar in performance to the binary approximation. Also the linked references seem to use the binary approximations. I could add the top-K ones as well, just say so
- I reused `epsilon` high/low for `delta` high/low. `epsilon` does not exist in the DPPO formulation, but `delta` has the same role (threshold for masking). Is that okay, or should we add a `delta` parameter?
- The experimental implementation has an importance ratio clipping with `high=20.0`, the reference implementation with `low=-20.0` and `high=20.0`. This seems very generous and imo does not demand another hyperparameter. Happy to implement it though, if you like.
- I thought a long time about how to integrate the test in `TestGRPORolloutDispatch`, since there is no Liger Kernel for DPPO yet (I will add a PR later today/tomorrow). Depending on that, the new method can be merged with the other losses again, soon. But for now I think it is easier to keep it separate, instead of complex pytest parametrizations.
- the actual loss implementation is close to the experimental one, which was merged after getting feedback from the paper author @QPHutu 

I am happy to change things, please provide feedback on the PR :)


Fixes #4998 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case: https://github.com/huggingface/trl/issues/4998#issuecomment-4619874612
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human. (with AI review before submitting the PR)
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR. @albertvillanova 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GRPO loss computation and training behavior for new loss types; scope is localized but affects RL training stability paths.
> 
> **Overview**
> **DPPO** (Divergence Proximal Policy Optimization) is now available on the main **`GRPOTrainer`** path via new `loss_type` values **`dppo_tv`** and **`dppo_kl`**, instead of the experimental `DPPOTrainer` / `DPPOConfig` API.
> 
> `GRPOTrainer` adds **`get_divergence_mask`**, which masks tokens using binary **Total Variation** or **KL** divergence between current and sampling policies, with thresholds mapped from existing **`epsilon`** / **`epsilon_high`**. The DPPO loss uses a detached, capped importance ratio (max 20) times the divergence mask and per-token log-probs, and follows the same batch normalization as DAPO/CISPO/VESPO. **vLLM importance-sampling correction** is skipped for DPPO losses (like VESPO), since the DPPO objective already handles off-policy behavior.
> 
> Docs in **`paper_index.md`** now show `GRPOConfig(loss_type="dppo_tv"|"dppo_kl")` and document binary TV/KL only (not top-K modes). Tests add unit coverage for the divergence mask and an integration **`test_train_dppo_loss_types`** for both loss types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f1f0bc93eb508f74cc16f78dcc6a7fb6cfbd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->