### PR TITLE
Fix broken code examples in docs (RLOO syntax, SFTConfig max_length)

### DIFF
--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -292,7 +292,7 @@ training_args = SFTConfig(
     # required
     pad_to_multiple_of=2,    # Must equal sp_size
     # to get the most out of SP
-    max_seq_length=4096,
+    max_length=4096,
     packing=True,
     attn_implementation="flash_attention_2",
     per_device_train_batch_size=1,

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1341,10 +1341,10 @@ from trl import RLOOConfig
 
 training_args = RLOOConfig(
     per_device_train_batch_size=512,  # section C Training Detail of the paper
-    steps_per_generation=2  # section C Training Detail of the paper
-    beta=0.03  # section C Training Detail of the paper
+    steps_per_generation=2,  # section C Training Detail of the paper
+    beta=0.03,  # section C Training Detail of the paper
     num_generations=2,  # experiments of paper different num_generations={2,4}
-    learning_rate=1e-6  # section C Training Detail of the paper
+    learning_rate=1e-6,  # section C Training Detail of the paper
 )
 ```
 


### PR DESCRIPTION
# What does this PR do?

Two documented code snippets are broken as written:

1. **`docs/source/paper_index.md`** — the RLOO reproduction example is missing commas after `steps_per_generation=2` and `beta=0.03`, so the snippet raises `SyntaxError: invalid syntax. Perhaps you forgot a comma?` and cannot run.

2. **`docs/source/distributing_training.md`** — the sequence-parallel `SFTConfig` example passes `max_seq_length=4096`, but `SFTConfig` has no such field (the field is `max_length`). As written it raises `TypeError: SFTConfig.__init__() got an unexpected keyword argument 'max_seq_length'`.

This PR adds the missing commas and renames `max_seq_length` → `max_length` so both examples run as intended.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to example snippets; no library or training code changes.
> 
> **Overview**
> Fixes two **copy-pasteable doc examples** that previously failed at runtime.
> 
> In **`docs/source/paper_index.md`**, the RLOO reproduction snippet now uses valid Python: commas were added after `steps_per_generation=2` and `beta=0.03` in the `RLOOConfig(...)` call so it no longer raises a syntax error.
> 
> In **`docs/source/distributing_training.md`**, the ALST/Ulysses sequence-parallel `SFTConfig` example now passes **`max_length=4096`** instead of **`max_seq_length`**, matching the actual `SFTConfig` API and avoiding an unexpected keyword argument error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1f7ce6c7034dff837b01dbe2ba997e995997c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->