### PR TITLE
Fix OnlineDPOTrainer evaluation

### DIFF
--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -113,6 +113,7 @@ class TestOnlineDPOTrainer(TrlTestCase):
 
         assert metrics["eval_loss"] >= 0
         assert all(param.grad is None for param in self.model.parameters())
+        assert all(len(values) == 0 for values in trainer.stats.values())
 
     def test_train_with_ref_model(self):
         training_args = OnlineDPOConfig(

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -89,6 +89,31 @@ class TestOnlineDPOTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
+    def test_evaluate(self):
+        training_args = OnlineDPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_eval_batch_size=2,
+            max_new_tokens=8,
+            use_cpu=True,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train").select(range(2))
+
+        trainer = OnlineDPOTrainer(
+            model=self.model,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+            eval_dataset=dataset,
+            processing_class=self.tokenizer,
+            reward_processing_classes=self.reward_tokenizer,
+        )
+
+        metrics = trainer.evaluate()
+
+        assert metrics["eval_loss"] >= 0
+        assert all(param.grad is None for param in self.model.parameters())
+
     def test_train_with_ref_model(self):
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -1093,7 +1093,7 @@ class OnlineDPOTrainer(_BaseTrainer):
         logprobs = torch.take_along_dim(logits.log_softmax(dim=-1), completion_ids.unsqueeze(-1), dim=2).squeeze(-1)
         return logprobs
 
-    def _compute_loss(self, model: nn.Module, inputs: dict[str, torch.Tensor | Any]) -> torch.Tensor:
+    def _compute_loss(self, model: nn.Module, inputs: dict[str, torch.Tensor | Any], log_stats: bool = True) -> torch.Tensor:
         prompts = inputs["prompt"]
         batch_size = len(prompts)
 
@@ -1232,44 +1232,47 @@ class OnlineDPOTrainer(_BaseTrainer):
 
         loss = losses.mean()
 
-        # Log everything
-        if self.reward_funcs is not None:
-            # When using reward_funcs, we have rewards instead of scores
-            scores_margin = rewards[chosen_indices] - rewards[rejected_indices]
-            self.stats["objective/scores_margin"].append(
-                self.accelerator.gather_for_metrics(scores_margin.mean()).mean().item()
+        if log_stats:
+            # Log everything
+            if self.reward_funcs is not None:
+                # When using reward_funcs, we have rewards instead of scores
+                scores_margin = rewards[chosen_indices] - rewards[rejected_indices]
+                self.stats["objective/scores_margin"].append(
+                    self.accelerator.gather_for_metrics(scores_margin.mean()).mean().item()
+                )
+                self.stats["objective/scores"].append(self.accelerator.gather_for_metrics(rewards.mean()).mean().item())
+            self.stats["val/contain_eos_token"].append(contain_eos_token.float().mean().item())
+            self.stats["logps/chosen"].append(self.accelerator.gather_for_metrics(chosen_logprobs_sum).mean().item())
+            self.stats["logps/rejected"].append(self.accelerator.gather_for_metrics(rejected_logprobs_sum).mean().item())
+
+            kl = logprobs - ref_logprobs
+            mean_kl = kl.sum(1).mean()
+            self.stats["objective/kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
+            non_score_reward = (-self.beta * kl).sum(1)
+            mean_non_score_reward = non_score_reward.mean()
+            self.stats["objective/non_score_reward"].append(
+                self.accelerator.gather_for_metrics(mean_non_score_reward).mean().item()
             )
-            self.stats["objective/scores"].append(self.accelerator.gather_for_metrics(rewards.mean()).mean().item())
-        self.stats["val/contain_eos_token"].append(contain_eos_token.float().mean().item())
-        self.stats["logps/chosen"].append(self.accelerator.gather_for_metrics(chosen_logprobs_sum).mean().item())
-        self.stats["logps/rejected"].append(self.accelerator.gather_for_metrics(rejected_logprobs_sum).mean().item())
+            if self.reward_funcs is not None:
+                # Calculate RLHF reward by combining rewards with non_score_reward
+                rlhf_reward = rewards + non_score_reward
+                self.stats["objective/rlhf_reward"].append(
+                    self.accelerator.gather_for_metrics(rlhf_reward).mean().item()
+                )
 
-        kl = logprobs - ref_logprobs
-        mean_kl = kl.sum(1).mean()
-        self.stats["objective/kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
-        non_score_reward = (-self.beta * kl).sum(1)
-        mean_non_score_reward = non_score_reward.mean()
-        self.stats["objective/non_score_reward"].append(
-            self.accelerator.gather_for_metrics(mean_non_score_reward).mean().item()
-        )
-        if self.reward_funcs is not None:
-            # Calculate RLHF reward by combining rewards with non_score_reward
-            rlhf_reward = rewards + non_score_reward
-            self.stats["objective/rlhf_reward"].append(self.accelerator.gather_for_metrics(rlhf_reward).mean().item())
-
-        mean_entropy = -logprobs.sum(1).mean()
-        self.stats["objective/entropy"].append(self.accelerator.gather_for_metrics(mean_entropy).mean().item())
-        chosen_rewards = self.beta * (chosen_logprobs_sum - chosen_ref_logprobs_sum)
-        gathered_chosen_rewards = self.accelerator.gather_for_metrics(chosen_rewards)
-        self.stats["rewards/chosen"].append(gathered_chosen_rewards.mean().item())
-        rejected_rewards = self.beta * (rejected_logprobs_sum - rejected_ref_logprobs_sum)
-        gathered_rejected_rewards = self.accelerator.gather_for_metrics(rejected_rewards)
-        self.stats["rewards/rejected"].append(gathered_rejected_rewards.mean().item())
-        margin = gathered_chosen_rewards - gathered_rejected_rewards
-        self.stats["rewards/margins"].append(margin.mean().item())
-        accuracy = margin > 0
-        self.stats["rewards/accuracies"].append(accuracy.float().mean().item())
-        self.stats["beta"].append(self.beta)
+            mean_entropy = -logprobs.sum(1).mean()
+            self.stats["objective/entropy"].append(self.accelerator.gather_for_metrics(mean_entropy).mean().item())
+            chosen_rewards = self.beta * (chosen_logprobs_sum - chosen_ref_logprobs_sum)
+            gathered_chosen_rewards = self.accelerator.gather_for_metrics(chosen_rewards)
+            self.stats["rewards/chosen"].append(gathered_chosen_rewards.mean().item())
+            rejected_rewards = self.beta * (rejected_logprobs_sum - rejected_ref_logprobs_sum)
+            gathered_rejected_rewards = self.accelerator.gather_for_metrics(rejected_rewards)
+            self.stats["rewards/rejected"].append(gathered_rejected_rewards.mean().item())
+            margin = gathered_chosen_rewards - gathered_rejected_rewards
+            self.stats["rewards/margins"].append(margin.mean().item())
+            accuracy = margin > 0
+            self.stats["rewards/accuracies"].append(accuracy.float().mean().item())
+            self.stats["beta"].append(self.beta)
 
         return loss
 
@@ -1308,7 +1311,7 @@ class OnlineDPOTrainer(_BaseTrainer):
     def prediction_step(self, model, inputs, prediction_loss_only, ignore_keys: list[str] | None = None):
         with torch.no_grad():
             with self.compute_loss_context_manager():
-                loss = self.compute_loss(model, inputs)
+                loss = self._compute_loss(model, inputs, log_stats=False)
             loss = loss.mean().detach()
         return loss, None, None
 

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -1093,11 +1093,7 @@ class OnlineDPOTrainer(_BaseTrainer):
         logprobs = torch.take_along_dim(logits.log_softmax(dim=-1), completion_ids.unsqueeze(-1), dim=2).squeeze(-1)
         return logprobs
 
-    def training_step(
-        self, model: nn.Module, inputs: dict[str, torch.Tensor | Any], num_items_in_batch: int | None = None
-    ) -> torch.Tensor:
-        model.train()
-
+    def _compute_loss(self, model: nn.Module, inputs: dict[str, torch.Tensor | Any]) -> torch.Tensor:
         prompts = inputs["prompt"]
         batch_size = len(prompts)
 
@@ -1275,6 +1271,19 @@ class OnlineDPOTrainer(_BaseTrainer):
         self.stats["rewards/accuracies"].append(accuracy.float().mean().item())
         self.stats["beta"].append(self.beta)
 
+        return loss
+
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        if return_outputs:
+            raise ValueError("The OnlineDPOTrainer does not support returning outputs")
+        return self._compute_loss(model, inputs)
+
+    def training_step(
+        self, model: nn.Module, inputs: dict[str, torch.Tensor | Any], num_items_in_batch: int | None = None
+    ) -> torch.Tensor:
+        model.train()
+        loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
+
         if (
             self.args.torch_empty_cache_steps is not None
             and self.state.global_step % self.args.torch_empty_cache_steps == 0
@@ -1293,6 +1302,15 @@ class OnlineDPOTrainer(_BaseTrainer):
         self.accelerator.backward(loss, **kwargs)
 
         return loss.detach() / self.args.gradient_accumulation_steps
+
+    # Online DPO batches contain prompts rather than model-ready labels, so Trainer's default prediction path cannot
+    # evaluate them directly. Reuse the policy loss without running the training-only backward pass.
+    def prediction_step(self, model, inputs, prediction_loss_only, ignore_keys: list[str] | None = None):
+        with torch.no_grad():
+            with self.compute_loss_context_manager():
+                loss = self.compute_loss(model, inputs)
+            loss = loss.mean().detach()
+        return loss, None, None
 
     # Same as Trainer._maybe_log_save_evaluate but log our metrics
     def _maybe_log_save_evaluate(


### PR DESCRIPTION
# What does this PR do?

Fixes #2228.

`OnlineDPOTrainer` currently implements the full policy-loss calculation inside `training_step`, including the backward pass. During evaluation, Transformers therefore falls back to its default prediction path and calls the model with the raw `prompt` field, which raises `TypeError`.

This splits the policy-loss calculation into `_compute_loss`, keeps the optimizer/backward behavior in `training_step`, and adds a `prediction_step` that evaluates the same loss under `torch.no_grad()`. The regression test exercises `trainer.evaluate()` and verifies that it returns an eval loss without creating gradients.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #2228 and the current-main confirmation there.
- [x] Did you make sure to update the documentation with your changes? No documentation change is needed for this bug fix.
- [x] Did you write any new necessary tests?

## Validation

- `pytest -q tests/experimental/test_online_dpo_trainer.py -k test_evaluate`
- CPU one-step `OnlineDPOTrainer.train()` smoke test
- `ruff check trl/experimental/online_dpo/online_dpo_trainer.py tests/experimental/test_online_dpo_trainer.py`
- `ruff format --check trl/experimental/online_dpo/online_dpo_trainer.py tests/experimental/test_online_dpo_trainer.py`
- `git diff --check`

The repository's existing `test_train` cases require a GPU-capable bf16 environment and fail during `OnlineDPOConfig` validation on this CPU-only Windows host before reaching the changed code.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core online DPO training/eval loss path (generation, rewards, backward vs no_grad); behavior should match training except stats logging, but eval now runs full on-policy generation like a train step.
> 
> **Overview**
> Fixes **`OnlineDPOTrainer.evaluate()`** failing when eval batches only carry **`prompt`** fields (not standard model labels), which previously triggered Transformers’ default prediction path and a **`TypeError`**.
> 
> The online DPO policy loss is **refactored** out of `training_step` into **`_compute_loss`** (with a **`log_stats`** flag so training metrics are not written during eval). **`compute_loss`** and a slimmed **`training_step`** (loss + backward only) wrap that path. A new **`prediction_step`** runs the same loss under **`torch.no_grad()`** with **`log_stats=False`**, yielding a valid **`eval_loss`**.
> 
> A CPU **`test_evaluate`** regression test checks **`eval_loss`**, no parameter gradients, and empty **`trainer.stats`** after evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e4bc7ee4ba6f1ad6ac7575b3eea7265fea3c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->