### PR TITLE
docs: sync SDFT/SDPO config docstrings with their fields

### DIFF
--- a/trl/experimental/sdft/sdft_config.py
+++ b/trl/experimental/sdft/sdft_config.py
@@ -122,6 +122,11 @@ class SDFTConfig(_BaseConfig):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, the trainer will use vLLM for generation
             instead of the default model.generate(). Requires `vllm` to be installed.
+        use_teacher_server (`bool`, *optional*, defaults to `False`):
+            Compute teacher logprobs from the running vLLM generation server instead of a local teacher forward. Only
+            supported for `teacher_model_kind='live'` with `use_vllm=True` and `vllm_mode='server'`, and
+            `distillation_mode` in {'sampled_token', 'topk_logits'} (the server returns the teacher's top-k logprobs,
+            not the full vocabulary; `topk_logits` distills over the teacher's own top-k support).
         vllm_mode (`str`, *optional*, defaults to `"colocate"`):
             Mode to use for vLLM integration when `use_vllm` is set to `True`. Must be one of `'server'` or
             `'colocate'`. `'server'`: The trainer will send generation requests to a separate vLLM server. Make sure a

--- a/trl/experimental/sdft/sdft_config.py
+++ b/trl/experimental/sdft/sdft_config.py
@@ -166,8 +166,6 @@ class SDFTConfig(_BaseConfig):
 
         > Parameters that control the training
 
-        loss_type (`str`, *optional*, defaults to `"grpo"`):
-            Policy loss aggregation. Supported: `grpo`, `bnpo`, `dr_grpo`, `dapo`.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
         generation_batch_size (`int`, *optional*):

--- a/trl/experimental/sdpo/sdpo_config.py
+++ b/trl/experimental/sdpo/sdpo_config.py
@@ -178,6 +178,12 @@ class SDPOConfig(_BaseConfig):
         use_vllm (`bool`, *optional*, defaults to `False`):
             Whether to use vLLM for generating completions. If set to `True`, the trainer will use vLLM for generation
             instead of the default model.generate(). Requires `vllm` to be installed.
+        use_teacher_server (`bool`, *optional*, defaults to `False`):
+            Compute teacher logprobs from the running vLLM generation server instead of a local teacher forward. Only
+            supported for `teacher_model_kind='live'` with `use_vllm=True`, `vllm_mode='server'`,
+            `distillation_weight=1.0` (pure distillation), and `distillation_mode` in {'sampled_token', 'topk_logits'}
+            (the server returns the teacher's top-k logprobs, not the full vocabulary; `topk_logits` distills over the
+            teacher's own top-k support).
         vllm_mode (`str`, *optional*, defaults to `"colocate"`):
             Mode to use for vLLM integration when `use_vllm` is set to `True`. Must be one of `'server'` or
             `'colocate'`. `'server'`: The trainer will send generation requests to a separate vLLM server. Make sure a


### PR DESCRIPTION
## What does this PR do?

Audits the SDFT/SDPO config docstrings against their actual fields and fixes two inconsistencies (both directions):

### 1. Missing entry: `use_teacher_server` (added in #5989) is absent from both docstrings

#5989 added the `use_teacher_server` field to `SDFTConfig` and `SDPOConfig` with field-level `help` text, but the class docstrings' parameter lists — which feed the auto-generated API docs — were not updated, so the new parameter doesn't show up there. Neighboring fields (`use_vllm`, `vllm_mode`, `teacher_model_kind`) all have both.

Added the missing entries, mirroring each config's own help wording (SDPO's keeps its extra `distillation_weight=1.0` requirement), placed between `use_vllm` and `vllm_mode` to match the field declaration order.

### 2. Ghost entry: `SDFTConfig` documents a `loss_type` parameter that doesn't exist

The SDFTConfig docstring documents `loss_type` ("Policy loss aggregation. Supported: `grpo`, `bnpo`, `dr_grpo`, `dapo`"), but no such field exists on `SDFTConfig`, its `_BaseConfig` parent, or anywhere in `sdft_trainer.py` — following the docs and passing `SDFTConfig(loss_type=...)` raises `TypeError`. The entry was carried over from `SDPOConfig`, where `loss_type` **is** a real field (SDPO aggregates a policy-style loss; SDFT does not). Dropped the stale entry; SDPOConfig is untouched.

Docstring-only; +11 / −2 lines, no behavior change.

## Before submitting

- [x] This PR improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A — docstring consistency fixes.)_
- [x] Did you make sure to update the documentation with your changes? _(This PR is the documentation change.)_
- [ ] Did you write any new necessary tests? _(N/A.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no runtime or training behavior impact.
> 
> **Overview**
> Documents **`use_teacher_server`** in the class docstrings for **`SDFTConfig`** and **`SDPOConfig`** so it appears in auto-generated API docs alongside the existing field `help` text from #5989. Each entry sits between **`use_vllm`** and **`vllm_mode`**, and spells out when teacher logprobs come from the vLLM server (live teacher, server mode, supported distillation modes; SDPO also notes **`distillation_weight=1.0`**).
> 
> **`SDFTConfig`** also drops a stale **`loss_type`** parameter blurb from the docstring that no longer matches the config fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba1c5e8f7adc4f9a53a8eebc015847cf69526ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->