### PR TITLE
Simplify agent skills target and default to `.agents`

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -456,14 +456,8 @@ class TestListAgentNames:
     def test_contains_expected_agents(self):
         """Test that list includes expected agent names."""
         agents = list_agent_names()
+        assert "agents" in agents
         assert "claude" in agents
-        assert "codex" in agents
-        assert "opencode" in agents
-
-    def test_agents_are_sorted(self):
-        """Test that agent names are sorted."""
-        agents = list_agent_names()
-        assert agents == sorted(agents)
 
 
 class TestResolveTargetPath:

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -233,15 +233,14 @@ class TestCLIArgumentParsing:
         args = parser.parse_args(["list", "--target", "claude"])
         assert args.target == "claude"
 
-    def test_install_command_requires_target(self):
-        """Test that install command requires target."""
+    def test_default_target_is_agents(self):
+        """Test that default target is 'agents'."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")
         add_skills_subcommands(subparsers)
 
-        # Should fail without target
-        with pytest.raises(SystemExit):
-            parser.parse_args(["install", "trl-training"])
+        args = parser.parse_args(["install", "trl-training"])
+        assert args.target == "agents"
 
     def test_scope_choices(self):
         """Test that scope parameter accepts valid choices."""

--- a/trl/skills/cli.py
+++ b/trl/skills/cli.py
@@ -36,14 +36,14 @@ def add_skills_subcommands(subparsers: argparse._SubParsersAction) -> None:
     target_parser = argparse.ArgumentParser(add_help=False)
     target_parser.add_argument(
         "--target",
-        required=True,
+        default="agents",
         help=f"Installation target: agent name ({', '.join(list_agent_names())}) or directory path",
     )
     target_parser.add_argument(
         "--scope",
         choices=["project", "global"],
         default="project",
-        help="Scope when using --target with agent name: project (./agent/skills/) or global (user-level like ~/.agent/skills/)",
+        help="Scope when using --target with agent name: project (./agents/skills/) or global (user-level like ~/.agents/skills/)",
     )
 
     # trl skills list (no target required - lists TRL's built-in skills by default)
@@ -60,7 +60,7 @@ def add_skills_subcommands(subparsers: argparse._SubParsersAction) -> None:
         "--scope",
         choices=["project", "global"],
         default="project",
-        help="Scope when using --target with agent name: project (./agent/skills/) or global (user-level like ~/.agent/skills/)",
+        help="Scope when using --target with agent name: project (./agents/skills/) or global (user-level like ~/.agents/skills/)",
     )
     list_parser.set_defaults(func=cmd_list)
 

--- a/trl/skills/skills.py
+++ b/trl/skills/skills.py
@@ -32,17 +32,13 @@ from pathlib import Path
 
 
 AGENT_PATHS = {
+    "agents": {
+        "global": Path("~/.agents/skills"),
+        "project": Path("./.agents/skills"),
+    },
     "claude": {
         "global": Path("~/.claude/skills"),
         "project": Path("./.claude/skills"),
-    },
-    "codex": {
-        "global": Path("~/.codex/skills"),
-        "project": Path("./.codex/skills"),
-    },
-    "opencode": {
-        "global": Path("~/.config/opencode/skills"),
-        "project": Path(".opencode/skills"),
     },
 }
 
@@ -52,7 +48,7 @@ def list_agent_names() -> list[str]:
     List available predefined agent names.
 
     Returns:
-        `list[str]`: Sorted list of agent names (e.g., ['claude', 'codex', 'opencode']).
+        `list[str]`: Sorted list of agent names (e.g., ['agents', 'claude']).
     """
     return sorted(AGENT_PATHS.keys())
 
@@ -76,9 +72,9 @@ def resolve_target_path(target: str | Path, scope: str = "project") -> Path:
     Converts semantic agent names (e.g., 'claude') with scope to actual filesystem paths, or normalizes provided paths.
 
     Args:
-        target (`str | Path`): Agent name (e.g., 'claude', 'codex') or directory path.
+        target (`str | Path`): Agent name (e.g., 'agents', 'claude') or directory path.
         scope (`str`, defaults to `"project"`):
-            Scope for agent names: 'global' (user-level like ~/.agent/skills/) or 'project' (./agent/skills/).
+            Scope for agent names: 'global' (user-level like ~/.agents/skills/) or 'project' (./agents/skills/).
 
     Returns:
         `Path`: Resolved absolute path.
@@ -253,7 +249,7 @@ def install_skill(
 
     Args:
         skill_name (`str`): Name of skill to install.
-        target (`str | Path`): Agent name (e.g., 'claude', 'codex') or directory path.
+        target (`str | Path`): Agent name (e.g., 'agents', 'claude') or directory path.
         scope (`str`, defaults to `"project"`):
             Scope for agent names: 'global' (user-level) or 'project' (current directory).
         source (`str | Path`, *optional*):
@@ -329,7 +325,7 @@ def uninstall_skill(skill_name: str, target: str | Path, scope: str = "project")
 
     Args:
         skill_name (`str`): Name of skill to uninstall.
-        target (`str | Path`): Agent name (e.g., 'claude', 'codex') or directory path.
+        target (`str | Path`): Agent name (e.g., 'agents', 'claude') or directory path.
         scope (`str`, defaults to `"project"`):
             Scope for agent names: 'global' (user-level) or 'project' (current directory).
 


### PR DESCRIPTION
Simplify agent skills target and default to `.agents`.

This PR updates the handling of agent names and target paths for skills management. The main changes remove support for the `codex` and `opencode` agents, introduce a generic `agents` target, and update documentation and tests to reflect these changes. The changes also clarify and standardize the directory structure for agent skills.

### Changes

**Agent and Target Handling Updates:**

* Removed support for `codex` and `opencode` agents from `AGENT_PATHS` and related logic, and added a new generic `agents` target with appropriate global and project paths (`trl/skills/skills.py`).
* Updated the `list_agent_names` function to only return `agents` and `claude` as available agent names, and updated its docstring accordingly (`trl/skills/skills.py`).
* Updated all relevant docstrings and CLI help messages to reflect the new agent names and directory structure (e.g., `./agents/skills/` and `~/.agents/skills/`) in both `trl/skills/skills.py` and `trl/skills/cli.py`.

**Testing and Validation:**

* Modified tests to remove checks for `codex` and `opencode`, and to ensure that `agents` is included in the list of agent names (`tests/test_skills.py`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default install location and removes previously supported agent targets, which can surprise users or scripts that relied on codex/opencode or omitted `--target` expecting a required flag.
> 
> **Overview**
> **Simplifies TRL skills install targets** by dropping built-in `codex` and `opencode` paths and adding a generic **`agents`** target (`./.agents/skills` / `~/.agents/skills`), while keeping **`claude`**.
> 
> **`trl skills install` / `uninstall`** no longer require `--target`; it **defaults to `agents`**, so `trl skills install trl-training` installs to the standard Agents layout without extra flags. CLI help and API docstrings are aligned with the new paths.
> 
> Tests now expect **`agents`** and **`claude`** only, and assert the default target instead of requiring `--target` on install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea34b814618b073f142b37db0f077cb3180ccc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->