### PR TITLE
Fix broken doc links (CONTRIBUTING online DPO paths, async GRPO anchor)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Based on the community and maintainer feedback, the next step will be to impleme
 
 * Paired preference optimisation: [`dpo_trainer.py`](./trl/trainer/dpo_trainer.py) and [`dpo_config.py`](./trl/trainer/dpo_config.py)
 * RL-based optimisation: [`rloo_trainer.py`](./trl/trainer/rloo_trainer.py) and [`rloo_config.py`](./trl/trainer/rloo_config.py)
-* Online optimisation: [`online_dpo_trainer.py`](./trl/trainer/online_dpo_trainer.py) and [`online_dpo_config.py`](./trl/trainer/online_dpo_config.py)
+* Online optimisation: [`online_dpo_trainer.py`](./trl/experimental/online_dpo/online_dpo_trainer.py) and [`online_dpo_config.py`](./trl/experimental/online_dpo/online_dpo_config.py)
 
 ## Do you want to add documentation?
 

--- a/docs/source/async_grpo_trainer.md
+++ b/docs/source/async_grpo_trainer.md
@@ -18,7 +18,7 @@ This trainer was contributed by [Quentin Gallouédec](https://huggingface.co/qga
 
 ## How it differs from [`GRPOTrainer`]
 
-In the standard [`GRPOTrainer`], generation and training are sequential: generate a batch, compute the loss, update weights, repeat. Even in [vLLM colocate mode](grpo_trainer#speed-up-training-with-vllm), where generation runs on the same GPUs, one phase must finish before the other begins.
+In the standard [`GRPOTrainer`], generation and training are sequential: generate a batch, compute the loss, update weights, repeat. Even in [vLLM colocate mode](grpo_trainer#speed-up-training-with-vllm-powered-generation), where generation runs on the same GPUs, one phase must finish before the other begins.
 
 [`AsyncGRPOTrainer`] separates these two concerns:
 


### PR DESCRIPTION
# What does this PR do?

Fixes two broken internal documentation links:

1. **`CONTRIBUTING.md`** — the "Online optimisation" bullet links `online_dpo_trainer.py` / `online_dpo_config.py` at `./trl/trainer/`, but those files now live under `./trl/experimental/online_dpo/`. The links 404. (The sibling `dpo_*`/`rloo_*` links above are still correct and are left unchanged.)

2. **`docs/source/async_grpo_trainer.md`** — links to `grpo_trainer#speed-up-training-with-vllm`, but the target heading in `grpo_trainer.md` is "Speed up training with vLLM-powered generation", whose anchor is `#speed-up-training-with-vllm-powered-generation`. The current anchor doesn't resolve.

Both are corrected to point at the existing paths/anchor.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link corrections with no runtime or API impact.
> 
> **Overview**
> Fixes two broken internal documentation links so contributor and async GRPO docs resolve correctly.
> 
> In **CONTRIBUTING.md**, the "Online optimisation" example links now point at `./trl/experimental/online_dpo/` for `online_dpo_trainer.py` and `online_dpo_config.py` instead of the old `./trl/trainer/` paths. DPO and RLOO example links are unchanged.
> 
> In **async_grpo_trainer.md**, the vLLM colocate cross-link now uses the anchor `#speed-up-training-with-vllm-powered-generation`, matching the heading in `grpo_trainer.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98029a87e9836ed4f7364dcb39d8075cc284fae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->