### PR TITLE
Align KTO with DPO: Unwrap VLM batch dimension for text-only data in _tokenize

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -754,9 +754,14 @@ class KTOTrainer(_BaseTrainer):
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
         if isinstance(input, list):  # conversational: list of message dicts
+            if self._is_vlm:
+                input = prepare_multimodal_messages(input)
             result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
         else:  # non-conversational: plain text string
             result = processing_class(text=input)
+        # VLMs emit a batch dimension even for single examples; unwrap it
+        if self._is_vlm:
+            return {k: v[0] for k, v in result.items()}
         return result
 
     def _get_kl_dataset(


### PR DESCRIPTION
Align KTO with DPO: Unwrap VLM batch dimension for text-only data in _tokenize.

This PR aligns KTO `_tokenize` with `DPOTrainer._tokenize`, by adding `prepare_multimodal_messages` for conversational VLM input and unwrapping the spurious batch dimension for all VLM processor outputs.

Part of:
- #4786

### Motivation

When a VLM model (e.g. `Qwen2_5_VLForConditionalGeneration`) is trained on text-only data, `KTOTrainer._prepare_dataset` runs the text-only tokenization path, calling `_tokenize` with the VLM processor. Unlike a plain tokenizer, a VLM processor adds a batch dimension to its output even for a single example — so `input_ids` came back as `[[tok1, tok2, ...]]` instead of `[tok1, tok2, ...]`.

This causes two silent corruption issues in `tokenize_fn`:
- `len(prompt_ids)` evaluated to 1 (the batch size) instead of the sequence length, so `completion_ids` was sliced incorrectly.
- When the `DataCollatorForUnpairedPreference` called `torch.tensor(full_ids)`, the 2D input produced a 3D padded batch tensor, which eventually caused a `ValueError: too many values to unpack (expected 3)` deep inside the Qwen2.5-VL attention layer (`bsz, q_len, _ = hidden_states.size()`).

### Changes

Multimodal and VLM support:

* Added a check for VLMs (`self._is_vlm`) to preprocess conversational input using `prepare_multimodal_messages`, ensuring that multimodal messages are correctly formatted before tokenization.
* Adjusted output handling for VLMs by unwrapping the batch dimension from the result, so that single examples return a flat dictionary rather than a batch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change aligned with existing DPO behavior; fixes incorrect token shapes rather than altering training logic for standard tokenizer paths.
> 
> **Overview**
> **`KTOTrainer._tokenize`** is updated to match **`DPOTrainer._tokenize`** for vision-language processors used on the text-only dataset path.
> 
> For conversational inputs when `self._is_vlm`, messages are passed through **`prepare_multimodal_messages`** before `apply_chat_template`. After tokenization, VLM processor outputs are normalized by stripping the extra batch dimension (`{k: v[0] for k, v in result.items()}`), so `input_ids` are flat `list[int]` as `tokenize_fn` and **`DataCollatorForUnpairedPreference`** expect.
> 
> This fixes silent bugs on text-only KTO with a VLM (e.g. Qwen2.5-VL): wrong `len(prompt_ids)`, bad `completion_ids` slicing, and 3D tensors that break attention (`too many values to unpack`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e87f2c3701f23cd64c8a4b2f7446125534bdf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->