### PR TITLE
fix(docs): Fix rendering typos

### DIFF
--- a/docs/source/openenv.md
+++ b/docs/source/openenv.md
@@ -139,7 +139,7 @@ TRL's [`GRPOTrainer`] supports interactive environment training through the `env
 Your environment class must follow these rules:
 
 - **`__init__(self)`** *(optional)*: If provided, must take no arguments. Use it to initialize state or clients. If you need external configuration (e.g., a URL), capture it from the enclosing scope or module-level variables.
-- **`reset(self, **kwargs)`**: Called at the start of each episode. Receives all dataset columns as keyword arguments. Return a string observation (or `None` for no initial observation).
+- **`reset`**`(self, **kwargs)`: Called at the start of each episode. Receives all dataset columns as keyword arguments. Return a string observation (or `None` for no initial observation).
 - **Tool methods**: Any public method (not starting with `_`) other than `reset` is automatically exposed as a tool. Each tool method must have a docstring with `Args:` descriptions, since the trainer uses these to generate the tool schema for the model.
 
 ### Tips for environment classes

--- a/docs/source/openenv.md
+++ b/docs/source/openenv.md
@@ -138,8 +138,8 @@ TRL's [`GRPOTrainer`] supports interactive environment training through the `env
 
 Your environment class must follow these rules:
 
-- **`__init__(self)`** *(optional)*: If provided, must take no arguments. Use it to initialize state or clients. If you need external configuration (e.g., a URL), capture it from the enclosing scope or module-level variables.
-- **`reset`**`(self, **kwargs)`: Called at the start of each episode. Receives all dataset columns as keyword arguments. Return a string observation (or `None` for no initial observation).
+- `__init__(self)` *(optional)*: If provided, must take no arguments. Use it to initialize state or clients. If you need external configuration (e.g., a URL), capture it from the enclosing scope or module-level variables.
+- `reset(self, **kwargs)`: Called at the start of each episode. Receives all dataset columns as keyword arguments. Return a string observation (or `None` for no initial observation).
 - **Tool methods**: Any public method (not starting with `_`) other than `reset` is automatically exposed as a tool. Each tool method must have a docstring with `Args:` descriptions, since the trainer uses these to generate the tool schema for the model.
 
 ### Tips for environment classes

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -62,7 +62,7 @@ At each training step, we sample a batch of prompts and generate a set of  \\( G
 
 In RLOO, the reward consists of two components: the reward provided by the reward model (or reward function) and a KL penalty that discourages the policy from deviating too far from a fixed reference policy
 
-1. For each of the  \\( G \\) generated sequences  \\( o_i = (o_{i,1}, \dots, o_{i,T}) \\) conditioned on a query \\( q \\), we compute a scalar reward using a reward model  \\( R(o_i, q) \\).
+1. For each of the  \\( G \\) generated sequences  \\( o_i = (o_{i,1}, \dots, o_{i,T}) \\) conditioned on a query  \\( q \\), we compute a scalar reward using a reward model  \\( R(o_i, q) \\).
 2. Concurrently, we estimate the KL divergence between the current policy  \\( \pi_\theta \\) and the fixed reference policy  \\( \pi_{\text{ref}} \\) over the sequence. The KL estimate for sequence  \\( o_i \\) is:
 
 $$


### PR DESCRIPTION
# What does this PR do?

Fixes rendering issues in:
- RLOO Trainer docs by adding a whitespace before the math expression 
- In OpenEnv docs by pulling out `**` corresponding to boldface before the `**kwargs` which was escaping it and killing the rendering for the entire bulletpoint. 


## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting only; no runtime, API, or training behavior changes.
> 
> **Overview**
> Fixes **Markdown rendering** in two TRL docs pages without changing technical content.
> 
> In **OpenEnv** (`openenv.md`), the environment class requirement bullets for `__init__` and `reset` no longer use bold (`**`) around signatures that include `**kwargs`, which was breaking the list item. Those entries now use inline `` `code` `` formatting so the full bullet renders correctly.
> 
> In **RLOO Trainer** (`rloo_trainer.md`), a missing space before an inline math fragment (`\( q \)`) in the reward computation step is added so the LaTeX/math displays properly in the numbered list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b96f6e4a14994aa88139be782a366f76b7e393a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->