### PR TITLE
Fix malformed ScaleRL paper link in GRPOConfig epsilon_high help

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -615,8 +615,8 @@ class GRPOConfig(_BaseConfig):
         metadata={
             "help": "Upper-bound epsilon value for clipping. If not specified, it defaults to the same value as the "
             "lower-bound specified in argument `epsilon`. Paper DAPO recommends `0.28`. "
-            "When used with `loss_type='cispo'`, this corresponds to the ε_max param specified in the"
-            "[ScaleRL paper]https://huggingface.co/papers/2510.13786) and the recommended value is `5.0`."
+            "When used with `loss_type='cispo'`, this corresponds to the ε_max param specified in the "
+            "[ScaleRL paper](https://huggingface.co/papers/2510.13786) and the recommended value is `5.0`."
         },
     )
     sapo_temperature_neg: float = field(


### PR DESCRIPTION
# What does this PR do?

The `epsilon_high` field in `GRPOConfig` has a malformed markdown link in its `metadata={"help": ...}` string:

```
"...the ε_max param specified in the"
"[ScaleRL paper]https://huggingface.co/papers/2510.13786) and the recommended value is `5.0`."
```

Two issues: the opening `(` of the markdown link is missing (`[ScaleRL paper]https://...` instead of `[ScaleRL paper](https://...`), and the preceding implicitly-concatenated string is missing a trailing space, so the rendered text reads `...in the[ScaleRL paper]...`.

The class docstring for the same field (a few hundred lines up) already renders this link correctly — this PR just brings the `help` string in line with it:

```
"...the ε_max param specified in the "
"[ScaleRL paper](https://huggingface.co/papers/2510.13786) and the recommended value is `5.0`."
```

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a help string; no runtime or training behavior impact.
> 
> **Overview**
> Fixes broken markdown in the `epsilon_high` `metadata["help"]` string in `GRPOConfig`: adds the missing space before the ScaleRL reference and corrects the link syntax to `[ScaleRL paper](https://...)`.
> 
> CLI/`--help` and argparse-driven docs for that field should now match the class docstring and render a clickable ScaleRL paper link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc70e4cb5f7eefe82fa9a092142e5640a58aec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->