### PR TITLE
Align KTO with DPO: Rename kto_loss_fn to liger_loss_fn

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -705,7 +705,7 @@ class KTOTrainer(_BaseTrainer):
                 raise ValueError(
                     "You cannot use `use_liger_kernel=True` with Peft models. Please set `use_liger_kernel=False`."
                 )
-            self.kto_loss_fn = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
+            self.liger_loss_fn = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
 
         if self.precompute_ref_logps:
             if isinstance(self.train_dataset, IterableDataset) or isinstance(
@@ -1234,7 +1234,7 @@ class KTOTrainer(_BaseTrainer):
                 chosen_rewards_sum,
                 rejected_rewards_sum,
             ),
-        ) = self.kto_loss_fn(
+        ) = self.liger_loss_fn(
             _input=outputs.last_hidden_state[:, :-1],
             lin_weight=lm_head.weight,
             target=target,


### PR DESCRIPTION
Align KTO with DPO: Rename `kto_loss_fn` to `liger_loss_fn`.

This PR renames the instance variable `self.kto_loss_fn` to `self.liger_loss_fn` throughout the code. This improves code clarity by aligning the variable name with its actual usage and the type of loss function being used.

Part of:
- #4786

### Changes

- Renamed `self.kto_loss_fn` to `self.liger_loss_fn` in the class initialization and in the `_compute_loss_liger` method to better reflect the use of the `LigerFusedLinearKTOLoss` class. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only rename in the Liger KTO path; no logic or API surface changes.
> 
> **Overview**
> Renames the Liger-kernel loss handle on **`KTOTrainer`** from `self.kto_loss_fn` to **`self.liger_loss_fn`**, matching **`DPOTrainer`** and the fact that the object is a `LigerFusedLinearKTOLoss` instance.
> 
> The rename applies where the fused loss is constructed when `use_liger_kernel=True`, and where **`_compute_loss_liger`** invokes it. Training behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e280816bbbe560e829929815562a00deed47f815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->