### PR TITLE
Hide DeepSpeed/FSDP distributed backend boilerplate

### DIFF
--- a/trl/distributed.py
+++ b/trl/distributed.py
@@ -1,0 +1,91 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed training backend abstraction."""
+
+from contextlib import contextmanager
+
+
+class DistributedBackend:
+    """Abstracts distributed backend specifics (DeepSpeed ZeRO, FSDP) behind a uniform API.
+
+    Detects the active backend once at construction from ``accelerator.state``, then provides context managers that are
+    no-ops on backends where the operation is not needed.
+
+    Args:
+        accelerator ([`~accelerate.Accelerator`]):
+            The accelerator instance managing the distributed state.
+
+    Example:
+
+    ```python
+    >>> dist = DistributedBackend(accelerator)
+    >>> with dist.gather_params(list(model.parameters())):
+    ...     model.merge_adapter()
+    >>> with dist.summon_full_params(model, recurse=False):
+    ...     outputs = model.generate(inputs)
+    ```
+    """
+
+    def __init__(self, accelerator):
+        ds_plugin = accelerator.state.deepspeed_plugin
+        fsdp_plugin = getattr(accelerator.state, "fsdp_plugin", None)
+        self.zero_stage = ds_plugin.zero_stage if ds_plugin else 0
+        self.fsdp_version = getattr(fsdp_plugin, "fsdp_version", None) if fsdp_plugin else None
+
+    @property
+    def is_zero3(self) -> bool:
+        """Whether DeepSpeed ZeRO Stage 3 is active."""
+        return self.zero_stage == 3
+
+    @property
+    def is_fsdp(self) -> bool:
+        """Whether FSDP (any version) is active."""
+        return self.fsdp_version is not None
+
+    @contextmanager
+    def gather_params(self, params):
+        """Gather sharded parameters under DeepSpeed ZeRO-3; no-op otherwise.
+
+        Args:
+            params (iterable of `torch.nn.Parameter`):
+                Parameters to gather.
+        """
+        if self.is_zero3:
+            import deepspeed
+
+            with deepspeed.zero.GatheredParameters(params):
+                yield
+        else:
+            yield
+
+    @contextmanager
+    def summon_full_params(self, module, **kwargs):
+        """Materialize full FSDP v1 parameters; no-op for FSDP v2 or non-FSDP backends.
+
+        FSDP v2 parameters are always accessible and require no explicit materialization.
+
+        Args:
+            module (`torch.nn.Module`):
+                The FSDP-wrapped module.
+            **kwargs:
+                Forwarded to ``FSDP.summon_full_params`` (e.g. ``recurse``, ``writeback``).
+        """
+        if self.fsdp_version == 1:
+            from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+            with FSDP.summon_full_params(module, **kwargs):
+                yield
+        else:
+            yield

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -618,7 +618,6 @@ class DistillationTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 mode=args.vllm_mode,
                 structured_outputs_regex=args.vllm_structured_outputs_regex,

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -913,7 +913,6 @@ class GOLDTrainer(SFTTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 mode=args.vllm_mode,
                 structured_outputs_regex=args.vllm_structured_outputs_regex,

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -418,7 +418,6 @@ class SDFTTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 mode=args.vllm_mode,
                 server_base_url=args.vllm_server_base_url,

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -547,7 +547,6 @@ class SDPOTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 mode=args.vllm_mode,
                 server_base_url=args.vllm_server_base_url,

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -229,7 +229,6 @@ class SSDTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 mode=args.vllm_mode,
                 server_base_url=args.vllm_server_base_url,

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -434,6 +434,13 @@ class VLLMGeneration:
                 llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
                 llm_model.load_weights([(name, param)])
 
+    def _sync_fsdp_params_to_vllm(self, model: nn.Module):
+        """Dispatch FSDP weight sync to the version-appropriate method."""
+        if self._dist.fsdp_version == 1:
+            self._sync_fsdp1_params_to_vllm(model)
+        elif self._dist.fsdp_version == 2:
+            self._sync_fsdp2_params_to_vllm(model)
+
     def sync_weights(self):
         """Synchronize model weights to vLLM.
 

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -32,6 +32,7 @@ from transformers.utils import (
     is_torch_xpu_available,
 )
 
+from ..distributed import DistributedBackend
 from ..extras.profiling import ProfilingContext
 from ..import_utils import is_vllm_available
 from ..trainer.utils import ensure_master_addr_port
@@ -118,8 +119,6 @@ class VLLMGeneration:
             Model to use for generation.
         accelerator ([`~accelerate.Accelerator`]):
             Accelerator for distributed training.
-        is_fsdp_enabled (`bool`):
-            Whether FSDP is enabled.
         processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
             Tokenizer or processor for the model.
 
@@ -224,7 +223,6 @@ class VLLMGeneration:
         self,
         model: "PreTrainedModel | PeftModel",
         accelerator: "Accelerator",
-        is_fsdp_enabled: bool,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         # vLLM configuration
         mode: str = "colocate",
@@ -254,7 +252,7 @@ class VLLMGeneration:
     ):
         self.model = model
         self.accelerator = accelerator
-        self.is_fsdp_enabled = is_fsdp_enabled
+        self._dist = DistributedBackend(accelerator)
         self.processing_class = processing_class
 
         # vLLM configuration

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -455,35 +455,18 @@ class VLLMGeneration:
 
         model = self.model
         accelerator = self.accelerator
-        is_fsdp_enabled = self.is_fsdp_enabled
-
-        # For DeepSpeed ZeRO-3 and FSDP, we need to gather all parameters before operations
-        deepspeed_plugin = accelerator.state.deepspeed_plugin
-        zero_stage_3 = deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3
-        if zero_stage_3:
-            import deepspeed
-
-            gather_if_zero3 = deepspeed.zero.GatheredParameters
-        else:
-            gather_if_zero3 = nullcontext
 
         if is_peft_model(model):
             # With PEFT and FSDP/DeepSpeed ZeRO Stage 3, we must gather the full model at once before merging, as
             # merging adapters in a sharded manner is not supported.
             # TODO: does this work with FSDP?
-            with gather_if_zero3(list(model.parameters())):
+            with self._dist.gather_params(list(model.parameters())):
                 model.merge_adapter()
 
                 # Update vLLM weights while parameters are gathered
-                if is_fsdp_enabled:  # note if using FSDP, gather_if_zero3 is nullcontext
-                    # Update vLLM weights while parameters are gathered
+                if self._dist.is_fsdp:  # note if using FSDP, gather_params is a no-op
                     # For PEFT with FSDP we need to use the memory efficient post-order traversal
-                    fsdp_plugin = getattr(accelerator.state, "fsdp_plugin", None)
-                    fsdp_version = getattr(fsdp_plugin, "fsdp_version", 1) if fsdp_plugin else 1
-                    if fsdp_version == 1:
-                        self._sync_fsdp1_params_to_vllm(model)  # use memory-efficient post-order traversal for FSDP
-                    elif fsdp_version == 2:
-                        self._sync_fsdp2_params_to_vllm(model)
+                    self._sync_fsdp_params_to_vllm(model)
                 else:
                     # DeepSpeed ZeRO-3 with PEFT
                     for name, param in model.named_parameters():
@@ -507,17 +490,12 @@ class VLLMGeneration:
                 # Parameters will automatically be repartitioned when exiting the context
         else:
             # For non-PEFT models, simply gather (if needed) and update each parameter individually.
-            if is_fsdp_enabled:
-                fsdp_plugin = getattr(accelerator.state, "fsdp_plugin", None)
-                fsdp_version = getattr(fsdp_plugin, "fsdp_version", 1) if fsdp_plugin else 1
-                if fsdp_version == 1:
-                    self._sync_fsdp1_params_to_vllm(model)  # use memory-efficient post-order traversal for FSDP
-                elif fsdp_version == 2:
-                    self._sync_fsdp2_params_to_vllm(model)
+            if self._dist.is_fsdp:
+                self._sync_fsdp_params_to_vllm(model)
             else:
                 for name, param in model.named_parameters():
                     name = self._fix_param_name_to_vllm(name)
-                    with gather_if_zero3([param]):
+                    with self._dist.gather_params([param]):
                         if self.mode == "server" and accelerator.is_main_process:
                             self.vllm_client.update_named_param(name, param.data)
                         elif self.mode == "colocate":

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -134,7 +134,9 @@ def _unwrap_model_for_generation(
     is_gradient_checkpointing = unwrapped_model.is_gradient_checkpointing
     if is_gradient_checkpointing:
         unwrapped_model.gradient_checkpointing_disable()
-    if accelerator.state.deepspeed_plugin is not None and accelerator.state.deepspeed_plugin.zero_stage == 3:
+    from ..distributed import DistributedBackend
+
+    if DistributedBackend(accelerator).is_zero3:
         if not gather_deepspeed3_params:
             yield accelerator.unwrap_model(model)
         else:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -40,7 +40,6 @@ from datasets import Dataset, IterableDataset
 from huggingface_hub import CommitScheduler, DatasetCard, DatasetCardData, create_repo
 from packaging.version import Version
 from torch import nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.utils.data import Sampler
 from transformers import (
     AutoModelForSequenceClassification,
@@ -64,6 +63,7 @@ from ..chat_template_utils import (
     supports_tool_calling,
 )
 from ..data_utils import apply_chat_template, is_conversational, prepare_multimodal_messages
+from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
 from ..import_utils import is_jmespath_available, is_liger_kernel_available
@@ -821,6 +821,7 @@ class GRPOTrainer(_BaseTrainer):
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set
         # self.model_accepts_loss_kwargs to False to enable scaling.
         self.model_accepts_loss_kwargs = False
+        self._dist = DistributedBackend(self.accelerator)
 
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
@@ -1374,7 +1375,7 @@ class GRPOTrainer(_BaseTrainer):
                     self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
                 ) as unwrapped_model,
                 torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
+                self._dist.summon_full_params(self.model_wrapped, recurse=False),
             ):
                 # Cast to the appropriate dtype based on training configuration
                 if self.args.bf16:
@@ -1417,7 +1418,7 @@ class GRPOTrainer(_BaseTrainer):
                     generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model,
                 torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
+                self._dist.summon_full_params(self.model_wrapped, recurse=False),
             ):
                 prompt_completion_ids = unwrapped_model.generate(
                     **generate_inputs, generation_config=self.generation_config

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -767,7 +767,6 @@ class GRPOTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 # vLLM configuration
                 mode=args.vllm_mode,

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -21,7 +21,6 @@ import textwrap
 import time
 from collections import defaultdict, deque
 from collections.abc import Callable
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -35,7 +34,6 @@ from accelerate.utils import gather, gather_object, is_peft_model, set_seed
 from datasets import Dataset, IterableDataset
 from packaging.version import Version
 from torch import nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.utils.data import Sampler
 from transformers import (
     AutoModelForSequenceClassification,
@@ -52,6 +50,7 @@ from transformers import (
 from transformers.utils import is_peft_available, is_rich_available
 
 from ..data_utils import apply_chat_template, is_conversational, prepare_multimodal_messages
+from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
 from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
@@ -560,6 +559,7 @@ class RLOOTrainer(_BaseTrainer):
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set
         # self.model_accepts_loss_kwargs to False to enable scaling.
         self.model_accepts_loss_kwargs = False
+        self._dist = DistributedBackend(self.accelerator)
 
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
@@ -983,7 +983,7 @@ class RLOOTrainer(_BaseTrainer):
                     self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation
                 ) as unwrapped_model,
                 torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
+                self._dist.summon_full_params(self.model_wrapped, recurse=False),
             ):
                 # Cast to the appropriate dtype based on training configuration
                 if self.args.bf16:
@@ -1023,7 +1023,7 @@ class RLOOTrainer(_BaseTrainer):
                     generation_kwargs=self.generation_kwargs,  # Override model.generation_config with generation_kwargs to fix transformers#42762
                 ) as unwrapped_model,
                 torch.no_grad(),
-                FSDP.summon_full_params(self.model_wrapped, recurse=False) if self.is_fsdp_enabled else nullcontext(),
+                self._dist.summon_full_params(self.model_wrapped, recurse=False),
             ):
                 prompt_completion_ids = unwrapped_model.generate(
                     **generate_inputs, generation_config=self.generation_config

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -506,7 +506,6 @@ class RLOOTrainer(_BaseTrainer):
             self.vllm_generation = VLLMGeneration(
                 model=self.model,
                 accelerator=self.accelerator,
-                is_fsdp_enabled=self.is_fsdp_enabled,
                 processing_class=self.processing_class,
                 # vLLM configuration
                 mode=args.vllm_mode,


### PR DESCRIPTION
Hide DeepSpeed/FSDP distributed backend boilerplate-

This PR introduces a new `DistributedBackend` abstraction to unify and simplify how distributed training backends (DeepSpeed ZeRO and FSDP) are handled across the codebase. It replaces backend-specific logic with a consistent API, reducing code duplication and improving maintainability. The refactor also updates all trainer and generation classes to use this new abstraction, removing the need to explicitly pass or check FSDP/DeepSpeed settings.

Centralizing backend detection and dispatch also simplifies future deprecations: dropping support for FSDP v1, DeepSpeed, or any other distributed backend will require changes in one place rather than hunting down scattered conditionals across every trainer and generation path.

### Motivation

Scattered across `vllm_generation.py`, `models/utils.py`, and the main trainers, the same distributed-backend detection logic was repeated at every call site:
- ZeRO-3 detection → conditional deepspeed import → assign `gather_if_zero3 = GatheredParameters or nullcontext`
- `getattr(state, "fsdp_plugin", None)` → `getattr(plugin, "fsdp_version", 1)` → `if fsdp_version == 1 / elif fsdp_version == 2`
- `FSDP.summon_full_params(...) if self.is_fsdp_enabled else nullcontext()

### Solution

This PR introduces `trl/distributed.py` with a single `DistributedBackend` class that detects the active backend once at construction and exposes two context managers:
- `gather_params(params)` — `deepspeed.zero.GatheredParameters` under ZeRO-3, no-op otherwise
- `summon_full_params(module, **kwargs)` — `FSDP.summon_full_params` under FSDP v1, explicit
    no-op under FSDP v2 (whose parameters are always accessible) and non-FSDP backends

`VLLMGeneration` no longer takes `is_fsdp_enabled` as a constructor argument; it derives the backend from `accelerator.state` via `DistributedBackend`. A private `_sync_fsdp_params_to_vllm` helper consolidates the FSDP v1/v2 dispatch that was duplicated in both the PEFT and non-PEFT branches of `sync_weights`.

### Changes

Distributed training backend abstraction:

* Added a new `DistributedBackend` class in `trl/distributed.py` that abstracts DeepSpeed ZeRO and FSDP backend detection and provides unified context managers for parameter gathering and full parameter materialization.
* Updated `VLLMGeneration` and all trainer classes to use `DistributedBackend` for backend detection and parameter gathering, removing the need for `is_fsdp_enabled` and direct DeepSpeed/FSDP checks.

Code simplification and consistency:

* Removed redundant imports and logic related to FSDP and DeepSpeed from trainers and generation code, centralizing all distributed backend logic in `DistributedBackend`. 
* Refactored `sync_weights` and related methods in `VLLMGeneration` to use the new abstraction, ensuring correct parameter gathering and synchronization for both PEFT and non-PEFT models. 

Trainer and generation API changes:

* Updated all trainer and generation class initializations to remove the `is_fsdp_enabled` argument and instead instantiate and use `DistributedBackend`. 
* Changed context management for parameter gathering and full parameter access in generation and evaluation routines to use `DistributedBackend` context managers. 

These changes make distributed training support more robust and easier to extend in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect vLLM weight sync and generation under FSDP v1/v2 and ZeRO-3; behavior should match prior logic but mistakes in gather/summon could break distributed RL training.
> 
> **Overview**
> Introduces **`DistributedBackend`** in `trl/distributed.py` to detect DeepSpeed ZeRO stage and FSDP version from the accelerator once, and expose **`gather_params`** (ZeRO-3 gather, else no-op) and **`summon_full_params`** (FSDP v1 only; no-op for FSDP v2 and other backends).
> 
> **`VLLMGeneration`** drops the **`is_fsdp_enabled`** argument; it builds **`DistributedBackend`** internally and refactors **`sync_weights`** to use **`gather_params`** and a single **`_sync_fsdp_params_to_vllm`** dispatcher instead of duplicated ZeRO/FSDP branching. Experimental trainers that construct **`VLLMGeneration`** no longer pass FSDP flags.
> 
> **GRPO** and **RLOO** store **`self._dist`** and replace inline **`FSDP.summon_full_params` / `nullcontext`** checks with **`self._dist.summon_full_params`** during transformers generation. **`unwrap_model_for_generation`** in **`models/utils.py`** uses **`DistributedBackend(accelerator).is_zero3`** instead of reading the DeepSpeed plugin directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c55187c5bb39967807974b076cdbbd1ddb4448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->