### PR TITLE
docs: sync experimental trainer docstrings with their __init__ signatures

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -318,6 +318,11 @@ class AsyncGRPOTrainer(_BaseTrainer):
             method should return either `None` or a string: when it returns a string, that string is appended to the
             last user message before generation. This feature is experimental and may change or be removed at any time
             without prior notice.
+        rollout_worker (`RolloutWorkerProtocol`, *optional*):
+            Custom rollout worker implementing [`RolloutWorkerProtocol`]. If `None`, a default [`AsyncRolloutWorker`]
+            is created, which spawns a CUDA-free child process and scores completions with the trainer's
+            `reward_funcs`. Pass a custom worker to plug in a different rollout/scoring backend instead — for example,
+            one that runs reward models on their own GPUs.
     """
 
     _tag_names = ["trl", "async-grpo"]

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -387,6 +387,12 @@ class BCOTrainer(_BaseTrainer):
             Name of the train target PEFT adapter, when using LoRA with multiple adapters.
         ref_adapter_name (`str`, defaults to `None`):
             Name of the reference PEFT adapter, when using LoRA with multiple adapters.
+        embedding_func (`Callable`, *optional*):
+            Function to compute prompt embeddings, used to train the underlying distribution matching (UDM) classifier
+            when the desirable and undesirable datasets have divergent prompt distributions. Requires the scikit-learn
+            and joblib libraries.
+        embedding_tokenizer ([`~transformers.PreTrainedTokenizerBase`], *optional*):
+            Tokenizer used to prepare prompts for `embedding_func`.
     """
 
     _tag_names = ["trl", "bco"]

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -169,6 +169,15 @@ class DPPOTrainer(GRPOTrainer):
             process and the trainer instance. It must return a dict with `"prompt_ids"`, `"completion_ids"`, and
             `"logprobs"` fields. Any other fields are forwarded to the reward functions. This feature is experimental
             and may change or be removed at any time without prior notice.
+        environment_factory (`EnvironmentFactory`, *optional*):
+            A callable that creates and returns an environment instance. The environment class should define methods
+            that can be invoked as tools during generation. Each method should comply with the same requirements as the
+            `tools` described above. If `environment_factory` is provided, an instance of the environment is created
+            for each generation in the batch, allowing for parallel and independent interactions. The environment must
+            also implement a callable `reset` method that can be used to reset state between generations. The `reset`
+            method should return either `None` or a string: when it returns a string, that string is appended to the
+            last user message before generation. This feature is experimental and may change or be removed at any time
+            without prior notice.
     """
 
     _tag_names = ["trl", "dppo"]

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -74,6 +74,14 @@ class XPOTrainer(OnlineDPOTrainer):
             Processing class used to process the data. If provided, will be used to automatically process the inputs
             for the model, and it will be saved along the model to make it easier to rerun an interrupted training or
             reuse the fine-tuned model.
+        reward_processing_classes ([`~transformers.PreTrainedTokenizerBase`] or `list[PreTrainedTokenizerBase]`, *optional*):
+            Processing classes corresponding to the reward functions specified in `reward_funcs`. Can be either:
+
+            - A single processing class: Used when `reward_funcs` contains only one reward function.
+            - A list of processing classes: Must match the order and length of the reward functions in `reward_funcs`.
+
+            If set to `None`, the tokenizer for each model-based reward function is automatically loaded using
+            [`~transformers.AutoTokenizer.from_pretrained`].
         peft_config ([`~peft.PeftConfig`], *optional*):
             The peft config to use for training.
         compute_metrics (`Callable[[EvalPrediction], dict]`, *optional*):


### PR DESCRIPTION
## What does this PR do?

Follow-up to #5992 / #5995, extending the docstring-vs-code audit from config dataclasses to the trainer classes themselves: four experimental trainers accept `__init__` parameters that their class docstrings' Args sections never mention.

| Trainer | Added entry | Wording source |
|---|---|---|
| `XPOTrainer` | `reward_processing_classes` | the `OnlineDPOTrainer` parent entry it forwards to |
| `DPPOTrainer` | `environment_factory` | the `GRPOTrainer` entry (param is forwarded verbatim) |
| `BCOTrainer` | `embedding_func`, `embedding_tokenizer` | the UDM section of the BCO docs page |
| `AsyncGRPOTrainer` | `rollout_worker` | the `RolloutWorkerProtocol` docstring |

Entries are placed to match the `__init__` parameter order. Docstring-only; +28 lines, no behavior change.

## Before submitting

- [x] This PR improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A — docstring completeness.)_
- [x] Did you make sure to update the documentation with your changes? _(This PR is the documentation change.)_
- [ ] Did you write any new necessary tests? _(N/A.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates with no code paths modified; zero functional or security impact.
> 
> **Overview**
> **Documentation-only:** class docstrings for four experimental trainers now list `__init__` parameters that were missing from the **Args** sections, ordered to match each constructor.
> 
> **`AsyncGRPOTrainer`** documents **`rollout_worker`** (custom [`RolloutWorkerProtocol`] vs default [`AsyncRolloutWorker`]). **`DPPOTrainer`** documents **`environment_factory`** (forwarded to [`GRPOTrainer`]). **`BCOTrainer`** documents **`embedding_func`** and **`embedding_tokenizer`** for UDM when prompt distributions diverge. **`XPOTrainer`** documents **`reward_processing_classes`** (aligned with parent [`OnlineDPOTrainer`]).
> 
> No runtime or API changes—~28 lines of docstrings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae2a581e6574efe175d9fbc4c715fb14d6507a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->