### PR TITLE
fix(cli): drop duplicate "to" in trl skills install description

### DIFF
--- a/trl/skills/cli.py
+++ b/trl/skills/cli.py
@@ -69,7 +69,7 @@ def add_skills_subcommands(subparsers: argparse._SubParsersAction) -> None:
         "install",
         parents=[target_parser],
         help="Install skill",
-        description="Install TRL skill to to target",
+        description="Install TRL skill to target",
     )
     install_parser.add_argument("skill", nargs="?", help="Skill name to install (omit to use --all)")
     install_parser.add_argument("--all", action="store_true", help="Install all available TRL skills")


### PR DESCRIPTION
## What does this PR do?

The `install` subparser added in #5987 has a doubled word in its argparse description — `trl skills install --help` currently prints:

> Install TRL skill **to to** target

Drop the extra `to`. One-word deletion in `trl/skills/cli.py`.

## Before submitting

- [x] This PR fixes a typo (user-visible `--help` text).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A — one-word typo.)_
- [ ] Did you write any new necessary tests? _(N/A.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible help text only; no runtime or CLI logic changes.
> 
> **Overview**
> Fixes a typo in the `trl skills install` argparse **description** so `--help` reads “Install TRL skill to target” instead of “Install TRL skill **to to** target”.
> 
> Single-line change in `trl/skills/cli.py` on the `install` subparser; no behavior change beyond help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe94e17d4958861343fca3056da4f7e3664abce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->