### PR TITLE
Add raises test with vision dataset and text model for DPO and SFT

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1240,6 +1240,17 @@ class TestDPOTrainer(TrlTestCase):
             )
 
     @require_vision
+    def test_vision_dataset_with_text_model_raises(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_preference", split="train")
+        training_args = DPOConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="vision-related.*vision-language model"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    @require_vision
     def test_precompute_ref_log_probs_raises_for_vision(self):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_preference", split="train")
         training_args = DPOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1884,6 +1884,17 @@ class TestSFTTrainer(TrlTestCase):
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
+    @require_vision
+    def test_vision_dataset_with_text_model_raises(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="vision-related.*vision-language model"):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_peft
     def test_prompt_tuning(self):
         """Test that SFT works with Prompt Tuning."""


### PR DESCRIPTION
Add raises test with vision dataset and text model for DPO and SFT.

This PR adds new tests to ensure that an error is raised when a vision dataset is used with a text-only model in both the DPO and SFT trainers. These tests help confirm that the code correctly prevents incompatible model-dataset combinations.

### Motivation

Both `DPOTrainer` and `SFTTrainer` raise a `ValueError` when a vision dataset (containing an `image`/`images` key) is passed with a text-only model, but neither trainer had a test covering this guard.

### Changes

Tests for model-dataset compatibility:

* Added `test_vision_dataset_with_text_model_raises` to `tests/test_dpo_trainer.py` to verify that using a vision dataset with a text-only model in `DPOTrainer` raises a `ValueError` with an appropriate message.
* Added `test_vision_dataset_with_text_model_raises` to `tests/test_sft_trainer.py` to verify that using a vision dataset with a text-only model in `SFTTrainer` raises a `ValueError` with an appropriate message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no trainer or runtime behavior is modified.
> 
> **Overview**
> Adds regression tests so **vision datasets** (`zen-image`) paired with a **text-only** Qwen2 causal LM fail fast at trainer init for both **DPO** and **SFT**.
> 
> Each new `test_vision_dataset_with_text_model_raises` (gated with `@require_vision`) asserts a `ValueError` whose message matches `vision-related.*vision-language model`, covering the existing model–dataset compatibility check that was previously untested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59388d59a0cf7194b522720a258bf59e5b6588e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->