### PR TITLE
Use relative imports in async_grpo to match the rest of trl/experimental`

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass, field
 
-from trl.trainer.base_config import _BaseConfig
+from ...trainer.base_config import _BaseConfig
 
 
 @dataclass

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -30,9 +30,8 @@ from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase, TrainerCallback
 from transformers.data.data_collator import DataCollatorMixin
 
-from trl.trainer.base_trainer import _BaseTrainer
-from trl.trainer.utils import pad, patch_chunked_lm_head
-
+from ...trainer.base_trainer import _BaseTrainer
+from ...trainer.utils import pad, patch_chunked_lm_head
 from .async_grpo_config import AsyncGRPOConfig
 from .async_rollout_worker import AsyncRolloutWorker
 from .weight_transfer import WeightTransferClient

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -34,14 +34,14 @@ from accelerate.logging import get_logger
 from datasets import Dataset
 from transformers import PreTrainedTokenizerBase
 
-from trl.chat_template_utils import (
+from ...chat_template_utils import (
     add_response_schema,
     get_training_chat_template,
     is_chat_template_prefix_preserving,
     parse_response,
 )
-from trl.import_utils import is_vllm_available
-from trl.trainer.utils import print_prompt_completions_sample
+from ...import_utils import is_vllm_available
+from ...trainer.utils import print_prompt_completions_sample
 
 
 logger = get_logger(__name__)

--- a/trl/experimental/async_grpo/weight_transfer.py
+++ b/trl/experimental/async_grpo/weight_transfer.py
@@ -18,7 +18,7 @@ import time
 import requests
 from accelerate.logging import get_logger
 
-from trl.import_utils import is_vllm_available
+from ...import_utils import is_vllm_available
 
 
 if is_vllm_available(min_version="0.17.1"):


### PR DESCRIPTION
`async_grpo` is the only module under `trl/experimental/` that imports core code with absolute paths (`from trl.trainer...`). Every other experimental trainer (a2po, bco, cpo, kto, ppo, …) and the canonical `GRPOTrainer` use relative imports. Align for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only refactor with no logic changes; behavior should be unchanged.
> 
> **Overview**
> **`async_grpo` now imports core TRL code with relative paths** (`from ...trainer...`, `from ...chat_template_utils`, `from ...import_utils`) instead of absolute `from trl.trainer...` / `from trl.chat_template_utils` style.
> 
> Updates span four files: `async_grpo_config.py`, `async_grpo_trainer.py`, `async_rollout_worker.py`, and `weight_transfer.py`. No runtime or API behavior changes—only import paths, aligned with other `trl/experimental/` trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff3382a9a6084975db0c8323fed3da0268c3089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->