### PR TITLE
Document bnb_4bit_quant_storage and normalize docstring param headers

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -186,10 +186,10 @@ class VLLMGeneration:
             Parameter for repetition penalty. It penalizes new tokens based on whether they appear in the prompt and
             the generated text so far. Values > 1 encourage the model to use new tokens, while values < 1 encourage the
             model to repeat tokens. Default `1.0` means no penalty.
-        temperature(`float`, *optional*, defaults to `1.0`):
+        temperature (`float`, *optional*, defaults to `1.0`):
             Sampling temperature. It controls the randomness of the sampling. Lower values make the model more
             deterministic, while higher values make the model more random and increase diversity.
-        top_p: (`float`, *optional*, defaults to `1.0`):
+        top_p (`float`, *optional*, defaults to `1.0`):
             Top-p sampling parameter. It controls the cumulative probability of the top tokens to consider. Defaults to
             `1.0` to consider all tokens.
         top_k (`int`, *optional*, defaults to `0`):

--- a/trl/rewards/accuracy_rewards.py
+++ b/trl/rewards/accuracy_rewards.py
@@ -39,7 +39,7 @@ def accuracy_reward(
         completions (`list[list[dict[str, str]]]`):
             List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
             containing the key `"content"` with the value being the text of the completion.
-        solution: (`list[str]`):
+        solution (`list[str]`):
             List of the raw-text solutions to the questions/problems/prompts.
         log_extra (`callable`, *optional*):
             Callable to log extra columns to the completions table, provided automatically by the trainer. Defaults to
@@ -130,7 +130,7 @@ def reasoning_accuracy_reward(
         completions (`list[list[dict[str, str]]]`):
             List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
             containing the key `"content"` with the value being the text of the completion.
-        solution: (`list[str]`):
+        solution (`list[str]`):
             List of the raw-text solutions to the questions/problems/prompts.
         reasoning_delimiters (`list[str]]`, *optional*):
             List of strings indicating where the reasoning content ends. The final answer is assumed to be after the

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -73,11 +73,11 @@ class GRPOConfig(_BaseConfig):
 
         > Parameters that control generation
 
-        generation_batch_size: (`int`, *optional*):
+        generation_batch_size (`int`, *optional*):
             Batch size to use for generation. If `None`, it defaults to the effective training batch size:
             `per_device_train_batch_size * num_processes * steps_per_generation`. In other words, there is one
             generation batch processed per optimization step. Mutually exclusive with `steps_per_generation`.
-        steps_per_generation: (`int`, *optional*):
+        steps_per_generation (`int`, *optional*):
             Number of steps per generation. If `None`, it defaults to `gradient_accumulation_steps`. Mutually exclusive
             with `generation_batch_size`.
         temperature (`float`, defaults to `1.0`):

--- a/trl/trainer/model_config.py
+++ b/trl/trainer/model_config.py
@@ -78,6 +78,8 @@ class ModelConfig:
             Quantization type (`"fp4"` or `"nf4"`).
         use_bnb_nested_quant (`bool`, *optional*, defaults to `False`):
             Whether to use nested quantization.
+        bnb_4bit_quant_storage (`str`, *optional*):
+            Quantization storage dtype.
     """
 
     model_name_or_path: str | None = field(

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -68,11 +68,11 @@ class RLOOConfig(_BaseConfig):
 
         > Parameters that control generation
 
-        generation_batch_size: (`int`, *optional*):
+        generation_batch_size (`int`, *optional*):
             Batch size to use for generation. If `None`, it defaults to the effective training batch size:
             `per_device_train_batch_size * num_processes * steps_per_generation`. In other words, there is one
             generation batch processed per optimization step. Mutually exclusive with `steps_per_generation`.
-        steps_per_generation: (`int`, *optional*):
+        steps_per_generation (`int`, *optional*):
             Number of steps per generation. If `None`, it defaults to `gradient_accumulation_steps`. Mutually exclusive
             with `generation_batch_size`.
         temperature (`float`, defaults to `1.0`):


### PR DESCRIPTION
# What does this PR do?

Two small docstring corrections:

1. **`ModelConfig` is missing `bnb_4bit_quant_storage` in its class docstring.** The field exists (`bnb_4bit_quant_storage: str | None = field(default=None, ...)`) and all 19 sibling fields are documented, but this one was never added — so it doesn't appear in the rendered API docs (autodoc renders the class docstring). Added the entry, worded from the field's own `help` metadata.

2. **Normalize 8 param headers that deviate from the repository docstring format** (`name (`type`...):`):
   - stray colon after the param name (`name: (`type`)`) — `generation_batch_size` / `steps_per_generation` in `GRPOConfig` and `RLOOConfig`, `top_p` in `VLLMGeneration.generate`, `solution` in `accuracy_reward` and `reasoning_accuracy_reward`;
   - missing space (`temperature(`float``) in `VLLMGeneration.generate`.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring formatting only; no runtime, training, or API behavior changes.
> 
> **Overview**
> **Documents `bnb_4bit_quant_storage` on `ModelConfig`** so the existing dataclass field shows up in autodoc-rendered API docs alongside the other bitsandbytes options.
> 
> **Normalizes eight `Args` / class-doc parameter lines** to the repo convention `name (`type`, ...):` — fixes stray colons after names (`generation_batch_size`, `steps_per_generation` in `GRPOConfig` and `RLOOConfig`; `solution` in `accuracy_reward` / `reasoning_accuracy_reward`; `top_p` in `VLLMGeneration`) and adds the missing space before `(` for `temperature` in `VLLMGeneration`. No code or default behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac89dca6c208c396a3480edaa30095ef2a5d29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->