### PR TITLE
fix: reject mixed reward margins

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -106,6 +106,25 @@ class TestDataCollatorForPreference(TrlTestCase):
         )
         torch.testing.assert_close(result["margin"], torch.tensor([0.1, 0.2]))
 
+    @pytest.mark.parametrize(
+        "examples",
+        [
+            [
+                {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5]},
+                {"chosen_ids": [6, 7], "rejected_ids": [8], "margin": 0.2},
+            ],
+            [
+                {"chosen_ids": [1, 2, 3], "rejected_ids": [4, 5], "margin": 0.1},
+                {"chosen_ids": [6, 7], "rejected_ids": [8]},
+            ],
+        ],
+    )
+    def test_collate_rejects_mixed_margin_batches(self, examples):
+        collator = DataCollatorForPreference(pad_token_id=0)
+
+        with pytest.raises(ValueError, match="all examples or no examples"):
+            collator(examples)
+
 
 class TestRewardTrainer(TrlTestCase):
     def test_raises_error_when_model_num_labels_not_one(self):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -201,7 +201,10 @@ class DataCollatorForPreference(DataCollatorMixin):
         # Convert to tensor
         chosen_ids = [torch.tensor(example["chosen_ids"]) for example in examples]
         rejected_ids = [torch.tensor(example["rejected_ids"]) for example in examples]
-        if "margin" in examples[0]:
+        has_margin = ["margin" in example for example in examples]
+        if any(has_margin) and not all(has_margin):
+            raise ValueError("Either all examples or no examples must include a `margin` field.")
+        if all(has_margin):
             margins = torch.tensor([example["margin"] for example in examples], dtype=torch.float)
         input_ids = chosen_ids + rejected_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
@@ -221,7 +224,7 @@ class DataCollatorForPreference(DataCollatorMixin):
             padding_side="right",
             pad_to_multiple_of=self.pad_to_multiple_of,
         )
-        if "margin" in examples[0]:
+        if all(has_margin):
             output["margin"] = margins
         return output
 


### PR DESCRIPTION
# What does this PR do?

`DataCollatorForPreference` currently decides whether a batch has reward margins by checking only `examples[0]`. That makes the behavior depend on batch order: if the first row has no margin, later margins are silently dropped; if the first row has a margin and a later row does not, collation raises a raw `KeyError`.

This PR checks the whole batch before building the margin tensor. Batches with no margins and batches where every row has a margin keep the existing behavior. Mixed batches now raise a clear `ValueError`, because a partially annotated margin batch changes the reward-loss semantics and should be fixed at the dataset boundary rather than silently filled.

Fixes #5539

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. Issue: #5539.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this collator validation change.
- [x] Did you write any new necessary tests?

Validation run locally:

- `python -m pytest tests/test_reward_trainer.py -q -k "collate"`
- `python -m pytest tests/test_reward_trainer.py::TestDataCollatorForPreference -q`
- `python -m py_compile trl/trainer/reward_trainer.py tests/test_reward_trainer.py`
- `python -m ruff check trl/trainer/reward_trainer.py tests/test_reward_trainer.py`
- `git diff --check`

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small collator validation change with tests; homogeneous batches are unchanged and only invalid mixed-margin data fails earlier.
> 
> **Overview**
> **`DataCollatorForPreference`** no longer infers whether a batch uses reward margins from only the first example. It now checks every row: batches with no `margin` fields or with `margin` on every row behave as before; **mixed batches raise a clear `ValueError`** instead of silently dropping margins or failing with a `KeyError`.
> 
> Tests cover both orderings (margin missing on the first vs. later example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f91aa2f06117cec17513850ecf8bc31d22cb7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->