### PR TITLE
chore(docs): Add GRPO clipping viz and explanation

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -108,6 +108,16 @@ $$
 $$
 
 where  \\(\text{clip}(\cdot, 1 - \epsilon, 1 + \epsilon) \\) ensures that updates do not deviate excessively from the reference policy by bounding the policy ratio between  \\( 1 - \epsilon \\) and  \\( 1 + \epsilon \\).
+
+Below is a compact visual guide showing where exactly clipping happens, depending on whether the advantage is positive or negative:
+
+![GRPO clipping](https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/grpo_clipping.png)
+
+Intuitively, the clipped objective behaves as follows:
+- When the advantage is positive  \\( A > 0 \\), we want to increase the probability of the chosen action. If the current policy already makes the action substantially more likely than the old policy did, i.e.  \\( \pi_{\theta} > (1 + \epsilon) \pi_{\theta_{\text{old}}} \\), the ratio is clipped and the gradient becomes 0, so we don't over-reinforce that action. Otherwise, we increase its probability under the current policy.
+- Conversely, when the advantage is negative  \\( A < 0 \\), we want to decrease the probability of the chosen action. If the current policy already makes the action substantially less likely than the old policy did, i.e.  \\( \pi_{\theta} < (1 - \epsilon) \pi_{\theta_{\text{old}}} \\), the ratio is clipped and the gradient becomes 0, so we don't over-suppress that action. Otherwise, we decrease its probability under the current policy.
+
+
 When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifies to the original objective.
 
 #### Loss Types


### PR DESCRIPTION
# What does this PR do?

This PR adds a visual explanation of the regions where clipping happens in GRPO, which should be much more intuitive rather than the nested analytical form of the objective.

I wrote about this analysis/decomposition of the regions in the [RLHF Book](https://github.com/natolambert/rlhf-book/pull/139). This time, I updated the diagram to actually show all the cases and values, instead of writing it out in lengthy form.
 
<img width="4155" height="3893" alt="grpo_clipping" src="https://github.com/user-attachments/assets/69b69cb6-220a-4e8c-9e90-9ac95bd5e204" />


It should also be quite useful to understand the logged parameters related to clipping mentioned on the page below. 

> [!IMPORTANT]
> I don't have permissions to upload the image to the trl org in order to reference it here.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or training logic impact.
> 
> **Overview**
> Extends the **clipped surrogate objective** section in `grpo_trainer.md` with a diagram (`grpo_clipping.png` on the trl-lib docs dataset) that shows where GRPO clipping applies for positive vs negative advantages.
> 
> Adds a short intuitive walkthrough: for **positive** advantage, updates stop (zero gradient) when the policy ratio is already above `1 + ε`; for **negative** advantage, the same happens below `1 - ε`, so the doc ties the math to over-reinforcement and over-suppression behavior and complements the existing `clip_ratio/*` logged metrics on the same page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935aaeec2bc9ce187b2814aa90f06666512cb588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->