### PR TITLE
fix: reject mixed reward margins

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,25 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    @pytest.mark.parametrize(
+        "examples",
+        [
+            [
+                {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5]},
+                {"chosen_ids": [6, 7], "rejected_ids": [8], "margin": 0.2},
+            ],
+            [
+                {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5], "margin": 0.1},
+                {"chosen_ids": [6, 7], "rejected_ids": [8]},
+            ],
+        ],
+    )
+    def test_collate_rejects_mixed_margin_batches(self, examples):
+        collator = DataCollatorForPreference(pad_token_id=0)
+
+        with pytest.raises(ValueError, match="all examples or no examples"):
+            collator(examples)
+
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,7 +201,10 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
+        has_margin = ["margin" in example for example in examples]
+        if any(has_margin) and not all(has_margin):
+            raise ValueError("Either all examples or no examples must include a `margin` field.")
+        if all(has_margin):
             margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
@@ -221,7 +224,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if all(has_margin):
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
Fixes #5539.

## Summary
- check the whole batch before deciding whether to pass `margin` to the reward loss
- keep batches with no margins and batches with all margins working as before
- raise a clear `ValueError` for mixed batches instead of silently dropping later margins or crashing with `KeyError`
- add regression coverage for both mixed-batch orders

I chose the strict error path rather than filling missing margins with `0.0`, because a mixed batch usually means the dataset was built inconsistently. Failing at collation keeps that data problem visible instead of changing the reward loss semantics for only part of the batch.

## To verify
- python -m pytest tests\test_reward_trainer.py -q -k "collate"
- python -m pytest tests\test_reward_trainer.py::TestDataCollatorForPreference -q
- python -m py_compile trl\trainer\reward_trainer.py tests\test_reward_trainer.py
- python -m ruff check trl\trainer\reward_trainer.py tests\test_reward_trainer.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to reward data collation with explicit validation; training semantics unchanged for valid batches.
> 
> **Overview**
> **`DataCollatorForPreference`** no longer keys off only the first example for optional **`margin`**. It requires every row in a batch to either all include **`margin`** or none do; mixed batches raise a clear **`ValueError`** instead of omitting **`margin`** from the collated output or failing later with **`KeyError`**.
> 
> Uniform batches behave as before (no **`margin`** key vs. a **`margin`** tensor for all rows). Regression tests cover both orderings of a mixed batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f91aa2f06117cec17513850ecf8bc31d22cb7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->