### PR TITLE
Announce upcoming SFT `loss_type` default change from `'nll'` to `'chunked_nll'`

### DIFF
--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -99,8 +99,13 @@ class SFTConfig(_BaseConfig):
             on the assistant responses, which is supported only for [conversational](#conversational) datasets. If
             `False`, loss is computed on the entire sequence.
         loss_type (`str`, *optional*, defaults to `"nll"`):
-            Type of loss to use. Defaults to `"nll"`. This default will change to `"chunked_nll"` in TRL 1.7. Possible
-            values are:
+            Type of loss to use. Possible values are:
+
+            <Deprecated version="1.6.0">
+
+            The default value of `loss_type` will change from `"nll"` to `"chunked_nll"` in TRL 1.7.
+
+            </Deprecated>
 
             - `"nll"`: standard negative log-likelihood (default).
             - `"dft"`: Dynamic Fine-Tuning, as described in
@@ -266,7 +271,7 @@ class SFTConfig(_BaseConfig):
         default=None,
         metadata={
             "help": "Type of loss to use. Defaults to `'nll'`. This default will change to `'chunked_nll'` in TRL "
-            "1.6. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
+            "1.7. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
             "(Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), and `'chunked_nll'` (same math as "
             "`'nll'`, but the `lm_head` projection is computed on non-ignored tokens only and the cross-entropy is "
             "processed in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`. "
@@ -295,7 +300,8 @@ class SFTConfig(_BaseConfig):
                 "this is transparent (same math, lower memory) and no action is needed — you'll get the new default "
                 "automatically on upgrade. If you use a custom model, check ahead of time that "
                 "`loss_type='chunked_nll'` runs and yields the same loss as `'nll'`; if it doesn't, pin "
-                "`loss_type='nll'` to keep the current behavior.",
+                "`loss_type='nll'` to keep the current behavior and please open an issue at "
+                "https://github.com/huggingface/trl/issues so we can address the edge case.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -98,7 +98,7 @@ class SFTConfig(_BaseConfig):
             Whether to compute loss only on the assistant part of the sequence. If set to `True`, loss is computed only
             on the assistant responses, which is supported only for [conversational](#conversational) datasets. If
             `False`, loss is computed on the entire sequence.
-        loss_type (`str`, *optional*):
+        loss_type (`str`, *optional*, defaults to `"nll"`):
             Type of loss to use. Defaults to `"nll"`. This default will change to `"chunked_nll"` in TRL 1.7. Possible
             values are:
 

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -291,9 +291,11 @@ class SFTConfig(_BaseConfig):
         super().__post_init__()
         if self.loss_type is None:
             warnings.warn(
-                "The default `loss_type` will change from `'nll'` to `'chunked_nll'` in TRL 1.7. To keep the current "
-                "behavior, set `loss_type='nll'`. Otherwise no action is needed — you'll get the new default "
-                "automatically on upgrade.",
+                "The default `loss_type` will change from `'nll'` to `'chunked_nll'` in TRL 1.7. For standard models "
+                "this is transparent (same math, lower memory) and no action is needed — you'll get the new default "
+                "automatically on upgrade. If you use a custom model, check ahead of time that "
+                "`loss_type='chunked_nll'` runs and yields the same loss as `'nll'`; if it doesn't, pin "
+                "`loss_type='nll'` to keep the current behavior.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -98,8 +98,9 @@ class SFTConfig(_BaseConfig):
             Whether to compute loss only on the assistant part of the sequence. If set to `True`, loss is computed only
             on the assistant responses, which is supported only for [conversational](#conversational) datasets. If
             `False`, loss is computed on the entire sequence.
-        loss_type (`str`, *optional*, defaults to `"nll"`):
-            Type of loss to use. Possible values are:
+        loss_type (`str`, *optional*):
+            Type of loss to use. Defaults to `"nll"`. This default will change to `"chunked_nll"` in TRL 1.7. Possible
+            values are:
 
             - `"nll"`: standard negative log-likelihood (default).
             - `"dft"`: Dynamic Fine-Tuning, as described in
@@ -261,10 +262,11 @@ class SFTConfig(_BaseConfig):
             )
         },
     )
-    loss_type: str = field(
-        default="nll",
+    loss_type: str | None = field(
+        default=None,
         metadata={
-            "help": "Type of loss to use. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
+            "help": "Type of loss to use. Defaults to `'nll'`. This default will change to `'chunked_nll'` in TRL "
+            "1.6. Possible values are `'nll'` (negative log-likelihood, default), `'dft'` "
             "(Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), and `'chunked_nll'` (same math as "
             "`'nll'`, but the `lm_head` projection is computed on non-ignored tokens only and the cross-entropy is "
             "processed in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`. "
@@ -287,6 +289,15 @@ class SFTConfig(_BaseConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.loss_type is None:
+            warnings.warn(
+                "The default `loss_type` will change from `'nll'` to `'chunked_nll'` in TRL 1.7. To keep the current "
+                "behavior, set `loss_type='nll'`. Otherwise no action is needed — you'll get the new default "
+                "automatically on upgrade.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            self.loss_type = "nll"
         if self.pad_token is not None:
             warnings.warn(
                 "`pad_token` is deprecated and will be removed in v2.0.0. "


### PR DESCRIPTION
The default `SFTConfig.loss_type` will change from `"nll"` to `"chunked_nll"` in TRL 1.7 (https://github.com/huggingface/trl/pull/5846)

This PR adds a `FutureWarning` (shipping in 1.6) when `loss_type` is left unset. No behavior change yet, the default still resolves to `"nll"`.
The warning tells users no action is needed (they'll get the new default automatically on upgrade) unless they want to pin the current behavior with `loss_type="nll"` (which can be necessary for custom models)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and deprecation warning only; effective default remains `nll` until TRL 1.7.
> 
> **Overview**
> Prepares for TRL 1.7 by **announcing** that `SFTConfig.loss_type` will default to `"chunked_nll"` instead of `"nll"`.
> 
> `loss_type` now defaults to `None` in the dataclass; `__post_init__` still sets it to `"nll"` when unset, but emits a **`FutureWarning`** explaining the upcoming change and when to pin `loss_type="nll"` (e.g. custom models). Docs and field help text add a **Deprecated** note (1.6.0) and mention the future default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c874456fe3ef34cc26e2877667789ffd4c87fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->