### PR TITLE
chore(docs): Highlight the role of KL in RLOO compared to GRPO

### DIFF
--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -119,6 +119,17 @@ $$
 
 In a fully online, single-step setting (default),  \\( \frac{\pi_\theta(o_i \mid q)}{\pi_{\theta_\text{old}}(o_i \mid q)} = 1 \\) and this reduces to standard REINFORCE.
 
+> [!NOTE]
+> Unlike GRPO, RLOO does not backpropagate gradients through the KL term. Here the KL is purely used for reward shaping: it is computed under `no_grad` and folded into the scalar reward  \\( r_i \\), which becomes the detached advantage  \\( \hat{A}_i \\). 
+>
+> In other words, the only path the gradient takes into the policy is the importance-ratio term  \\( \frac{\pi_\theta(o_i \mid q)}{\pi_{\theta_\text{old}}(o_i \mid q)} \\), and the KL term does not backpropagate into the policy. 
+>
+> In contrast, GRPO  adds an explicit, differentiable KL term to its objective, computed on the fly with the current policy  \\( \pi_\theta \\):
+>
+> \\( \mathcal{L}_{\text{GRPO}}(\theta) = -\frac{1}{\sum_{i=1}^G |o_i|} \sum_{i=1}^G \sum_{t=1}^{|o_i|} \left[ \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_\text{old}}(o_{i,t} \mid q, o_{i,< t})} \hat{A}_{i,t} - \beta \, \mathbb{D}_{\mathrm{KL}}\!\left[\pi_\theta \| \pi_{\text{ref}}\right] \right] \\)
+>
+> so its gradient flows through both the ratio term and the KL penalty, whereas RLOO's flows through the ratio term alone.
+
 ## Logged metrics
 
 While training and evaluating, we record the following reward metrics:

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -124,11 +124,7 @@ In a fully online, single-step setting (default),  \\( \frac{\pi_\theta(o_i \mid
 >
 > In other words, the only path the gradient takes into the policy is the importance-ratio term  \\( \frac{\pi_\theta(o_i \mid q)}{\pi_{\theta_\text{old}}(o_i \mid q)} \\), and the KL term does not backpropagate into the policy. 
 >
-> In contrast, GRPO  adds an explicit, differentiable KL term to its objective, computed on the fly with the current policy  \\( \pi_\theta \\):
->
-> \\( \mathcal{L}_{\text{GRPO}}(\theta) = -\frac{1}{\sum_{i=1}^G |o_i|} \sum_{i=1}^G \sum_{t=1}^{|o_i|} \left[ \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_\text{old}}(o_{i,t} \mid q, o_{i,< t})} \hat{A}_{i,t} - \beta \, \mathbb{D}_{\mathrm{KL}}\!\left[\pi_\theta \| \pi_{\text{ref}}\right] \right] \\)
->
-> so its gradient flows through both the ratio term and the KL penalty, whereas RLOO's flows through the ratio term alone.
+> In contrast, [GRPO](grpo_trainer) adds an explicit, differentiable KL term to its objective, computed on the fly with the current policy  \\( \pi_\theta \\), so its gradient flows through both the ratio term and the KL penalty.
 
 ## Logged metrics
 


### PR DESCRIPTION
# What does this PR do?

This PR adds a note blockquote to highlight the different role the KL term plays in the RLOO objective compared to the GRPO objective. 

In short, it is my understanding that:
- In RLOO, the KL term is simply reward shaping - the advantage is detached, so no gradients flow through it into the policy we are training
- In GRPO, we have an explicit KL term added to the loss, which is computed with the current policy and we backprop through that term. 

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or training behavior impact; content aligns with existing RLOO/GRPO trainer implementations.
> 
> **Overview**
> Adds a **`[!NOTE]`** blockquote in `docs/source/rloo_trainer.md` immediately after the clipped RLOO loss formula, clarifying how **KL interacts with gradients** versus [GRPO](grpo_trainer).
> 
> The note states that in **RLOO**, KL is **reward shaping only**: it is folded into the scalar reward (and thus detached advantages), so policy gradients flow **only** through the importance-sampling ratio term—not through KL. In **GRPO**, KL is an **explicit differentiable term** in the objective computed with the current policy, so gradients flow through both the ratio and the KL penalty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e66adebbca591e2a8faeeb05af16feaa228eec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->