### PR TITLE
Align trainers: Remove redundant else branch

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1501,8 +1501,7 @@ class DPOTrainer(_BaseTrainer):
         try:
             if self.use_liger_kernel:
                 return self._compute_loss_liger(model, inputs, return_outputs)
-            else:
-                return self._compute_loss(model, inputs, return_outputs)
+            return self._compute_loss(model, inputs, return_outputs)
         except ValueError as e:
             if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:
                 raise ValueError(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2395,8 +2395,7 @@ class GRPOTrainer(_BaseTrainer):
             # Compute the loss using the liger grpo loss
             unwrapped_model = self.accelerator.unwrap_model(model)
             return self._forward_redirection(model, unwrapped_model, self.compute_liger_loss, unwrapped_model, inputs)
-        else:
-            return self._compute_loss(model, inputs)
+        return self._compute_loss(model, inputs)
 
     @staticmethod
     def get_off_policy_mask(


### PR DESCRIPTION
Align trainers: Remove redundant else branch.

This PR simplifies the loss computation logic in both the `DPOTrainer` and `GRPOTrainer` classes by removing unnecessary `else` statements. This change makes the code more concise and easier to read, without altering functionality.

This follows the AGENTS.md principle: "prefer less code".

### Changes

Code simplification:

* `trl/trainer/dpo_trainer.py`: Removed an unnecessary `else` statement in the `compute_loss` method, streamlining the conditional logic for selecting the loss computation method.
* `trl/trainer/grpo_trainer.py`: Removed an unnecessary `else` statement in the `compute_loss` method, simplifying the flow for loss calculation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure control-flow cleanup in loss dispatch; training logic and exception handling are unchanged.
> 
> **Overview**
> **DPO** and **GRPO** `compute_loss` now use an early return when `use_liger_kernel` is set, then fall through to the standard `_compute_loss` path instead of wrapping that path in `else`.
> 
> Behavior is unchanged: Liger still short-circuits; otherwise the same loss helpers run. The surrounding `try`/`except` in **DPO** (e.g. multimodal `max_length` guidance) is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c23acf214168c34052ce9abd5ce2d448c5f4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->