### PR TITLE
Remove silently-ignored W&B/Hub fields from GOLD and Distillation configs

### DIFF
--- a/trl/experimental/distillation/distillation_config.py
+++ b/trl/experimental/distillation/distillation_config.py
@@ -138,12 +138,6 @@ class DistillationConfig(_BaseConfig):
 
         > Parameters that control logging
 
-        wandb_entity (`str` or `None`, *optional*):
-            The W&B entity to store runs under.
-        wandb_project (`str` or `None`, *optional*):
-            The W&B project to store runs under.
-        wandb_run_group (`str` or `None`, *optional*):
-            The W&B group to store runs under.
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `log_completions_steps` steps. If `rich` is
             installed, it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb`
@@ -351,18 +345,6 @@ class DistillationConfig(_BaseConfig):
     )
 
     # W&B
-    wandb_entity: str | None = field(
-        default=None,
-        metadata={"help": "The W&B entity to store runs under."},
-    )
-    wandb_project: str | None = field(
-        default=None,
-        metadata={"help": "The W&B project to store runs under."},
-    )
-    wandb_run_group: str | None = field(
-        default=None,
-        metadata={"help": "The W&B group to store runs under."},
-    )
 
     # Logging
     log_completions: bool = field(

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -152,22 +152,10 @@ class GOLDConfig(SFTConfig):
             `True`.
         num_completions_to_print (`int` or `None`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.
-        wandb_entity (`str` or `None`, *optional*):
-            The entity to store runs under.
-        wandb_project (`str` or `None`, *optional*):
-            The project to store runs under.
-        wandb_run_group (`str` or `None`, *optional*):
-            The group to store runs under.
         wandb_log_unique_prompts (`bool`, *optional*, defaults to `True`):
             Whether to log the unique prompts to wandb. This will create a new run for each unique prompt.
         callbacks (`list[str]`, *optional*, defaults to `[]`):
             The callbacks to run during training.
-        hub_model_revision (`str` or `None`, *optional*, defaults to `"main"`):
-            The Hub model branch to push the model to.
-        overwrite_hub_revision (`bool`, *optional*, defaults to `False`):
-            Whether to overwrite the Hub revision.
-        push_to_hub_revision (`bool`, *optional*, defaults to `False`):
-            Whether to push to a Hub revision/branch.
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
@@ -437,18 +425,6 @@ class GOLDConfig(SFTConfig):
         default=None,
         metadata={"help": "Number of completions to print with `rich`. If `None`, all completions are logged."},
     )
-    wandb_entity: str | None = field(
-        default=None,
-        metadata={"help": ("The entity to store runs under.")},
-    )
-    wandb_project: str | None = field(
-        default=None,
-        metadata={"help": ("The project to store runs under.")},
-    )
-    wandb_run_group: str | None = field(
-        default=None,
-        metadata={"help": ("The group to store runs under.")},
-    )
     wandb_log_unique_prompts: bool = field(
         default=True,
         metadata={
@@ -459,11 +435,6 @@ class GOLDConfig(SFTConfig):
         default_factory=lambda: [],
         metadata={"help": "The callbacks to run during training."},
     )
-    hub_model_revision: str | None = field(
-        default="main", metadata={"help": "The Hub model branch to push the model to."}
-    )
-    overwrite_hub_revision: bool = field(default=False, metadata={"help": "Whether to overwrite the Hub revision."})
-    push_to_hub_revision: bool = field(default=False, metadata={"help": "Whether to push to a Hub revision/branch."})
 
     def __post_init__(self):
         super().__post_init__()


### PR DESCRIPTION
## What does this PR do?

`GOLDConfig` carries six fields and `DistillationConfig` three that **nothing in TRL reads**:

| Config | Silently-ignored fields |
|---|---|
| `GOLDConfig` | `wandb_entity`, `wandb_project`, `wandb_run_group`, `hub_model_revision`, `overwrite_hub_revision`, `push_to_hub_revision` |
| `DistillationConfig` | `wandb_entity`, `wandb_project`, `wandb_run_group` |

Verified by searching the whole tree: no trainer references them, there's no `WANDB_*` env-var wiring, no Hub-revision push logic, and no test sets them. They appear to be carried over from open-r1-style configs, where `init_wandb_training()` and a push-to-hub-revision callback consume them — those consumers were never ported to TRL.

The result is the worst kind of API surface: `GOLDConfig(wandb_project="my-project")` is accepted, documented, and **does nothing, with no warning**. This PR removes the nine fields (and their docstring entries) so misuse fails loudly with a `TypeError` instead. Both configs live under `trl.experimental`, which makes no backward-compatibility promises.

Deliberately kept:
- `wandb_log_unique_prompts` — read by the GOLD trainer;
- `callbacks` — consumption couldn't be ruled out mechanically.

Happy to go the other way and **wire the fields up** (env-var setup à la open-r1's `init_wandb_training`) instead of removing them, if you'd rather support them — let me know which direction you prefer.

Found by extending the docstring/code audit (#5992 → #6011 → #6015 → #6022) to "config fields with zero readers".

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a GitHub issue? _(N/A — small experimental-module cleanup; alternative direction offered above.)_
- [x] Did you make sure to update the documentation with your changes? _(Docstring entries removed together with the fields.)_
- [ ] Did you write any new necessary tests? _(N/A — removal only.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental-module API cleanup only; no trainer or runtime behavior changes beyond stricter config construction.
> 
> **Overview**
> Removes **nine undocumented config knobs** that were accepted by `GOLDConfig` and `DistillationConfig` but never read by any TRL trainer or callback.
> 
> From **`DistillationConfig`**: `wandb_entity`, `wandb_project`, and `wandb_run_group` (fields and docstring entries). From **`GOLDConfig`**: the same three W&B fields plus `hub_model_revision`, `overwrite_hub_revision`, and `push_to_hub_revision`. Logging-related options that are actually used (e.g. `wandb_log_unique_prompts`, `log_completions`) are unchanged.
> 
> Passing removed kwargs (e.g. `GOLDConfig(wandb_project="…")`) now fails at construction instead of being silently ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39be122c8ea5bf1119aa4d00aea9f3ac6e550857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->