### PR TITLE
Add missing use_liger_kernel guard to SDPO teacher-server validation

### DIFF
--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -482,6 +482,11 @@ class SDPOTrainer(_BaseTrainer):
                     "vocabulary, so `full_logits` is unavailable. Note `topk_logits` distills over the teacher's own "
                     "top-k support (the server cannot score the student's top-k indices)."
                 )
+            if args.use_liger_kernel:
+                raise ValueError(
+                    "`use_teacher_server=True` is incompatible with `use_liger_kernel`: the server returns top-k "
+                    "logprobs while the Liger fused loss needs full-vocabulary hidden states."
+                )
         # Liger fused JSD loss for `full_logits`: same generalized JSD as `compute_divergence`, so alpha maps to beta.
         self.use_liger_loss = False
         if args.use_liger_kernel:


### PR DESCRIPTION
# What does this PR do?

#5989 added the `use_teacher_server` validation block to both SDFT and SDPO, but only **SDFT** got the `use_liger_kernel` incompatibility guard ([`sdft_trainer.py#L367-L371`](https://github.com/huggingface/trl/blob/main/trl/experimental/sdft/sdft_trainer.py#L367-L371)). The SDPO block validates server mode / live teacher / `distillation_weight` / `distillation_mode`, but is missing the Liger check — even though the SDPO docs added in the same PR state:

> - `use_liger_kernel` is not supported

**Impact without the guard:** `SDPOConfig(use_teacher_server=True, use_liger_kernel=True, distillation_mode="sampled_token", ...)` passes teacher-server validation and then fails in the later Liger block with *"`use_liger_kernel` only supports `distillation_mode='full_logits'`"* — while the teacher-server block forbids `full_logits` (*"the server returns the teacher's top-k logprobs... `full_logits` is unavailable"*). The two errors point in opposite directions; the accurate message (the combination is fundamentally incompatible) is the one SDFT already raises.

**Fix:** mirror SDFT's guard word-for-word into SDPO's `use_teacher_server` block, keeping the duplicated trainer copies aligned.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? (Docs already document the constraint — this aligns the code with them.)
- [ ] Did you write any new necessary tests? (Matches SDFT, whose guard is likewise enforced in `__init__`; kept the copies symmetric.)

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@kashif @LeonEricsson (authors of #5989)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time config validation only; no training or loss-path behavior changes for valid configs.
> 
> **Overview**
> Adds **`use_liger_kernel` validation** inside SDPO’s existing `use_teacher_server` config checks in `sdpo_trainer.py`, matching SDFT.
> 
> When both `use_teacher_server=True` and `use_liger_kernel=True`, **`__init__` now raises immediately** with a clear incompatibility message (teacher server only exposes top-k logprobs; Liger needs full-vocabulary hidden states). That avoids a later, misleading error from the separate Liger block requiring `distillation_mode='full_logits'`, which teacher-server mode cannot satisfy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b726c29bc5408aaa9e46f9555e27c2bb4f3c3031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->