### PR TITLE
[CI] Check that training chat templates keep the stop token in the loss mask

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -684,6 +684,64 @@ class TestGetTrainingChatTemplate:
             pytest.skip("Template does not support tool calling; prefix-preservation check is not applicable.")
         assert is_chat_template_prefix_preserving(tokenizer) is True
 
+    @pytest.mark.parametrize("append_role", ["user", "system"])
+    def test_new_chat_template_is_prefix_preserving_for_appended_role(self, tokenizer_name, append_role, request):
+        # Multi-turn rollouts can append user or system messages mid-conversation, and the same prefix-preservation
+        # property applies per role. Templates that reject a role outright are skipped (failing loud is safe);
+        # templates that silently rewrite earlier turns are known breaks, marked as strict xfail so CI flags them as
+        # soon as a template gains the surface. None are fixable byte-identically: the rewrites are inherent to the
+        # original templates.
+        known_breaks = {
+            ("trl-internal-testing/tiny-GptOssForCausalLM", "user"): (
+                "appending demotes the final assistant turn and rewrites its <|return|> terminator to <|end|>"
+            ),
+            ("trl-internal-testing/tiny-GptOssForCausalLM", "system"): (
+                "appending demotes the final assistant turn and rewrites its <|return|> terminator to <|end|>"
+            ),
+            ("trl-internal-testing/tiny-Phi3ForCausalLM-3", "user"): (
+                "the final render carries a trailing eos token that appending removes"
+            ),
+            ("trl-internal-testing/tiny-Phi3ForCausalLM-3", "system"): (
+                "the final render carries a trailing eos token that appending removes"
+            ),
+            ("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", "user"): (
+                "the final render carries a trailing eos token that appending removes"
+            ),
+            ("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", "system"): (
+                "the final render carries a trailing eos token that appending removes"
+            ),
+            ("trl-internal-testing/tiny-Cohere2ForCausalLM", "system"): (
+                "the system message is hoisted into the developer preamble at the front of the render"
+            ),
+            ("trl-internal-testing/tiny-DeepseekV3ForCausalLM", "system"): (
+                "the system message is hoisted to the front of the render"
+            ),
+            ("trl-internal-testing/tiny-LlavaForConditionalGeneration", "user"): (
+                "the role markers are plain text, and the trailing space merges with them under BPE"
+            ),
+            ("trl-internal-testing/tiny-LlavaForConditionalGeneration", "system"): (
+                "the role markers are plain text, and the trailing space merges with them under BPE"
+            ),
+            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "user"): (
+                "the role markers are plain text, and the trailing space merges with them under BPE"
+            ),
+            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "system"): (
+                "the role markers are plain text, and the trailing space merges with them under BPE"
+            ),
+        }
+        reason = known_breaks.get((tokenizer_name, append_role))
+        if reason:
+            request.node.add_marker(pytest.mark.xfail(strict=True, reason=f"{tokenizer_name}: {reason}"))
+        tokenizer = self._load(tokenizer_name)
+        chat_template = get_training_chat_template(tokenizer)
+        if chat_template is not None:
+            tokenizer.chat_template = chat_template
+        try:
+            preserved = is_chat_template_prefix_preserving(tokenizer, append_role=append_role)
+        except TemplateError:
+            pytest.skip(f"Template does not support appending a {append_role} message.")
+        assert preserved is True
+
     def test_new_chat_template_trains_stop_token(self, tokenizer_name, request):
         # Known failures, marked as strict xfail rather than skip so that CI flags them (and gains coverage) as soon
         # as the underlying processor is fixed.

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -677,7 +677,7 @@ class TestGetTrainingChatTemplate:
     def test_new_chat_template_is_prefix_preserving(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
         new_chat_template = get_training_chat_template(tokenizer)
-        if chat_template is not None:
+        if new_chat_template is not None:
             tokenizer.chat_template = new_chat_template
         # Prefix-preservation is only meaningful for templates that actually support tool messages — the check
         # itself renders one. Skip the assertion for tool-less templates (e.g. Gemma).

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -556,6 +556,11 @@ class TestIsChatTemplateStopTokenTrained:
         {%- endif %}""")
         assert is_chat_template_stop_token_trained(tokenizer) is False
 
+    def test_template_error_returns_false(self):
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen3MoeForCausalLM")
+        tokenizer.chat_template = "{{ raise_exception('probe rejected') }}"
+        assert is_chat_template_stop_token_trained(tokenizer) is False
+
 
 @pytest.mark.parametrize(
     "tokenizer_name",

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -691,7 +691,7 @@ class TestGetTrainingChatTemplate:
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
         ):
             reason = f"{tokenizer_name}: the processor returns an all-zero assistant tokens mask"
-            request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
+            request.node.add_marker(pytest.mark.xfail(strict=False, reason=reason))
         tokenizer = self._load(tokenizer_name)
         new_chat_template = get_training_chat_template(tokenizer)
         assert is_chat_template_stop_token_trained(tokenizer, chat_template=new_chat_template) is True

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -676,9 +676,9 @@ class TestGetTrainingChatTemplate:
 
     def test_new_chat_template_is_prefix_preserving(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
-        chat_template = get_training_chat_template(tokenizer)
+        new_chat_template = get_training_chat_template(tokenizer)
         if chat_template is not None:
-            tokenizer.chat_template = chat_template
+            tokenizer.chat_template = new_chat_template
         # Prefix-preservation is only meaningful for templates that actually support tool messages — the check
         # itself renders one. Skip the assertion for tool-less templates (e.g. Gemma).
         if not supports_tool_calling(tokenizer):

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -25,6 +25,7 @@ from trl.chat_template_utils import (
     add_response_schema,
     get_training_chat_template,
     is_chat_template_prefix_preserving,
+    is_chat_template_stop_token_trained,
     parse_response,
     supports_tool_calling,
 )
@@ -513,6 +514,48 @@ class TestIsChatTemplatePrefixPreserving:
         assert is_chat_template_prefix_preserving(processor) is True
 
 
+class TestIsChatTemplateStopTokenTrained:
+    def test_stop_token_trained(self):
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen3MoeForCausalLM")
+        # The assistant turn is closed by <|im_end|> inside the generation span, so the end-of-turn token is masked
+        # in and the model is trained to stop.
+        # docstyle-ignore
+        tokenizer.chat_template = textwrap.dedent(r"""
+        {%- for message in messages %}
+        {%- if message.role == 'user' %}
+            {{- '<|im_start|>user\n' + message.content + '<|im_end|>\n' }}
+        {%- elif message.role == 'assistant' %}
+            {{- '<|im_start|>assistant\n' }}
+            {%- generation %}{{- message.content + '<|im_end|>' }}{%- endgeneration %}
+            {{- '\n' }}
+        {%- endif %}
+        {%- endfor %}
+        {%- if add_generation_prompt %}
+            {{- '<|im_start|>assistant\n' }}
+        {%- endif %}""")
+        assert is_chat_template_stop_token_trained(tokenizer) is True
+
+    def test_stop_token_not_trained(self):
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen3MoeForCausalLM")
+        # GLM-style: the assistant's end-of-turn token is emitted as the prefix of the following message, so the
+        # generation span covers content only and the model is never trained to stop.
+        # docstyle-ignore
+        tokenizer.chat_template = textwrap.dedent(r"""
+        {%- for message in messages %}
+        {%- if message.role == 'user' %}
+            {{- '<|im_start|>user\n' + message.content + '<|im_end|>\n' }}
+        {%- elif message.role == 'assistant' %}
+            {{- '<|im_start|>assistant\n' }}
+            {%- generation %}{{- message.content }}{%- endgeneration %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+        {%- endfor %}
+        {%- if add_generation_prompt %}
+            {{- '<|im_start|>assistant\n' }}
+        {%- endif %}""")
+        assert is_chat_template_stop_token_trained(tokenizer) is False
+
+
 @pytest.mark.parametrize(
     "tokenizer_name",
     [
@@ -634,6 +677,27 @@ class TestGetTrainingChatTemplate:
         if not supports_tool_calling(tokenizer):
             pytest.skip("Template does not support tool calling; prefix-preservation check is not applicable.")
         assert is_chat_template_prefix_preserving(tokenizer) is True
+
+    def test_new_chat_template_trains_stop_token(self, tokenizer_name, request):
+        # Known failures, marked as strict xfail rather than skip so that CI flags them (and gains coverage) as soon
+        # as the underlying template or processor is fixed.
+        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
+            # GLM closes the assistant turn with the next role marker (<|user|>/<|observation|>) rather than a
+            # dedicated end-of-turn token, so the terminator is attributed to the following message and falls
+            # outside the loss mask — the model is never trained to stop.
+            reason = f"{tokenizer_name}: end-of-turn token is not included in the loss mask"
+            request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
+        elif tokenizer_name in (
+            "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+        ):
+            reason = f"{tokenizer_name}: processor does not propagate the assistant tokens mask"
+            request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
+        tokenizer = self._load(tokenizer_name)
+        chat_template = get_training_chat_template(tokenizer)
+        assert is_chat_template_stop_token_trained(tokenizer, chat_template=chat_template) is True
 
     def test_behavior_unchanged_single_user_no_generation_prompt(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -680,14 +680,8 @@ class TestGetTrainingChatTemplate:
 
     def test_new_chat_template_trains_stop_token(self, tokenizer_name, request):
         # Known failures, marked as strict xfail rather than skip so that CI flags them (and gains coverage) as soon
-        # as the underlying template or processor is fixed.
-        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
-            # GLM closes the assistant turn with the next role marker (<|user|>/<|observation|>) rather than a
-            # dedicated end-of-turn token, so the terminator is attributed to the following message and falls
-            # outside the loss mask — the model is never trained to stop.
-            reason = f"{tokenizer_name}: end-of-turn token is not included in the loss mask"
-            request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
-        elif tokenizer_name in (
+        # as the underlying processor is fixed.
+        if tokenizer_name in (
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -677,7 +677,9 @@ class TestGetTrainingChatTemplate:
 
     def test_new_chat_template_is_prefix_preserving(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
-        tokenizer.chat_template = get_training_chat_template(tokenizer)
+        chat_template = get_training_chat_template(tokenizer)
+        if chat_template is not None:
+            tokenizer.chat_template = chat_template
         # Prefix-preservation is only meaningful for templates that actually support tool messages — the check
         # itself renders one. Skip the assertion for tool-less templates (e.g. Gemma).
         if not supports_tool_calling(tokenizer):

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -17,6 +17,7 @@ import textwrap
 
 import pytest
 import transformers
+from jinja2 import TemplateError
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoProcessor, AutoTokenizer
 
@@ -731,6 +732,39 @@ class TestGetTrainingChatTemplate:
 
         before = tokenizer.apply_chat_template(messages, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
+        after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
+        assert before == after
+
+    def test_behavior_unchanged_consecutive_assistant_messages(self, tokenizer_name):
+        if tokenizer_name in (
+            "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think",
+            "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+        ):
+            pytest.skip(
+                "The original template renders think tags only for the last assistant message, so the training "
+                "template (which renders them for every assistant message to preserve prefixes) intentionally "
+                "differs on consecutive assistant messages."
+            )
+        tokenizer = self._load(tokenizer_name)
+        messages = [
+            {"role": "user", "content": "What color is the sky?"},
+            {"role": "assistant", "content": "Let me think."},
+            {"role": "assistant", "content": "It is blue."},
+            {"role": "user", "content": "Are you sure?"},
+        ]
+        if self.is_vlm:
+            messages = prepare_multimodal_messages(messages)
+
+        new_chat_template = get_training_chat_template(tokenizer)
+        try:
+            before = tokenizer.apply_chat_template(messages, tokenize=False)
+        except TemplateError:
+            # Some templates reject non-alternating roles; the training template must reject them too.
+            with pytest.raises(TemplateError):
+                tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
+            return
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
         assert before == after
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -686,64 +686,6 @@ class TestGetTrainingChatTemplate:
             pytest.skip("Template does not support tool calling; prefix-preservation check is not applicable.")
         assert is_chat_template_prefix_preserving(tokenizer) is True
 
-    @pytest.mark.parametrize("append_role", ["user", "system"])
-    def test_new_chat_template_is_prefix_preserving_for_appended_role(self, tokenizer_name, append_role, request):
-        # Multi-turn rollouts can append user or system messages mid-conversation, and the same prefix-preservation
-        # property applies per role. Templates that reject a role outright are skipped (failing loud is safe);
-        # templates that silently rewrite earlier turns are known breaks, marked as strict xfail so CI flags them as
-        # soon as a template gains the surface. None are fixable byte-identically: the rewrites are inherent to the
-        # original templates.
-        known_breaks = {
-            ("trl-internal-testing/tiny-GptOssForCausalLM", "user"): (
-                "appending demotes the final assistant turn and rewrites its <|return|> terminator to <|end|>"
-            ),
-            ("trl-internal-testing/tiny-GptOssForCausalLM", "system"): (
-                "appending demotes the final assistant turn and rewrites its <|return|> terminator to <|end|>"
-            ),
-            ("trl-internal-testing/tiny-Phi3ForCausalLM-3", "user"): (
-                "the final render carries a trailing eos token that appending removes"
-            ),
-            ("trl-internal-testing/tiny-Phi3ForCausalLM-3", "system"): (
-                "the final render carries a trailing eos token that appending removes"
-            ),
-            ("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", "user"): (
-                "the final render carries a trailing eos token that appending removes"
-            ),
-            ("trl-internal-testing/tiny-Phi3ForCausalLM-3.5", "system"): (
-                "the final render carries a trailing eos token that appending removes"
-            ),
-            ("trl-internal-testing/tiny-Cohere2ForCausalLM", "system"): (
-                "the system message is hoisted into the developer preamble at the front of the render"
-            ),
-            ("trl-internal-testing/tiny-DeepseekV3ForCausalLM", "system"): (
-                "the system message is hoisted to the front of the render"
-            ),
-            ("trl-internal-testing/tiny-LlavaForConditionalGeneration", "user"): (
-                "the role markers are plain text, and the trailing space merges with them under BPE"
-            ),
-            ("trl-internal-testing/tiny-LlavaForConditionalGeneration", "system"): (
-                "the role markers are plain text, and the trailing space merges with them under BPE"
-            ),
-            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "user"): (
-                "the role markers are plain text, and the trailing space merges with them under BPE"
-            ),
-            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "system"): (
-                "the role markers are plain text, and the trailing space merges with them under BPE"
-            ),
-        }
-        reason = known_breaks.get((tokenizer_name, append_role))
-        if reason:
-            request.node.add_marker(pytest.mark.xfail(strict=True, reason=f"{tokenizer_name}: {reason}"))
-        tokenizer = self._load(tokenizer_name)
-        chat_template = get_training_chat_template(tokenizer)
-        if chat_template is not None:
-            tokenizer.chat_template = chat_template
-        try:
-            preserved = is_chat_template_prefix_preserving(tokenizer, append_role=append_role)
-        except TemplateError:
-            pytest.skip(f"Template does not support appending a {append_role} message.")
-        assert preserved is True
-
     def test_new_chat_template_trains_stop_token(self, tokenizer_name, request):
         # Known failures, marked as strict xfail rather than skip so that CI flags them (and gains coverage) as soon
         # as the underlying processor is fixed.

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -17,7 +17,6 @@ import textwrap
 
 import pytest
 import transformers
-from jinja2 import TemplateError
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoProcessor, AutoTokenizer
 
@@ -687,15 +686,11 @@ class TestGetTrainingChatTemplate:
         assert is_chat_template_prefix_preserving(tokenizer) is True
 
     def test_new_chat_template_trains_stop_token(self, tokenizer_name, request):
-        # Known failures, marked as strict xfail rather than skip so that CI flags them (and gains coverage) as soon
-        # as the underlying processor is fixed.
         if tokenizer_name in (
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
-            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
         ):
-            reason = f"{tokenizer_name}: processor does not propagate the assistant tokens mask"
+            reason = f"{tokenizer_name}: the processor returns an all-zero assistant tokens mask"
             request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
         tokenizer = self._load(tokenizer_name)
         chat_template = get_training_chat_template(tokenizer)
@@ -739,39 +734,6 @@ class TestGetTrainingChatTemplate:
 
         before = tokenizer.apply_chat_template(messages, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
-        after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-        assert before == after
-
-    def test_behavior_unchanged_consecutive_assistant_messages(self, tokenizer_name):
-        if tokenizer_name in (
-            "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
-            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
-            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think",
-            "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
-        ):
-            pytest.skip(
-                "The original template renders think tags only for the last assistant message, so the training "
-                "template (which renders them for every assistant message to preserve prefixes) intentionally "
-                "differs on consecutive assistant messages."
-            )
-        tokenizer = self._load(tokenizer_name)
-        messages = [
-            {"role": "user", "content": "What color is the sky?"},
-            {"role": "assistant", "content": "Let me think."},
-            {"role": "assistant", "content": "It is blue."},
-            {"role": "user", "content": "Are you sure?"},
-        ]
-        if self.is_vlm:
-            messages = prepare_multimodal_messages(messages)
-
-        new_chat_template = get_training_chat_template(tokenizer)
-        try:
-            before = tokenizer.apply_chat_template(messages, tokenize=False)
-        except TemplateError:
-            # Some templates reject non-alternating roles; the training template must reject them too.
-            with pytest.raises(TemplateError):
-                tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-            return
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
         assert before == after
 

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -693,8 +693,8 @@ class TestGetTrainingChatTemplate:
             reason = f"{tokenizer_name}: the processor returns an all-zero assistant tokens mask"
             request.node.add_marker(pytest.mark.xfail(strict=True, reason=reason))
         tokenizer = self._load(tokenizer_name)
-        chat_template = get_training_chat_template(tokenizer)
-        assert is_chat_template_stop_token_trained(tokenizer, chat_template=chat_template) is True
+        new_chat_template = get_training_chat_template(tokenizer)
+        assert is_chat_template_stop_token_trained(tokenizer, chat_template=new_chat_template) is True
 
     def test_behavior_unchanged_single_user_no_generation_prompt(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -572,8 +572,8 @@ def is_chat_template_stop_token_trained(
     Prefix preservation guarantees that earlier turns render identically, but not that the token the model must emit to
     *end* its turn is part of the loss. Some templates attribute an assistant turn's end-of-turn token to the message
     that follows it, so when masking with `return_assistant_tokens_mask=True` that token falls outside the assistant
-    span and the model is never trained to stop. This renders a single assistant turn and checks that the masked span
-    ends on an end-of-turn token rather than on content.
+    span and the model is never trained to stop. This renders an assistant turn followed by a user message and checks
+    that the assistant's masked span ends on an end-of-turn token rather than on content.
 
     The template must define `{% generation %}` / `{% endgeneration %}` markers (see [`get_training_chat_template`]),
     otherwise the assistant mask is empty and this returns `False`.
@@ -588,9 +588,12 @@ def is_chat_template_stop_token_trained(
         `bool`:
             `True` if the assistant turn's end-of-turn token is included in the loss mask, `False` otherwise.
     """
+    # The assistant turn is followed by a user message because some templates never terminate the final assistant
+    # turn; the boundary with the next message is where the end-of-turn token must be attributed.
     messages = [
         {"role": "user", "content": "dummy"},
         {"role": "assistant", "content": "dummy"},
+        {"role": "user", "content": "dummy"},
     ]
     is_vlm = isinstance(processing_class, ProcessorMixin)
     if is_vlm:
@@ -619,7 +622,7 @@ def is_chat_template_stop_token_trained(
     # The model stops by emitting an end-of-turn token, which is part of the added vocabulary rather than produced by
     # the base tokenizer's merges. Ignoring trailing whitespace, the last masked token must be that terminator; if it
     # is plain content, the end-of-turn token was attributed to the following message and is never trained.
-    tokenizer = getattr(processing_class, "tokenizer", processing_class)
+    tokenizer = processing_class.tokenizer if is_vlm else processing_class
     added_ids = set(tokenizer.get_added_vocab().values())
     masked_ids = [token_id for token_id, masked in zip(input_ids, assistant_masks, strict=False) if masked]
     for token_id in reversed(masked_ids):

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -511,44 +511,33 @@ def supports_tool_calling(processing_class) -> bool:
     return all(s in rendered for s in (_name_sentinel, _arg_key_sentinel, _arg_val_sentinel, _content_sentinel))
 
 
-def is_chat_template_prefix_preserving(
-    processing_class: PreTrainedTokenizerBase | ProcessorMixin, append_role: str = "tool"
-) -> bool:
+def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizerBase | ProcessorMixin) -> bool:
     """
-    Check whether the chat template preserves prefixes when a message of the given role is appended.
+    Check whether the chat template preserves prefixes when applied.
 
-    A prefix-preserving chat template renders earlier messages identically regardless of what messages follow. For tool
-    messages this property is required by `_get_tool_suffix_ids`, which extracts tool response formatting tokens by
-    comparing tokenizations with and without tool messages appended. Multi-turn rollouts that append user or system
-    messages mid-conversation rely on the same property for those roles.
+    A prefix-preserving chat template renders earlier messages identically regardless of what messages follow. This
+    property is required by `_get_tool_suffix_ids`, which extracts tool response formatting tokens by comparing
+    tokenizations with and without tool messages appended.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or processor instance to check.
-        append_role (`str`, *optional*, defaults to `"tool"`):
-            Role of the appended message to probe: `"tool"`, `"user"`, or `"system"`.
 
     Returns:
         `bool`:
             `True` if the chat template preserves prefixes, `False` otherwise.
     """
-    if append_role == "tool":
-        # Use the same dummy messages as _get_tool_suffix_ids to test the exact property it relies on.
-        dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": {}}}]
-        messages1 = [
-            {"role": "user", "content": "dummy"},
-            {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
-        ]
-        messages2 = messages1 + [{"role": "tool", "name": "dummy", "content": "dummy"}]
-    elif append_role in ("user", "system"):
-        messages1 = [
-            {"role": "user", "content": "dummy"},
-            {"role": "assistant", "content": "dummy"},
-        ]
-        messages2 = messages1 + [{"role": append_role, "content": "dummy2"}]
-    else:
-        raise ValueError(f"Unsupported append_role: {append_role!r}. Expected 'tool', 'user', or 'system'.")
-
+    # Use the same dummy messages as _get_tool_suffix_ids to test the exact property it relies on.
+    dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": {}}}]
+    messages1 = [
+        {"role": "user", "content": "dummy"},
+        {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
+    ]
+    messages2 = [
+        {"role": "user", "content": "dummy"},
+        {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
+        {"role": "tool", "name": "dummy", "content": "dummy"},
+    ]
     # VLM processors expect structured list-of-blocks content, and image-token expansion only kicks in when an image
     # is actually present, so include a dummy image to exercise the real code path.
     is_vlm = isinstance(processing_class, ProcessorMixin)
@@ -565,8 +554,6 @@ def is_chat_template_prefix_preserving(
             messages2, tokenize=True, return_dict=False, add_generation_prompt=True
         )
     except TypeError:
-        if append_role != "tool":
-            raise
         # Best-effort fallback for templates that reject dict args (e.g. DeepSeek-V3). This is a chat template
         # bug (see transformers#45419), and the training chat template fixes it to avoid blocking users.
         dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": "{}"}}]

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -619,7 +619,7 @@ def is_chat_template_stop_token_trained(
             return_assistant_tokens_mask=True,
             chat_template=chat_template,
         )
-    except (TypeError, ValueError):
+    except (TemplateError, TypeError, ValueError):
         return False
 
     input_ids = output["input_ids"]

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -511,33 +511,44 @@ def supports_tool_calling(processing_class) -> bool:
     return all(s in rendered for s in (_name_sentinel, _arg_key_sentinel, _arg_val_sentinel, _content_sentinel))
 
 
-def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizerBase | ProcessorMixin) -> bool:
+def is_chat_template_prefix_preserving(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin, append_role: str = "tool"
+) -> bool:
     """
-    Check whether the chat template preserves prefixes when applied.
+    Check whether the chat template preserves prefixes when a message of the given role is appended.
 
-    A prefix-preserving chat template renders earlier messages identically regardless of what messages follow. This
-    property is required by `_get_tool_suffix_ids`, which extracts tool response formatting tokens by comparing
-    tokenizations with and without tool messages appended.
+    A prefix-preserving chat template renders earlier messages identically regardless of what messages follow. For tool
+    messages this property is required by `_get_tool_suffix_ids`, which extracts tool response formatting tokens by
+    comparing tokenizations with and without tool messages appended. Multi-turn rollouts that append user or system
+    messages mid-conversation rely on the same property for those roles.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
             Tokenizer or processor instance to check.
+        append_role (`str`, *optional*, defaults to `"tool"`):
+            Role of the appended message to probe: `"tool"`, `"user"`, or `"system"`.
 
     Returns:
         `bool`:
             `True` if the chat template preserves prefixes, `False` otherwise.
     """
-    # Use the same dummy messages as _get_tool_suffix_ids to test the exact property it relies on.
-    dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": {}}}]
-    messages1 = [
-        {"role": "user", "content": "dummy"},
-        {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
-    ]
-    messages2 = [
-        {"role": "user", "content": "dummy"},
-        {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
-        {"role": "tool", "name": "dummy", "content": "dummy"},
-    ]
+    if append_role == "tool":
+        # Use the same dummy messages as _get_tool_suffix_ids to test the exact property it relies on.
+        dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": {}}}]
+        messages1 = [
+            {"role": "user", "content": "dummy"},
+            {"role": "assistant", "content": "", "tool_calls": dummy_tool_calls},
+        ]
+        messages2 = messages1 + [{"role": "tool", "name": "dummy", "content": "dummy"}]
+    elif append_role in ("user", "system"):
+        messages1 = [
+            {"role": "user", "content": "dummy"},
+            {"role": "assistant", "content": "dummy"},
+        ]
+        messages2 = messages1 + [{"role": append_role, "content": "dummy2"}]
+    else:
+        raise ValueError(f"Unsupported append_role: {append_role!r}. Expected 'tool', 'user', or 'system'.")
+
     # VLM processors expect structured list-of-blocks content, and image-token expansion only kicks in when an image
     # is actually present, so include a dummy image to exercise the real code path.
     is_vlm = isinstance(processing_class, ProcessorMixin)
@@ -554,6 +565,8 @@ def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizerBase
             messages2, tokenize=True, return_dict=False, add_generation_prompt=True
         )
     except TypeError:
+        if append_role != "tool":
+            raise
         # Best-effort fallback for templates that reject dict args (e.g. DeepSeek-V3). This is a chat template
         # bug (see transformers#45419), and the training chat template fixes it to avoid blocking users.
         dummy_tool_calls = [{"type": "function", "function": {"name": "dummy", "arguments": "{}"}}]

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -563,6 +563,72 @@ def is_chat_template_prefix_preserving(processing_class: PreTrainedTokenizerBase
     return ids2[: len(ids1)] == ids1
 
 
+def is_chat_template_stop_token_trained(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin, chat_template: str | None = None
+) -> bool:
+    """
+    Check whether the chat template includes an assistant turn's end-of-turn token in the loss mask.
+
+    Prefix preservation guarantees that earlier turns render identically, but not that the token the model must emit to
+    *end* its turn is part of the loss. Some templates attribute an assistant turn's end-of-turn token to the message
+    that follows it, so when masking with `return_assistant_tokens_mask=True` that token falls outside the assistant
+    span and the model is never trained to stop. This renders a single assistant turn and checks that the masked span
+    ends on an end-of-turn token rather than on content.
+
+    The template must define `{% generation %}` / `{% endgeneration %}` markers (see [`get_training_chat_template`]),
+    otherwise the assistant mask is empty and this returns `False`.
+
+    Args:
+        processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
+            Tokenizer or processor instance to check.
+        chat_template (`str`, *optional*):
+            Chat template to check. Defaults to the one attached to `processing_class`.
+
+    Returns:
+        `bool`:
+            `True` if the assistant turn's end-of-turn token is included in the loss mask, `False` otherwise.
+    """
+    messages = [
+        {"role": "user", "content": "dummy"},
+        {"role": "assistant", "content": "dummy"},
+    ]
+    is_vlm = isinstance(processing_class, ProcessorMixin)
+    if is_vlm:
+        from PIL import Image
+
+        dummy_image = Image.new("RGB", (8, 8))
+        messages = prepare_multimodal_messages(messages, images=[dummy_image])
+
+    try:
+        output = processing_class.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=True,
+            return_assistant_tokens_mask=True,
+            chat_template=chat_template,
+        )
+    except (TypeError, ValueError):
+        return False
+
+    input_ids = output["input_ids"]
+    assistant_masks = output["assistant_masks"]
+    if is_vlm:
+        input_ids = input_ids[0]
+        assistant_masks = assistant_masks[0]
+
+    # The model stops by emitting an end-of-turn token, which is part of the added vocabulary rather than produced by
+    # the base tokenizer's merges. Ignoring trailing whitespace, the last masked token must be that terminator; if it
+    # is plain content, the end-of-turn token was attributed to the following message and is never trained.
+    tokenizer = getattr(processing_class, "tokenizer", processing_class)
+    added_ids = set(tokenizer.get_added_vocab().values())
+    masked_ids = [token_id for token_id, masked in zip(input_ids, assistant_masks, strict=False) if masked]
+    for token_id in reversed(masked_ids):
+        if tokenizer.decode([token_id]).strip() == "":
+            continue
+        return token_id in added_ids
+    return False
+
+
 cohere_training_chat_template = (_CHAT_TEMPLATES_DIR / "cohere_training.jinja").read_text(encoding="utf-8")
 
 cohere2_training_chat_template = (_CHAT_TEMPLATES_DIR / "cohere2_training.jinja").read_text(encoding="utf-8")

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -606,10 +606,10 @@ def is_chat_template_stop_token_trained(
     ]
     is_vlm = isinstance(processing_class, ProcessorMixin)
     if is_vlm:
-        from PIL import Image
-
-        dummy_image = Image.new("RGB", (8, 8))
-        messages = prepare_multimodal_messages(messages, images=[dummy_image])
+        # Probe without images: assistant masks are computed before multimodal token expansion and not re-aligned
+        # afterwards, so any image would zero or shift the mask regardless of what the template attributes.
+        for message in messages:
+            message["content"] = [{"type": "text", "text": message["content"]}]
 
     try:
         output = processing_class.apply_chat_template(

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import warnings
 from pathlib import Path
 from typing import TypeVar
@@ -23,6 +24,14 @@ from .data_utils import prepare_multimodal_messages
 
 
 _CHAT_TEMPLATES_DIR = Path(__file__).parent / "chat_templates"
+
+
+def has_generation_markers(chat_template: str) -> bool:
+    """
+    Check whether the chat template defines `{% generation %}` markers, accounting for whitespace-trim variants such as
+    `{%- generation %}` and `{%- generation -%}`.
+    """
+    return re.search(r"\{%-?\s*generation\s*-?%\}", chat_template) is not None
 
 
 def clone_chat_template(
@@ -763,7 +772,7 @@ def get_training_chat_template(
     # First check if patching is needed. Prefix-preservation only matters when the template actually supports tools
     # (the check itself renders a tool message), so skip it otherwise.
     prefix_ok = not supports_tool_calling(processing_class) or is_chat_template_prefix_preserving(processing_class)
-    if prefix_ok and "{% generation %}" in processing_class.chat_template:
+    if prefix_ok and has_generation_markers(processing_class.chat_template):
         return None  # No patching needed
 
     if processing_class.chat_template == cohere_chat_template:

--- a/trl/chat_templates/glm4moe_training.jinja
+++ b/trl/chat_templates/glm4moe_training.jinja
@@ -58,7 +58,7 @@ For each function call, output the function name and arguments within the follow
 {{ visible_text(m.content) }}
 {{- '/nothink' if (enable_thinking is defined and not enable_thinking and not visible_text(m.content).endswith("/nothink")) else '' -}}
 {%- elif m.role == 'assistant' -%}
-<|assistant|>
+{{- '<|assistant|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
 {%- set reasoning_content = '' %}
 {%- set content = visible_text(m.content) %}
 {%- if m.reasoning_content is string %}

--- a/trl/chat_templates/glm4moe_training.jinja
+++ b/trl/chat_templates/glm4moe_training.jinja
@@ -58,7 +58,7 @@ For each function call, output the function name and arguments within the follow
 {{ visible_text(m.content) }}
 {{- '/nothink' if (enable_thinking is defined and not enable_thinking and not visible_text(m.content).endswith("/nothink")) else '' -}}
 {%- elif m.role == 'assistant' -%}
-{{- '<|assistant|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
+<|assistant|>
 {%- set reasoning_content = '' %}
 {%- set content = visible_text(m.content) %}
 {%- if m.reasoning_content is string %}
@@ -91,9 +91,9 @@ For each function call, output the function name and arguments within the follow
 {% endfor %}
 </tool_call>{% endfor %}
 {% endif %}
-{%- if not loop.last %}
+{%- if not loop.last and messages[loop.index0 + 1].role != 'assistant' %}
 {%- set next_role = messages[loop.index0 + 1].role %}
-{{- '<|user|>' if next_role == 'user' else '<|observation|>' if next_role == 'tool' else '<|assistant|>' if next_role == 'assistant' else '<|system|>' }}
+{{- '<|user|>' if next_role == 'user' else '<|observation|>' if next_role == 'tool' else '<|system|>' }}
 {%- endif %}
 {%- endgeneration %}
 {%- elif m.role == 'tool' -%}

--- a/trl/chat_templates/glm4moe_training.jinja
+++ b/trl/chat_templates/glm4moe_training.jinja
@@ -4,6 +4,10 @@
       Always check for both tags to avoid edge cases where the model generates only one tag.
     - Added {% generation %} / {% endgeneration %} around assistant message output to support
       assistant-only loss masking in SFT training.
+    - The role marker of the message following an assistant turn (<|user|>/<|observation|>/...) is the
+      inference-time stop token that closes the turn, so it is emitted inside the assistant's generation
+      block (and suppressed at the start of the following message) to include it in the loss mask. The
+      rendered text is unchanged.
 -#}
 [gMASK]<sop>
 {%- if tools -%}
@@ -49,7 +53,8 @@ For each function call, output the function name and arguments within the follow
     {%- endif %}
 {%- endfor %}
 {% for m in messages %}
-{%- if m.role == 'user' -%}<|user|>
+{%- if m.role == 'user' -%}
+{{- '<|user|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
 {{ visible_text(m.content) }}
 {{- '/nothink' if (enable_thinking is defined and not enable_thinking and not visible_text(m.content).endswith("/nothink")) else '' -}}
 {%- elif m.role == 'assistant' -%}
@@ -86,24 +91,28 @@ For each function call, output the function name and arguments within the follow
 {% endfor %}
 </tool_call>{% endfor %}
 {% endif %}
+{%- if not loop.last %}
+{%- set next_role = messages[loop.index0 + 1].role %}
+{{- '<|user|>' if next_role == 'user' else '<|observation|>' if next_role == 'tool' else '<|assistant|>' if next_role == 'assistant' else '<|system|>' }}
+{%- endif %}
 {%- endgeneration %}
 {%- elif m.role == 'tool' -%}
 {%- if m.content is string -%}
-{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+{%- if loop.first or (messages[loop.index0 - 1].role not in ["tool", "assistant"]) %}
     {{- '<|observation|>' }}
 {%- endif %}
 {{- '\n<tool_response>\n' }}
 {{- m.content }}
 {{- '\n</tool_response>' }}
 {%- else -%}
-<|observation|>{% for tr in m.content %}
+{{- '<|observation|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}{% for tr in m.content %}
 
 <tool_response>
 {{ tr.output if tr.output is defined else tr }}
 </tool_response>{% endfor -%}
 {% endif -%}
 {%- elif m.role == 'system' -%}
-<|system|>
+{{- '<|system|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
 {{ visible_text(m.content) }}
 {%- endif -%}
 {%- endfor -%}

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -18,6 +18,7 @@ import multiprocessing as mp
 import os
 import pickle
 import queue
+import re
 import threading
 import time
 import traceback
@@ -259,10 +260,10 @@ class _AsyncRolloutLoop:
 
         # A prefix-preserving template can still attribute the assistant's end-of-turn token to the next message,
         # leaving it out of the loss mask so the model is never trained to stop. Warn if the template we resolved
-        # has that issue. The check only applies to templates with `{% generation %}` markers; without them the
-        # assistant mask is empty and the check is meaningless.
+        # has that issue. The check only applies to templates with `{% generation %}` markers (matched with their
+        # whitespace-trim variants); without them the assistant mask is empty and the check is meaningless.
         chat_template = self.chat_template or self.tokenizer.chat_template
-        if "{% generation %}" in chat_template and not is_chat_template_stop_token_trained(
+        if re.search(r"\{%-?\s*generation\s*-?%\}", chat_template) and not is_chat_template_stop_token_trained(
             self.tokenizer, chat_template=chat_template
         ):
             logger.warning(

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -18,7 +18,6 @@ import multiprocessing as mp
 import os
 import pickle
 import queue
-import re
 import threading
 import time
 import traceback
@@ -38,6 +37,7 @@ from transformers import PreTrainedTokenizerBase
 from trl.chat_template_utils import (
     add_response_schema,
     get_training_chat_template,
+    has_generation_markers,
     is_chat_template_prefix_preserving,
     is_chat_template_stop_token_trained,
     parse_response,
@@ -260,11 +260,13 @@ class _AsyncRolloutLoop:
 
         # A prefix-preserving template can still attribute the assistant's end-of-turn token to the next message,
         # leaving it out of the loss mask so the model is never trained to stop. Warn if the template we resolved
-        # has that issue. The check only applies to templates with `{% generation %}` markers (matched with their
-        # whitespace-trim variants); without them the assistant mask is empty and the check is meaningless.
+        # has that issue. The check only applies to templates with `{% generation %}` markers; without them the
+        # assistant mask is empty and the check is meaningless.
         chat_template = self.chat_template or self.tokenizer.chat_template
-        if re.search(r"\{%-?\s*generation\s*-?%\}", chat_template) and not is_chat_template_stop_token_trained(
-            self.tokenizer, chat_template=chat_template
+        if (
+            chat_template
+            and has_generation_markers(chat_template)
+            and not is_chat_template_stop_token_trained(self.tokenizer, chat_template=chat_template)
         ):
             logger.warning(
                 "The chat template does not include the assistant turn's end-of-turn token in the loss mask; "

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -259,9 +259,11 @@ class _AsyncRolloutLoop:
 
         # A prefix-preserving template can still attribute the assistant's end-of-turn token to the next message,
         # leaving it out of the loss mask so the model is never trained to stop. Warn if the template we resolved
-        # has that issue.
-        if self.chat_template is not None and not is_chat_template_stop_token_trained(
-            self.tokenizer, chat_template=self.chat_template
+        # has that issue. The check only applies to templates with `{% generation %}` markers; without them the
+        # assistant mask is empty and the check is meaningless.
+        chat_template = self.chat_template or self.tokenizer.chat_template
+        if "{% generation %}" in chat_template and not is_chat_template_stop_token_trained(
+            self.tokenizer, chat_template=chat_template
         ):
             logger.warning(
                 "The chat template does not include the assistant turn's end-of-turn token in the loss mask; "

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -37,9 +37,7 @@ from transformers import PreTrainedTokenizerBase
 from trl.chat_template_utils import (
     add_response_schema,
     get_training_chat_template,
-    has_generation_markers,
     is_chat_template_prefix_preserving,
-    is_chat_template_stop_token_trained,
     parse_response,
 )
 from trl.import_utils import is_vllm_available
@@ -257,21 +255,6 @@ class _AsyncRolloutLoop:
             self.chat_template = get_training_chat_template(self.tokenizer)
         else:
             self.chat_template = None
-
-        # A prefix-preserving template can still attribute the assistant's end-of-turn token to the next message,
-        # leaving it out of the loss mask so the model is never trained to stop. Warn if the template we resolved
-        # has that issue. The check only applies to templates with `{% generation %}` markers; without them the
-        # assistant mask is empty and the check is meaningless.
-        chat_template = self.chat_template or self.tokenizer.chat_template
-        if (
-            chat_template
-            and has_generation_markers(chat_template)
-            and not is_chat_template_stop_token_trained(self.tokenizer, chat_template=chat_template)
-        ):
-            logger.warning(
-                "The chat template does not include the assistant turn's end-of-turn token in the loss mask; "
-                "the model may not learn to stop."
-            )
 
         self._groups_to_score: asyncio.Queue[RolloutGroup | None] = asyncio.Queue(maxsize=16)
         self._total_completion_tokens = 0

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -38,6 +38,7 @@ from trl.chat_template_utils import (
     add_response_schema,
     get_training_chat_template,
     is_chat_template_prefix_preserving,
+    is_chat_template_stop_token_trained,
     parse_response,
 )
 from trl.import_utils import is_vllm_available
@@ -255,6 +256,17 @@ class _AsyncRolloutLoop:
             self.chat_template = get_training_chat_template(self.tokenizer)
         else:
             self.chat_template = None
+
+        # A prefix-preserving template can still attribute the assistant's end-of-turn token to the next message,
+        # leaving it out of the loss mask so the model is never trained to stop. Warn if the template we resolved
+        # has that issue.
+        if self.chat_template is not None and not is_chat_template_stop_token_trained(
+            self.tokenizer, chat_template=self.chat_template
+        ):
+            logger.warning(
+                "The chat template does not include the assistant turn's end-of-turn token in the loss mask; "
+                "the model may not learn to stop."
+            )
 
         self._groups_to_score: asyncio.Queue[RolloutGroup | None] = asyncio.Queue(maxsize=16)
         self._total_completion_tokens = 0

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -47,7 +47,7 @@ from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
-from ..chat_template_utils import clone_chat_template, get_training_chat_template
+from ..chat_template_utils import clone_chat_template, get_training_chat_template, has_generation_markers
 from ..data_utils import (
     apply_chat_template,
     is_conversational,
@@ -1217,7 +1217,7 @@ class SFTTrainer(_BaseTrainer):
 
         # When assistant_only_loss is enabled, swap in a training chat template with {% generation %} markers
         # if the current template doesn't already have them.
-        if args.assistant_only_loss and "{% generation %}" not in processing_class.chat_template:
+        if args.assistant_only_loss and not has_generation_markers(processing_class.chat_template):
             self.chat_template = get_training_chat_template(processing_class)
         else:
             self.chat_template = None

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -47,7 +47,12 @@ from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
-from ..chat_template_utils import clone_chat_template, get_training_chat_template, has_generation_markers
+from ..chat_template_utils import (
+    clone_chat_template,
+    get_training_chat_template,
+    has_generation_markers,
+    is_chat_template_stop_token_trained,
+)
 from ..data_utils import (
     apply_chat_template,
     is_conversational,
@@ -1221,6 +1226,16 @@ class SFTTrainer(_BaseTrainer):
             self.chat_template = get_training_chat_template(processing_class)
         else:
             self.chat_template = None
+
+        # A template can define generation markers and still attribute the assistant's end-of-turn token to the next
+        # message, leaving it out of the assistant mask so the model is never trained to stop.
+        if args.assistant_only_loss and not is_chat_template_stop_token_trained(
+            processing_class, chat_template=self.chat_template
+        ):
+            logger.warning(
+                "The chat template does not include the assistant turn's end-of-turn token in the loss mask; "
+                "the model may not learn to stop."
+            )
 
         # Dataset
         if self.padding_free and not args.packing and args.max_length is not None and not self._is_vision_dataset:


### PR DESCRIPTION
A chat template can pass the prefix-preservation check and still attribute the assistant's end-of-turn token to the *following* message. With `assistant_only_loss=True` that token then falls outside the assistant mask, and the model never learns to stop. SFT runs fine, loss goes down, and the bug only shows up at inference as endless generations.

This PR adds a check for that property, gates the shipped training templates on it in CI, and fixes the one template the gate caught:

- `is_chat_template_stop_token_trained`: renders an assistant turn followed by a user message and checks that the assistant's masked span ends on an end-of-turn token (added vocab) rather than on content. Lives next to `is_chat_template_prefix_preserving`, same calling convention.
- A new test in `TestGetTrainingChatTemplate` runs the check against every supported family. It found a real case: GLM closes the assistant turn with the next role marker (`<|user|>`/`<|observation|>`), so the terminator was never trained.
- `glm4moe_training.jinja` is fixed accordingly: the following message's role marker is emitted inside the assistant's `{% generation %}` block (and suppressed at the start of the next message), so it lands in the loss mask. The rendered text is byte-identical to the original template, and prefix preservation still holds.
- Known processor limitations (Llava, Gemma3, Qwen2-VL, Qwen2.5-VL don't propagate the assistant tokens mask) are `xfail(strict=True)`: CI stays green today but flips red the moment something is fixed upstream, so the markers can't go stale.
- SFT now logs a warning when `assistant_only_loss=True` and the resolved template has this problem.

Related to #4879 (auto-adding `{% generation %}` tags): this is the complementary verification side. Once a template has generation markers, this checks they actually cover the stop token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT chat-template selection/warnings and alters GLM-4-MoE training template masking behavior; impact is limited to assistant-only loss and template patching paths, not general inference templates.
> 
> **Overview**
> Adds **`is_chat_template_stop_token_trained`** to verify that, with `assistant_only_loss`, the assistant’s end-of-turn token is inside the `{% generation %}` loss mask—not attributed to the next message (a failure mode that can cause endless generation at inference).
> 
> **`has_generation_markers`** replaces brittle `{% generation %}` string checks (including `{%- generation %}` variants) in `get_training_chat_template` and SFT setup.
> 
> **CI** gains unit tests plus a per-family check that shipped training templates pass the stop-token gate; **GLM-4-MoE** `glm4moe_training.jinja` is fixed so the following role marker is emitted inside the assistant generation block (rendered text unchanged). **SFT** logs a warning when `assistant_only_loss=True` and the resolved template still fails the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3275bfaa6969a610afa6a710d0e94b68794f31b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->