### PR TITLE
vLLM adapter-only LoRA sync: zero-config auto-detect for all VLLMGeneration trainers, server + colocate

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -428,3 +428,57 @@ training_args = RLOOConfig(
 
 > [!WARNING]
 > To reduce GPU memory usage when running vLLM, consider [enabling vLLM sleep mode](reducing_memory_usage#vllm-sleep-mode).
+
+### Faster weight sync for LoRA training
+
+When you train a [PEFT](peft_integration) LoRA model, TRL syncs only the small LoRA adapter to vLLM each step instead of merging and transferring the full model weights. This is much faster — only a few megabytes move per step — and it activates **automatically**, with no configuration flag, whenever vLLM is set up to serve LoRA adapters. If the requirement isn't met, TRL transparently falls back to merging and syncing the full weights.
+
+<hfoptions id="lora sync modes">
+<hfoption id="Server mode">
+
+Launch the server with LoRA enabled, passing `--max-lora-rank` (it must be at least the adapter's `r`):
+
+```bash
+trl vllm-serve --model <model_name> --enable-lora --max-lora-rank 32
+```
+
+Then train as usual with a LoRA `peft_config`. TRL detects the LoRA-enabled server (reported on the server's `/health/` endpoint) and switches to adapter-only sync automatically:
+
+```python
+from peft import LoraConfig
+
+from trl import GRPOConfig, GRPOTrainer
+
+trainer = GRPOTrainer(
+    model="<model_name>",
+    args=GRPOConfig(..., use_vllm=True, vllm_mode="server"),
+    peft_config=LoraConfig(r=32),
+    ...,
+)
+```
+
+If you train a LoRA model against a server launched **without** `--enable-lora`, TRL warns and falls back to full merged-weight sync. If the adapter's rank exceeds the server's `--max-lora-rank`, training stops early with a clear error.
+
+</hfoption>
+<hfoption id="Colocate mode">
+
+In colocate mode the trainer owns the vLLM engine, so there is nothing to configure on a server: TRL enables LoRA on the engine itself and infers `max_lora_rank` from the adapter. Just pass a LoRA `peft_config`:
+
+```python
+from peft import LoraConfig
+
+from trl import GRPOConfig, GRPOTrainer
+
+trainer = GRPOTrainer(
+    model="<model_name>",
+    args=GRPOConfig(..., use_vllm=True, vllm_mode="colocate"),
+    peft_config=LoraConfig(r=32),
+    ...,
+)
+```
+
+</hfoption>
+</hfoptions>
+
+> [!WARNING]
+> Adapter-only sync supports a single active, plain LoRA adapter. Configs with `modules_to_save`, DoRA, or a non-zero `bias` are not supported for fast sync and will raise an error; remove them or train without vLLM LoRA serving to fall back to full-weight sync.

--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -436,7 +436,7 @@ When you train a [PEFT](peft_integration) LoRA model, TRL syncs only the small L
 <hfoptions id="lora sync modes">
 <hfoption id="Server mode">
 
-Launch the server with LoRA enabled, passing `--max-lora-rank` (it must be at least the adapter's `r`):
+Launch the server with LoRA enabled, passing `--max-lora-rank`. It must be at least the adapter's `r`, and vLLM only accepts one of `1`, `8`, `16`, `32`, `64`, `128`, `256`, `320`, `512` — so for an `r=4` adapter, pass `8`:
 
 ```bash
 trl vllm-serve --model <model_name> --enable-lora --max-lora-rank 32

--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -774,8 +774,10 @@ def test_non_vllm_on_policy_does_not_trim_padded_width_when_real_prompt_fits(mon
 def test_gold_trainer_init_defaults_vllm_max_model_length_to_max_length(monkeypatch):
     captured = {}
 
-    class DummyStudentModel:
+    # A real `nn.Module`: the trainer calls `is_peft_model` on it, which unwraps via `extract_model_from_parallel`.
+    class DummyStudentModel(torch.nn.Module):
         def __init__(self):
+            super().__init__()
             config = SimpleNamespace(_name_or_path="student", vocab_size=17)
             config.get_text_config = lambda: config
             self.config = config
@@ -827,6 +829,9 @@ def test_gold_trainer_init_defaults_vllm_max_model_length_to_max_length(monkeypa
         self.is_fsdp_enabled = False
 
     class CapturingVLLMGeneration:
+        # Adapter-only LoRA sync is off, so the trainer skips its LoRA-adapter validation.
+        lora_sync = False
+
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
@@ -859,6 +864,7 @@ def test_gold_trainer_init_defaults_vllm_max_model_length_to_max_length(monkeypa
         per_device_train_batch_size=1,
         gradient_accumulation_steps=1,
         use_vllm=True,
+        output_dir="gold-adapter-sync",
         vllm_mode="colocate",
         vllm_structured_outputs_regex=None,
         vllm_server_base_url=None,
@@ -2361,8 +2367,10 @@ def test_gold_trainer_vlm_vllm_init_uses_identity_collator(monkeypatch):
     """
     captured = {}
 
-    class DummyStudentModel:
+    # A real `nn.Module`: the trainer calls `is_peft_model` on it, which unwraps via `extract_model_from_parallel`.
+    class DummyStudentModel(torch.nn.Module):
         def __init__(self):
+            super().__init__()
             self.config = SimpleNamespace(
                 _name_or_path="student",
                 vocab_size=17,
@@ -2410,6 +2418,9 @@ def test_gold_trainer_vlm_vllm_init_uses_identity_collator(monkeypatch):
         self.is_fsdp_enabled = False
 
     class CapturingVLLMGeneration:
+        # Adapter-only LoRA sync is off, so the trainer skips its LoRA-adapter validation.
+        lora_sync = False
+
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
@@ -2449,6 +2460,7 @@ def test_gold_trainer_vlm_vllm_init_uses_identity_collator(monkeypatch):
         per_device_train_batch_size=1,
         gradient_accumulation_steps=1,
         use_vllm=True,
+        output_dir="gold-adapter-sync",
         vllm_mode="colocate",
         vllm_structured_outputs_regex=None,
         vllm_server_base_url=None,
@@ -2486,8 +2498,10 @@ def test_gold_trainer_vlm_vllm_init_uses_identity_collator(monkeypatch):
 def _make_dummy_vlm_models(student_model_type, teacher_model_type):
     """Helper to create dummy student/teacher VLM models with specified model_type."""
 
-    class DummyStudentModel:
+    # A real `nn.Module`: the trainer calls `is_peft_model` on it, which unwraps via `extract_model_from_parallel`.
+    class DummyStudentModel(torch.nn.Module):
         def __init__(self):
+            super().__init__()
             self.config = SimpleNamespace(
                 _name_or_path="student",
                 vocab_size=17,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -299,10 +299,7 @@ class TestGRPOTrainer(TrlTestCase):
         # Adapter-only LoRA sync is auto-detected, so the trainer just reports whether the model is a PEFT model and
         # lets the generation backend decide based on the server's reported `enable_lora`.
         training_args = self.get_vllm_args()
-        with (
-            patch("trl.trainer.grpo_trainer.is_vllm_available", return_value=True),
-            patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation,
-        ):
+        with patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation:
             mock_vllm_generation.return_value.lora_sync = False
             GRPOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
@@ -328,10 +325,7 @@ class TestGRPOTrainer(TrlTestCase):
         # When the generation backend auto-detects adapter-only sync (`lora_sync=True`), the trainer validates that the
         # active adapter is syncable as a plain LoRA adapter.
         training_args = self.get_vllm_args()
-        with (
-            patch("trl.trainer.grpo_trainer.is_vllm_available", return_value=True),
-            patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation,
-        ):
+        with patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation:
             mock_vllm_generation.return_value.lora_sync = True
             with pytest.raises(ValueError, match=error_message):
                 GRPOTrainer(
@@ -403,7 +397,9 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.group_port = 51216
         vllm_generation.server_timeout = 0
         vllm_generation.model = model if model is not None else MagicMock()
-        vllm_generation.accelerator = SimpleNamespace(is_main_process=True, wait_for_everyone=MagicMock())
+        vllm_generation.accelerator = SimpleNamespace(
+            is_main_process=True, wait_for_everyone=MagicMock(), device=torch.device("cpu")
+        )
         fake_client = SimpleNamespace(
             server_enable_lora=server_enable_lora,
             server_max_lora_rank=server_max_lora_rank,
@@ -413,7 +409,6 @@ class TestGRPOTrainer(TrlTestCase):
             patch("trl.generation.vllm_generation.is_vllm_available", return_value=True),
             patch("trl.generation.vllm_generation.VLLMClient", return_value=fake_client),
             patch("trl.generation.vllm_generation.broadcast_object_list"),  # single process: leave obj_list unchanged
-            patch("torch.cuda.current_device", return_value=0),
         ):
             vllm_generation._init_vllm()
         return vllm_generation, fake_client
@@ -4301,7 +4296,6 @@ class TestGRPOTrainerSlow(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             quantization_config=quantization_config,
-            device_map=get_kbit_device_map(),
         )
         model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"]))
         vllm_generation = object.__new__(VLLMGeneration)

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -455,6 +455,47 @@ class TestGRPOTrainer(TrlTestCase):
         )
         assert vllm_generation.lora_sync is True
 
+    @pytest.mark.parametrize(("adapter_rank", "expected_max_lora_rank"), [(4, 8), (8, 8), (12, 16), (200, 256)])
+    def test_vllm_lora_sync_colocate_rounds_max_lora_rank(self, adapter_rank, expected_max_lora_rank):
+        # vLLM only accepts a fixed set of `max_lora_rank` values, so the inferred rank is rounded up to the smallest
+        # one that fits. Passing an adapter's raw `r` (e.g. 4) would crash the engine with a pydantic literal error.
+        model = MagicMock()
+        model.active_adapters = ["default"]
+        model.peft_config = {"default": SimpleNamespace(r=adapter_rank, rank_pattern={})}
+        model.named_modules = MagicMock(return_value=[])
+
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "colocate"
+        vllm_generation.is_lora_model = True
+        vllm_generation.model = model
+        vllm_generation.tensor_parallel_size = 1
+        vllm_generation.gpu_memory_utilization = 0.1
+        vllm_generation.max_model_length = None
+        vllm_generation.max_num_seqs = None
+        vllm_generation.enable_sleep_mode = False
+        vllm_generation.model_impl = "auto"
+        vllm_generation.trust_remote_code = False
+        vllm_generation.accelerator = SimpleNamespace(
+            is_main_process=True,
+            wait_for_everyone=MagicMock(),
+            num_processes=1,
+            process_index=0,
+            local_process_index=0,
+        )
+        with (
+            patch("trl.generation.vllm_generation.is_vllm_available", return_value=True),
+            patch("trl.generation.vllm_generation.is_bitsandbytes_available", return_value=False),
+            patch("trl.generation.vllm_generation.ensure_master_addr_port"),
+            patch("trl.generation.vllm_generation.LLM") as mock_llm,
+            # `_init_vllm` sets RANK/LOCAL_RANK/WORLD_SIZE for vLLM; restore the environment afterwards so later tests
+            # don't see a half-configured distributed setup (MASTER_ADDR is never set, since the helper is patched).
+            patch.dict(os.environ),
+        ):
+            vllm_generation._init_vllm()
+
+        assert mock_llm.call_args.kwargs["enable_lora"] is True
+        assert mock_llm.call_args.kwargs["max_lora_rank"] == expected_max_lora_rank
+
     @require_peft
     def test_save_lora_adapter_writes_non_empty_adapter(self):
         from safetensors.torch import load_file

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -39,7 +39,7 @@ from transformers.testing_utils import backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
-from trl.generation.vllm_generation import VLLMGeneration
+from trl.generation.vllm_generation import VLLMGeneration, round_lora_rank
 from trl.import_utils import is_liger_kernel_available
 
 from .testing_utils import (
@@ -498,6 +498,20 @@ class TestGRPOTrainer(TrlTestCase):
 
         assert mock_llm.call_args.kwargs["enable_lora"] is True
         assert mock_llm.call_args.kwargs["max_lora_rank"] == expected_max_lora_rank
+
+    def test_vllm_lora_sync_rejects_adapter_rank_above_vllm_max(self):
+        # vLLM cannot serve a rank above the largest value it accepts; fail with a clear message rather than the bare
+        # `StopIteration` that rounding would otherwise raise.
+        with pytest.raises(ValueError, match=r"exceeds the largest rank vLLM can serve \(512\)"):
+            round_lora_rank(1024)
+
+    @pytest.mark.parametrize(("lora_sync", "expected_level"), [(True, 1), (False, 2)])
+    def test_sleep_level_depends_on_lora_sync(self, lora_sync, expected_level):
+        # Sleep level 2 discards the weights, which merged sync re-pushes every step. Adapter-only sync never pushes
+        # the frozen base model, so it must use level 1, which offloads to CPU and restores on wake.
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.lora_sync = lora_sync
+        assert vllm_generation._sleep_level == expected_level
 
     @require_peft
     def test_save_lora_adapter_writes_non_empty_adapter(self):

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -513,6 +513,61 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.lora_sync = lora_sync
         assert vllm_generation._sleep_level == expected_level
 
+    @require_vllm
+    @require_peft
+    def test_vllm_lora_sync_restores_weights_for_second_generate_in_one_step(self):
+        # Adapter-only sync sleeps at level 1, which offloads the weights to CPU rather than discarding them. The
+        # trainer only calls `sync_weights()` when the training step advanced, so a second `generate()` within the
+        # same step (an eval loop with more than one batch, say) has to bring them back itself. Without that, the
+        # forward pass runs against unmapped weight memory and hangs.
+        #
+        # This uses a real 0.5B model rather than a tiny test one: with a tiny model vLLM falls back to the
+        # flex-attention backend, whose inverse block table is sized by KV block count, and the resulting block
+        # count is large enough that cudagraph capture tries to allocate tens of GiB.
+        from accelerate import Accelerator
+
+        model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16)
+        model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"], r=8))
+
+        accelerator = Accelerator()
+        model = model.to(accelerator.device)
+
+        vllm_generation = VLLMGeneration(
+            model=model,
+            accelerator=accelerator,
+            processing_class=tokenizer,
+            mode="colocate",
+            gpu_memory_utilization=0.15,
+            enable_sleep_mode=True,
+            is_lora_model=True,
+            max_model_length=512,
+            max_completion_length=8,
+            temperature=0.0,  # greedy, so the two runs are directly comparable
+            lora_sync_output_dir=self.tmp_dir,
+        )
+        assert vllm_generation.lora_sync, "adapter-only sync did not activate; this would not cover the bug"
+        assert vllm_generation._sleep_level == 1
+
+        prompts = [tokenizer("The capital of France is")["input_ids"]] * 2
+
+        # Step boundary: the trainer syncs once per step, which wakes the weights and pushes the adapter.
+        vllm_generation.sync_weights()
+        _, first_completions, _, _ = vllm_generation.generate(prompts, images=None, num_generations=1)
+
+        # Asserted before the second `generate()` on purpose. On the buggy path this is False, so the failure
+        # surfaces here rather than as a hang in the forward pass below.
+        assert vllm_generation._llm_weights_sleeping is True
+
+        # Second batch of the same step -- deliberately no `sync_weights()` in between.
+        _, second_completions, _, _ = vllm_generation.generate(prompts, images=None, num_generations=1)
+        assert second_completions == first_completions
+
+        # `generate()` leaves the engine asleep. Tearing the allocator down while its allocations are
+        # still unmapped makes its destructor fail with "CUDA Error: invalid argument", so wake it first.
+        vllm_generation.llm.wake_up()
+
     @require_peft
     def test_save_lora_adapter_writes_non_empty_adapter(self):
         from safetensors.torch import load_file

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -365,6 +365,75 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.model.merge_adapter.assert_not_called()
         vllm_generation.model.unmerge_adapter.assert_not_called()
 
+    @staticmethod
+    def _run_server_autodetect(*, is_lora_model, server_enable_lora, server_max_lora_rank=None, model=None):
+        # Drive the server-mode auto-detect block of `VLLMGeneration._init_vllm` with a fake client, so we can assert
+        # the `lora_sync` decision without a live server or distributed setup.
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "server"
+        vllm_generation.is_lora_model = is_lora_model
+        vllm_generation.lora_sync = False
+        vllm_generation.server_base_url = "http://localhost:8000"
+        vllm_generation.group_port = 51216
+        vllm_generation.server_timeout = 0
+        vllm_generation.model = model if model is not None else MagicMock()
+        vllm_generation.accelerator = SimpleNamespace(is_main_process=True, wait_for_everyone=MagicMock())
+        fake_client = SimpleNamespace(
+            server_enable_lora=server_enable_lora,
+            server_max_lora_rank=server_max_lora_rank,
+            init_communicator=MagicMock(),
+        )
+        with (
+            patch("trl.generation.vllm_generation.is_vllm_available", return_value=True),
+            patch("trl.generation.vllm_generation.VLLMClient", return_value=fake_client),
+            patch("trl.generation.vllm_generation.broadcast_object_list"),  # single process: leave obj_list unchanged
+            patch("torch.cuda.current_device", return_value=0),
+        ):
+            vllm_generation._init_vllm()
+        return vllm_generation, fake_client
+
+    @pytest.mark.parametrize("is_lora_model", [True, False])
+    @pytest.mark.parametrize("server_enable_lora", [True, False])
+    def test_vllm_lora_sync_auto_detect_decision(self, is_lora_model, server_enable_lora):
+        # Adapter-only sync activates iff the model is LoRA *and* the server was launched with `--enable-lora`.
+        vllm_generation, fake_client = self._run_server_autodetect(
+            is_lora_model=is_lora_model, server_enable_lora=server_enable_lora
+        )
+        assert vllm_generation.lora_sync is (is_lora_model and server_enable_lora)
+        # The merged-sync communicator is initialized only when adapter sync is off.
+        if vllm_generation.lora_sync:
+            fake_client.init_communicator.assert_not_called()
+        else:
+            fake_client.init_communicator.assert_called_once()
+
+    def test_vllm_lora_sync_warns_on_merged_fallback(self):
+        # A LoRA model against a non-LoRA server falls back to merged-weight sync and warns loudly.
+        with patch("trl.generation.vllm_generation.logger") as mock_logger:
+            vllm_generation, _ = self._run_server_autodetect(is_lora_model=True, server_enable_lora=False)
+        assert vllm_generation.lora_sync is False
+        mock_logger.warning.assert_called_once()
+        assert "--enable-lora" in mock_logger.warning.call_args.args[0]
+
+    def test_vllm_lora_sync_rejects_adapter_rank_above_server_max(self):
+        # The adapter rank must fit the server's `--max-lora-rank`; otherwise fail fast with a clear message.
+        model = MagicMock()
+        model.active_adapters = ["default"]
+        model.peft_config = {"default": SimpleNamespace(r=16, rank_pattern={})}
+        with pytest.raises(ValueError, match=r"adapter rank \(16\) exceeds the vLLM server's `--max-lora-rank` \(8\)"):
+            self._run_server_autodetect(
+                is_lora_model=True, server_enable_lora=True, server_max_lora_rank=8, model=model
+            )
+
+    def test_vllm_lora_sync_accepts_adapter_rank_within_server_max(self):
+        # rank_pattern can raise individual modules above the base `r`; the max must still fit.
+        model = MagicMock()
+        model.active_adapters = ["default"]
+        model.peft_config = {"default": SimpleNamespace(r=8, rank_pattern={"q_proj": 16})}
+        vllm_generation, _ = self._run_server_autodetect(
+            is_lora_model=True, server_enable_lora=True, server_max_lora_rank=16, model=model
+        )
+        assert vllm_generation.lora_sync is True
+
     @require_peft
     def test_save_lora_adapter_writes_non_empty_adapter(self):
         from safetensors.torch import load_file

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -168,6 +168,7 @@ class TestGRPORolloutDispatch:
         trainer.accelerator = SimpleNamespace(
             device=torch.device("cpu"),
             is_main_process=True,
+            is_local_main_process=True,
             gather=lambda t: t,
         )
         trainer.args = SimpleNamespace(report_to=[])
@@ -322,19 +323,16 @@ class TestGRPOTrainer(TrlTestCase):
         ],
     )
     def test_vllm_lora_sync_rejects_unsupported_lora_configs(self, peft_config_kwargs, error_message):
-        # When the generation backend auto-detects adapter-only sync (`lora_sync=True`), the trainer validates that the
-        # active adapter is syncable as a plain LoRA adapter.
-        training_args = self.get_vllm_args()
-        with patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation:
-            mock_vllm_generation.return_value.lora_sync = True
-            with pytest.raises(ValueError, match=error_message):
-                GRPOTrainer(
-                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                    reward_funcs=self.reward_func,
-                    args=training_args,
-                    train_dataset=self.get_prompt_dataset(),
-                    peft_config=LoraConfig(**peft_config_kwargs),
-                )
+        # Adapter-only sync requires a plain LoRA adapter. The generation backend owns this check, next to the other
+        # vLLM capability checks, so it fires before any LoRA-only config field is read.
+        model = MagicMock()
+        model.active_adapters = ["default"]
+        model.peft_config = {"default": LoraConfig(**peft_config_kwargs)}
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.model = model
+
+        with pytest.raises(ValueError, match=error_message):
+            vllm_generation._active_lora_config()
 
     def test_vllm_lora_sync_path_loads_adapter_without_merging(self):
         vllm_generation = object.__new__(VLLMGeneration)
@@ -396,7 +394,11 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.server_base_url = "http://localhost:8000"
         vllm_generation.group_port = 51216
         vllm_generation.server_timeout = 0
-        vllm_generation.model = model if model is not None else MagicMock()
+        if model is None:
+            model = MagicMock()
+            model.active_adapters = ["default"]
+            model.peft_config = {"default": LoraConfig()}
+        vllm_generation.model = model
         vllm_generation.accelerator = SimpleNamespace(
             is_main_process=True, wait_for_everyone=MagicMock(), device=torch.device("cpu")
         )
@@ -439,7 +441,7 @@ class TestGRPOTrainer(TrlTestCase):
         # The adapter rank must fit the server's `--max-lora-rank`; otherwise fail fast with a clear message.
         model = MagicMock()
         model.active_adapters = ["default"]
-        model.peft_config = {"default": SimpleNamespace(r=16, rank_pattern={})}
+        model.peft_config = {"default": LoraConfig(r=16)}
         with pytest.raises(ValueError, match=r"adapter rank \(16\) exceeds the vLLM server's `--max-lora-rank` \(8\)"):
             self._run_server_autodetect(
                 is_lora_model=True, server_enable_lora=True, server_max_lora_rank=8, model=model
@@ -449,7 +451,7 @@ class TestGRPOTrainer(TrlTestCase):
         # rank_pattern can raise individual modules above the base `r`; the max must still fit.
         model = MagicMock()
         model.active_adapters = ["default"]
-        model.peft_config = {"default": SimpleNamespace(r=8, rank_pattern={"q_proj": 16})}
+        model.peft_config = {"default": LoraConfig(r=8, rank_pattern={"q_proj": 16})}
         vllm_generation, _ = self._run_server_autodetect(
             is_lora_model=True, server_enable_lora=True, server_max_lora_rank=16, model=model
         )
@@ -461,7 +463,7 @@ class TestGRPOTrainer(TrlTestCase):
         # one that fits. Passing an adapter's raw `r` (e.g. 4) would crash the engine with a pydantic literal error.
         model = MagicMock()
         model.active_adapters = ["default"]
-        model.peft_config = {"default": SimpleNamespace(r=adapter_rank, rank_pattern={})}
+        model.peft_config = {"default": LoraConfig(r=adapter_rank)}
         model.named_modules = MagicMock(return_value=[])
 
         vllm_generation = object.__new__(VLLMGeneration)
@@ -477,6 +479,7 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.trust_remote_code = False
         vllm_generation.accelerator = SimpleNamespace(
             is_main_process=True,
+            is_local_main_process=True,
             wait_for_everyone=MagicMock(),
             num_processes=1,
             process_index=0,
@@ -503,9 +506,11 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"]))
         vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "server"
         vllm_generation.model = model
         vllm_generation.accelerator = SimpleNamespace(
             is_main_process=True,
+            is_local_main_process=True,
             wait_for_everyone=lambda: None,
             state=SimpleNamespace(deepspeed_plugin=None),
         )
@@ -4340,9 +4345,11 @@ class TestGRPOTrainerSlow(TrlTestCase):
         )
         model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"]))
         vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "server"
         vllm_generation.model = model
         vllm_generation.accelerator = SimpleNamespace(
             is_main_process=True,
+            is_local_main_process=True,
             wait_for_everyone=lambda: None,
             state=SimpleNamespace(deepspeed_plugin=None),
         )

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -16,6 +16,7 @@ import gc
 import os
 import warnings
 from collections.abc import Callable
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -38,6 +39,7 @@ from transformers.testing_utils import backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
+from trl.generation.vllm_generation import VLLMGeneration
 from trl.import_utils import is_liger_kernel_available
 
 from .testing_utils import (
@@ -275,6 +277,120 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    def get_vllm_args(self, **kwargs):
+        defaults = {
+            "output_dir": self.tmp_dir,
+            "report_to": "none",
+            "use_vllm": True,
+            "vllm_mode": "server",
+        }
+        defaults.update(kwargs)
+        return GRPOConfig(**defaults)
+
+    def get_prompt_dataset(self):
+        return Dataset.from_dict({"prompt": ["hello", "hello"]})
+
+    @staticmethod
+    def reward_func(completions, **kwargs):
+        return [0.0] * len(completions)
+
+    @require_peft
+    def test_is_lora_model_passed_to_vllm_generation(self):
+        # Adapter-only LoRA sync is auto-detected, so the trainer just reports whether the model is a PEFT model and
+        # lets the generation backend decide based on the server's reported `enable_lora`.
+        training_args = self.get_vllm_args()
+        with (
+            patch("trl.trainer.grpo_trainer.is_vllm_available", return_value=True),
+            patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation,
+        ):
+            mock_vllm_generation.return_value.lora_sync = False
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=self.reward_func,
+                args=training_args,
+                train_dataset=self.get_prompt_dataset(),
+                peft_config=LoraConfig(),
+            )
+
+        assert mock_vllm_generation.call_args.kwargs["is_lora_model"] is True
+        assert mock_vllm_generation.call_args.kwargs["lora_sync_output_dir"] == self.tmp_dir
+
+    @require_peft
+    @pytest.mark.parametrize(
+        ("peft_config_kwargs", "error_message"),
+        [
+            ({"modules_to_save": ["lm_head"]}, "does not support LoRA configs with `modules_to_save`"),
+            ({"use_dora": True}, "does not support DoRA adapters"),
+            ({"bias": "all"}, "does not support LoRA adapters with bias"),
+        ],
+    )
+    def test_vllm_lora_sync_rejects_unsupported_lora_configs(self, peft_config_kwargs, error_message):
+        # When the generation backend auto-detects adapter-only sync (`lora_sync=True`), the trainer validates that the
+        # active adapter is syncable as a plain LoRA adapter.
+        training_args = self.get_vllm_args()
+        with (
+            patch("trl.trainer.grpo_trainer.is_vllm_available", return_value=True),
+            patch("trl.trainer.grpo_trainer.VLLMGeneration") as mock_vllm_generation,
+        ):
+            mock_vllm_generation.return_value.lora_sync = True
+            with pytest.raises(ValueError, match=error_message):
+                GRPOTrainer(
+                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                    reward_funcs=self.reward_func,
+                    args=training_args,
+                    train_dataset=self.get_prompt_dataset(),
+                    peft_config=LoraConfig(**peft_config_kwargs),
+                )
+
+    def test_vllm_lora_sync_path_loads_adapter_without_merging(self):
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "server"
+        vllm_generation.enable_sleep_mode = False
+        vllm_generation.lora_sync = True
+        vllm_generation.lora_name = "trl_lora_adapter"
+        vllm_generation.accelerator = SimpleNamespace(is_main_process=True, wait_for_everyone=MagicMock())
+        vllm_generation.vllm_client = MagicMock()
+        vllm_generation.model = MagicMock()
+        vllm_generation.model.merge_adapter = MagicMock()
+        vllm_generation.model.unmerge_adapter = MagicMock()
+        vllm_generation._save_lora_adapter = MagicMock(return_value="/tmp/adapter")
+
+        vllm_generation.sync_weights()
+
+        vllm_generation._save_lora_adapter.assert_called_once()
+        vllm_generation.vllm_client.load_lora_adapter.assert_called_once_with(
+            "trl_lora_adapter", "/tmp/adapter", load_inplace=True
+        )
+        vllm_generation.vllm_client.reset_prefix_cache.assert_called_once()
+        vllm_generation.model.merge_adapter.assert_not_called()
+        vllm_generation.model.unmerge_adapter.assert_not_called()
+
+    @require_peft
+    def test_save_lora_adapter_writes_non_empty_adapter(self):
+        from safetensors.torch import load_file
+
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
+        model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"]))
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.model = model
+        vllm_generation.accelerator = SimpleNamespace(
+            is_main_process=True,
+            wait_for_everyone=lambda: None,
+            state=SimpleNamespace(deepspeed_plugin=None),
+        )
+        vllm_generation._dist = SimpleNamespace(
+            gather_params=lambda params: nullcontext(),
+            summon_full_params=lambda model, **kwargs: nullcontext(),
+        )
+        vllm_generation.lora_sync_output_dir = self.tmp_dir
+        vllm_generation._lora_sync_version = 0
+
+        adapter_dir = vllm_generation._save_lora_adapter()
+
+        assert os.path.exists(os.path.join(adapter_dir, "adapter_config.json"))
+        adapter_state_dict = load_file(os.path.join(adapter_dir, "adapter_model.safetensors"))
+        assert adapter_state_dict
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
@@ -4074,6 +4190,46 @@ class TestGRPOTrainerSlow(TrlTestCase):
         gc.collect()
         backend_empty_cache(torch_device)
         gc.collect()
+
+    @require_bitsandbytes
+    @require_peft
+    @require_torch_accelerator
+    def test_save_lora_adapter_with_qlora_writes_non_empty_adapter(self):
+        from safetensors.torch import load_file
+
+        quantization_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_use_double_quant=True,
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            quantization_config=quantization_config,
+            device_map=get_kbit_device_map(),
+        )
+        model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"]))
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.model = model
+        vllm_generation.accelerator = SimpleNamespace(
+            is_main_process=True,
+            wait_for_everyone=lambda: None,
+            state=SimpleNamespace(deepspeed_plugin=None),
+        )
+        vllm_generation._dist = SimpleNamespace(
+            gather_params=lambda params: nullcontext(),
+            summon_full_params=lambda model, **kwargs: nullcontext(),
+        )
+        vllm_generation.lora_sync_output_dir = self.tmp_dir
+        vllm_generation._lora_sync_version = 0
+
+        adapter_dir = vllm_generation._save_lora_adapter()
+
+        assert os.path.exists(os.path.join(adapter_dir, "adapter_config.json"))
+        adapter_state_dict = load_file(os.path.join(adapter_dir, "adapter_model.safetensors"))
+        assert adapter_state_dict
+
+        release_memory(model)
 
     @pytest.mark.parametrize(
         "model_name",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -365,6 +365,32 @@ class TestGRPOTrainer(TrlTestCase):
         vllm_generation.model.merge_adapter.assert_not_called()
         vllm_generation.model.unmerge_adapter.assert_not_called()
 
+    def test_vllm_lora_sync_colocate_loads_adapter_without_merging(self):
+        vllm_generation = object.__new__(VLLMGeneration)
+        vllm_generation.mode = "colocate"
+        vllm_generation.enable_sleep_mode = False
+        vllm_generation.lora_sync = True
+        vllm_generation.lora_name = "trl_lora_adapter"
+        vllm_generation._lora_request = None
+        vllm_generation.accelerator = SimpleNamespace(is_main_process=True, wait_for_everyone=MagicMock())
+        vllm_generation.llm = MagicMock()
+        vllm_generation.model = MagicMock()
+        vllm_generation.model.merge_adapter = MagicMock()
+        vllm_generation.model.unmerge_adapter = MagicMock()
+        vllm_generation._save_lora_adapter = MagicMock(return_value="/tmp/adapter")
+
+        vllm_generation.sync_weights()
+
+        vllm_generation._save_lora_adapter.assert_called_once()
+        # Each colocate rank reloads the adapter in-place into its own engine (the #42125 stale-prefix-cache guard).
+        vllm_generation.llm.llm_engine.add_lora.assert_called_once()
+        assert vllm_generation.llm.llm_engine.add_lora.call_args.args[0].load_inplace is True
+        vllm_generation.llm.reset_prefix_cache.assert_called_once()
+        # `generate` references the loaded adapter by `lora_request`.
+        assert vllm_generation._lora_request is not None
+        vllm_generation.model.merge_adapter.assert_not_called()
+        vllm_generation.model.unmerge_adapter.assert_not_called()
+
     @staticmethod
     def _run_server_autodetect(*, is_lora_model, server_enable_lora, server_max_lora_rank=None, model=None):
         # Drive the server-mode auto-detect block of `VLLMGeneration._init_vllm` with a fake client, so we can assert

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -47,6 +47,54 @@ class TestRLOOTrainer(TrlTestCase):
             train_dataset=dataset,
         )
 
+    @staticmethod
+    def reward_func(completions, **kwargs):
+        return [0.0] * len(completions)
+
+    @require_peft
+    def test_is_lora_model_passed_to_vllm_generation(self):
+        # Adapter-only LoRA sync is auto-detected, so the trainer just reports whether the model is a PEFT model and
+        # lets the generation backend decide based on the server's reported `enable_lora`.
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none", use_vllm=True, vllm_mode="server")
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        with patch("trl.trainer.rloo_trainer.VLLMGeneration") as mock_vllm_generation:
+            mock_vllm_generation.return_value.lora_sync = False
+            RLOOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=self.reward_func,
+                args=training_args,
+                train_dataset=dataset,
+                peft_config=LoraConfig(),
+            )
+
+        assert mock_vllm_generation.call_args.kwargs["is_lora_model"] is True
+        assert mock_vllm_generation.call_args.kwargs["lora_sync_output_dir"] == self.tmp_dir
+
+    @require_peft
+    @pytest.mark.parametrize(
+        ("peft_config_kwargs", "error_message"),
+        [
+            ({"modules_to_save": ["lm_head"]}, "does not support LoRA configs with `modules_to_save`"),
+            ({"use_dora": True}, "does not support DoRA adapters"),
+            ({"bias": "all"}, "does not support LoRA adapters with bias"),
+        ],
+    )
+    def test_vllm_lora_sync_rejects_unsupported_lora_configs(self, peft_config_kwargs, error_message):
+        # When the generation backend auto-detects adapter-only sync (`lora_sync=True`), the trainer validates that the
+        # active adapter is syncable as a plain LoRA adapter.
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none", use_vllm=True, vllm_mode="server")
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        with patch("trl.trainer.rloo_trainer.VLLMGeneration") as mock_vllm_generation:
+            mock_vllm_generation.return_value.lora_sync = True
+            with pytest.raises(ValueError, match=error_message):
+                RLOOTrainer(
+                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                    reward_funcs=self.reward_func,
+                    args=training_args,
+                    train_dataset=dataset,
+                    peft_config=LoraConfig(**peft_config_kwargs),
+                )
+
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -70,31 +70,6 @@ class TestRLOOTrainer(TrlTestCase):
         assert mock_vllm_generation.call_args.kwargs["is_lora_model"] is True
         assert mock_vllm_generation.call_args.kwargs["lora_sync_output_dir"] == self.tmp_dir
 
-    @require_peft
-    @pytest.mark.parametrize(
-        ("peft_config_kwargs", "error_message"),
-        [
-            ({"modules_to_save": ["lm_head"]}, "does not support LoRA configs with `modules_to_save`"),
-            ({"use_dora": True}, "does not support DoRA adapters"),
-            ({"bias": "all"}, "does not support LoRA adapters with bias"),
-        ],
-    )
-    def test_vllm_lora_sync_rejects_unsupported_lora_configs(self, peft_config_kwargs, error_message):
-        # When the generation backend auto-detects adapter-only sync (`lora_sync=True`), the trainer validates that the
-        # active adapter is syncable as a plain LoRA adapter.
-        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none", use_vllm=True, vllm_mode="server")
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        with patch("trl.trainer.rloo_trainer.VLLMGeneration") as mock_vllm_generation:
-            mock_vllm_generation.return_value.lora_sync = True
-            with pytest.raises(ValueError, match=error_message):
-                RLOOTrainer(
-                    model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                    reward_funcs=self.reward_func,
-                    args=training_args,
-                    train_dataset=dataset,
-                    peft_config=LoraConfig(**peft_config_kwargs),
-                )
-
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -31,6 +31,8 @@ from .testing_utils import (
     TrlTestCase,
     kill_process,
     require_3_accelerators,
+    require_peft,
+    require_torch_accelerator,
     require_torch_multi_accelerator,
     require_vision,
     require_vllm,
@@ -1077,3 +1079,75 @@ class TestVLLMClientServerVLM(TrlTestCase):
     @classmethod
     def teardown_class(cls):
         kill_process(cls.server_process)
+
+
+@pytest.mark.slow
+@require_torch_accelerator
+@require_vllm
+@require_peft
+class TestVLLMClientServerLoRAInplaceSwap(TrlTestCase):
+    """
+    Regression guard for the in-place adapter swap (vLLM #42125): reloading a new adapter under the same name/int_id
+    with `load_inplace=True` (then resetting the prefix cache, exactly as `sync_weights` does) must actually change
+    the served output. If `load_inplace` were ignored or the prefix cache not reset, the server would keep serving the
+    previous adapter's weights/KV blocks and the swap would be silently lost — the failure mode this whole feature
+    must avoid.
+    """
+
+    model_id = "Qwen/Qwen2.5-1.5B"
+
+    @classmethod
+    def setup_class(cls):
+        import shutil
+        import tempfile
+
+        import torch
+        from peft import LoraConfig, get_peft_model
+
+        # Build two distinct adapters under the same config: A is the default save (PEFT zero-inits `lora_B`, so it is
+        # an identity adapter) and B has `lora_B` perturbed, so the two produce different greedy completions.
+        cls.tmp_adapters = tempfile.mkdtemp()
+        cls.adapter_a = os.path.join(cls.tmp_adapters, "adapter_a")
+        cls.adapter_b = os.path.join(cls.tmp_adapters, "adapter_b")
+        model = AutoModelForCausalLM.from_pretrained(cls.model_id)
+        peft_model = get_peft_model(
+            model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"], r=8)
+        )
+        peft_model.save_pretrained(cls.adapter_a)
+        torch.manual_seed(0)
+        with torch.no_grad():
+            for name, param in peft_model.named_parameters():
+                if "lora_B" in name:
+                    param.add_(torch.randn_like(param) * 5.0)
+        peft_model.save_pretrained(cls.adapter_b)
+        del model, peft_model
+
+        env = os.environ.copy()
+        VISIBLE_DEVICES = "ZE_AFFINITY_MASK" if torch_device == "xpu" else "CUDA_VISIBLE_DEVICES"
+        env[VISIBLE_DEVICES] = "0"
+        cls.server_process = subprocess.Popen(
+            ["trl", "vllm-serve", "--model", cls.model_id, "--enable_lora", "--max_lora_rank", "8"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        # This test only exercises adapter load + generate (no full-weight sync), so no `init_communicator`.
+        cls.client = VLLMClient(connection_timeout=240, host="localhost")
+        cls._shutil = shutil
+
+    def test_inplace_adapter_swap_changes_output(self):
+        prompts = ["The capital of France is"]
+        # Load adapter A, then generate greedily (temperature=0 → the adapter is the only variable).
+        self.client.load_lora_adapter("trl_lora_adapter", self.adapter_a, load_inplace=True)
+        self.client.reset_prefix_cache()
+        out_a = self.client.generate(prompts, n=1, temperature=0.0, max_tokens=16)["completion_ids"][0]
+        # Swap to adapter B in place under the same name/int_id and reset the prefix cache, exactly as `sync_weights`.
+        self.client.load_lora_adapter("trl_lora_adapter", self.adapter_b, load_inplace=True)
+        self.client.reset_prefix_cache()
+        out_b = self.client.generate(prompts, n=1, temperature=0.0, max_tokens=16)["completion_ids"][0]
+        assert out_a != out_b, "in-place adapter swap did not change output (stale adapter weights or prefix cache)"
+
+    @classmethod
+    def teardown_class(cls):
+        kill_process(cls.server_process)
+        cls._shutil.rmtree(cls.tmp_adapters, ignore_errors=True)

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -82,6 +82,17 @@ class TestVLLMClient(TrlTestCase):
             client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)
         assert client.server_enable_lora is enable_lora
 
+    @pytest.mark.parametrize("max_lora_rank", [16, None])
+    def test_check_server_reads_max_lora_rank(self, max_lora_rank):
+        response = SimpleNamespace(
+            status_code=200,
+            headers={},
+            json=lambda: {"status": "ok", "enable_lora": True, "max_lora_rank": max_lora_rank},
+        )
+        with patch("trl.generation.vllm_client.requests.get", return_value=response):
+            client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)
+        assert client.server_max_lora_rank == max_lora_rank
+
     def test_load_lora_adapter_posts_payload(self):
         with patch.object(VLLMClient, "check_server"):
             client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -15,6 +15,7 @@
 import os
 import subprocess
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from packaging.version import Version
@@ -69,6 +70,37 @@ class TestChunkList(TrlTestCase):
             [1, "two", 3.0],
             [{"four": 4}, ["f", "i", "v", "e"]],
         ]
+
+
+class TestVLLMClient(TrlTestCase):
+    @pytest.mark.parametrize("enable_lora", [True, False])
+    def test_check_server_reads_enable_lora(self, enable_lora):
+        response = SimpleNamespace(
+            status_code=200, headers={}, json=lambda: {"status": "ok", "enable_lora": enable_lora}
+        )
+        with patch("trl.generation.vllm_client.requests.get", return_value=response):
+            client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)
+        assert client.server_enable_lora is enable_lora
+
+    def test_load_lora_adapter_posts_payload(self):
+        with patch.object(VLLMClient, "check_server"):
+            client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)
+        client.session.post = MagicMock(return_value=SimpleNamespace(status_code=200))
+
+        client.load_lora_adapter("trl_lora_adapter", "/tmp/adapter", load_inplace=True)
+
+        client.session.post.assert_called_once_with(
+            "http://localhost:8000/v1/load_lora_adapter",
+            json={"lora_name": "trl_lora_adapter", "lora_path": "/tmp/adapter", "load_inplace": True},
+        )
+
+    def test_load_lora_adapter_raises_on_failure(self):
+        with patch.object(VLLMClient, "check_server"):
+            client = VLLMClient(base_url="http://localhost:8000", connection_timeout=0)
+        client.session.post = MagicMock(return_value=SimpleNamespace(status_code=500, text="error"))
+
+        with pytest.raises(Exception, match="Request failed: 500, error"):
+            client.load_lora_adapter("trl_lora_adapter", "/tmp/adapter", load_inplace=True)
 
 
 class TestExtractLogprobs(TrlTestCase):

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -1088,10 +1088,10 @@ class TestVLLMClientServerVLM(TrlTestCase):
 class TestVLLMClientServerLoRAInplaceSwap(TrlTestCase):
     """
     Regression guard for the in-place adapter swap (vLLM #42125): reloading a new adapter under the same name/int_id
-    with `load_inplace=True` (then resetting the prefix cache, exactly as `sync_weights` does) must actually change
-    the served output. If `load_inplace` were ignored or the prefix cache not reset, the server would keep serving the
-    previous adapter's weights/KV blocks and the swap would be silently lost — the failure mode this whole feature
-    must avoid.
+    with `load_inplace=True` (then resetting the prefix cache, exactly as `sync_weights` does) must actually change the
+    served output. If `load_inplace` were ignored or the prefix cache not reset, the server would keep serving the
+    previous adapter's weights/KV blocks and the swap would be silently lost — the failure mode this whole feature must
+    avoid.
     """
 
     model_id = "Qwen/Qwen2.5-1.5B"

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -1110,9 +1110,7 @@ class TestVLLMClientServerLoRAInplaceSwap(TrlTestCase):
         cls.adapter_a = os.path.join(cls.tmp_adapters, "adapter_a")
         cls.adapter_b = os.path.join(cls.tmp_adapters, "adapter_b")
         model = AutoModelForCausalLM.from_pretrained(cls.model_id)
-        peft_model = get_peft_model(
-            model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"], r=8)
-        )
+        peft_model = get_peft_model(model, LoraConfig(task_type="CAUSAL_LM", target_modules=["q_proj", "v_proj"], r=8))
         peft_model.save_pretrained(cls.adapter_a)
         torch.manual_seed(0)
         with torch.no_grad():

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -67,7 +67,7 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     import peft
-    from peft import PeftConfig, get_peft_model
+    from peft import LoraConfig, PeftConfig, get_peft_model
 
 
 if is_rich_available():
@@ -500,8 +500,25 @@ class DistillationTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=None,  # distillation trains on the teacher distribution, not sampled logprobs
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     # ──────────────────────────────────────────────────────────────────────
     #  Dataset / Dataloader

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -505,7 +505,6 @@ class DistillationTrainer(_BaseTrainer):
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
 
-
     # ──────────────────────────────────────────────────────────────────────
     #  Dataset / Dataloader
     # ──────────────────────────────────────────────────────────────────────

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -67,7 +67,7 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     import peft
-    from peft import LoraConfig, PeftConfig, get_peft_model
+    from peft import PeftConfig, get_peft_model
 
 
 if is_rich_available():
@@ -505,20 +505,6 @@ class DistillationTrainer(_BaseTrainer):
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
 
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     # ──────────────────────────────────────────────────────────────────────
     #  Dataset / Dataloader

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -91,7 +91,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import LoraConfig, PeftConfig
+    from peft import PeftConfig
 
 
 if is_rich_available():
@@ -1112,21 +1112,6 @@ class GOLDTrainer(SFTTrainer):
             )
             self.vllm_sync_frequency = args.vllm_sync_frequency
             self._last_vllm_sync_step = -self.vllm_sync_frequency
-
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     def _set_signature_columns_if_needed(self):
         super()._set_signature_columns_if_needed()

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -91,7 +91,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import PeftConfig
+    from peft import LoraConfig, PeftConfig
 
 
 if is_rich_available():
@@ -1107,9 +1107,26 @@ class GOLDTrainer(SFTTrainer):
                 min_p=getattr(args, "min_p", 0.0),
                 max_completion_length=args.max_completion_length,
                 logprobs=None,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
             self.vllm_sync_frequency = args.vllm_sync_frequency
             self._last_vllm_sync_step = -self.vllm_sync_frequency
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     def _set_signature_columns_if_needed(self):
         super()._set_signature_columns_if_needed()

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -25,7 +25,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
-from accelerate.utils import DistributedType, broadcast_object_list, gather_object
+from accelerate.utils import DistributedType, broadcast_object_list, gather_object, is_peft_model
 from datasets import Dataset
 from packaging.version import Version
 from torch.utils.data import DataLoader
@@ -56,7 +56,7 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     import peft
-    from peft import PeftConfig, get_peft_model
+    from peft import LoraConfig, PeftConfig, get_peft_model
 
 
 if is_rich_available():
@@ -680,9 +680,26 @@ class IWOPDTrainer(_BaseTrainer):
                 top_k=args.top_k,
                 max_completion_length=args.max_completion_length,
                 logprobs=0 if args.distillation_objective == "iw_opd" else None,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
             self.vllm_sync_frequency = args.vllm_sync_frequency
             self._last_vllm_sync_step = -1
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     @staticmethod
     def _local_teacher_tokenizers_match(

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -56,7 +56,7 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     import peft
-    from peft import LoraConfig, PeftConfig, get_peft_model
+    from peft import PeftConfig, get_peft_model
 
 
 if is_rich_available():
@@ -685,21 +685,6 @@ class IWOPDTrainer(_BaseTrainer):
             )
             self.vllm_sync_frequency = args.vllm_sync_frequency
             self._last_vllm_sync_step = -1
-
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     @staticmethod
     def _local_teacher_tokenizers_match(

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -72,7 +72,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import PeftConfig
+    from peft import LoraConfig, PeftConfig
 
 
 logger = get_logger(__name__)
@@ -447,7 +447,24 @@ class SDFTTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=None,
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
         # Per-rank read-only client to the same generation server for teacher scoring (weights are synced there by
         # `VLLMGeneration`; scoring needs no weight-update communicator). Mirrors the distillation trainer's

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -72,7 +72,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import LoraConfig, PeftConfig
+    from peft import PeftConfig
 
 
 logger = get_logger(__name__)
@@ -450,21 +450,6 @@ class SDFTTrainer(_BaseTrainer):
                 is_lora_model=is_peft_model(self.model),
                 lora_sync_output_dir=args.output_dir,
             )
-
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
         # Per-rank read-only client to the same generation server for teacher scoring (weights are synced there by
         # `VLLMGeneration`; scoring needs no weight-update communicator). Mirrors the distillation trainer's

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -77,7 +77,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import PeftConfig
+    from peft import LoraConfig, PeftConfig
 
 
 logger = get_logger(__name__)
@@ -579,7 +579,24 @@ class SDPOTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=None,
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
         # Per-rank read-only client to the same generation server for teacher scoring (weights are synced there by
         # `VLLMGeneration`; scoring needs no weight-update communicator). Mirrors the distillation trainer's

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -77,7 +77,7 @@ if is_liger_kernel_available():
 
 
 if is_peft_available():
-    from peft import LoraConfig, PeftConfig
+    from peft import PeftConfig
 
 
 logger = get_logger(__name__)
@@ -582,21 +582,6 @@ class SDPOTrainer(_BaseTrainer):
                 is_lora_model=is_peft_model(self.model),
                 lora_sync_output_dir=args.output_dir,
             )
-
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
         # Per-rank read-only client to the same generation server for teacher scoring (weights are synced there by
         # `VLLMGeneration`; scoring needs no weight-update communicator). Mirrors the distillation trainer's

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -65,7 +65,7 @@ from .ssd_config import SSDConfig
 
 
 if is_peft_available():
-    from peft import LoraConfig, PeftConfig
+    from peft import PeftConfig
 
 
 logger = get_logger(__name__)
@@ -261,21 +261,6 @@ class SSDTrainer(_BaseTrainer):
                 lora_sync_output_dir=args.output_dir,
             )
             self._last_loaded_step = -1
-
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(self.model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     def _set_signature_columns_if_needed(self):
         if self._signature_columns is None:

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -65,7 +65,7 @@ from .ssd_config import SSDConfig
 
 
 if is_peft_available():
-    from peft import PeftConfig
+    from peft import LoraConfig, PeftConfig
 
 
 logger = get_logger(__name__)
@@ -257,8 +257,25 @@ class SSDTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=None,
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(self.model),
+                lora_sync_output_dir=args.output_dir,
             )
             self._last_loaded_step = -1
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(self.model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = self.model.peft_config[self.model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
 
     def _set_signature_columns_if_needed(self):
         if self._signature_columns is None:

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -163,6 +163,7 @@ class VLLMClient:
             self.server_port = server_port
             self.base_url = f"http://{self.host}:{self.server_port}"
         self.group_port = group_port
+        self.server_enable_lora = False  # set from the /health/ response in check_server
         self.check_server(connection_timeout)  # check server and fail after timeout
 
     def check_server(self, total_timeout: float = 0.0, retry_interval: float = 2.0):
@@ -194,6 +195,9 @@ class VLLMClient:
                 if response.status_code == 200:
                     if "X-Forwarded-For" in response.headers:
                         self.host = response.headers["X-Forwarded-For"]
+                    # The server reports whether it was launched with `--enable-lora`, so the trainer can auto-detect
+                    # whether adapter-only LoRA sync is available.
+                    self.server_enable_lora = response.json().get("enable_lora", False)
                     logger.info("Server is up!")
                     return None
 
@@ -716,6 +720,18 @@ class VLLMClient:
             result["actual_logprobs"] = all_actual_lps
             result["actual_token_ids"] = all_actual_ids
         return result
+
+    def load_lora_adapter(self, lora_name: str, lora_path: str, load_inplace: bool = True):
+        """
+        Loads a LoRA adapter into the vLLM server.
+        """
+        url = f"{self.base_url}/v1/load_lora_adapter"
+        response = self.session.post(
+            url,
+            json={"lora_name": lora_name, "lora_path": lora_path, "load_inplace": load_inplace},
+        )
+        if response.status_code != 200:
+            raise Exception(f"Request failed: {response.status_code}, {response.text}")
 
     def reset_prefix_cache(self):
         """

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -164,6 +164,7 @@ class VLLMClient:
             self.base_url = f"http://{self.host}:{self.server_port}"
         self.group_port = group_port
         self.server_enable_lora = False  # set from the /health/ response in check_server
+        self.server_max_lora_rank = None  # the server's `--max-lora-rank`, set from /health/ (`None` if unset)
         self.check_server(connection_timeout)  # check server and fail after timeout
 
     def check_server(self, total_timeout: float = 0.0, retry_interval: float = 2.0):
@@ -197,7 +198,9 @@ class VLLMClient:
                         self.host = response.headers["X-Forwarded-For"]
                     # The server reports whether it was launched with `--enable-lora`, so the trainer can auto-detect
                     # whether adapter-only LoRA sync is available.
-                    self.server_enable_lora = response.json().get("enable_lora", False)
+                    health = response.json()
+                    self.server_enable_lora = health.get("enable_lora", False)
+                    self.server_max_lora_rank = health.get("max_lora_rank")
                     logger.info("Server is up!")
                     return None
 

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -727,6 +727,14 @@ class VLLMClient:
     def load_lora_adapter(self, lora_name: str, lora_path: str, load_inplace: bool = True):
         """
         Loads a LoRA adapter into the vLLM server.
+
+        Args:
+            lora_name (`str`):
+                Name the adapter is served under. Reusing the same name replaces the previously loaded adapter.
+            lora_path (`str`):
+                Path to the PEFT adapter directory, which must be readable by the server.
+            load_inplace (`bool`, *optional*, defaults to `True`):
+                Whether to swap the weights of the already-loaded adapter instead of registering a new one.
         """
         url = f"{self.base_url}/v1/load_lora_adapter"
         response = self.session.post(

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -58,6 +58,16 @@ logger = logging.getLogger(__name__)
 VLLM_LORA_RANKS = (1, 8, 16, 32, 64, 128, 256, 320, 512)
 
 
+def round_lora_rank(adapter_rank: int) -> int:
+    """Round a LoRA rank up to the smallest `max_lora_rank` vLLM accepts."""
+    if adapter_rank > VLLM_LORA_RANKS[-1]:
+        raise ValueError(
+            f"The LoRA adapter rank ({adapter_rank}) exceeds the largest rank vLLM can serve "
+            f"({VLLM_LORA_RANKS[-1]}). Train with a smaller `r`, or sync full merged weights instead."
+        )
+    return next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
+
+
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
 
@@ -362,7 +372,7 @@ class VLLMGeneration:
                     adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
                     if adapter_rank > server_max_lora_rank:
                         # Suggest a rank vLLM accepts, so the fix doesn't trade this error for a pydantic one.
-                        suggested_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
+                        suggested_rank = round_lora_rank(adapter_rank)
                         raise ValueError(
                             f"The LoRA adapter rank ({adapter_rank}) exceeds the vLLM server's `--max-lora-rank` "
                             f"({server_max_lora_rank}). Relaunch the server with `trl vllm-serve ... --max-lora-rank "
@@ -418,7 +428,7 @@ class VLLMGeneration:
                 # `rank_pattern` may raise individual modules above the base `r`; vLLM needs the max.
                 adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
                 # Round up to a rank vLLM accepts; a plain `r=4` adapter would otherwise crash the engine.
-                max_lora_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
+                max_lora_rank = round_lora_rank(adapter_rank)
                 lora_kwargs = {"enable_lora": True, "max_lora_rank": max_lora_rank}
 
             # Build LLM initialization kwargs
@@ -442,9 +452,10 @@ class VLLMGeneration:
                 **lora_kwargs,
             )
             if self.enable_sleep_mode:
-                self.llm.sleep(level=2)
-            # Sleep level 2 discards the weights; track it so that generate() knows it must re-push them
-            self._llm_weights_sleeping = self.enable_sleep_mode
+                self.llm.sleep(level=self._sleep_level)
+            # Sleep level 2 discards the weights; track it so that generate() knows it must re-push them. Level 1
+            # offloads them to CPU instead and `wake_up` restores them, so there is nothing to re-push.
+            self._llm_weights_sleeping = self.enable_sleep_mode and self._sleep_level == 2
         else:
             raise ValueError(f"vllm_mode must be either 'server' or 'colocate', got '{self.mode}'.")
 
@@ -517,6 +528,16 @@ class VLLMGeneration:
             self._sync_fsdp1_params_to_vllm(model)
         elif self._dist.fsdp_version == 2:
             self._sync_fsdp2_params_to_vllm(model)
+
+    @property
+    def _sleep_level(self) -> int:
+        """vLLM sleep level to use in colocate mode.
+
+        Level 2 discards the weights, which is free for merged sync because it re-pushes every parameter each step.
+        Adapter-only sync leaves the base model frozen and never pushes it, and `wake_up` leaves discarded memory
+        uninitialized, so it uses level 1 — weights are offloaded to CPU and restored on wake.
+        """
+        return 1 if self.lora_sync else 2
 
     def _active_lora_config(self) -> "LoraConfig":
         """Return the active adapter's config, checking it can be synced as a plain LoRA adapter."""
@@ -862,7 +883,7 @@ class VLLMGeneration:
                 logprob_token_ids = all_logprob_token_ids
 
             if self.enable_sleep_mode:
-                self.llm.sleep(level=2)
-                self._llm_weights_sleeping = True
+                self.llm.sleep(level=self._sleep_level)
+                self._llm_weights_sleeping = self._sleep_level == 2
 
         return prompt_ids, completion_ids, logprobs, logprob_token_ids

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -324,6 +324,7 @@ class VLLMGeneration:
                 # the model is LoRA but the server is not LoRA-enabled, fall back to merged-weight sync and warn loudly,
                 # since the user likely intended the fast adapter path.
                 lora_sync = self.is_lora_model and self.vllm_client.server_enable_lora
+                server_max_lora_rank = self.vllm_client.server_max_lora_rank
                 if self.is_lora_model and not self.vllm_client.server_enable_lora:
                     logger.warning(
                         "Training a LoRA model against a vLLM server that was not launched with `--enable-lora`. "
@@ -332,11 +333,25 @@ class VLLMGeneration:
                     )
             else:
                 lora_sync = False
+                server_max_lora_rank = None
             # Broadcast the decision so every process agrees: `_save_lora_adapter` runs collective gathers that would
-            # otherwise deadlock against the merged-sync path.
-            obj_list = [lora_sync]
+            # otherwise deadlock against the merged-sync path. `server_max_lora_rank` rides along so the rank check
+            # below fires identically on every rank.
+            obj_list = [lora_sync, server_max_lora_rank]
             broadcast_object_list(obj_list, from_process=0)
-            self.lora_sync = obj_list[0]
+            self.lora_sync, server_max_lora_rank = obj_list
+            # Fail fast with a clear message if the adapter rank exceeds the server's `--max-lora-rank` (only knowable
+            # when the server reported it), instead of hitting the server's opaque load-time error. `rank_pattern` may
+            # raise individual modules above the base `r`.
+            if self.lora_sync and server_max_lora_rank is not None:
+                active_peft_config = model.peft_config[model.active_adapters[0]]
+                adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
+                if adapter_rank > server_max_lora_rank:
+                    raise ValueError(
+                        f"The LoRA adapter rank ({adapter_rank}) exceeds the vLLM server's `--max-lora-rank` "
+                        f"({server_max_lora_rank}). Relaunch the server with `trl vllm-serve ... --max-lora-rank "
+                        f"{adapter_rank}` (or higher)."
+                    )
             if accelerator.is_main_process and not self.lora_sync:
                 self.vllm_client.init_communicator(device=accelerator.device)
 
@@ -479,6 +494,10 @@ class VLLMGeneration:
         self._lora_sync_version += 1
         root_dir = os.path.join(self.lora_sync_output_dir or os.getcwd(), ".vllm_lora_sync")
         adapter_dir = os.path.join(root_dir, f"sync_{self._lora_sync_version}")
+        # Write to a temp dir and atomically rename into place, so the server (which may read over NFS) never sees a
+        # half-flushed adapter dir. `os.rename` is atomic within the same filesystem, and tmp_dir/adapter_dir share
+        # root_dir.
+        tmp_dir = f"{adapter_dir}.tmp"
 
         with self._dist.gather_params([p for p in model.parameters() if p.requires_grad]):
             with self._dist.summon_full_params(model, recurse=True, writeback=False):
@@ -492,13 +511,15 @@ class VLLMGeneration:
                     for name, param in state_dict.items()
                 }
                 if accelerator.is_main_process:
-                    os.makedirs(adapter_dir, exist_ok=True)
+                    shutil.rmtree(tmp_dir, ignore_errors=True)  # clear any leftover from a crashed prior run
+                    os.makedirs(tmp_dir, exist_ok=True)
                     model.save_pretrained(
-                        adapter_dir,
+                        tmp_dir,
                         selected_adapters=[adapter_name],
                         state_dict=state_dict,
                         safe_serialization=True,
                     )
+                    os.rename(tmp_dir, adapter_dir)
 
         accelerator.wait_for_everyone()
         if accelerator.is_main_process and self._lora_sync_version > 2:

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -48,6 +48,10 @@ if is_vllm_available():
 
 logger = logging.getLogger(__name__)
 
+# The only values vLLM accepts for `max_lora_rank`. It is a capacity bound, not the served rank, so an adapter of any
+# rank is served correctly under the smallest of these that fits it.
+VLLM_LORA_RANKS = (1, 8, 16, 32, 64, 128, 256, 320, 512)
+
 
 def empty_cache() -> None:
     """Empties the cache of the available torch device.
@@ -351,10 +355,12 @@ class VLLMGeneration:
                 active_peft_config = model.peft_config[model.active_adapters[0]]
                 adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
                 if adapter_rank > server_max_lora_rank:
+                    # Suggest a rank vLLM actually accepts, so the fix doesn't trade this error for a pydantic one.
+                    suggested_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
                     raise ValueError(
                         f"The LoRA adapter rank ({adapter_rank}) exceeds the vLLM server's `--max-lora-rank` "
                         f"({server_max_lora_rank}). Relaunch the server with `trl vllm-serve ... --max-lora-rank "
-                        f"{adapter_rank}` (or higher)."
+                        f"{suggested_rank}` (or higher)."
                     )
             if accelerator.is_main_process and not self.lora_sync:
                 self.vllm_client.init_communicator(device=accelerator.device)
@@ -404,7 +410,9 @@ class VLLMGeneration:
                     raise ImportError("Adapter-only LoRA sync in colocate mode requires vLLM >= 0.15.0.")
                 active_peft_config = model.peft_config[model.active_adapters[0]]
                 # `rank_pattern` may raise individual modules above the base `r`; vLLM needs the max.
-                max_lora_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
+                adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
+                # Round up to a rank vLLM accepts; a plain `r=4` adapter would otherwise crash the engine.
+                max_lora_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
                 lora_kwargs = {"enable_lora": True, "max_lora_rank": max_lora_rank}
 
             # Build LLM initialization kwargs

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -28,6 +28,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.tensor import DTensor
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin, is_bitsandbytes_available
 from transformers.utils import (
+    is_peft_available,
     is_torch_mlu_available,
     is_torch_mps_available,
     is_torch_npu_available,
@@ -45,6 +46,9 @@ if is_vllm_available():
     from vllm import LLM, RequestOutput, SamplingParams
     from vllm.lora.request import LoRARequest
     from vllm.sampling_params import StructuredOutputsParams
+
+if is_peft_available():
+    from peft import LoraConfig
 
 
 logger = logging.getLogger(__name__)
@@ -349,20 +353,21 @@ class VLLMGeneration:
             obj_list = [lora_sync, server_max_lora_rank]
             broadcast_object_list(obj_list, from_process=0)
             self.lora_sync, server_max_lora_rank = obj_list
-            # Fail fast with a clear message if the adapter rank exceeds the server's `--max-lora-rank` (only knowable
-            # when the server reported it), instead of hitting the server's opaque load-time error. `rank_pattern` may
-            # raise individual modules above the base `r`.
-            if self.lora_sync and server_max_lora_rank is not None:
-                active_peft_config = model.peft_config[model.active_adapters[0]]
-                adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
-                if adapter_rank > server_max_lora_rank:
-                    # Suggest a rank vLLM actually accepts, so the fix doesn't trade this error for a pydantic one.
-                    suggested_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
-                    raise ValueError(
-                        f"The LoRA adapter rank ({adapter_rank}) exceeds the vLLM server's `--max-lora-rank` "
-                        f"({server_max_lora_rank}). Relaunch the server with `trl vllm-serve ... --max-lora-rank "
-                        f"{suggested_rank}` (or higher)."
-                    )
+            if self.lora_sync:
+                active_peft_config = self._active_lora_config()
+                # Fail fast with a clear message if the adapter rank exceeds the server's `--max-lora-rank` (only
+                # knowable when the server reported it), instead of hitting the server's opaque load-time error.
+                # `rank_pattern` may raise individual modules above the base `r`.
+                if server_max_lora_rank is not None:
+                    adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
+                    if adapter_rank > server_max_lora_rank:
+                        # Suggest a rank vLLM accepts, so the fix doesn't trade this error for a pydantic one.
+                        suggested_rank = next(rank for rank in VLLM_LORA_RANKS if rank >= adapter_rank)
+                        raise ValueError(
+                            f"The LoRA adapter rank ({adapter_rank}) exceeds the vLLM server's `--max-lora-rank` "
+                            f"({server_max_lora_rank}). Relaunch the server with `trl vllm-serve ... --max-lora-rank "
+                            f"{suggested_rank}` (or higher)."
+                        )
             if accelerator.is_main_process and not self.lora_sync:
                 self.vllm_client.init_communicator(device=accelerator.device)
 
@@ -409,7 +414,7 @@ class VLLMGeneration:
             if self.lora_sync:
                 if not is_vllm_available(min_version="0.15.0"):
                     raise ImportError("Adapter-only LoRA sync in colocate mode requires vLLM >= 0.15.0.")
-                active_peft_config = model.peft_config[model.active_adapters[0]]
+                active_peft_config = self._active_lora_config()
                 # `rank_pattern` may raise individual modules above the base `r`; vLLM needs the max.
                 adapter_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
                 # Round up to a rank vLLM accepts; a plain `r=4` adapter would otherwise crash the engine.
@@ -513,6 +518,22 @@ class VLLMGeneration:
         elif self._dist.fsdp_version == 2:
             self._sync_fsdp2_params_to_vllm(model)
 
+    def _active_lora_config(self) -> "LoraConfig":
+        """Return the active adapter's config, checking it can be synced as a plain LoRA adapter."""
+        model = self.model
+        if len(model.active_adapters) != 1:
+            raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+        active_peft_config = model.peft_config[model.active_adapters[0]]
+        if not isinstance(active_peft_config, LoraConfig):
+            raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+        if active_peft_config.modules_to_save:
+            raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+        if active_peft_config.use_dora:
+            raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+        if active_peft_config.bias != "none":
+            raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
+        return active_peft_config
+
     def _save_lora_adapter(self) -> str:
         """Save the active PEFT adapter to a versioned directory and return its path."""
         model = self.model
@@ -525,6 +546,10 @@ class VLLMGeneration:
         # half-flushed adapter dir. `os.rename` is atomic within the same filesystem, and tmp_dir/adapter_dir share
         # root_dir.
         tmp_dir = f"{adapter_dir}.tmp"
+        # In colocate mode every rank loads the adapter from this path, so one writer per node keeps multi-node runs
+        # working without shared storage. In server mode only rank 0's copy is read — by the server, which is why that
+        # path must be visible to it.
+        writes_adapter = accelerator.is_local_main_process if self.mode == "colocate" else accelerator.is_main_process
 
         with self._dist.gather_params([p for p in model.parameters() if p.requires_grad]):
             with self._dist.summon_full_params(model, recurse=True, writeback=False):
@@ -538,7 +563,7 @@ class VLLMGeneration:
                     name: param.full_tensor().detach().cpu() if isinstance(param, DTensor) else param.detach().cpu()
                     for name, param in state_dict.items()
                 }
-                if accelerator.is_main_process:
+                if writes_adapter:
                     shutil.rmtree(tmp_dir, ignore_errors=True)  # clear any leftover from a crashed prior run
                     os.makedirs(tmp_dir, exist_ok=True)
                     model.save_pretrained(
@@ -553,7 +578,7 @@ class VLLMGeneration:
                     os.rename(tmp_dir, adapter_dir)
 
         accelerator.wait_for_everyone()
-        if accelerator.is_main_process and self._lora_sync_version > 2:
+        if writes_adapter and self._lora_sync_version > 2:
             old_dir = os.path.join(root_dir, f"sync_{self._lora_sync_version - 2}")
             shutil.rmtree(old_dir, ignore_errors=True)
         accelerator.wait_for_everyone()

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -25,6 +25,7 @@ import torch
 from accelerate.utils import broadcast_object_list, gather_object, is_peft_model
 from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.tensor import DTensor
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin, is_bitsandbytes_available
 from transformers.utils import (
     is_torch_mlu_available,
@@ -533,7 +534,8 @@ class VLLMGeneration:
                     if "lora_" in name and f".{adapter_name}." in name
                 }
                 state_dict = {
-                    name: param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu()
+                    # FSDP2 shards parameters as DTensor; `full_tensor()` all-gathers just this one.
+                    name: param.full_tensor().detach().cpu() if isinstance(param, DTensor) else param.detach().cpu()
                     for name, param in state_dict.items()
                 }
                 if accelerator.is_main_process:
@@ -545,6 +547,9 @@ class VLLMGeneration:
                         state_dict=state_dict,
                         safe_serialization=True,
                     )
+                    # The version counter restarts at 1 in every process, so a prior run sharing this `output_dir` may
+                    # have left this version behind, and `os.rename` onto a non-empty directory fails.
+                    shutil.rmtree(adapter_dir, ignore_errors=True)
                     os.rename(tmp_dir, adapter_dir)
 
         accelerator.wait_for_everyone()

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -453,9 +453,10 @@ class VLLMGeneration:
             )
             if self.enable_sleep_mode:
                 self.llm.sleep(level=self._sleep_level)
-            # Sleep level 2 discards the weights; track it so that generate() knows it must re-push them. Level 1
-            # offloads them to CPU instead and `wake_up` restores them, so there is nothing to re-push.
-            self._llm_weights_sleeping = self.enable_sleep_mode and self._sleep_level == 2
+            # Tracks whether the weights are off the GPU, which is true at either sleep level. What differs is
+            # how they come back: level 2 discards them so they must be re-pushed from the training model, while
+            # level 1 offloads them to CPU and `wake_up` restores them in place.
+            self._llm_weights_sleeping = self.enable_sleep_mode
         else:
             raise ValueError(f"vllm_mode must be either 'server' or 'colocate', got '{self.mode}'.")
 
@@ -720,11 +721,24 @@ class VLLMGeneration:
         repetition_penalty = self.repetition_penalty
         max_completion_length = self.max_completion_length
 
-        # Sleep level 2 discards the weights, so waking up isn't enough: they must be re-pushed from the training
-        # model. vLLM's `reload_weights` can't be used here, as it reloads the initial checkpoint from disk rather
-        # than the current training weights. See https://github.com/vllm-project/vllm/issues/29341
+        # Bring the weights back if a previous `generate()` put them to sleep. `sync_weights()` does this too,
+        # but the trainer only calls it when the training step advanced, so a second `generate()` within one step
+        # (an eval loop with more than one batch, say) has to restore them here or it runs on offloaded weights.
         if self.mode == "colocate" and self.enable_sleep_mode and self._llm_weights_sleeping:
-            self.sync_weights()
+            if self._sleep_level == 2:
+                # Level 2 discards the weights, so waking up isn't enough: they must be re-pushed from the
+                # training model. vLLM's `reload_weights` can't be used here, as it reloads the initial
+                # checkpoint from disk rather than the current training weights.
+                # See https://github.com/vllm-project/vllm/issues/29341
+                self.sync_weights()
+            else:
+                # Level 1 only offloaded them to CPU. The base model is frozen and vLLM already holds the
+                # adapter this step generated with, so restoring in place is enough -- nothing to re-push.
+                # This is gated on `_llm_weights_sleeping` rather than done unconditionally below because
+                # `CuMemAllocator.wake_up` re-maps every matching allocation without checking whether it is
+                # already mapped, so waking "weights" twice between two sleeps would double-map.
+                self.llm.wake_up(tags=["weights"])
+                self._llm_weights_sleeping = False
 
         # Generate completions using vLLM: gather all prompts and use them in a single call in the main process
         if self.mode == "server":
@@ -884,6 +898,6 @@ class VLLMGeneration:
 
             if self.enable_sleep_mode:
                 self.llm.sleep(level=self._sleep_level)
-                self._llm_weights_sleeping = self._sleep_level == 2
+                self._llm_weights_sleeping = True
 
         return prompt_ids, completion_ids, logprobs, logprob_token_ids

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -42,6 +42,7 @@ from .vllm_client import VLLMClient
 
 if is_vllm_available():
     from vllm import LLM, RequestOutput, SamplingParams
+    from vllm.lora.request import LoRARequest
     from vllm.sampling_params import StructuredOutputsParams
 
 
@@ -297,6 +298,9 @@ class VLLMGeneration:
         self.lora_name = "trl_lora_adapter"
         self.lora_sync_output_dir = lora_sync_output_dir
         self._lora_sync_version = 0
+        # Colocate adapter sync references the currently-loaded adapter by `lora_request` at generation time; set by
+        # `sync_weights`. Unused in server mode (the server applies the loaded adapter by name automatically).
+        self._lora_request = None
 
         self._init_vllm()
 
@@ -390,6 +394,19 @@ class VLLMGeneration:
                     elif isinstance(module, bnb.nn.Linear8bitLt):
                         raise ValueError("vLLM does not support in-flight 8-bit quantization.")
 
+            # Adapter-only LoRA sync: in colocate mode the trainer owns the vLLM engine, so (unlike server mode) it
+            # enables LoRA itself and infers `max_lora_rank` from the adapter — no server capability to detect. The
+            # trainer validates the adapter is syncable as a plain LoRA adapter after `__init__` returns.
+            self.lora_sync = self.is_lora_model
+            lora_kwargs = {}
+            if self.lora_sync:
+                if not is_vllm_available(min_version="0.15.0"):
+                    raise ImportError("Adapter-only LoRA sync in colocate mode requires vLLM >= 0.15.0.")
+                active_peft_config = model.peft_config[model.active_adapters[0]]
+                # `rank_pattern` may raise individual modules above the base `r`; vLLM needs the max.
+                max_lora_rank = max([active_peft_config.r, *active_peft_config.rank_pattern.values()])
+                lora_kwargs = {"enable_lora": True, "max_lora_rank": max_lora_rank}
+
             # Build LLM initialization kwargs
             self.llm = LLM(
                 model=model.name_or_path,
@@ -408,6 +425,7 @@ class VLLMGeneration:
                 logprobs_mode="processed_logprobs",
                 quantization=quantization,
                 trust_remote_code=self.trust_remote_code,
+                **lora_kwargs,
             )
             if self.enable_sleep_mode:
                 self.llm.sleep(level=2)
@@ -546,13 +564,20 @@ class VLLMGeneration:
 
         if self.lora_sync:
             adapter_path = self._save_lora_adapter()
-            if accelerator.is_main_process:
-                # `load_inplace=True` reloads the adapter under the same name/id with the freshly trained weights. vLLM
-                # keys its prefix cache on `lora_name` only, so an in-place swap leaves stale KV blocks that would serve
-                # the previous policy's outputs (vLLM issue #42125). Resetting the prefix cache after every swap is
-                # required for correctness here — do not remove it.
-                self.vllm_client.load_lora_adapter(self.lora_name, adapter_path, load_inplace=True)
-                self.vllm_client.reset_prefix_cache()
+            # `load_inplace=True` reloads the adapter under the same name/id with the freshly trained weights. vLLM
+            # keys its prefix cache on `lora_name` only, so an in-place swap leaves stale KV blocks that would serve
+            # the previous policy's outputs (vLLM issue #42125). Resetting the prefix cache after every swap is
+            # required for correctness here — do not remove it.
+            if self.mode == "server":
+                if accelerator.is_main_process:
+                    self.vllm_client.load_lora_adapter(self.lora_name, adapter_path, load_inplace=True)
+                    self.vllm_client.reset_prefix_cache()
+            else:
+                # Colocate: each rank owns its engine, so each reloads the adapter (pinned `lora_int_id=1`, matching the
+                # server). `generate` then activates it by passing a plain `lora_request` referencing the same id.
+                self.llm.llm_engine.add_lora(LoRARequest(self.lora_name, 1, adapter_path, load_inplace=True))
+                self.llm.reset_prefix_cache()
+                self._lora_request = LoRARequest(self.lora_name, 1, adapter_path)
             accelerator.wait_for_everyone()
             return
 
@@ -772,7 +797,12 @@ class VLLMGeneration:
                 torch.distributed.barrier(device_ids=[accelerator.local_process_index])
 
             with profiler:
-                all_outputs = self.llm.generate(vllm_prompts, sampling_params=sampling_params, use_tqdm=False)
+                all_outputs = self.llm.generate(
+                    vllm_prompts,
+                    sampling_params=sampling_params,
+                    lora_request=self._lora_request,  # `None` unless adapter-only LoRA sync is active
+                    use_tqdm=False,
+                )
 
             all_prompt_ids = [output.prompt_token_ids for output in all_outputs]
             all_completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -17,6 +17,7 @@
 import logging
 import math
 import os
+import shutil
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -252,6 +253,8 @@ class VLLMGeneration:
         max_completion_length: int = 16,
         logprobs: int | None = 0,
         generation_kwargs: dict | None = None,
+        is_lora_model: bool = False,
+        lora_sync_output_dir: str | None = None,
     ):
         self.model = model
         self.accelerator = accelerator
@@ -287,6 +290,13 @@ class VLLMGeneration:
         self.max_completion_length = max_completion_length
         self.logprobs = logprobs
         self.generation_kwargs = generation_kwargs or {}
+        self.is_lora_model = is_lora_model
+        # Adapter-only LoRA sync is auto-detected in `_init_vllm`: it requires a LoRA model, server mode, and a server
+        # launched with `--enable-lora`. Otherwise we fall back to syncing full (merged) weights.
+        self.lora_sync = False
+        self.lora_name = "trl_lora_adapter"
+        self.lora_sync_output_dir = lora_sync_output_dir
+        self._lora_sync_version = 0
 
         self._init_vllm()
 
@@ -310,6 +320,24 @@ class VLLMGeneration:
                 self.vllm_client = VLLMClient(
                     base_url=base_url, group_port=self.group_port, connection_timeout=self.server_timeout
                 )
+                # Auto-detect adapter-only LoRA sync: a LoRA model against a server launched with `--enable-lora`. If
+                # the model is LoRA but the server is not LoRA-enabled, fall back to merged-weight sync and warn loudly,
+                # since the user likely intended the fast adapter path.
+                lora_sync = self.is_lora_model and self.vllm_client.server_enable_lora
+                if self.is_lora_model and not self.vllm_client.server_enable_lora:
+                    logger.warning(
+                        "Training a LoRA model against a vLLM server that was not launched with `--enable-lora`. "
+                        "Falling back to syncing full merged weights every step. To use the faster adapter-only sync, "
+                        "launch the server with `trl vllm-serve --model ... --enable-lora --max-lora-rank <rank>`."
+                    )
+            else:
+                lora_sync = False
+            # Broadcast the decision so every process agrees: `_save_lora_adapter` runs collective gathers that would
+            # otherwise deadlock against the merged-sync path.
+            obj_list = [lora_sync]
+            broadcast_object_list(obj_list, from_process=0)
+            self.lora_sync = obj_list[0]
+            if accelerator.is_main_process and not self.lora_sync:
                 self.vllm_client.init_communicator(device=accelerator.device)
 
         elif self.mode == "colocate":
@@ -443,6 +471,42 @@ class VLLMGeneration:
         elif self._dist.fsdp_version == 2:
             self._sync_fsdp2_params_to_vllm(model)
 
+    def _save_lora_adapter(self) -> str:
+        """Save the active PEFT adapter to a versioned directory and return its path."""
+        model = self.model
+        accelerator = self.accelerator
+        adapter_name = model.active_adapters[0]
+        self._lora_sync_version += 1
+        root_dir = os.path.join(self.lora_sync_output_dir or os.getcwd(), ".vllm_lora_sync")
+        adapter_dir = os.path.join(root_dir, f"sync_{self._lora_sync_version}")
+
+        with self._dist.gather_params([p for p in model.parameters() if p.requires_grad]):
+            with self._dist.summon_full_params(model, recurse=True, writeback=False):
+                state_dict = {
+                    name: param
+                    for name, param in model.state_dict().items()
+                    if "lora_" in name and f".{adapter_name}." in name
+                }
+                state_dict = {
+                    name: param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu()
+                    for name, param in state_dict.items()
+                }
+                if accelerator.is_main_process:
+                    os.makedirs(adapter_dir, exist_ok=True)
+                    model.save_pretrained(
+                        adapter_dir,
+                        selected_adapters=[adapter_name],
+                        state_dict=state_dict,
+                        safe_serialization=True,
+                    )
+
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process and self._lora_sync_version > 2:
+            old_dir = os.path.join(root_dir, f"sync_{self._lora_sync_version - 2}")
+            shutil.rmtree(old_dir, ignore_errors=True)
+        accelerator.wait_for_everyone()
+        return adapter_dir
+
     def sync_weights(self):
         """Synchronize model weights to vLLM.
 
@@ -458,6 +522,18 @@ class VLLMGeneration:
 
         model = self.model
         accelerator = self.accelerator
+
+        if self.lora_sync:
+            adapter_path = self._save_lora_adapter()
+            if accelerator.is_main_process:
+                # `load_inplace=True` reloads the adapter under the same name/id with the freshly trained weights. vLLM
+                # keys its prefix cache on `lora_name` only, so an in-place swap leaves stale KV blocks that would serve
+                # the previous policy's outputs (vLLM issue #42125). Resetting the prefix cache after every swap is
+                # required for correctness here — do not remove it.
+                self.vllm_client.load_lora_adapter(self.lora_name, adapter_path, load_inplace=True)
+                self.vllm_client.reset_prefix_cache()
+            accelerator.wait_for_everyone()
+            return
 
         if is_peft_model(model):
             # With PEFT and FSDP/DeepSpeed ZeRO Stage 3, we must gather the full model at once before merging, as

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -521,9 +521,14 @@ def main(script_args: ScriptArguments):
     async def health():
         """
         Health check endpoint to verify that the server is running. Also reports whether the server was launched with
-        LoRA support, so the client can auto-detect whether adapter-only sync is available.
+        LoRA support (and the `--max-lora-rank` it was launched with), so the client can auto-detect whether
+        adapter-only sync is available and validate the adapter rank fits.
         """
-        return {"status": "ok", "enable_lora": script_args.enable_lora}
+        return {
+            "status": "ok",
+            "enable_lora": script_args.enable_lora,
+            "max_lora_rank": script_args.max_lora_rank,
+        }
 
     @app.get("/get_world_size/")
     async def get_world_size():

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -465,6 +465,12 @@ def main(script_args: ScriptArguments):
     elif not is_vllm_available():
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
 
+    if script_args.enable_lora and script_args.max_lora_rank is None:
+        raise ValueError(
+            "`--enable-lora` requires `--max-lora-rank`. Pass one of 1, 8, 16, 32, 64, 128, 256, 320 or 512, at least "
+            "as large as the adapter's `r`."
+        )
+
     import uvicorn
     from fastapi import FastAPI
     from pydantic import BaseModel

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -461,7 +461,7 @@ def main(script_args: ScriptArguments):
         )
 
     if script_args.enable_lora and not is_vllm_available(min_version="0.15.0"):
-        raise ImportError("LoRA adapter loading in the vLLM serve script requires vLLM >= 0.15.0. ")
+        raise ImportError("LoRA adapter loading in the vLLM serve script requires vLLM >= 0.15.0.")
     elif not is_vllm_available():
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -217,6 +217,10 @@ class ScriptArguments:
         speculative_config (`str`, *optional*):
             JSON string for vLLM speculative decoding config, forwarded to `LLM(speculative_config=...)`. When unset,
             speculative decoding is disabled. Example: `'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}'`.
+        enable_lora (`bool`, *optional*, defaults to `False`):
+            Whether to enable vLLM LoRA support.
+        max_lora_rank (`int`, *optional*):
+            Maximum LoRA rank when LoRA support is enabled.
     """
 
     model: str = field(
@@ -327,12 +331,21 @@ class ScriptArguments:
             'Example: \'{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}\''
         },
     )
+    enable_lora: bool = field(
+        default=False,
+        metadata={"help": "Whether to enable vLLM LoRA support."},
+    )
+    max_lora_rank: int | None = field(
+        default=None,
+        metadata={"help": "Maximum LoRA rank when LoRA support is enabled."},
+    )
 
 
 def llm_worker(
     script_args: ScriptArguments, data_parallel_rank: int, master_port: int, connection: Connection
 ) -> None:
     from vllm import LLM
+    from vllm.lora.request import LoRARequest
 
     # Set required environment variables for DP to work with vLLM
     os.environ["VLLM_DP_RANK"] = str(data_parallel_rank)
@@ -360,6 +373,8 @@ def llm_worker(
         # Important so temperature scaling/logit tweaking affects the TIS log probs
         logprobs_mode="processed_logprobs",
         speculative_config=json.loads(script_args.speculative_config) if script_args.speculative_config else None,
+        enable_lora=script_args.enable_lora,
+        max_lora_rank=script_args.max_lora_rank,
     )
 
     # Send ready signal to parent process
@@ -377,10 +392,22 @@ def llm_worker(
         if command["type"] in ["call", "fire_and_forget"]:
             method_name = command["method"]
             args, kwargs = command.get("args", ()), command.get("kwargs", {})
+            if "lora_request_kwargs" in kwargs:
+                lora_request_kwargs = kwargs.pop("lora_request_kwargs")
+                kwargs["lora_request"] = LoRARequest(**lora_request_kwargs)
             method = getattr(llm, method_name)
             result = method(*args, **kwargs)
             if command["type"] == "call":
                 connection.send(result)
+        elif command["type"] == "load_lora_adapter":
+            lora_request = LoRARequest(
+                command["lora_name"],
+                command["lora_int_id"],
+                command["lora_path"],
+                load_inplace=command["load_inplace"],
+            )
+            llm.llm_engine.add_lora(lora_request)
+            connection.send({"message": "LoRA adapter loaded"})
         elif command["type"] == "shutdown":
             break
 
@@ -433,7 +460,9 @@ def main(script_args: ScriptArguments):
             "Uvicorn is required to run the vLLM serve script. Please install it using `pip install uvicorn`."
         )
 
-    if not is_vllm_available():
+    if script_args.enable_lora and not is_vllm_available(min_version="0.15.0"):
+        raise ImportError("LoRA adapter loading in the vLLM serve script requires vLLM >= 0.15.0. ")
+    elif not is_vllm_available():
         raise ImportError("vLLM is required to run the vLLM serve script. Please install it using `pip install vllm`.")
 
     import uvicorn
@@ -485,14 +514,16 @@ def main(script_args: ScriptArguments):
                 process.join()  # ensure process termination after calling terminate()
 
     app = FastAPI(lifespan=lifespan)
+    active_lora = {"name": None, "path": None, "int_id": 1}
 
     # Define the endpoints for the model server
     @app.get("/health/")
     async def health():
         """
-        Health check endpoint to verify that the server is running.
+        Health check endpoint to verify that the server is running. Also reports whether the server was launched with
+        LoRA support, so the client can auto-detect whether adapter-only sync is available.
         """
-        return {"status": "ok"}
+        return {"status": "ok", "enable_lora": script_args.enable_lora}
 
     @app.get("/get_world_size/")
     async def get_world_size():
@@ -638,6 +669,12 @@ def main(script_args: ScriptArguments):
             if not prompts:
                 prompts = ["<placeholder>"]
             kwargs = {"prompts": prompts, "sampling_params": sampling_params}
+            if active_lora["name"] is not None:
+                kwargs["lora_request_kwargs"] = {
+                    "lora_name": active_lora["name"],
+                    "lora_int_id": active_lora["int_id"],
+                    "lora_path": active_lora["path"],
+                }
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
 
         # Receive results
@@ -1094,6 +1131,12 @@ def main(script_args: ScriptArguments):
                 "chat_template_kwargs": request.chat_template_kwargs,
                 "tools": request.tools,
             }
+            if active_lora["name"] is not None:
+                kwargs["lora_request_kwargs"] = {
+                    "lora_name": active_lora["name"],
+                    "lora_int_id": active_lora["int_id"],
+                    "lora_path": active_lora["path"],
+                }
             connection.send({"type": "call", "method": "chat", "kwargs": kwargs})
 
         # Receive results
@@ -1114,6 +1157,36 @@ def main(script_args: ScriptArguments):
             "logprobs": logprobs,
             "logprob_token_ids": logprob_token_ids,
         }
+
+    class LoadLoRAAdapterRequest(BaseModel):
+        lora_name: str
+        lora_path: str
+        load_inplace: bool = True
+
+    @app.post("/v1/load_lora_adapter")
+    async def load_lora_adapter(request: LoadLoRAAdapterRequest):
+        """
+        Loads a LoRA adapter into the vLLM engine.
+        """
+        if not script_args.enable_lora:
+            raise ValueError(
+                "LoRA support is not enabled. Launch the server with "
+                "`trl vllm-serve --model ... --enable-lora --max-lora-rank <rank>`."
+            )
+        active_lora["name"] = request.lora_name
+        active_lora["path"] = request.lora_path
+        for connection in connections:
+            connection.send(
+                {
+                    "type": "load_lora_adapter",
+                    "lora_name": request.lora_name,
+                    "lora_path": request.lora_path,
+                    "lora_int_id": active_lora["int_id"],
+                    "load_inplace": request.load_inplace,
+                }
+            )
+        all_outputs = [connection.recv() for connection in connections]
+        return {"message": "LoRA adapter loaded", "worker_responses": all_outputs}
 
     class InitCommunicatorRequest(BaseModel):
         host: str

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -613,6 +613,7 @@ class GRPOConfig(_BaseConfig):
         default=None,
         metadata={"help": "Regex for vLLM structured outputs. If `None` (default), structured outputs is disabled."},
     )
+
     # Parameters that control the vLLM server (only used when `vllm_mode` is `"server"`)
     vllm_server_base_url: str | None = field(
         default=None,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -613,7 +613,6 @@ class GRPOConfig(_BaseConfig):
         default=None,
         metadata={"help": "Regex for vLLM structured outputs. If `None` (default), structured outputs is disabled."},
     )
-
     # Parameters that control the vLLM server (only used when `vllm_mode` is `"server"`)
     vllm_server_base_url: str | None = field(
         default=None,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -69,7 +69,7 @@ from ..data_utils import apply_chat_template, is_conversational, prepare_multimo
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
-from ..import_utils import is_jmespath_available, is_liger_kernel_available
+from ..import_utils import is_jmespath_available, is_liger_kernel_available, is_vllm_available
 from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import _ForwardRedirection, disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer
@@ -1113,8 +1113,25 @@ class GRPOTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=0,  # we only need the generated token logprobs for the importance sampling correction
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(model),
+                lora_sync_output_dir=args.output_dir,
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = model.peft_config[model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
         else:
             generation_kwargs = {
                 "max_new_tokens": self.max_completion_length,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1118,20 +1118,6 @@ class GRPOTrainer(_BaseTrainer):
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
 
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = model.peft_config[model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
         else:
             generation_kwargs = {
                 "max_new_tokens": self.max_completion_length,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -69,7 +69,7 @@ from ..data_utils import apply_chat_template, is_conversational, prepare_multimo
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
-from ..import_utils import is_jmespath_available, is_liger_kernel_available, is_vllm_available
+from ..import_utils import is_jmespath_available, is_liger_kernel_available
 from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import _ForwardRedirection, disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -684,8 +684,25 @@ class RLOOTrainer(_BaseTrainer):
                 max_completion_length=self.max_completion_length,
                 logprobs=None,  # we don't need logprobs from vLLM in RLOO
                 generation_kwargs=args.generation_kwargs,
+                is_lora_model=is_peft_model(model),
+                lora_sync_output_dir=args.output_dir,
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
+
+            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
+            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
+            if self.vllm_generation.lora_sync:
+                if len(model.active_adapters) != 1:
+                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
+                active_peft_config = model.peft_config[model.active_adapters[0]]
+                if not isinstance(active_peft_config, LoraConfig):
+                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
+                if active_peft_config.modules_to_save:
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
+                if active_peft_config.use_dora:
+                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
+                if active_peft_config.bias != "none":
+                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
         else:
             generation_kwargs = {
                 "max_new_tokens": self.max_completion_length,

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -689,20 +689,6 @@ class RLOOTrainer(_BaseTrainer):
             )
             self._last_loaded_step = -1  # tag to avoid useless loading during grad accumulation
 
-            # Adapter-only LoRA sync is auto-detected in the generation backend (LoRA model + server launched with
-            # `--enable-lora`). When it's active, the active adapter must be syncable as a plain LoRA adapter.
-            if self.vllm_generation.lora_sync:
-                if len(model.active_adapters) != 1:
-                    raise ValueError("Adapter-only LoRA sync currently supports exactly one active adapter.")
-                active_peft_config = model.peft_config[model.active_adapters[0]]
-                if not isinstance(active_peft_config, LoraConfig):
-                    raise ValueError("Adapter-only LoRA sync currently supports only PEFT LoRA adapters.")
-                if active_peft_config.modules_to_save:
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA configs with `modules_to_save`.")
-                if active_peft_config.use_dora:
-                    raise ValueError("Adapter-only LoRA sync does not support DoRA adapters.")
-                if active_peft_config.bias != "none":
-                    raise ValueError("Adapter-only LoRA sync does not support LoRA adapters with bias.")
         else:
             generation_kwargs = {
                 "max_new_tokens": self.max_completion_length,


### PR DESCRIPTION
## What does this PR do?

Adds an **adapter-only** LoRA weight-sync path for online trainers with vLLM. When training a PEFT LoRA model, TRL syncs just the LoRA adapter to vLLM each step instead of merging the adapter into the base model and transferring full weights.

This is **zero-config and auto-detected** — there is no `vllm_lora_sync` flag. Adapter sync activates whenever vLLM is set up to serve LoRA adapters, and falls back to full merged-weight sync otherwise.

Part of #5975.

### Why: it unblocks QLoRA + FSDP2, which cannot merge at all

The primary motivation is capability, not speed. With QLoRA + FSDP2 the base model is bitsandbytes-quantized and FSDP2 shards parameters as `DTensor`. PEFT's bitsandbytes merge path expects bitsandbytes parameters carrying quantization metadata (`quant_state`), so `merge_adapter()` on DTensor-sharded quantized weights fails outright (peft#2501, accelerate#3874). Any sync strategy built on merging is therefore unavailable for that combination, and TRL currently has to guard it. Adapter-only sync avoids the failing operation entirely.

Being explicit about the tradeoff, since it cuts both ways: **vLLM LoRA inference is slower than serving merged weights.** You are exchanging per-step sync cost (full model → a few MB) for per-token generation overhead, and generation usually dominates GRPO wall-clock. So this is not a blanket win, which is exactly why it is auto-detected rather than default-on: users who do not launch the server with `--enable-lora` are completely unaffected, and anyone whose bottleneck is generation can simply keep the merged path.

### How auto-detection works

```python
# server mode
adapter_sync = is_lora_model and server_was_launched_with_enable_lora
# colocate mode (trainer owns the engine, so it enables LoRA itself)
adapter_sync = is_lora_model
```

- **Server mode**: the server reports `enable_lora` and `max_lora_rank` on `/health/`. A LoRA model + an `--enable-lora` server → adapter sync. A LoRA model + a non-LoRA server → merged sync **with a warning**. The decision is broadcast to all ranks so the collective adapter-save cannot deadlock against the merged path.
- **Colocate mode**: the trainer owns the engine, so it sets `enable_lora=True` and infers `max_lora_rank` from the adapter.
- **Dense / non-LoRA models**: unchanged.

## Main changes

Server / client (`trl vllm-serve`, `VLLMClient`):
- `trl vllm-serve --enable-lora --max-lora-rank <rank>`. The server starts before it has seen any adapter, so the rank cannot be inferred there; `--enable-lora` without `--max-lora-rank` now fails at launch with a clear message instead of an opaque pydantic error.
- `/health/` reports `enable_lora` and `max_lora_rank`; `VLLMClient` stores them, defaulting to off for older servers.
- `POST /v1/load_lora_adapter` + `VLLMClient.load_lora_adapter(...)`; the active adapter is injected into `/generate/` and `/chat/`.

Generation backend (`VLLMGeneration`) — all adapter-sync logic lives here, so every trainer using this backend gets it:
- Auto-detect + broadcast the `lora_sync` decision; skip `init_communicator` in adapter mode.
- `_active_lora_config()` validates that the active adapter is syncable as a plain LoRA adapter (single active adapter, no `modules_to_save`, no DoRA, no LoRA bias). It sits with the other vLLM capability checks and runs *before* any LoRA-only config field is read, so unsupported setups get a clear `ValueError` rather than an `IndexError`/`AttributeError`.
- `_save_lora_adapter()` writes the adapter to a versioned dir, then **atomically renames** it into place (`sync_N.tmp/` → `sync_N/`) so a server reading over NFS never sees a half-flushed dir. The destination is cleared first, since the version counter restarts per process and a prior run sharing `output_dir` would otherwise collide on rename.
- Adapter-only `sync_weights()` branch (no merge/unmerge). Server: `load_lora_adapter(..., load_inplace=True)`. Colocate: `add_lora(LoRARequest(..., load_inplace=True))`, then `generate()` passes the `lora_request`.
- `reset_prefix_cache()` after every swap — vLLM keys its prefix cache on `lora_name` only, so an in-place swap otherwise serves the previous policy's stale KV blocks (vLLM #42125).
- The inferred `max_lora_rank` is rounded up to a value vLLM accepts (`1, 8, 16, …, 512`). It is a capacity bound, not the served rank, so an ordinary `r=4` adapter is served correctly under `8` — previously it crashed engine construction.
- In colocate mode every rank loads the adapter from the saved path, so the write happens once **per node** (`is_local_main_process`). Multi-node colocate therefore needs no shared storage. Server mode keeps rank 0 writing to a path the server can see, since the server is the only reader.

Trainers: pass `is_lora_model` / `lora_sync_output_dir` into `VLLMGeneration` (2 lines each). The deleted `GRPOConfig.vllm_lora_sync` field is gone.

## Scope

Supported — **every trainer that uses the shared `VLLMGeneration` backend**:
- `GRPOTrainer`, `RLOOTrainer`
- experimental: `gold`, `iw_opd`, `ssd`, `distillation`, `sdft`, `sdpo`
- vLLM **server and colocate** modes; PEFT LoRA / QLoRA, one active adapter
- server mode: a filesystem path visible to trainer rank 0 and the vLLM server

Out of scope, for architectural reasons rather than oversight:
- **`AsyncGRPOTrainer`** — does not use `VLLMGeneration`. It has its own `VLLMClient`, streams weights through vLLM's NCCL weight-transfer engine (requiring vLLM ≥ 0.22.0 rather than this PR's ≥ 0.15.0), and carries its own model-version/staleness protocol. Adapter sync there means streaming LoRA tensors over that group — a separate design, not wiring.
- **experimental `online_dpo`** — the one remaining trainer on the pre-`VLLMGeneration` path, with its own hand-rolled merge/`update_named_param` loop. It will inherit adapter sync for free once it moves onto the shared backend, so implementing it twice seems worse than waiting.
- multiple active adapters, `modules_to_save`, DoRA, LoRA bias
- the existing full-weight sync path for dense models

## Tests and validation

Unit tests:
- client `/health/` parse of `enable_lora` + `max_lora_rank`; `/v1/load_lora_adapter` payload/error handling
- auto-detect decision matrix (`is_lora_model × server_enable_lora`), merged-fallback warning, adapter-rank-too-large rejection, `max_lora_rank` rounding (`4→8`, `8→8`, `12→16`, `200→256`)
- backend rejection of unsupported adapter configs (`modules_to_save`, DoRA, bias)
- GRPO + RLOO `is_lora_model` wiring; merge-free sync path (server and colocate); non-empty PEFT/QLoRA adapter saves

Slow E2E test:
- `TestVLLMClientServerLoRAInplaceSwap` — loads adapter A, swaps to a perturbed adapter B in-place under the same name/int_id with `reset_prefix_cache`, asserts the served output changes (the #42125 stale-adapter regression guard).

Manual E2E (RTX 4090, vLLM 0.19.0, `Qwen/Qwen2.5-0.5B-Instruct`, LoRA `r=8`):
- **Server**: live `trl vllm-serve --enable-lora --max-lora-rank 8`; adapter sync auto-activated, versioned dirs written with no `.tmp` leftover, importance-sampling ratio ≈ 1.0 (adapter genuinely applied during generation).
- **Colocate**: adapter sync auto-activated, adapter advanced each step, importance-sampling ratio ≈ 1.0.
- **In-place swap**: greedy output changes between two distinct adapters under the same name, deterministic on reload.

### Notes for reviewers

- **PR CI does not exercise this feature.** The adapter-sync E2E tests, the QLoRA adapter-save test and the `r=4` colocate regression test are all `@pytest.mark.slow`, so `make test` deselects them and they only run in `slow-tests.yml`. A green PR check here is not evidence that the adapter path works; the manual runs above and the nightly slow suite are.
- **The per-node colocate write is reasoned, not multi-node tested** — validation was done on a single GPU. The design follows verl's approach of staging the adapter per node (verl-project/verl#6078) rather than requiring shared storage, but a real multi-node colocate run would be worth having before relying on it.
- **Removed the trainer-side `vLLM >= 0.15.0` check.** In server mode it tested the wrong process (the client does not run the engine) and was redundant: the server enforces the floor at launch and only reports `enable_lora=true` once started, so `adapter_sync ⟹ server ≥ 0.15.0`. In **colocate** mode the trainer does own the engine, so the gate is applied there instead.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Issue: #5975
- [x] Did you make sure to update the documentation with your changes? (`docs/source/vllm_integration.md`)
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches training–inference weight sync, distributed collectives, and vLLM LoRA/prefix-cache behavior; incorrect adapter swap or sleep/wake logic can cause silent wrong rollouts or hangs.
> 
> **Overview**
> Adds **automatic adapter-only LoRA sync** for online trainers using the shared `VLLMGeneration` backend. During PEFT LoRA training, each step saves and pushes only the LoRA adapter to vLLM (server `load_lora_adapter` or colocate `add_lora` with `load_inplace=True`) instead of merge + full-weight transfer—enabling paths like **QLoRA + FSDP2** where merge is not viable.
> 
> **Auto-detection (no new trainer flag):** server mode turns on adapter sync when the model is LoRA and `/health/` reports `enable_lora` (from `trl vllm-serve --enable-lora --max-lora-rank`); otherwise merged sync with a warning. Colocate mode enables LoRA on the engine and rounds `max_lora_rank` to vLLM-allowed values. Unsupported adapters (`modules_to_save`, DoRA, bias) fail fast via `_active_lora_config()`.
> 
> **Supporting changes:** `VLLMClient` reads server LoRA caps and calls `/v1/load_lora_adapter`; prefix cache reset after in-place swaps; sleep level **1** for adapter sync vs **2** for merged; `generate()` wakes level-1 weights on repeat calls within a step. All `VLLMGeneration` trainers wire `is_lora_model` and `lora_sync_output_dir`. Docs cover server vs colocate setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfe388b9126916fbc4910ab376ed6aa31d0132c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->