### PR TITLE
docs: fix function docstrings that drifted from their signatures

### DIFF
--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -111,6 +111,15 @@ def print_prompt_completions_sample_uld(
     >>> prompts = ["The sky is", "The sun is"]
     >>> completions = [" blue.", " in the sky."]
     >>> print_prompt_completions_sample_uld(prompts, completions, 42)
+    ╭─────────── Step 42 ───────────╮
+    │ ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓ │
+    │ ┃ Prompt     ┃ Completion   ┃ │
+    │ ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩ │
+    │ │ The sky is │  blue.       │ │
+    │ ├────────────┼──────────────┤ │
+    │ │ The sun is │  in the sky. │ │
+    │ └────────────┴──────────────┘ │
+    ╰───────────────────────────────╯
     ```
     """
     if not is_rich_available():

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -89,7 +89,7 @@ def print_prompt_completions_sample_uld(
     num_samples: int = None,
 ) -> None:
     """
-    Print out a sample of model completions to the console with multiple reward metrics.
+    Print out a sample of model completions to the console.
 
     This function creates a nicely formatted table showing prompt-completion pairs, useful for monitoring model outputs
     during training. It requires the `rich` library to be installed.
@@ -99,10 +99,6 @@ def print_prompt_completions_sample_uld(
             List of prompts.
         completions (`list[str]`):
             List of completions corresponding to the prompts.
-        rewards (`dict[str, list[float]]`):
-            Dictionary where keys are reward names and values are lists of rewards.
-        advantages (`list[float]`):
-            List of advantages corresponding to the prompts and completions.
         step (`int`):
             Current training step number, used in the output title.
         num_samples (`int` or `None`, *optional*, defaults to `None`):
@@ -110,27 +106,16 @@ def print_prompt_completions_sample_uld(
 
     Example:
     ```python
-    >>> from trl.trainer.utils import print_prompt_completions_sample
+    >>> from trl.experimental.gold.gold_trainer import print_prompt_completions_sample_uld
 
     >>> prompts = ["The sky is", "The sun is"]
     >>> completions = [" blue.", " in the sky."]
-    >>> rewards = {"Correctness": [0.123, 0.456], "Format": [0.789, 0.101]}
-    >>> advantages = [0.987, 0.654]
-    >>> print_prompt_completions_sample(prompts, completions, rewards, advantages, 42)
-    ╭──────────────────────────── Step 42 ─────────────────────────────╮
-    │ ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┓ │
-    │ ┃ Prompt     ┃ Completion   ┃ Correctness ┃ Format ┃ Advantage ┃ │
-    │ ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━┩ │
-    │ │ The sky is │  blue.       │        0.12 │   0.79 │      0.99 │ │
-    │ ├────────────┼──────────────┼─────────────┼────────┼───────────┤ │
-    │ │ The sun is │  in the sky. │        0.46 │   0.10 │      0.65 │ │
-    │ └────────────┴──────────────┴─────────────┴────────┴───────────┘ │
-    ╰──────────────────────────────────────────────────────────────────╯
+    >>> print_prompt_completions_sample_uld(prompts, completions, 42)
     ```
     """
     if not is_rich_available():
         raise ImportError(
-            "The function `print_prompt_completions_sample` requires the `rich` library. Please install it with "
+            "The function `print_prompt_completions_sample_uld` requires the `rich` library. Please install it with "
             "`pip install rich`."
         )
     console = Console()

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -475,7 +475,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         Args:
             groups_with_variance: Boolean tensor indicating which groups have reward variance
             group_advantages: Tensor of shape (num_groups, num_generations) containing advantage values
-            std_rewards: Tensor of shape (num_groups, num_generations) containing std of rewards per group
+            group_std_rewards: Tensor of shape (num_groups, num_generations) containing std of rewards per group
             prompt_ids: Tensor containing prompt token IDs
             prompt_mask: Tensor containing prompt attention masks
             completion_ids: Tensor containing completion token IDs
@@ -601,7 +601,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
         Args:
             group_advantages: Tensor of shape (num_groups, num_generations) containing advantage values
-            std_rewards: Tensor of shape (num_groups, num_generations) containing std of rewards per group
+            group_std_rewards: Tensor of shape (num_groups, num_generations) containing std of rewards per group
             prompt_ids: Tensor containing prompt token IDs
             prompt_mask: Tensor containing prompt attention masks
             completion_ids: Tensor containing completion token IDs

--- a/trl/experimental/minillm/minillm_trainer.py
+++ b/trl/experimental/minillm/minillm_trainer.py
@@ -259,15 +259,15 @@ class MiniLLMTrainer(GRPOTrainer):
             teacher_log_probs:
                 Per-token log-probabilities from the teacher, of shape (batch_size, sequence_length)
             mask:
-                Optional boolean tensor of shape (batch_size, sequence_length) selecting the tokens to include in
-                the loss (e.g. excluding padding)
+                Optional boolean tensor of shape (batch_size, sequence_length) selecting the tokens to include in the
+                loss (e.g. excluding padding)
             reduction:
-                Specifies the reduction to apply to the output: 'batchmean' (default), 'sum' or 'mean'; any other
-                value returns the unreduced per-token loss
+                Specifies the reduction to apply to the output: 'batchmean' (default), 'sum' or 'mean'; any other value
+                returns the unreduced per-token loss
 
         Returns:
-            loss: Scalar tensor with the single-step KL regularization loss (unreduced if `reduction` is not one of
-            the above)
+            loss: Scalar tensor with the single-step KL regularization loss (unreduced if `reduction` is not one of the
+            above)
         """
         reg_loss = F.kl_div(
             teacher_log_probs, student_log_probs, reduction="none", log_target=True

--- a/trl/experimental/minillm/minillm_trainer.py
+++ b/trl/experimental/minillm/minillm_trainer.py
@@ -254,22 +254,20 @@ class MiniLLMTrainer(GRPOTrainer):
         https://huggingface.co/papers/2306.08543 for the definition.
 
         Args:
-            student_logits:
-                Tensor of shape (batch_size, sequence_length, vocab_size)
-            teacher_logits:
-                Tensor of shape (batch_size, sequence_length, vocab_size)
-            labels:
-                Tensor of shape (batch_size, sequence_length) with -100 for padding tokens to ignore when computing
-                loss
-            beta:
-                Interpolation coefficient between 0 and 1 (default: 0.5)
-            temperature:
-                Softmax temperature (default: 1.0)
+            student_log_probs:
+                Per-token log-probabilities from the student, of shape (batch_size, sequence_length)
+            teacher_log_probs:
+                Per-token log-probabilities from the teacher, of shape (batch_size, sequence_length)
+            mask:
+                Optional boolean tensor of shape (batch_size, sequence_length) selecting the tokens to include in
+                the loss (e.g. excluding padding)
             reduction:
-                Specifies the reduction to apply to the output (default: 'batchmean')
+                Specifies the reduction to apply to the output: 'batchmean' (default), 'sum' or 'mean'; any other
+                value returns the unreduced per-token loss
 
         Returns:
-            loss: Scalar tensor with the generalized JSD loss
+            loss: Scalar tensor with the single-step KL regularization loss (unreduced if `reduction` is not one of
+            the above)
         """
         reg_loss = F.kl_div(
             teacher_log_probs, student_log_probs, reduction="none", log_target=True


### PR DESCRIPTION
## What does this PR do?

Extends the docstring-vs-code audit (#5992 → #6011 → #6015) one level deeper, to function/method docstrings. Three experimental-module functions carry docstrings copied from *other* functions, describing parameters and behavior they don't have:

### `MiniLLMTrainer._single_step_decomposition_loss`

The Args section documented `student_logits` / `teacher_logits` / `labels` / `beta` / `temperature` — none of which are parameters of this function; the real signature is `(student_log_probs, teacher_log_probs, mask=None, reduction="batchmean")`. The Returns line also described "the generalized JSD loss" while the function computes the single-step KL regularization term. Rewrote both to match the code.

### `gold_trainer.print_prompt_completions_sample_uld`

The docstring (including its Example block) was copied from `trainer.utils.print_prompt_completions_sample`:
- documents `rewards` and `advantages` parameters this variant doesn't accept;
- the Example imports the wrong function and calls it with the wrong arguments — following it raises `TypeError`;
- the rich `ImportError` message also names the wrong function.

Dropped the ghost entries, fixed the example, corrected the error message.

### `GRPOWithReplayBufferTrainer.update_replay_buffer` / `update_with_replay_buffer`

Both docstrings document `std_rewards`; the actual parameter is `group_std_rewards`. Renamed both entries.

Docstring + one error-message string; no behavior change.

## Before submitting

- [x] This PR fixes doc errors.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A.)_
- [x] Did you make sure to update the documentation with your changes? _(This PR is the documentation change.)_
- [ ] Did you write any new necessary tests? _(N/A.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and error-message strings only; no training, inference, or API logic changes.
> 
> **Overview**
> Aligns **experimental** function docstrings (and one `ImportError` message) with real signatures after copy-paste drift—**no code behavior changes**.
> 
> **`print_prompt_completions_sample_uld`** (`gold_trainer.py`): Drops documented `rewards` / `advantages` args; updates the example to import/call the ULD helper and show a two-column table; fixes the rich `ImportError` to name `print_prompt_completions_sample_uld`.
> 
> **`GRPOWithReplayBufferTrainer`**: In `update_replay_buffer` and `update_with_replay_buffer`, renames the documented parameter from `std_rewards` to **`group_std_rewards`** to match the method signatures.
> 
> **`MiniLLMTrainer._single_step_decomposition_loss`**: Replaces incorrect Args (`student_logits`, `teacher_logits`, `labels`, `beta`, `temperature`) with **`student_log_probs`**, **`teacher_log_probs`**, **`mask`**, **`reduction`**; updates Returns from “generalized JSD” to **single-step KL regularization**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c343b97e4bc61c4323779337e3cd99e362d455f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->