### PR TITLE
Align KTO with DPO: Remove unused use_dpo_data_collator attribute

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -563,16 +563,12 @@ class KTOTrainer(_BaseTrainer):
                 pad_token_id=self._tokenizer.pad_token_id,
                 max_length=args.max_length,
             )
-            self.use_dpo_data_collator = True
         elif data_collator is None and self._is_vision_dataset:
             data_collator = DataCollatorForVisionUnpairedPreference(
                 processor=processing_class,
                 max_length=args.max_length,
                 calculate_kl=calculate_kl,
             )
-            self.use_dpo_data_collator = True
-        else:
-            self.use_dpo_data_collator = False
 
         # Training arguments
         self.beta = args.beta


### PR DESCRIPTION
Align KTO with DPO: Remove unused `use_dpo_data_collator` attribute.

This PR simplifies the initialization logic in the `KTOTrainer` class by removing the `self.use_dpo_data_collator` attribute and its assignments. This makes the code cleaner and easier to maintain.

Part of:
- #4786

### Changes

Trainer initialization simplification:

* Removed the `self.use_dpo_data_collator` attribute and related assignments from the `__init__` method in `kto_trainer.py`, as it is no longer needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; no changes to collator logic or training behavior.
> 
> **Overview**
> Removes the unused **`self.use_dpo_data_collator`** flag from **`KTOTrainer.__init__`**, including the assignments when the default text or vision unpaired collators are chosen and the **`else`** branch that set it to **`False`** for custom collators.
> 
> Default collator selection (**`DataCollatorForUnpairedPreference`** / **`DataCollatorForVisionUnpairedPreference`**) is unchanged; this is cleanup to match **DPO** and the broader alignment in #4786.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c7f2d2b0597819a7d8360f0c7409cf1cb98b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->