### PR TITLE
fix(docs): correct broken GKD Trainer link in MiniLLM docs

### DIFF
--- a/docs/source/minillm_trainer.md
+++ b/docs/source/minillm_trainer.md
@@ -49,7 +49,7 @@ training_args = MiniLLMConfig(
 )
 ```
 
-\\( L_{\text{MiniLLM}} \\) becomes the reverse KLD version of the GKD loss as in [GKD Trainer](./gkd.md):
+\\( L_{\text{MiniLLM}} \\) becomes the reverse KLD version of the GKD loss as in [GKD Trainer](./gkd_trainer.md):
 
 $$
 L_{\text{GKD-RKL}}=\mathbb{E}_{x\sim \pi_{\theta}} \text{KL}\left[\pi_\theta(\cdot|x_{1..t})||\pi_{\text{teacher}}(\cdot | x_{1..t})\right].


### PR DESCRIPTION
# What does this PR do?

Fixes a broken documentation link. The MiniLLM trainer page links to the GKD Trainer as `./gkd.md`, but that file does not exist — the page is `gkd_trainer.md` (as registered in `docs/source/_toctree.yml`), so the link currently 404s.

This changes the link target `./gkd.md` → `./gkd_trainer.md` in `docs/source/minillm_trainer.md`. One-line docs fix.

Fixes # (no issue)

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone in the community is free to review — it's a one-line docs link fix.