### PR TITLE
Align KTO with DPO: Improve error message for VLM truncation

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1402,9 +1402,18 @@ class KTOTrainer(_BaseTrainer):
         return (loss, outputs) if return_outputs else loss
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        if self.use_liger_kernel:
-            return self._compute_loss_liger(model, inputs, return_outputs)
-        return self._compute_loss(model, inputs, return_outputs)
+        try:
+            if self.use_liger_kernel:
+                return self._compute_loss_liger(model, inputs, return_outputs)
+            return self._compute_loss(model, inputs, return_outputs)
+        except ValueError as e:
+            if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:
+                raise ValueError(
+                    f"The current `max_length` ({self.args.max_length}) is too short and causes image placeholder "
+                    f"tokens in `input_ids` to be truncated, while the corresponding image features remain intact. "
+                    f"Please increase `max_length` or set it to `None` to disable truncation."
+                ) from e
+            raise
 
     def _get_train_sampler(self, train_dataset: Dataset | None = None) -> torch.utils.data.Sampler | None:
         if self.calculate_KL and Version(transformers.__version__) < Version("5.2.0"):


### PR DESCRIPTION
Align KTO with DPO: Improve error message for VLM truncation.

Follow-up to:
- https://github.com/huggingface/trl/pull/5927#pullrequestreview-4419408830

Part of:
- #4786

This PR adds improved error handling to the `compute_loss` method in `KTOTrainer`. Now, if a `ValueError` is raised due to a mismatch between image features and image tokens (often caused by truncation from a too-low `max_length`), the error message will clearly indicate the problem and suggest increasing `max_length` or disabling truncation.

### Changes

Error handling improvements:

* Added a try-except block to `compute_loss` to catch specific `ValueError`s related to image feature and token mismatches, and provide a detailed, actionable error message to help users resolve the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-handling only around compute_loss; no change to loss math or training flow except clearer failures when max_length truncates image tokens.
> 
> **Overview**
> **KTOTrainer** now wraps `compute_loss` in a try/except so vision-language training failures are easier to diagnose.
> 
> When a `ValueError` mentions **"Image features and image tokens do not match"** and `max_length` is set, the trainer re-raises with guidance that truncation likely removed image placeholder tokens while image features stayed full—suggesting a higher `max_length` or `None` to turn truncation off. Other `ValueError`s and the existing liger vs standard loss dispatch are unchanged.
> 
> This mirrors the DPO trainer behavior from #5927.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d856b9863c0f8014f5ab87dbb905fddae7a139b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->