### PR TITLE
fix(profiling): log ProfilingContext metrics to Trackio backend

### DIFF
--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Callable
 
 from transformers import Trainer
-from transformers.integrations import is_mlflow_available, is_wandb_available
+from transformers.integrations import is_mlflow_available, is_trackio_available, is_wandb_available
 
 
 if is_wandb_available():
@@ -26,19 +26,22 @@ if is_wandb_available():
 if is_mlflow_available():
     import mlflow
 
+if is_trackio_available():
+    import trackio
+
 
 class ProfilingContext:
     """
     Context manager for profiling code blocks with configurable logging.
 
-    This class handles timing of code execution and logging metrics to various backends (Weights & Biases, MLflow)
+    This class handles timing of code execution and logging metrics to various backends (Weights & Biases, MLflow, Trackio)
     without being coupled to the Trainer class.
 
     Args:
         name (`str`):
             Name of the profiling context. Used in the metric name.
         report_to (`list` of `str`):
-            List of integrations to report metrics to (e.g., ["wandb", "mlflow"]).
+            List of integrations to report metrics to (e.g., ["wandb", "mlflow", "trackio"]).
         is_main_process (`bool`, *optional*, defaults to `True`):
             Whether this is the main process in distributed training. Metrics are only logged from the main process.
         step (`int` or `None`, *optional*):
@@ -120,6 +123,10 @@ class ProfilingContext:
         # Log to MLflow if configured
         if "mlflow" in self.report_to and is_mlflow_available() and mlflow.active_run() is not None:
             mlflow.log_metrics(metrics, step=self.step)
+
+        # Log to Trackio if configured
+        if "trackio" in self.report_to and is_trackio_available():
+            trackio.log(metrics, step=self.step)
 
 
 def profiling_context(trainer: Trainer, name: str) -> ProfilingContext:


### PR DESCRIPTION
# What does this PR do?

`ProfilingContext._log_metrics` logs profiling timings (reward-function runtime, generation time, etc.) to Weights & Biases and MLflow, but **not** to Trackio. Since Trackio is documented as *"the recommended tracking solution for TRL"*, users who select `report_to="trackio"` silently lose all profiling metrics.

This PR adds a Trackio branch to `_log_metrics`, mirroring the existing wandb/mlflow handling:

```python
# Log to Trackio if configured
if "trackio" in self.report_to and is_trackio_available():
    trackio.log(metrics, step=self.step)
```

- `is_trackio_available` / `import trackio` follow the exact pattern already used in `trl/trainer/grpo_trainer.py`.
- The guard (`"trackio" in self.report_to`, no extra active-run check) matches how `grpo_trainer.py` itself appends Trackio as a logging backend — when `report_to` includes `trackio`, the `TrackioCallback` has already called `trackio.init()`, so a run is active.
- `trackio.log(metrics, step=...)` matches the public signature `log(metrics: dict, step: int | None = None)`.
- Docstrings updated to mention Trackio alongside W&B/MLflow.

This removes the need for the monkeypatch shown in the issue.

Fixes #5973.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case (Fixes #5973).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
