### PR TITLE
docs: sync Distillation/GOLD/OnlineDPO config docstrings with their fields

### DIFF
--- a/trl/experimental/distillation/distillation_config.py
+++ b/trl/experimental/distillation/distillation_config.py
@@ -60,6 +60,9 @@ class DistillationConfig(_BaseConfig):
             `beta == 0` or `loss_top_k != 1`.
         max_completion_length (`int`, *optional*, defaults to `512`):
             Maximum number of tokens to generate per completion during on-policy generation.
+        max_prompt_length (`int` or `None`, *optional*):
+            Maximum number of tokens for the prompt. If `None`, auto-computed as `max_length - max_completion_length`.
+            Prompts are truncated according to the tokenizer's `truncation_side` setting.
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the student model during training.
 
@@ -135,6 +138,12 @@ class DistillationConfig(_BaseConfig):
 
         > Parameters that control logging
 
+        wandb_entity (`str` or `None`, *optional*):
+            The W&B entity to store runs under.
+        wandb_project (`str` or `None`, *optional*):
+            The W&B project to store runs under.
+        wandb_run_group (`str` or `None`, *optional*):
+            The W&B group to store runs under.
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `log_completions_steps` steps. If `rich` is
             installed, it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb`

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -33,6 +33,12 @@ class GOLDConfig(SFTConfig):
 
         temperature (`float`, *optional*, defaults to `0.9`):
             Temperature for sampling. The higher the temperature, the more random the completions.
+        top_p (`float`, *optional*, defaults to `0.95`):
+            If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
+            `top_p` or higher are kept for generation.
+        top_k (`int`, *optional*, defaults to `0`):
+            Number of highest probability vocabulary tokens to keep for top-k-filtering. If `0`, top-k-filtering is
+            disabled and all tokens are considered.
         lmbda (`float`, *optional*, defaults to `0.5`):
             Lambda parameter that controls the student data fraction (i.e., the proportion of on-policy
             student-generated outputs).
@@ -68,6 +74,24 @@ class GOLDConfig(SFTConfig):
         use_uld_loss (`bool`, *optional*, defaults to `False`):
             Whether to use Universal Logit Distillation (ULD) loss instead of Generalized Jensen-Shannon Divergence
             loss.
+        use_extended_uld (`bool`, *optional*, defaults to `True`):
+            Whether to enable extended ULD alignment that uses tokenizers to align and merge token probabilities
+            across student and teacher tokenizations. When `True`, the trainer will compute token mappings and merge
+            probabilities for split tokens; when `False`, ULD will use simple positional truncation like in the
+            original ULD paper.
+        uld_use_hybrid_loss (`bool`, *optional*, defaults to `False`):
+            Whether to use a hybrid loss that combines ULD loss and JSD loss. When `True`, the final loss is a
+            combination of JSD for known token mappings and ULD for unknown token mappings.
+        uld_hybrid_matched_weight (`float` or `None`, *optional*):
+            Weight for the matched token loss component when using hybrid ULD + JSD loss. This weight scales the JSD
+            loss computed over tokens that have a direct mapping between student and teacher tokenizations. If `None`,
+            uses adaptive weighting based on vocabulary overlap. Must be set together with
+            `uld_hybrid_unmatched_weight` (both `None` or both `float`).
+        uld_hybrid_unmatched_weight (`float` or `None`, *optional*):
+            Weight for the unmatched token loss component when using hybrid ULD + JSD loss. This weight scales the ULD
+            loss computed over tokens that do not have a direct mapping between student and teacher tokenizations. If
+            `None`, uses adaptive weighting based on vocabulary overlap. Must be set together with
+            `uld_hybrid_matched_weight` (both `None` or both `float`).
         uld_crossentropy_weight (`float`, *optional*, defaults to `0.0`):
             Weight for the cross-entropy loss component in ULD loss. If 0, only ULD distillation loss is used.
         uld_distillation_weight (`float`, *optional*, defaults to `1.0`):
@@ -117,6 +141,33 @@ class GOLDConfig(SFTConfig):
         vllm_enable_sleep_mode (`bool`, *optional*, defaults to `False`):
             Enable vLLM sleep mode to offload student weights/cache during the optimizer step. Keeps GPU memory usage
             low, but waking the engine adds host–device transfer latency.
+
+        > Parameters that control logging
+
+        log_completions (`bool`, *optional*, defaults to `False`):
+            Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
+            it prints the sample. If `wandb` logging is enabled, it logs it to `wandb`.
+        log_completions_steps (`int`, *optional*, defaults to `100`):
+            Number of steps between logging (prompt, completion) pairs. Only used if `log_completions` is set to
+            `True`.
+        num_completions_to_print (`int` or `None`, *optional*):
+            Number of completions to print with `rich`. If `None`, all completions are logged.
+        wandb_entity (`str` or `None`, *optional*):
+            The entity to store runs under.
+        wandb_project (`str` or `None`, *optional*):
+            The project to store runs under.
+        wandb_run_group (`str` or `None`, *optional*):
+            The group to store runs under.
+        wandb_log_unique_prompts (`bool`, *optional*, defaults to `True`):
+            Whether to log the unique prompts to wandb. This will create a new run for each unique prompt.
+        callbacks (`list[str]`, *optional*, defaults to `[]`):
+            The callbacks to run during training.
+        hub_model_revision (`str` or `None`, *optional*, defaults to `"main"`):
+            The Hub model branch to push the model to.
+        overwrite_hub_revision (`bool`, *optional*, defaults to `False`):
+            Whether to overwrite the Hub revision.
+        push_to_hub_revision (`bool`, *optional*, defaults to `False`):
+            Whether to push to a Hub revision/branch.
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -144,6 +144,9 @@ class OnlineDPOConfig(_BaseConfig):
         model_init_kwargs (`dict[str, Any]`, *optional*):
             Keyword arguments to pass to `AutoModelForCausalLM.from_pretrained` when instantiating the model from a
             string.
+        reward_weights (`list[float]`, *optional*):
+            Weights for combining multiple reward functions. Must match the number of reward functions. If `None`, all
+            reward functions are equally weighted.
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:


### PR DESCRIPTION
# What does this PR do?

Follow-up to #5992 (which did the same sync for SDFT/SDPO): 22 fields exist on three experimental configs but are absent from their class docstrings, so they don't appear in the rendered API docs (autodoc renders the class docstring):

- **`DistillationConfig`** — `max_prompt_length`, `wandb_entity`, `wandb_project`, `wandb_run_group`
- **`GOLDConfig`** — `top_p`, `top_k`, `use_extended_uld`, `uld_use_hybrid_loss`, `uld_hybrid_matched_weight`, `uld_hybrid_unmatched_weight`, `log_completions`, `log_completions_steps`, `num_completions_to_print`, `wandb_entity`, `wandb_project`, `wandb_run_group`, `wandb_log_unique_prompts`, `callbacks`, `hub_model_revision`, `overwrite_hub_revision`, `push_to_hub_revision`
- **`OnlineDPOConfig`** — `reward_weights`

Each new entry is worded from the field's own `help` metadata, placed to mirror the field order, and follows the repository docstring format. GOLD's logging/Hub entries sit under a new `> Parameters that control logging` header, matching the header convention already used in the file and in `DistillationConfig`.

Docs-only; no behavior changes.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to class docstrings; no code paths, defaults, or validation logic change.
> 
> **Overview**
> Brings **DistillationConfig**, **GOLDConfig**, and **OnlineDPOConfig** class docstrings in line with their existing dataclass fields so autodoc shows the full API (same follow-up pattern as #5992 for SDFT/SDPO).
> 
> **DistillationConfig** gains `max_prompt_length` under generation/distillation and `wandb_entity`, `wandb_project`, `wandb_run_group` under the logging section. **GOLDConfig** documents `top_p` / `top_k`, extended ULD and hybrid ULD weights, plus a new **Parameters that control logging** block (completions logging, W&B, callbacks, Hub revision flags). **OnlineDPOConfig** documents `reward_weights` under other parameters. Wording is taken from each field’s `help` metadata; no runtime or default changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4cbf5b898dfe7d3de6f2f603458781f4cf02f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->