### PR TITLE
Remove invalid max_prompt_length argument from GRPO example

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -56,7 +56,6 @@ from trl import GRPOConfig, GRPOTrainer
 # Based on the Open-R1 recipe for Qwen-7B
 training_args = GRPOConfig(
     learning_rate=4.0e-5,
-    max_prompt_length=4096,
     max_completion_length=32768, # Support for long Chain-of-Thought
     num_generations=16,          # Sample 16 outputs per prompt for group relative advantage
     beta=0.001,                  # KL coefficient


### PR DESCRIPTION
# What does this PR do?

The DeepSeek-R1 reproduction example in `docs/source/paper_index.md` constructs `GRPOConfig` with a `max_prompt_length=4096` argument:

```python
training_args = GRPOConfig(
    learning_rate=4.0e-5,
    max_prompt_length=4096,        # not a GRPOConfig field
    max_completion_length=32768,
    ...
)
```

`GRPOConfig` has no `max_prompt_length` field (unlike `DPOConfig` / `SFTConfig`), so the snippet as written raises:

```
TypeError: GRPOConfig.__init__() got an unexpected keyword argument 'max_prompt_length'
```

GRPO does not truncate prompts via the config — prompts are expected to be pre-truncated in the dataset. This PR removes the invalid argument so the example runs. The remaining arguments (`learning_rate`, `max_completion_length`, `num_generations`, `beta`, `use_vllm`) are all valid `GRPOConfig` fields.

Docs-only, one-line change; no code paths or tests affected.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only one-line change; no runtime code or tests affected.
> 
> **Overview**
> Fixes the **DeepSeek-R1** `GRPOConfig` snippet in `docs/source/paper_index.md` by dropping `max_prompt_length=4096`, which is not a `GRPOConfig` field (unlike `DPOConfig` / `SFTConfig`).
> 
> Copy-pasting the example no longer raises `TypeError: GRPOConfig.__init__() got an unexpected keyword argument 'max_prompt_length'`. The rest of the sample args are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1210a3c812801da73a94554e22fc33748e1ef0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->