### PR TITLE
docs: fix stale default values in config docstrings

### DIFF
--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_config.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_config.py
@@ -21,7 +21,7 @@ from ...trainer.grpo_config import GRPOConfig
 class GRPOWithReplayBufferConfig(GRPOConfig):
     """
     New Parameters:
-        replay_buffer_size (`int`, *optional*, defaults to `0`):
+        replay_buffer_size (`int`, *optional*, defaults to `64`):
                 A cache that stores the rollouts with the highest advantage scores and variance per group. If a new
                 group has 0 variance, it is replaced with a group sampled from the replay buffer.
     """

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -38,7 +38,7 @@ class OnlineDPOConfig(_BaseConfig):
             Path to the reward model.
         max_new_tokens (`int`, *optional*, defaults to `64`):
             Maximum number of tokens to generate per completion.
-        max_length (`int`, *optional*, defaults to `256`):
+        max_length (`int`, *optional*, defaults to `512`):
             Maximum total length of the sequence (prompt + completion) used to compute log probabilities. If the
             sequence exceeds this limit, the leftmost tokens will be truncated to preserve as much of the completion as
             possible.


### PR DESCRIPTION
## What does this PR do?

Two config docstrings claim defaults that don't match the actual field defaults — defaults are the most-read part of a parameter's docs, so the drift is actively misleading:

| Param | Docstring claims | Actual field default |
|---|---|---|
| `GRPOWithReplayBufferConfig.replay_buffer_size` | `0` | `64` |
| `OnlineDPOConfig.max_length` | `256` | `512` |

(E.g. the first one reads as "replay buffer disabled by default" when it's actually enabled with size 64.)

Updates the two docstrings to match the fields. Found by the same docstring-vs-field audit as #5992 / #6011, this time comparing `defaults to`-claims against the AST field defaults. `SFTConfig.loss_type` (doc `"nll"` vs field `None`) was deliberately left alone — that's the announced-deprecation sentinel from #5997.

+2 / −2, docstring-only.

## Before submitting

- [x] This PR fixes doc errors.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A.)_
- [x] Did you make sure to update the documentation with your changes? _(This PR is the documentation change.)_
- [ ] Did you write any new necessary tests? _(N/A.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits with no runtime, API, or training behavior impact.
> 
> **Overview**
> Fixes misleading **defaults** text in two experimental config class docstrings so they match the actual `field(default=...)` values.
> 
> In `GRPOWithReplayBufferConfig`, `replay_buffer_size` is documented as defaulting to **`64`** instead of **`0`** (the field already used `64`, so the old text implied the replay buffer was off by default). In `OnlineDPOConfig`, `max_length` is documented as **`512`** instead of **`256`**, matching the real default used for log-probability sequence length.
> 
> No code or behavior changes—documentation only (+2 / −2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fded87b064c3b5e33888e79ad78f62e270eac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->