### PR TITLE
Support multiple environments in GRPO

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -721,6 +721,66 @@ trainer.train()
 
 `reset` can return either `None` or a string. In GRPO, when it returns a string, that string is appended to the last user message before generation.
 
+### Multiple environments
+
+To train on a mix of tasks in a single run (e.g. a coding task and a game), pass a dictionary mapping environment names to factories instead of a single callable. Each example then selects its environment through an `environment` field in the dataset, and **only that environment's tools are exposed in the example's prompt**. This avoids leaking irrelevant tools (the game's `move` tool to a coding example, and vice versa).
+
+```python
+from datasets import Dataset
+from trl import GRPOConfig, GRPOTrainer
+
+dataset = Dataset.from_dict(
+    {
+        "prompt": [
+            [{"role": "user", "content": "Compute the 7th Fibonacci number."}],
+            [{"role": "user", "content": "Reach the goal tile."}],
+        ],
+        "environment": ["coding", "game"],  # selects the factory for each example
+    }
+)
+
+class CodingEnv:
+    def reset(self, **kwargs) -> str | None:
+        ...
+
+    def run_code(self, code: str) -> str:  # exposed as a tool only for "coding" examples
+        """Run the given Python code and return its stdout.
+
+        Args:
+            code: The Python source to execute.
+
+        Returns:
+            The captured standard output.
+        """
+        ...
+
+class GameEnv:
+    def reset(self, **kwargs) -> str | None:
+        ...
+
+    def move(self, action: str) -> str:  # exposed as a tool only for "game" examples
+        """Apply an action to the game and return the new observation.
+
+        Args:
+            action: One of "up", "down", "left", "right".
+
+        Returns:
+            The observation after the move.
+        """
+        ...
+
+trainer = GRPOTrainer(
+    model="Qwen/Qwen3-0.6B",
+    args=GRPOConfig(chat_template_kwargs={"enable_thinking": False}),
+    train_dataset=dataset,
+    reward_funcs=reward_func,
+    environment_factory={"coding": CodingEnv, "game": GameEnv},
+)
+trainer.train()
+```
+
+The reward function still receives every example's environment through `reward_kwargs["environments"]`, so it can branch on the environment type (e.g. `isinstance(env, CodingEnv)`). Environment instances are reused across steps (reset between episodes), so an expensive `__init__` is paid once rather than every step. The `environment` field is consumed by the trainer and is **not** forwarded to `reset`.
+
 ### Multimodal Tool Responses
 
 Tools can return images alongside text by returning a list of content blocks. This is useful for VLM agent training where the tool provides visual feedback (e.g., screenshots, plots, camera captures).

--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import multiprocessing as mp
 import queue
 
 import numpy as np
@@ -21,7 +22,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
-from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
+from trl.experimental.async_grpo.async_rollout_worker import RolloutSample, _AsyncRolloutLoop
 
 from ..testing_utils import TrlTestCase
 
@@ -128,3 +129,94 @@ class TestAsyncGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+
+class TestAsyncRolloutWorkerEnvironments(TrlTestCase):
+    """Unit tests for the rollout worker's environment/tool wiring (no vLLM required)."""
+
+    def _make_loop(self, environment_factory):
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+        # `_AsyncRolloutLoop.__init__` only sets up state (no vLLM connection / generation happens here).
+        return _AsyncRolloutLoop(
+            model_name=model_id,
+            dataset=dataset,
+            reward_funcs=[dummy_reward_func],
+            processing_class=AutoTokenizer.from_pretrained(model_id),
+            rollout_buffer=mp.Queue(),
+            model_version_value=mp.Value("i", 0),
+            heartbeat_value=mp.Value("d", 0.0),
+            failed_event=mp.Event(),
+            exception_info_queue=mp.Queue(),
+            environment_factory=environment_factory,
+            num_generations=2,
+            max_inflight_tasks=4,
+        )
+
+    def test_multiple_environments_expose_only_their_own_tools(self):
+        class CounterEnvironment:
+            def reset(self, **kwargs): ...
+
+            def increment(self, step: int) -> int:
+                """Increment the counter.
+
+                Args:
+                    step: Value to add.
+
+                Returns:
+                    The updated value.
+                """
+                return step
+
+        class EchoEnvironment:
+            def reset(self, **kwargs): ...
+
+            def shout(self, text: str) -> str:
+                """Shout the text.
+
+                Args:
+                    text: Text to shout.
+
+                Returns:
+                    The text in upper case.
+                """
+                return text.upper()
+
+        loop = self._make_loop({"counter": CounterEnvironment, "echo": EchoEnvironment})
+        try:
+            assert loop._multi_environment is True
+            # Each environment exposes only its own tool, used to render that example's prompt schema.
+            assert [tool.__name__ for tool in loop._env_tools["counter"]] == ["increment"]
+            assert [tool.__name__ for tool in loop._env_tools["echo"]] == ["shout"]
+            # `self.tools` is the union, used only to decide whether a training chat template is needed.
+            assert sorted(tool.__name__ for tool in loop.tools) == ["increment", "shout"]
+            # The probe instances seed the reuse pool, so they are not wasted.
+            assert len(loop._environment_pool["counter"]) == 1
+            assert len(loop._environment_pool["echo"]) == 1
+        finally:
+            loop._loop.close()
+
+    def test_single_environment_is_normalized(self):
+        class CounterEnvironment:
+            def reset(self, **kwargs): ...
+
+            def increment(self, step: int) -> int:
+                """Increment the counter.
+
+                Args:
+                    step: Value to add.
+
+                Returns:
+                    The updated value.
+                """
+                return step
+
+        loop = self._make_loop(CounterEnvironment)
+        try:
+            # A single callable is normalized to one unnamed (`None`) environment shared by every example.
+            assert loop._multi_environment is False
+            assert list(loop.environment_factories) == [None]
+            assert [tool.__name__ for tool in loop._env_tools[None]] == ["increment"]
+            assert len(loop._environment_pool[None]) == 1
+        finally:
+            loop._loop.close()

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2599,6 +2599,139 @@ class TestGRPOTrainer(TrlTestCase):
     )
     @require_jmespath
     @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
+    def test_train_with_multiple_environments(self):
+        # When `environment_factory` is a dict, each example selects its environment via its `environment` field, and
+        # only that environment's tools are exposed in the example's prompt. Here we build a mixed batch with both
+        # environments and check that a tool call from a "counter" example dispatches to the CounterEnvironment's
+        # `increment`, while a tool call from an "echo" example dispatches to the EchoEnvironment's `shout`.
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+        # Tag each example with an environment, alternating between the two available ones. With `shuffle_dataset=False`
+        # and `num_generations=2`, every generation batch is then [counter, counter, echo, echo].
+        dataset = dataset.map(
+            lambda example, idx: {"environment": "counter" if idx % 2 == 0 else "echo"}, with_indices=True
+        )
+
+        reset_kwargs_seen = {"counter": [], "echo": []}
+        tool_calls_made = {"increment": [], "shout": []}
+
+        class CounterEnvironment:
+            def reset(self, **kwargs):
+                reset_kwargs_seen["counter"].append(kwargs)
+
+            def increment(self, step: int) -> int:
+                """
+                Increment the internal counter.
+
+                Args:
+                    step: Value to add to the counter.
+
+                Returns:
+                    The updated counter value.
+                """
+                tool_calls_made["increment"].append(step)
+                return step
+
+        class EchoEnvironment:
+            def reset(self, **kwargs):
+                reset_kwargs_seen["echo"].append(kwargs)
+
+            def shout(self, text: str) -> str:
+                """
+                Shout the given text.
+
+                Args:
+                    text: Text to shout.
+
+                Returns:
+                    The text in upper case.
+                """
+                tool_calls_made["shout"].append(text)
+                return text.upper()
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=4,  # 2 prompts x 2 generations, so a batch mixes both environments
+            num_generations=2,
+            shuffle_dataset=False,  # keep the [counter, counter, echo, echo] batch layout deterministic
+            report_to="none",
+        )
+
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+            environment_factory={"counter": CounterEnvironment, "echo": EchoEnvironment},
+        )
+
+        # Each environment exposes only its own tool.
+        assert [tool.__name__ for tool in trainer._env_tools["counter"]] == ["increment"]
+        assert [tool.__name__ for tool in trainer._env_tools["echo"]] == ["shout"]
+        # The probe instances seed the reuse pool, so they are not wasted.
+        assert len(trainer._environment_pool["counter"]) == 1
+        assert len(trainer._environment_pool["echo"]) == 1
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        def fake_generate(input_ids, **kwargs):
+            if input_ids.shape[0] == 4:  # first generation: batch is [counter, counter, echo, echo]
+                # fmt: off
+                completion_ids = torch.tensor(
+                    [
+                        # counter example: valid `increment` tool call (only CounterEnvironment exposes it)
+                        # '<tool_call>\n{"name": "increment", "arguments": {"step": 1}}\n</tool_call><|im_end|>' + pad
+                        [151657, 198, 4913, 606, 788, 330, 35744, 497, 330, 16370, 788, 5212, 9520, 788, 220, 16, 11248, 151658, 151645, 151643],
+                        # counter example: no tool call (gives reward variance within the group so gradients are non-zero)
+                        # "I won't<|im_end|>" + pad
+                        [40, 2765, 944, 151645, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643],
+                        # echo example: valid `shout` tool call (only EchoEnvironment exposes it)
+                        # '<tool_call>\n{"name": "shout", "arguments": {"text": "hi"}}\n</tool_call><|im_end|>'
+                        [151657, 198, 4913, 606, 788, 330, 927, 411, 497, 330, 16370, 788, 5212, 1318, 788, 330, 6023, 95642, 151658, 151645],
+                        # echo example: no tool call
+                        # "Done!<|im_end|>" + pad
+                        [17453, 0, 151645, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643, 151643],
+                    ],
+                    device=input_ids.device,
+                )
+                # fmt: on
+            else:  # regeneration after tool execution: only the two examples that issued a (valid) tool call
+                completion_ids = torch.tensor(
+                    [
+                        [17453, 0, 151645],  # 'Done!<|im_end|>'
+                        [17453, 0, 151645],
+                    ],
+                    device=input_ids.device,
+                )
+            return torch.cat([input_ids, completion_ids], dim=-1)
+
+        with patch.object(trainer.model, "generate", side_effect=fake_generate):
+            trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        # The tool call from the counter example ran `increment` (defined only on CounterEnvironment) and the one from
+        # the echo example ran `shout` (defined only on EchoEnvironment): each rollout dispatched to its own tools.
+        assert tool_calls_made["increment"]
+        assert tool_calls_made["shout"]
+        # 2 of the 4 rollouts issued a tool call, and both calls succeeded.
+        assert trainer.state.log_history[-1]["tools/call_frequency"] == pytest.approx(2 / 4)
+        assert trainer.state.log_history[-1]["tools/failure_frequency"] == pytest.approx(0.0)
+        # Both environments were selected and reset, and `environment` is a control field not forwarded to `reset`.
+        assert reset_kwargs_seen["counter"] and reset_kwargs_seen["echo"]
+        assert all("environment" not in kwargs for kwargs in reset_kwargs_seen["counter"] + reset_kwargs_seen["echo"])
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.2.0"),
+        reason="Environment factory support is not available in transformers versions below 5.2.0",
+        strict=True,
+    )
+    @require_jmespath
+    @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
     def test_train_with_environment_factory(self):
         # In this test, we define a simple tool that increments an internal counter. Regardless of the input prompt,
         # the model will generate 3 completions, 2 of which will be valid tool calls. Among the 2 tool calls, one will

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -309,15 +309,20 @@ class AsyncGRPOTrainer(_BaseTrainer):
             https://huggingface.co/docs/transformers/en/chat_extras#passing-tools. The model uses the function's name,
             type hints, and docstring to determine how to call it. Ensure that the model's chat template supports tool
             use and that it has been fine-tuned for tool calling.
-        environment_factory (`EnvironmentFactory`, *optional*):
-            A callable that creates and returns an environment instance. The environment class should define methods
-            that can be invoked as tools during generation. Each method should comply with the same requirements as the
-            `tools` described above. If `environment_factory` is provided, an instance of the environment is created
-            for each generation in the batch, allowing for parallel and independent interactions. The environment must
+        environment_factory (`EnvironmentFactory` or `dict[str, EnvironmentFactory]`, *optional*):
+            A callable that creates and returns an environment instance, or a dictionary mapping environment names to
+            such callables. The environment class should define methods that can be invoked as tools during generation.
+            Each method should comply with the same requirements as the `tools` described above. The environment must
             also implement a callable `reset` method that can be used to reset state between generations. The `reset`
             method should return either `None` or a string: when it returns a string, that string is appended to the
-            last user message before generation. This feature is experimental and may change or be removed at any time
-            without prior notice.
+            last user message before generation.
+
+            When a single callable is provided, an instance of the environment is created for each generation in the
+            batch, allowing for parallel and independent interactions. When a dictionary is provided, each example must
+            carry an `environment` field naming which environment to use; the matching factory is instantiated per
+            example and only that environment's tools are exposed in the example's prompt. This allows training on a mix
+            of tasks (e.g. a coding environment and a game environment) in a single run. This feature is experimental
+            and may change or be removed at any time without prior notice.
     """
 
     _tag_names = ["trl", "async-grpo"]
@@ -345,7 +350,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         tools: list[Callable] | None = None,
-        environment_factory: EnvironmentFactory | None = None,
+        environment_factory: EnvironmentFactory | dict[str, EnvironmentFactory] | None = None,
         rollout_worker: RolloutWorkerProtocol | None = None,
     ):
         self.args = args or AsyncGRPOConfig()

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -187,7 +187,7 @@ class _AsyncRolloutLoop:
         failed_event: MPEvent,
         exception_info_queue: MPQueue,
         tools: list[Callable] | None = None,
-        environment_factory: Callable[[], object] | None = None,
+        environment_factory: Callable[[], object] | dict[str, Callable[[], object]] | None = None,
         num_generations: int = 8,
         max_inflight_tasks: int = 128,
         queue_maxsize: int = 0,
@@ -224,30 +224,54 @@ class _AsyncRolloutLoop:
         self.num_completions_to_print = num_completions_to_print
         self.vllm_server_url = vllm_server_url.rstrip("/")
 
-        self.environments = None
-        environment_methods = [[] for _ in range(max_inflight_tasks)]
-        if environment_factory is not None:
-            self.environments = [environment_factory() for _ in range(max_inflight_tasks)]
-            for i, environment in enumerate(self.environments):
+        tools = tools or []
+        self._standalone_tools = tools  # tools that are not bound to an environment
+
+        # Normalize `environment_factory` to a `{name: factory}` mapping. A single callable is the special case of one
+        # unnamed (`None`) environment shared by every example; a dict maps the `environment` field of each example to
+        # its factory. `_multi_environment` records which case we are in: only then is the `environment` field read.
+        self._multi_environment = isinstance(environment_factory, dict)
+        if environment_factory is None:
+            self.environment_factories = None
+        elif self._multi_environment:
+            self.environment_factories = environment_factory
+        else:
+            self.environment_factories = {None: environment_factory}
+
+        if self.environment_factories is not None:
+            # Probe one instance of each environment to validate its `reset` method and extract its tool methods, used
+            # to render the per-example tool schema in the prompt. Instances are pooled and reused (reset) across
+            # rollouts; the probe seeds the pool so it is not wasted. The pool grows only when more concurrent instances
+            # of an environment are needed than have been created so far, preserving the "construct once, reset often"
+            # contract even when rollouts mix environments.
+            self._env_tools = {}  # {environment name: tools exposed when this environment is selected}
+            self._environment_pool = {}  # {environment name: list of reusable instances}
+            for name, factory in self.environment_factories.items():
+                instance = factory()
                 has_reset = False
-                for name, member in inspect.getmembers(environment, predicate=inspect.ismethod):
-                    if name == "reset":
+                methods = []
+                for member_name, member in inspect.getmembers(instance, predicate=inspect.ismethod):
+                    if member_name == "reset":
                         has_reset = True
-                    elif not name.startswith("_"):
-                        environment_methods[i].append(member)
+                    elif not member_name.startswith("_"):
+                        methods.append(member)
                 if not has_reset:
                     raise ValueError(
-                        "Each environment instance returned by `environment_factory` must define `reset`."
+                        "Each environment instance returned by `environment_factory` must define a callable `reset`."
                     )
+                self._env_tools[name] = tools + methods
+                self._environment_pool[name] = [instance]
+            # Union of every environment's tools, used only to decide whether a training chat template is needed.
+            self.tools = list(tools)
+            for env_tools in self._env_tools.values():
+                self.tools += [tool for tool in env_tools if tool not in self.tools]
+        else:
+            self.tools = tools
 
-        base_tools = tools or []
-        self._sync_tool_dicts = [{} for _ in range(max_inflight_tasks)]
-        for i in range(max_inflight_tasks):
-            for tool in base_tools + (environment_methods[i] if self.environments is not None else []):
-                if inspect.iscoroutinefunction(tool):
-                    raise ValueError("Asynchronous tools are not supported yet.")
-                self._sync_tool_dicts[i][tool.__name__] = tool
-        self.tools = base_tools + (environment_methods[0] if self.environments is not None else [])
+        # The async worker can't await tools in its tool loop, so asynchronous tools are not supported.
+        for tool in self.tools:
+            if inspect.iscoroutinefunction(tool):
+                raise ValueError("Asynchronous tools are not supported yet.")
 
         # The chat template must be prefix-preserving in multi-turn training; if the tokenizer's
         # template isn't, swap in a training-safe one.
@@ -302,7 +326,7 @@ class _AsyncRolloutLoop:
     async def _generate_loop(self, stop_event: asyncio.Event) -> None:
         pending_groups: dict[int, RolloutGroup] = {}
         pending_completed: dict[int, int] = {}
-        inflight_tasks: dict[asyncio.Task, tuple[int, int]] = {}
+        inflight_tasks: dict[asyncio.Task, tuple[int, int, Any, object]] = {}
         free_slots = set(range(self.max_inflight_tasks))
         work_iter = self._repeat_iterator()
 
@@ -313,13 +337,17 @@ class _AsyncRolloutLoop:
                 self._heartbeat_value.value = time.time()
                 while free_slots and not stop_event.is_set():
                     group_id, row = next(work_iter)
+                    # The environment is the same for all generations of a group; only its tools are exposed in the
+                    # example's prompt. When there are no environments, every example shares the standalone tools.
+                    name = row["environment"] if self._multi_environment else None
+                    tools = self._env_tools[name] if self.environment_factories is not None else self.tools
                     if group_id not in pending_groups:
                         prompt = row["prompt"]
                         prompt_ids = self.tokenizer.apply_chat_template(
                             prompt,
                             return_dict=False,
                             add_generation_prompt=True,
-                            tools=self.tools or None,  # `or None`: Llama bug: renders tool boilerplate for tools=[]
+                            tools=tools or None,  # `or None`: Llama bug: renders tool boilerplate for tools=[]
                             chat_template=self.chat_template,
                             **self.chat_template_kwargs,
                         )
@@ -343,13 +371,31 @@ class _AsyncRolloutLoop:
                         pending_completed[group_id] = 0
 
                     slot = free_slots.pop()
-                    if self.environments is not None:
-                        self.environments[slot].reset(**row)
+                    # Draw a reusable environment instance for this rollout (creating one only if the pool is exhausted)
+                    # and reset it; it is returned to the pool when the task completes. `environment` is a control field
+                    # in multi-environment mode, so it is not forwarded to `reset`.
+                    environment = None
+                    if self.environment_factories is not None:
+                        pool = self._environment_pool[name]
+                        environment = pool.pop() if pool else self.environment_factories[name]()
+                        reset_kwargs = (
+                            {k: v for k, v in row.items() if k != "environment"} if self._multi_environment else row
+                        )
+                        environment.reset(**reset_kwargs)
+                    # Build this rollout's tool dict: the standalone tools plus the methods of its environment.
+                    methods = []
+                    if environment is not None:
+                        methods = [
+                            member
+                            for member_name, member in inspect.getmembers(environment, predicate=inspect.ismethod)
+                            if member_name != "reset" and not member_name.startswith("_")
+                        ]
+                    tool_dict = {tool.__name__: tool for tool in self._standalone_tools + methods}
 
                     task = asyncio.create_task(
-                        self._generate_one(pending_groups[group_id].prompt, tool_dict=self._sync_tool_dicts[slot])
+                        self._generate_one(pending_groups[group_id].prompt, tool_dict=tool_dict, tools=tools)
                     )
-                    inflight_tasks[task] = (group_id, slot)
+                    inflight_tasks[task] = (group_id, slot, name, environment)
 
                 if not inflight_tasks:
                     if stop_event.is_set():
@@ -362,8 +408,10 @@ class _AsyncRolloutLoop:
                     continue
 
                 for task in done:
-                    group_id, slot = inflight_tasks.pop(task)
+                    group_id, slot, name, environment = inflight_tasks.pop(task)
                     free_slots.add(slot)
+                    if environment is not None:
+                        self._environment_pool[name].append(environment)
                     if task.exception() is not None:
                         raise task.exception()
 
@@ -481,7 +529,7 @@ class _AsyncRolloutLoop:
             group_id += 1
 
     async def _generate_one(
-        self, prompt: Messages, tool_dict: dict[str, Callable]
+        self, prompt: Messages, tool_dict: dict[str, Callable], tools: list[Callable]
     ) -> tuple[list[dict[str, str]], list[int], list[float], list[int], int, int]:
         completion, completion_ids, completion_logprobs, tool_mask = [], [], [], []
         tool_call_count = 0
@@ -492,7 +540,7 @@ class _AsyncRolloutLoop:
             prompt,
             return_dict=False,
             add_generation_prompt=True,
-            tools=self.tools or None,
+            tools=tools or None,
             chat_template=self.chat_template,
             **self.chat_template_kwargs,
         )

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -241,15 +241,20 @@ class GRPOTrainer(_BaseTrainer):
             with no duplication; it is responsible for returning the correct number of completions per prompt (see
             `num_generations` / `num_generations_eval` on the trainer). This feature is experimental and may change or
             be removed at any time without prior notice.
-        environment_factory (`EnvironmentFactory`, *optional*):
-            A callable that creates and returns an environment instance. The environment class should define methods
-            that can be invoked as tools during generation. Each method should comply with the same requirements as the
-            `tools` described above. If `environment_factory` is provided, an instance of the environment is created
-            for each generation in the batch, allowing for parallel and independent interactions. The environment must
+        environment_factory (`EnvironmentFactory` or `dict[str, EnvironmentFactory]`, *optional*):
+            A callable that creates and returns an environment instance, or a dictionary mapping environment names to
+            such callables. The environment class should define methods that can be invoked as tools during generation.
+            Each method should comply with the same requirements as the `tools` described above. The environment must
             also implement a callable `reset` method that can be used to reset state between generations. The `reset`
             method should return either `None` or a string: when it returns a string, that string is appended to the
-            last user message before generation. This feature is experimental and may change or be removed at any time
-            without prior notice.
+            last user message before generation.
+
+            When a single callable is provided, an instance of the environment is created for each generation in the
+            batch, allowing for parallel and independent interactions. When a dictionary is provided, each example must
+            carry an `environment` field naming which environment to use; the matching factory is instantiated per
+            example and only that environment's tools are exposed in the example's prompt. This allows training on a mix
+            of tasks (e.g. a coding environment and a game environment) in a single run. This feature is experimental
+            and may change or be removed at any time without prior notice.
     """
 
     _tag_names = ["trl", "grpo"]
@@ -281,7 +286,7 @@ class GRPOTrainer(_BaseTrainer):
         peft_config: "PeftConfig | None" = None,
         tools: list[Callable] | None = None,
         rollout_func: RolloutFunc | None = None,
-        environment_factory: EnvironmentFactory | None = None,
+        environment_factory: EnvironmentFactory | dict[str, EnvironmentFactory] | None = None,
     ):
         # Args
         if args is None:
@@ -491,36 +496,59 @@ class GRPOTrainer(_BaseTrainer):
                     "full tool-calling conversation (user -> assistant with tool_calls -> tool)."
                 )
 
-        # Create the environments and extract their methods to be used as tools. We create one environment per rollout
-        generation_batch_size = args.per_device_train_batch_size * args.steps_per_generation
-        if environment_factory is not None:
-            self.environments = [environment_factory() for _ in range(generation_batch_size)]
-            environment_methods = [[] for _ in range(generation_batch_size)]
-            for i, environment in enumerate(self.environments):
+        # Set up the environments and extract their methods to be used as tools.
+        tools = tools or []
+        self._standalone_tools = tools  # tools that are not bound to an environment
+
+        # Normalize `environment_factory` to a `{name: factory}` mapping. A single callable is the special case of one
+        # unnamed (`None`) environment shared by every example; a dict maps the `environment` field of each example to
+        # its factory. `_multi_environment` records which case we are in: only then is the `environment` field read.
+        self._multi_environment = isinstance(environment_factory, dict)
+        if environment_factory is None:
+            self.environment_factories = None
+        elif self._multi_environment:
+            self.environment_factories = environment_factory
+        else:
+            self.environment_factories = {None: environment_factory}
+
+        if self.environment_factories is not None:
+            # The environment an example uses is only known at batch time (it depends on the data). Here we just probe
+            # one instance of each environment to validate its `reset` method and extract its tool methods, used to
+            # render the per-example tool schema in the prompt. Instances are pooled and reused (reset) across batches;
+            # the probe seeds the pool so it is not wasted. The pool grows only when a batch needs more concurrent
+            # instances of an environment than have been created so far, preserving the "construct once, reset often"
+            # contract even when batches mix environments.
+            self._env_tools = {}  # {environment name: tools exposed when this environment is selected}
+            self._environment_pool = {}  # {environment name: list of reusable instances}
+            for name, factory in self.environment_factories.items():
+                instance = factory()
                 has_reset = False
-                for name, member in inspect.getmembers(environment, predicate=inspect.ismethod):
-                    if name == "reset":
+                methods = []
+                for member_name, member in inspect.getmembers(instance, predicate=inspect.ismethod):
+                    if member_name == "reset":
                         has_reset = True
-                    elif not name.startswith("_"):
-                        environment_methods[i].append(member)
+                    elif not member_name.startswith("_"):
+                        methods.append(member)
                 if not has_reset:
                     raise ValueError(
-                        "Each environment instance returned by `environment_factory` must define a callable `reset` "
+                        "Each environment instance returned by `environment_factory` must define a callable `reset`."
                     )
+                self._env_tools[name] = tools + methods
+                self._environment_pool[name] = [instance]
+            # Union of every environment's tools. Used where only the presence of a tool matters (chat template
+            # validation, async loop setup, tool metrics); the per-example schema is rendered in `_tokenize_prompts`.
+            self.tools = list(tools)
+            for env_tools in self._env_tools.values():
+                self.tools += [tool for tool in env_tools if tool not in self.tools]
         else:
-            self.environments = None
+            self.tools = tools
 
-        tools = tools or []
-        self._sync_tool_dicts = [{} for _ in range(generation_batch_size)]
-        self._async_tool_dicts = [{} for _ in range(generation_batch_size)]
-        for i in range(generation_batch_size):
-            for tool in tools + (environment_methods[i] if self.environments is not None else []):
-                if inspect.iscoroutinefunction(tool):
-                    self._async_tool_dicts[i][tool.__name__] = tool
-                else:
-                    self._sync_tool_dicts[i][tool.__name__] = tool
-
-        self.tools = tools + (environment_methods[0] if self.environments is not None else [])
+        # The per-rollout environment instances and tool dicts both depend on the batch (which environment each example
+        # selects), so they are built in `_generate_and_score_completions`, right before generation. Only
+        # `self.environments` needs a default here, because `_calculate_rewards` reads it for every batch (including
+        # batches with no environments); the tool dicts are only read in the tool-calling loop, which runs after they
+        # have been (re)built.
+        self.environments = None
 
         # Check for async functions to start an event loop on a daemon thread
         self._has_async_funcs = any(inspect.iscoroutinefunction(func) for func in self.reward_funcs + self.tools)
@@ -1314,6 +1342,27 @@ class GRPOTrainer(_BaseTrainer):
                 images.append(prompt_images if prompt_images else None)
             images = images if has_images else None
 
+            if self.environment_factories is not None:
+                # Tools differ per example across environments, so render each prompt with its own tool schema.
+                prompt_ids = []
+                multimodal_fields = {}
+                for prompt, name in zip(prompts, self._batch_environments, strict=True):
+                    tokenized = self.processing_class.apply_chat_template(
+                        conversation=[prompt],
+                        tools=self._env_tools[name] or None,  # `or None`: Llama bug: tool boilerplate for tools=[]
+                        chat_template=self.chat_template,
+                        add_generation_prompt=True,
+                        tokenize=True,
+                        return_dict=True,
+                        **self.chat_template_kwargs,
+                    )
+                    prompt_ids.append(tokenized["input_ids"][0])
+                    # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
+                    for k, v in tokenized.items():
+                        if k not in ("input_ids", "attention_mask"):
+                            multimodal_fields.setdefault(k, []).append(v[0])
+                return prompt_ids, images, multimodal_fields
+
             # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
             # batched unpadded input (transformers#44514).
             # Fixed in transformers 5.4.0 (transformers#44563).
@@ -1832,8 +1881,47 @@ class GRPOTrainer(_BaseTrainer):
 
         prompts = [x["prompt"] for x in inputs]
 
+        # Resolve each example's environment and draw one reusable instance per rollout from the pool, creating more
+        # only when this batch needs more concurrent instances of an environment than exist. `_batch_environments`
+        # records each example's environment so `_tokenize_prompts` can render the matching tool schema.
+        if self.environment_factories is not None:
+            self._batch_environments = [x["environment"] if self._multi_environment else None for x in inputs]
+            self.environments = []
+            pool_cursor = {}  # how many instances of each environment have been handed out so far this batch
+            for name in self._batch_environments:
+                pool = self._environment_pool[name]
+                index = pool_cursor.get(name, 0)
+                if index == len(pool):
+                    pool.append(self.environment_factories[name]())
+                pool_cursor[name] = index + 1
+                self.environments.append(pool[index])
+
+        # Build the per-rollout tool dicts for this batch: the standalone tools plus, for each rollout, the methods of
+        # its environment. Done here (not at init) because each example's environment, hence its tools, is data-dependent.
+        if self.tools:
+            self._sync_tool_dicts = []
+            self._async_tool_dicts = []
+            for i in range(len(inputs)):
+                methods = []
+                if self.environments:
+                    methods = [
+                        member
+                        for member_name, member in inspect.getmembers(self.environments[i], predicate=inspect.ismethod)
+                        if member_name != "reset" and not member_name.startswith("_")
+                    ]
+                sync_tool_dict, async_tool_dict = {}, {}
+                for tool in self._standalone_tools + methods:
+                    if inspect.iscoroutinefunction(tool):
+                        async_tool_dict[tool.__name__] = tool
+                    else:
+                        sync_tool_dict[tool.__name__] = tool
+                self._sync_tool_dicts.append(sync_tool_dict)
+                self._async_tool_dicts.append(async_tool_dict)
+
         if self.environments:
-            for prompt, environment, reset_kwargs in zip(prompts, self.environments, inputs, strict=True):
+            for prompt, environment, x in zip(prompts, self.environments, inputs, strict=True):
+                # `environment` is a control field in multi-environment mode, so it is not forwarded to `reset`.
+                reset_kwargs = {k: v for k, v in x.items() if k != "environment"} if self._multi_environment else x
                 observation = environment.reset(**reset_kwargs)
                 if observation is None:
                     continue
@@ -1954,11 +2042,15 @@ class GRPOTrainer(_BaseTrainer):
             image_inputs = super()._prepare_inputs(image_inputs)
             forward_kwargs = dict(image_inputs)
         elif images is not None:
+            if self.environment_factories is not None:
+                per_prompt_tools = [self._env_tools[name] for name in self._batch_environments]
+            else:
+                per_prompt_tools = [self.tools] * len(prompts)
             prompts_text = [
                 apply_chat_template(
-                    {"prompt": prompt}, self.processing_class, tools=self.tools, **self.chat_template_kwargs
+                    {"prompt": prompt}, self.processing_class, tools=prompt_tools, **self.chat_template_kwargs
                 )["prompt"]
-                for prompt in prompts
+                for prompt, prompt_tools in zip(prompts, per_prompt_tools, strict=True)
             ]
             prompt_inputs = self.processing_class(images=images, text=prompts_text, padding=True, return_tensors="pt")
             prompt_inputs = super()._prepare_inputs(prompt_inputs)


### PR DESCRIPTION
`environment_factory` now also accepts a `dict[str, factory]`. Each dataset example selects its environment via an `environment` field, and **only that environment's tools are exposed in the example's prompt** — so a coding task and a game can be trained together in one run without leaking each other's tools.

A single callable keeps working: it's just the special case of one unnamed environment shared by every example. Both go through one code path — environment instances are pooled and reused (reset between steps), and the per-rollout tool dicts + per-example tool schema are built per batch, right before generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the generation and tool-calling path in GRPOTrainer and async rollouts, but single-callable usage is preserved and the feature is covered by new integration tests.
> 
> **Overview**
> **`environment_factory`** can now be a **`dict[str, factory]`** so mixed-task GRPO runs pick an environment per dataset row via an **`environment`** column, while a single callable still maps to one shared unnamed environment.
> 
> **GRPOTrainer** and the **async rollout worker** normalize factories, **pool and reuse** environment instances (probe at init, grow pool per batch/slot, **`reset`** between rollouts), build **per-rollout tool dicts** at generation time, and apply **per-example chat templates** so only that row’s environment tools appear in the prompt; the **`environment`** field is stripped before **`reset`**. VLM paths use matching per-prompt tools for text rendering.
> 
> Docs add a **Multiple environments** section; tests cover async loop wiring, a full multi-env GRPO train with mocked generation, and existing single-factory behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86f197b8fee0ee444fec34e12db98b5afb5a68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->