### PR TITLE
Fix GRPO KL estimator overflow

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -39,6 +39,7 @@ from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
 from trl.import_utils import is_liger_kernel_available
+from trl.trainer.grpo_trainer import _compute_kl
 from trl.trainer.utils import get_kbit_device_map
 
 from .testing_utils import (
@@ -238,6 +239,72 @@ class TestGRPORolloutDispatch:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    def test_kl_log_ratio_clip_helper(self):
+        log_ratio = torch.tensor([1000.0])
+
+        assert torch.isinf(_compute_kl(log_ratio))
+        assert torch.isfinite(_compute_kl(log_ratio, 20.0))
+
+    def test_kl_log_ratio_clip(self):
+        def compute_loss(kl_log_ratio_clip):
+            trainer = object.__new__(GRPOTrainer)
+            trainer._get_per_token_logps_and_entropies = lambda *args, **kwargs: (
+                torch.zeros((1, 1), requires_grad=True),
+                torch.zeros((1, 1)),
+            )
+            trainer.top_entropy_quantile = 1.0
+            trainer.off_policy_mask_threshold = None
+            trainer.importance_sampling_level = "token"
+            trainer.beta = 0.1
+            trainer.args = SimpleNamespace(
+                delta=None,
+                kl_log_ratio_clip=kl_log_ratio_clip,
+                use_bias_correction_kl=False,
+            )
+            trainer.loss_type = "grpo"
+            trainer.epsilon_low = 0.2
+            trainer.epsilon_high = 0.2
+            trainer.use_vllm = False
+            trainer.vllm_importance_sampling_correction = False
+            trainer.current_gradient_accumulation_steps = 1
+            trainer.max_completion_length = 1
+            trainer.accelerator = SimpleNamespace(num_processes=1, gather=lambda value: value)
+            trainer._metrics = {
+                "train": {
+                    "kl": [],
+                    "entropy": [],
+                    "clip_ratio/low_mean": [],
+                    "clip_ratio/low_min": [],
+                    "clip_ratio/high_mean": [],
+                    "clip_ratio/high_max": [],
+                    "clip_ratio/region_mean": [],
+                }
+            }
+            model = SimpleNamespace(training=True)
+            trainer.model = model
+            inputs = {
+                "prompt_ids": torch.tensor([[1]]),
+                "prompt_mask": torch.tensor([[1]]),
+                "completion_ids": torch.tensor([[2]]),
+                "completion_mask": torch.tensor([[1.0]]),
+                "advantages": torch.tensor([0.0]),
+                "old_per_token_logps": torch.tensor([[0.0]]),
+                "ref_per_token_logps": torch.tensor([[1000.0]]),
+            }
+            return trainer._compute_loss(model, inputs)
+
+        assert torch.isinf(compute_loss(None))
+        assert torch.isfinite(compute_loss(20.0))
+
+    @pytest.mark.parametrize("value", [0.0, -1.0])
+    def test_kl_log_ratio_clip_must_be_positive(self, value):
+        with pytest.raises(ValueError, match="kl_log_ratio_clip must be greater than 0"):
+            GRPOConfig(output_dir=self.tmp_dir, kl_log_ratio_clip=value, use_cpu=True)
+
+    def test_kl_log_ratio_clip_is_not_supported_with_liger(self):
+        with pytest.raises(ValueError, match="kl_log_ratio_clip is not supported with use_liger_kernel=True"):
+            GRPOConfig(output_dir=self.tmp_dir, kl_log_ratio_clip=20.0, use_cpu=True, use_liger_kernel=True)
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -46,7 +46,7 @@ from ...data_utils import (
 from ...extras.profiling import profiling_context, profiling_decorator
 from ...models import unwrap_model_for_generation
 from ...models.utils import disable_gradient_checkpointing
-from ...trainer.grpo_trainer import EnvironmentFactory, GRPOTrainer, RewardFunc, RolloutFunc
+from ...trainer.grpo_trainer import EnvironmentFactory, GRPOTrainer, RewardFunc, RolloutFunc, _compute_kl
 from ...trainer.utils import (
     entropy_from_logits,
     nanstd,
@@ -1332,9 +1332,7 @@ class DPPOTrainer(GRPOTrainer):
         # KL divergence with reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            per_token_kl = _compute_kl(ref_per_token_logps - per_token_logps, self.args.kl_log_ratio_clip)
             per_token_loss = per_token_loss + self.beta * per_token_kl
 
         mode = "train" if self.model.training else "eval"

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -15,6 +15,7 @@
 import torch
 
 from ...trainer.grpo_trainer import GRPOTrainer as _GRPOTrainer
+from ...trainer.grpo_trainer import _compute_kl
 from ...trainer.utils import nanmax, nanmin
 
 
@@ -50,9 +51,7 @@ class GRPOTrainer(_GRPOTrainer):
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            per_token_kl = _compute_kl(ref_per_token_logps - per_token_logps, self.args.kl_log_ratio_clip)
 
         # Compute the loss
         advantages = inputs["advantages"]

--- a/trl/experimental/papo/papo_trainer.py
+++ b/trl/experimental/papo/papo_trainer.py
@@ -19,7 +19,7 @@ import torch
 from datasets import Dataset, IterableDataset
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
 
-from ...trainer.grpo_trainer import GRPOTrainer, RewardFunc
+from ...trainer.grpo_trainer import GRPOTrainer, RewardFunc, _compute_kl
 from ...trainer.utils import nanmax, nanmin
 from .papo_config import PAPOConfig
 
@@ -242,9 +242,7 @@ class PAPOTrainer(GRPOTrainer):
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            per_token_kl = _compute_kl(ref_per_token_logps - per_token_logps, self.args.kl_log_ratio_clip)
 
         # Compute the loss
         advantages = inputs["advantages"]

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -309,6 +309,9 @@ class GRPOConfig(_BaseConfig):
             Whether to use the unbiased KL divergence estimator with importance sampling correction. This corrects the
             KL divergence estimate by multiplying it with the importance sampling ratio. This is described in the
             [DeepSeek-V3.2 paper](https://huggingface.co/papers/2512.02556).
+        kl_log_ratio_clip (`float`, *optional*):
+            Maximum value for the log-ratio used by the KL estimator before exponentiation. This can prevent overflow
+            when the policy and reference model drift far apart. If `None`, the log-ratio is not clipped.
 
         > Parameters that control the logging
 
@@ -835,6 +838,13 @@ class GRPOConfig(_BaseConfig):
             "This is described in the [DeepSeek-V3.2 paper](https://huggingface.co/papers/2512.02556)."
         },
     )
+    kl_log_ratio_clip: float | None = field(
+        default=None,
+        metadata={
+            "help": "Maximum value for the log-ratio used by the KL estimator before exponentiation. This can prevent "
+            "overflow when the policy and reference model drift far apart. If `None`, the log-ratio is not clipped."
+        },
+    )
 
     # Parameters that control the logging
     log_completions: bool = field(
@@ -903,6 +913,12 @@ class GRPOConfig(_BaseConfig):
                 "log_completions_hub_repo is set, but log_completions is False. Enable log_completions to upload "
                 "completions to the Hub, or unset log_completions_hub_repo."
             )
+
+        if self.kl_log_ratio_clip is not None:
+            if self.kl_log_ratio_clip <= 0:
+                raise ValueError("kl_log_ratio_clip must be greater than 0.")
+            if self.use_liger_kernel:
+                raise ValueError("kl_log_ratio_clip is not supported with use_liger_kernel=True.")
 
         num_processes = self.world_size
         # The current default effective batch size

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -123,6 +123,12 @@ RewardFunc = str | PreTrainedModel | Callable[..., list[float | None]]
 RolloutFunc = Callable[[list[str], "GRPOTrainer"], dict[str, Any]]
 
 
+def _compute_kl(log_ratio: torch.Tensor, log_ratio_clip: float | None = None) -> torch.Tensor:
+    if log_ratio_clip is not None:
+        log_ratio = torch.clamp(log_ratio, max=log_ratio_clip)
+    return torch.exp(log_ratio) - log_ratio - 1
+
+
 class _SupportsReset(Protocol):
     def reset(self, **kwargs) -> str | None: ...
 
@@ -2547,9 +2553,7 @@ class GRPOTrainer(_BaseTrainer):
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            per_token_kl = _compute_kl(ref_per_token_logps - per_token_logps, self.args.kl_log_ratio_clip)
             # Importance sampling correction for the KL divergence
             if self.args.use_bias_correction_kl:
                 per_token_kl = per_token_kl * coef_1


### PR DESCRIPTION
# What does this PR do?

Adds an opt-in `kl_log_ratio_clip` setting for GRPO's KL estimator. When configured, the reference-to-policy log-ratio is clipped before `exp()`, preventing an infinite KL penalty when the policy and reference model have drifted far apart.

The default remains `None`, so existing training behavior is unchanged. The config rejects non-positive values and explicitly rejects the option with Liger until Liger's fused loss supports the same behavior.

Fixes #3015

## Validation

- `python -m pytest tests/test_grpo_trainer.py -k "kl_log_ratio_clip" -q` (4 passed)
- `python -m pytest tests/test_grpo_trainer.py -k "kl_log_ratio_clip or compute_liger_loss_passes_vllm_is_ratio" -q` (4 passed, 1 skipped because Liger is not installed)
- `python -m pytest tests/test_cli.py -k "help_no_type_error and grpo" -q` (1 passed)
- `python -m ruff check trl/trainer/grpo_config.py trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py`
- `git diff --check`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #3015.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core GRPO loss/KL math across multiple trainers; default None preserves prior behavior, but enabled clipping changes KL penalties during training.
> 
> **Overview**
> Adds optional **`kl_log_ratio_clip`** on `GRPOConfig` (default `None`) so training can cap the reference–policy log-ratio before `exp()` in the KL term, avoiding infinite KL when models diverge. A shared **`_compute_kl`** helper centralizes `exp(log_ratio) - log_ratio - 1` with optional upper clamping; **`GRPOTrainer`** and GRPO-derived trainers (DPPO, GSPO token, PAPO) call it instead of inlined formulas.
> 
> Config validation rejects non-positive clip values and disallows the option with **`use_liger_kernel=True`** until Liger supports the same behavior. Tests cover the helper, end-to-end loss finiteness, and config errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db26eea35b0979dd12cbd752b90ef3a416080f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->