### PR TITLE
Add testing for Olmo3

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/olmo3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/olmo3_for_causal_lm.py
@@ -1,0 +1,64 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import AutoTokenizer, GenerationConfig, Olmo3Config, Olmo3ForCausalLM
+
+from .._common import (
+    check_dtype_pattern,
+    check_transformers_version,
+    init_weights_tiny_model,
+    print_config_diff,
+    push_to_hub,
+    smoke_test,
+)
+
+
+# 4.57.0 (the release that introduced Olmo 3) was yanked for a packaging issue, so pin the first non-yanked patch.
+check_transformers_version("4.57.1")
+
+MODEL_ID = "allenai/Olmo-3-7B-Think"
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+config = Olmo3Config(
+    vocab_size=len(tokenizer.vocab),
+    hidden_size=8,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    num_hidden_layers=2,
+    intermediate_size=32,
+    # Non-size fields kept aligned with the reference so the tiny config only differs in what we scale down.
+    max_position_embeddings=65536,
+    rms_norm_eps=1e-06,
+    rope_theta=500000,
+    rope_scaling={
+        "attention_factor": 1.2079441541679836,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "factor": 8.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "yarn",
+    },
+    bos_token_id=None,
+    eos_token_id=100257,
+    pad_token_id=100277,
+    use_cache=False,
+)
+model = Olmo3ForCausalLM(config).to(dtype=torch.bfloat16)
+init_weights_tiny_model(model)
+smoke_test(model, tokenizer)
+check_dtype_pattern(MODEL_ID, model)
+print_config_diff(MODEL_ID, model)
+push_to_hub(model, tokenizer, generation_config, "tiny")

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -331,6 +331,9 @@ class TestSupportsToolCalling:
             # Silently drops both tool_calls and tool messages
             pytest.param("trl-internal-testing/tiny-Cohere2ForCausalLM", id="cohere2"),
             pytest.param("trl-internal-testing/tiny-LlavaForConditionalGeneration", id="llava"),
+            # Olmo3 uses a bespoke function-calling schema (a `functions`/`function_calls` string on the
+            # message plus an `environment` role) instead of the standard `tools`/`tool_calls`/`tool`
+            # interface, so a standard tool-calling conversation is silently dropped.
             pytest.param(
                 "trl-internal-testing/tiny-Olmo3ForCausalLM",
                 id="olmo3",

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -331,6 +331,14 @@ class TestSupportsToolCalling:
             # Silently drops both tool_calls and tool messages
             pytest.param("trl-internal-testing/tiny-Cohere2ForCausalLM", id="cohere2"),
             pytest.param("trl-internal-testing/tiny-LlavaForConditionalGeneration", id="llava"),
+            pytest.param(
+                "trl-internal-testing/tiny-Olmo3ForCausalLM",
+                id="olmo3",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("4.57.0"),
+                    reason="Olmo 3 was introduced in transformers>=4.57.0",
+                ),
+            ),
             pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3", id="phi3"),
             pytest.param("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", id="phi3.5"),
             # Renders tool message content as plain text but drops assistant tool_calls

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -563,6 +563,13 @@ class TestApplyChatTemplate(TrlTestCase):
                 reason="Nemotron 3 tokenizer requires transformers>=5.3.0",
             ),
         ),
+        pytest.param(
+            "trl-internal-testing/tiny-Olmo3ForCausalLM",
+            marks=pytest.mark.skipif(
+                Version(transformers.__version__) < Version("4.57.0"),
+                reason="Olmo 3 requires transformers>=4.57.0",
+            ),
+        ),
         "trl-internal-testing/tiny-Phi3ForCausalLM-3",
         "trl-internal-testing/tiny-Phi3ForCausalLM-3.5",
         "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -179,6 +179,13 @@ class TestDPOTrainer(TrlTestCase):
                     reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
                 ),
             ),
+            pytest.param(
+                "trl-internal-testing/tiny-Olmo3ForCausalLM",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("4.57.0"),
+                    reason="Olmo 3 requires transformers>=4.57.0",
+                ),
+            ),
         ],
     )
     def test_train(self, model_id):

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -378,6 +378,13 @@ class TestSFTTrainer(TrlTestCase):
                     reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
                 ),
             ),
+            pytest.param(
+                "trl-internal-testing/tiny-Olmo3ForCausalLM",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("4.57.0"),
+                    reason="Olmo 3 requires transformers>=4.57.0",
+                ),
+            ),
         ],
     )
     def test_train(self, model_id):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1147,6 +1147,13 @@ _CHUNKED_LM_HEAD_MODEL_IDS = [
             reason="Nemotron 3 was introduced in transformers>=5.3.0",
         ),
     ),
+    pytest.param(
+        "trl-internal-testing/tiny-Olmo3ForCausalLM",
+        marks=pytest.mark.skipif(
+            Version(transformers.__version__) < Version("4.57.0"),
+            reason="Olmo 3 was introduced in transformers>=4.57.0",
+        ),
+    ),
     "trl-internal-testing/tiny-Phi3ForCausalLM-3",
     "trl-internal-testing/tiny-Phi3ForCausalLM-3.5",
     "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",


### PR DESCRIPTION
Olmo3 is one of the most used model in trl, and we don't have testing for it. This PRs adds a tiny model: https://huggingface.co/trl-internal-testing/tiny-Olmo3ForCausalLM, and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and script-only changes; no production trainer or API logic modified.
> 
> **Overview**
> Adds **Olmo 3** coverage by introducing a tiny-model generator and folding `trl-internal-testing/tiny-Olmo3ForCausalLM` into existing CI matrices.
> 
> A new script builds a minimal `Olmo3ForCausalLM` from `allenai/Olmo-3-7B-Think` (tokenizer/generation config preserved, dimensions shrunk) and publishes via the shared tiny-model helpers, with **transformers ≥ 4.57.1** enforced for the generator.
> 
> **Tests** now include the tiny Olmo3 checkpoint (skipped below **transformers 4.57.0**) for chat-template tool-calling behavior (documented as **not** supporting standard `tools`/`tool_calls`), `apply_chat_template`, **DPO** and **SFT** `test_train`, and chunked LM-head patching in `test_utils`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e325042d32837705e8a046a88c97d9bcabc23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->