### PR TITLE
Secure trl vllm-serve server defaults

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -211,7 +211,7 @@ $ trl vllm-serve --help
 usage: trl vllm-serve [-h] --model MODEL [--revision REVISION] [--tensor_parallel_size TENSOR_PARALLEL_SIZE] [--data_parallel_size DATA_PARALLEL_SIZE] [--host HOST]
                       [--port PORT] [--gpu_memory_utilization GPU_MEMORY_UTILIZATION] [--dtype DTYPE] [--max_model_len MAX_MODEL_LEN]
                       [--enable_prefix_caching ENABLE_PREFIX_CACHING] [--enforce_eager [ENFORCE_EAGER]] [--kv_cache_dtype KV_CACHE_DTYPE]
-                      [--trust_remote_code [TRUST_REMOTE_CODE]] [--log_level LOG_LEVEL] [--vllm_model_impl VLLM_MODEL_IMPL]
+                      [--trust_remote_code [TRUST_REMOTE_CODE]] [--log_level LOG_LEVEL] [--api_key API_KEY] [--vllm_model_impl VLLM_MODEL_IMPL]
 
 options:
   -h, --help            show this help message and exit
@@ -223,7 +223,7 @@ options:
                         Number of data parallel workers to use. For dense models, keep this at 1. Starting from vLLM `0.14.0`, setting
                         this above `1` for dense models is no longer supported/useful and will error out (see vLLM PR #30739).
                         (default: 1)
-  --host HOST           Host address to run the server on. (default: 0.0.0.0)
+  --host HOST           Host address to run the server on. (default: 127.0.0.1)
   --port PORT           Port to run the server on. (default: 8000)
   --gpu_memory_utilization GPU_MEMORY_UTILIZATION, --gpu-memory-utilization GPU_MEMORY_UTILIZATION
                         Ratio (between 0 and 1) of GPU memory to reserve for the model weights, activations, and KV cache on the device dedicated to generation
@@ -231,6 +231,9 @@ options:
                         it may cause out-of-memory (OOM) errors during initialization. (default: 0.9)
   --dtype DTYPE         Data type to use for vLLM generation. If set to 'auto', the data type will be automatically determined based on the model configuration.
                         Find the supported values in the vLLM documentation. (default: auto)
+  --api_key API_KEY, --api-key API_KEY
+                        API key required for HTTP requests to the vLLM server. Can also be set with TRL_VLLM_SERVER_API_KEY.
+                        Required when binding to a non-loopback host. (default: None)
   --max_model_len MAX_MODEL_LEN, --max-model-len MAX_MODEL_LEN
                         If set, the `max_model_len` to use for vLLM. This can be useful when running with reduced `vllm_gpu_memory_utilization`, leading to a
                         reduced KV cache size. If not set, vLLM will use the model context size, which might be much larger than the KV cache, leading to

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -15,6 +15,7 @@
 import os
 import subprocess
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from packaging.version import Version
@@ -24,7 +25,7 @@ from transformers.testing_utils import torch_device
 from trl.generation.vllm_client import VLLMClient
 from trl.generation.vllm_generation import extract_logprobs
 from trl.import_utils import is_vllm_available
-from trl.scripts.vllm_serve import chunk_list
+from trl.scripts.vllm_serve import ScriptArguments, _is_loopback_host, _validate_auth_config, chunk_list
 
 from .testing_utils import (
     TrlTestCase,
@@ -46,6 +47,28 @@ else:
 
 
 class TestChunkList(TrlTestCase):
+    def test_vllm_server_defaults_to_loopback(self):
+        args = ScriptArguments(model="dummy")
+        assert args.host == "127.0.0.1"
+        assert _is_loopback_host(args.host)
+        assert not _is_loopback_host("0.0.0.0")
+
+    def test_vllm_server_requires_api_key_for_non_loopback(self):
+        with pytest.raises(ValueError, match="non-loopback host without authentication"):
+            _validate_auth_config("0.0.0.0", None)
+
+        _validate_auth_config("0.0.0.0", "secret")
+        _validate_auth_config("127.0.0.1", None)
+
+    def test_vllm_client_uses_api_key_env(self):
+        with patch("trl.generation.vllm_client.is_vllm_available", return_value=True):
+            with patch.object(VLLMClient, "check_server"):
+                with patch.dict(os.environ, {"TRL_VLLM_SERVER_API_KEY": "secret"}):
+                    client = VLLMClient()
+
+        assert client.base_url == "http://127.0.0.1:8000"
+        assert client.session.headers["Authorization"] == "Bearer secret"
+
     def test_even_split(self):
         assert chunk_list([1, 2, 3, 4, 5, 6], 2) == [[1, 2, 3], [4, 5, 6]]
 

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import socket
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -53,6 +54,28 @@ class TestChunkList(TrlTestCase):
         assert _is_loopback_host(args.host)
         assert not _is_loopback_host("0.0.0.0")
 
+    def test_vllm_server_api_key_env_is_read_at_instantiation(self):
+        with patch.dict(os.environ, {"TRL_VLLM_SERVER_API_KEY": "secret"}):
+            args = ScriptArguments(model="dummy")
+
+        assert args.api_key == "secret"
+
+    def test_vllm_server_loopback_host_resolves_hostname(self):
+        with patch(
+            "trl.scripts.vllm_serve.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))],
+        ):
+            assert _is_loopback_host("loopback.local")
+
+        with patch(
+            "trl.scripts.vllm_serve.socket.getaddrinfo",
+            return_value=[
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0)),
+            ],
+        ):
+            assert not _is_loopback_host("mixed.local")
+
     def test_vllm_server_requires_api_key_for_non_loopback(self):
         with pytest.raises(ValueError, match="non-loopback host without authentication"):
             _validate_auth_config("0.0.0.0", None)
@@ -68,6 +91,14 @@ class TestChunkList(TrlTestCase):
 
         assert client.base_url == "http://127.0.0.1:8000"
         assert client.session.headers["Authorization"] == "Bearer secret"
+
+    def test_vllm_client_check_server_fails_on_unauthorized_health(self):
+        client = object.__new__(VLLMClient)
+        client.base_url = "http://127.0.0.1:8000"
+        client.session = SimpleNamespace(get=lambda url: SimpleNamespace(status_code=401, headers={}))
+
+        with pytest.raises(Exception, match="HTTP 401"):
+            client.check_server(total_timeout=240, retry_interval=0)
 
     def test_even_split(self):
         assert chunk_list([1, 2, 3, 4, 5, 6], 2) == [[1, 2, 3], [4, 5, 6]]

--- a/trl/experimental/distillation/distillation_config.py
+++ b/trl/experimental/distillation/distillation_config.py
@@ -110,7 +110,7 @@ class DistillationConfig(_BaseConfig):
             Mode for student vLLM integration. Either `"server"` or `"colocate"`.
         vllm_server_base_url (`str` or `None`, *optional*):
             Base URL for the student vLLM server. If provided, `vllm_server_host` and `vllm_server_port` are ignored.
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the student vLLM server.
         vllm_server_port (`int`, *optional*, defaults to `8001`):
             Port of the student vLLM server.
@@ -297,7 +297,7 @@ class DistillationConfig(_BaseConfig):
         metadata={"help": "Base URL for the student vLLM server."},
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host of the student vLLM server."},
     )
     vllm_server_port: int = field(

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -80,7 +80,7 @@ class GOLDConfig(SFTConfig):
         vllm_mode (`str`, *optional*, defaults to `"colocate"`):
             Mode for student vLLM integration. Either `"server"` (connect to a running TRL vLLM server) or `"colocate"`
             (run vLLM in the same process).
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server for the student model (if `vllm_mode="server"`).
         vllm_server_port (`int`, *optional*, defaults to `8001`):
             Port of the vLLM server for the student model (if `vllm_mode="server"`).
@@ -304,7 +304,7 @@ class GOLDConfig(SFTConfig):
         },
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": 'Host of the vLLM server when `vllm_mode="server"`.'},
     )
     vllm_server_port: int = field(

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -109,7 +109,7 @@ class OnlineDPOConfig(_BaseConfig):
         vllm_server_base_url (`str`, *optional*):
             Base URL for the vLLM server (e.g., `"http://localhost:8000"`). If provided, `vllm_server_host` and
             `vllm_server_port` are ignored.
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
         vllm_server_port (`int`, *optional*, defaults to `8000`):
             Port of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
@@ -301,7 +301,7 @@ class OnlineDPOConfig(_BaseConfig):
         },
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host of the vLLM server to connect to. Ignored if vllm_server_base_url is provided."},
     )
     vllm_server_port: int = field(

--- a/trl/experimental/ssd/ssd_config.py
+++ b/trl/experimental/ssd/ssd_config.py
@@ -73,7 +73,7 @@ class SSDConfig(_BaseConfig):
             Model implementation for vLLM: `"vllm"`, `"transformers"`, or `"auto"`.
         vllm_server_base_url (`str` or `None`, *optional*):
             Base URL for the vLLM server. If provided, `vllm_server_host` and `vllm_server_port` are ignored.
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server (server mode only).
         vllm_server_port (`int`, *optional*, defaults to `8000`):
             Port of the vLLM server (server mode only).
@@ -181,7 +181,7 @@ class SSDConfig(_BaseConfig):
         },
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host of the vLLM server (server mode only)."},
     )
     vllm_server_port: int = field(

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -205,6 +205,18 @@ class VLLMClient:
                     logger.info("Server is up!")
                     return None
 
+                elapsed_time = time.time() - start_time
+                if response.status_code == 401:
+                    raise ConnectionError(
+                        f"The vLLM server at {self.base_url} rejected the health check with HTTP 401. "
+                        "Set the correct TRL_VLLM_SERVER_API_KEY or pass api_key to VLLMClient."
+                    )
+                if elapsed_time >= total_timeout:
+                    raise ConnectionError(
+                        f"The vLLM server at {self.base_url} returned HTTP {response.status_code} after "
+                        f"{total_timeout} seconds."
+                    )
+
             # Retry logic: wait before trying again
             logger.info(f"Server is not up yet. Retrying in {retry_interval} seconds...")
             time.sleep(retry_interval)

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -16,6 +16,7 @@ import atexit
 import base64
 import copy
 import logging
+import os
 import socket
 import time
 from io import BytesIO
@@ -66,10 +67,13 @@ class VLLMClient:
         base_url (`str`, *optional*):
             Base URL for the vLLM server (e.g., `"http://localhost:8000"`). If provided, `host` and `server_port` are
             ignored.
-        host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        host (`str`, *optional*, defaults to `"127.0.0.1"`):
             IP address of the vLLM server. Ignored if `base_url` is provided.
         server_port (`int`, *optional*, defaults to `8000`):
             Port number of the vLLM server. Ignored if `base_url` is provided.
+        api_key (`str`, *optional*):
+            API key used to authenticate with the vLLM server. If not provided, the client reads
+            `TRL_VLLM_SERVER_API_KEY` from the environment.
         group_port (`int`, *optional*, defaults to `51216`):
             Port number for the weight update group.
         connection_timeout (`float`, *optional*, defaults to `0.0`):
@@ -83,7 +87,7 @@ class VLLMClient:
         $ trl vllm-serve --model Qwen/Qwen2.5-7B
         ...
         INFO:     Application startup complete.
-        INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+        INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
         ```
 
         Use the client to generate completions and update model weights:
@@ -122,8 +126,9 @@ class VLLMClient:
     def __init__(
         self,
         base_url: str | None = None,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         server_port: int = 8000,
+        api_key: str | None = None,
         group_port: int = 51216,
         connection_timeout: float = 0.0,
     ):
@@ -133,6 +138,9 @@ class VLLMClient:
             raise ImportError("vLLM is not installed. Please install it with `pip install trl[vllm]`.")
 
         self.session = requests.Session()
+        self.api_key = api_key or os.environ.get("TRL_VLLM_SERVER_API_KEY")
+        if self.api_key is not None:
+            self.session.headers.update({"Authorization": f"Bearer {self.api_key}"})
 
         # Configure retries for HTTP requests made through this session.
         # This is not strictly required for correctness, but it helps make training more robust to rare, transient
@@ -181,7 +189,7 @@ class VLLMClient:
 
         while True:
             try:
-                response = requests.get(url)
+                response = self.session.get(url)
             except requests.exceptions.RequestException as exc:
                 # Check if the total timeout duration has passed
                 elapsed_time = time.time() - start_time
@@ -424,7 +432,7 @@ class VLLMClient:
         """
         # Get the world size from the server
         url = f"{self.base_url}/get_world_size/"
-        response = requests.get(url)
+        response = self.session.get(url)
         if response.status_code == 200:
             vllm_world_size = response.json()["world_size"]
         else:

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -141,7 +141,7 @@ class VLLMGeneration:
         server_base_url (`str`, *optional*):
             Base URL for the vLLM server (e.g., `"http://localhost:8000"`). If provided, `server_host` and
             `server_port` are ignored.
-        server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server to connect to. Ignored if `server_base_url` is provided.
         server_port (`int`, *optional*, defaults to `8000`):
             Port of the vLLM server to connect to. Ignored if `server_base_url` is provided.
@@ -231,7 +231,7 @@ class VLLMGeneration:
         structured_outputs_regex: str | None = None,
         # Server mode configuration
         server_base_url: str | None = None,
-        server_host: str = "0.0.0.0",
+        server_host: str = "127.0.0.1",
         server_port: int = 8000,
         server_timeout: float = 240.0,
         group_port: int = 51216,

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -14,6 +14,7 @@
 
 import argparse
 import base64
+import ipaddress
 import json
 import logging
 import math
@@ -177,7 +178,7 @@ class ScriptArguments:
             Number of data parallel workers to use. For dense models, keep this at 1. Starting from vLLM `0.14.0`,
             setting this above `1` for dense models is no longer supported/useful and will error out (see vLLM PR
             #30739).
-        host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host address to run the server on.
         port (`int`, *optional*, defaults to `8000`):
             Port to run the server on.
@@ -211,6 +212,8 @@ class ScriptArguments:
         log_level (`str`, *optional*, defaults to `"info"`):
             Log level for uvicorn. Possible choices: `"critical"`, `"error"`, `"warning"`, `"info"`, `"debug"`,
             `"trace"`.
+        api_key (`str`, *optional*):
+            API key required for HTTP requests to the vLLM server. Required when binding to a non-loopback host.
         distributed_executor_backend (`str` or `None`, *optional*):
             Distributed executor backend for vLLM. Set to `"ray"` to distribute tensor parallel workers across multiple
             nodes via a Ray cluster. Required when `tensor_parallel_size` exceeds the number of local GPUs. If not set,
@@ -240,7 +243,7 @@ class ScriptArguments:
         },
     )
     host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host address to run the server on."},
     )
     port: int = field(
@@ -304,6 +307,13 @@ class ScriptArguments:
         metadata={
             "help": "Log level for uvicorn. Possible choices: 'critical', 'error', 'warning', 'info', 'debug', "
             "'trace'."
+        },
+    )
+    api_key: str | None = field(
+        default=os.environ.get("TRL_VLLM_SERVER_API_KEY"),
+        metadata={
+            "help": "API key required for HTTP requests to the vLLM server. Can also be set with the "
+            "TRL_VLLM_SERVER_API_KEY environment variable. Required when binding to a non-loopback host."
         },
     )
     vllm_model_impl: str = field(
@@ -407,6 +417,25 @@ def chunk_list(lst: list, n: int) -> list[list]:
     return [lst[i * k + min(i, r) : (i + 1) * k + min(i + 1, r)] for i in range(n)]
 
 
+def _is_loopback_host(host: str) -> bool:
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_auth_config(host: str, api_key: str | None) -> None:
+    if api_key or _is_loopback_host(host):
+        return
+
+    raise ValueError(
+        "Refusing to bind the TRL vLLM server to a non-loopback host without authentication. "
+        "Set --api-key or TRL_VLLM_SERVER_API_KEY, or bind to 127.0.0.1."
+    )
+
+
 def main(script_args: ScriptArguments):
     import asyncio
 
@@ -439,7 +468,7 @@ def main(script_args: ScriptArguments):
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
 
     import uvicorn
-    from fastapi import FastAPI
+    from fastapi import Depends, FastAPI, Header, HTTPException
     from pydantic import BaseModel
     from vllm import SamplingParams
     from vllm.sampling_params import StructuredOutputsParams
@@ -449,6 +478,8 @@ def main(script_args: ScriptArguments):
         from PIL import Image
 
     logger = logging.getLogger(__name__)
+
+    _validate_auth_config(script_args.host, script_args.api_key)
 
     # Spawn dp workers, and setup pipes for communication
     master_port = get_open_port()
@@ -486,7 +517,20 @@ def main(script_args: ScriptArguments):
                 process.terminate()
                 process.join()  # ensure process termination after calling terminate()
 
-    app = FastAPI(lifespan=lifespan)
+    def require_api_key(
+        authorization: str | None = Header(default=None),
+        x_trl_api_key: str | None = Header(default=None),
+    ) -> None:
+        if script_args.api_key is None:
+            return
+
+        expected_bearer = f"Bearer {script_args.api_key}"
+        if authorization == expected_bearer or x_trl_api_key == script_args.api_key:
+            return
+
+        raise HTTPException(status_code=401, detail="Invalid or missing TRL vLLM server API key")
+
+    app = FastAPI(lifespan=lifespan, dependencies=[Depends(require_api_key)])
 
     # Define the endpoints for the model server
     @app.get("/health/")
@@ -1033,7 +1077,7 @@ def main(script_args: ScriptArguments):
 
         Example request:
         ```bash
-        curl -X POST 'http://0.0.0.0:8000/chat/' \
+        curl -X POST 'http://127.0.0.1:8000/chat/' \
           -H 'Content-Type: application/json' \
           -d '{"messages": [[{ "role": "user", "content": "Hello!" }]]}'
         ```

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -14,11 +14,13 @@
 
 import argparse
 import base64
+import hmac
 import ipaddress
 import json
 import logging
 import math
 import os
+import socket
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -310,7 +312,7 @@ class ScriptArguments:
         },
     )
     api_key: str | None = field(
-        default=os.environ.get("TRL_VLLM_SERVER_API_KEY"),
+        default_factory=lambda: os.environ.get("TRL_VLLM_SERVER_API_KEY"),
         metadata={
             "help": "API key required for HTTP requests to the vLLM server. Can also be set with the "
             "TRL_VLLM_SERVER_API_KEY environment variable. Required when binding to a non-loopback host."
@@ -418,12 +420,21 @@ def chunk_list(lst: list, n: int) -> list[list]:
 
 
 def _is_loopback_host(host: str) -> bool:
-    if host in {"localhost", "127.0.0.1", "::1"}:
+    normalized_host = host.strip("[]").lower()
+    if normalized_host in {"localhost", "127.0.0.1", "::1"}:
         return True
     try:
-        return ipaddress.ip_address(host).is_loopback
+        return ipaddress.ip_address(normalized_host).is_loopback
     except ValueError:
+        pass
+
+    try:
+        addr_infos = socket.getaddrinfo(normalized_host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
         return False
+
+    resolved_addresses = {addr_info[4][0] for addr_info in addr_infos}
+    return bool(resolved_addresses) and all(ipaddress.ip_address(address).is_loopback for address in resolved_addresses)
 
 
 def _validate_auth_config(host: str, api_key: str | None) -> None:
@@ -524,8 +535,19 @@ def main(script_args: ScriptArguments):
         if script_args.api_key is None:
             return
 
-        expected_bearer = f"Bearer {script_args.api_key}"
-        if authorization == expected_bearer or x_trl_api_key == script_args.api_key:
+        expected_api_key = script_args.api_key
+        provided_bearer = None
+        if authorization is not None:
+            auth_parts = authorization.split(None, 1)
+            if len(auth_parts) == 2 and auth_parts[0].lower() == "bearer":
+                provided_bearer = auth_parts[1]
+
+        if (
+            provided_bearer is not None
+            and hmac.compare_digest(provided_bearer, expected_api_key)
+            or x_trl_api_key is not None
+            and hmac.compare_digest(x_trl_api_key, expected_api_key)
+        ):
             return
 
         raise HTTPException(status_code=401, detail="Invalid or missing TRL vLLM server API key")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -130,7 +130,7 @@ class GRPOConfig(_BaseConfig):
         vllm_server_base_url (`str`, *optional*):
             Base URL for the vLLM server (e.g., `"http://localhost:8000"`). If provided, `vllm_server_host` and
             `vllm_server_port` are ignored.
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
         vllm_server_port (`int`, *optional*, defaults to `8000`):
             Port of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
@@ -538,7 +538,7 @@ class GRPOConfig(_BaseConfig):
         },
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host of the vLLM server to connect to. Ignored if vllm_server_base_url is provided."},
     )
     vllm_server_port: int = field(

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -125,7 +125,7 @@ class RLOOConfig(_BaseConfig):
         vllm_server_base_url (`str`, *optional*):
             Base URL for the vLLM server (e.g., `"http://localhost:8000"`). If provided, `vllm_server_host` and
             `vllm_server_port` are ignored.
-        vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
+        vllm_server_host (`str`, *optional*, defaults to `"127.0.0.1"`):
             Host of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
         vllm_server_port (`int`, *optional*, defaults to `8000`):
             Port of the vLLM server to connect to. Ignored if `vllm_server_base_url` is provided.
@@ -405,7 +405,7 @@ class RLOOConfig(_BaseConfig):
         },
     )
     vllm_server_host: str = field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         metadata={"help": "Host of the vLLM server to connect to. Ignored if vllm_server_base_url is provided."},
     )
     vllm_server_port: int = field(


### PR DESCRIPTION
# What does this PR do?

Secures `trl vllm-serve` server mode by:

- binding the server/client defaults to `127.0.0.1`
- adding `--api-key` / `TRL_VLLM_SERVER_API_KEY`
- refusing to bind to a non-loopback host without authentication
- applying the API key check to all FastAPI routes
- making `VLLMClient` send the configured bearer token
- updating docs and regression tests

This avoids accidentally exposing internal server-mode routes on untrusted networks while keeping explicit multi-host training possible.

No public issue. This follows a private security report sent to Hugging Face Security.

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [x] Did you read the contributor guideline?
- [ ] Was this discussed/approved via a GitHub issue? No public issue; reported privately to Hugging Face Security.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

TRL maintainers familiar with `trl vllm-serve` / vLLM server mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-critical HTTP surface and breaking default bind change (`0.0.0.0` → `127.0.0.1`); remote/multi-host setups must set `--api-key` and matching client env vars.
> 
> **Overview**
> Hardens **TRL vLLM server mode** so generation and weight-sync HTTP endpoints are not exposed by default on all interfaces.
> 
> **Defaults and configs:** `trl vllm-serve`, `VLLMClient`, `VLLMGeneration`, and trainer configs (`GRPO`, `RLOO`, Online DPO, distillation, GOLD, SSD) now default **`vllm_server_host` / `--host` to `127.0.0.1`** instead of `0.0.0.0`.
> 
> **Authentication:** Adds **`--api-key` / `TRL_VLLM_SERVER_API_KEY`**. Startup calls **`_validate_auth_config`**: binding to a **non-loopback** host without a key raises **`ValueError`**. When a key is set, a FastAPI **`require_api_key`** dependency protects **all routes** (Bearer or `X-TRL-API-Key`, constant-time compare).
> 
> **Client:** `VLLMClient` accepts **`api_key`**, reads the env var, sets **`Authorization: Bearer`**, routes health and API calls through **`self.session`**, and fails fast on **401** during health checks.
> 
> **Tests/docs:** Unit tests for loopback detection, auth validation, and client headers; vLLM integration docs updated for the new flags and default host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b42f071f24b11e1ace2832b0a84284bd2257538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->