### PR TITLE
Align KTO with DPO: Add VLM tests

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -26,6 +26,116 @@ from trl.experimental.kto.kto_trainer import DataCollatorForVisionUnpairedPrefer
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft, require_vision
 
 
+@require_vision
+class TestDataCollatorForVisionUnpairedPreference(TrlTestCase):
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.3.0"),
+        reason="mm_token_type_ids are returned by default since transformers-5.3.0 (see transformers#43972)",
+    )
+    def test_mm_token_type_ids_shape(self):
+        # Regression guard: when the processor returns mm_token_type_ids (Qwen2.5-VL after transformers#43972),
+        # the collator must produce a KL_completion_token_type_ids whose width matches KL_completion_input_ids,
+        # not the main completion's width (the two differ whenever their text lengths differ).
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        image = Image.new("RGB", (16, 16))
+        examples = [
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "What is this?"}],
+                "completion": [{"role": "assistant", "content": "A red square."}],
+                "label": True,
+            },
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Describe it."}],
+                "completion": [{"role": "assistant", "content": "An image."}],
+                "label": False,
+            },
+        ]
+        output = collator(examples)
+
+        assert "mm_token_type_ids" in output
+        assert output["mm_token_type_ids"].shape == output["completion_input_ids"].shape, (
+            f"mm_token_type_ids shape {output['mm_token_type_ids'].shape} != "
+            f"completion_input_ids shape {output['completion_input_ids'].shape}"
+        )
+        assert "KL_completion_mm_token_type_ids" in output
+        assert output["KL_completion_mm_token_type_ids"].shape == output["KL_completion_input_ids"].shape, (
+            f"KL_completion_mm_token_type_ids shape {output['KL_completion_mm_token_type_ids'].shape} != "
+            f"KL_completion_input_ids shape {output['KL_completion_input_ids'].shape}"
+        )
+
+    def test_output_keys(self):
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        image = Image.new("RGB", (16, 16))
+
+        def make_examples():
+            return [
+                {
+                    "images": [image],
+                    "prompt": [{"role": "user", "content": "What is this?"}],
+                    "completion": [{"role": "assistant", "content": "A red square."}],
+                    "label": True,
+                },
+                {
+                    "images": [image],
+                    "prompt": [{"role": "user", "content": "Describe it."}],
+                    "completion": [{"role": "assistant", "content": "An image."}],
+                    "label": False,
+                },
+            ]
+
+        # With KL
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        output = collator(make_examples())
+        for key in ["completion_input_ids", "completion_attention_mask", "completion_mask", "pixel_values", "label"]:
+            assert key in output, f"Missing key: {key}"
+        for key in ["KL_completion_input_ids", "KL_completion_attention_mask", "KL_completion_mask"]:
+            assert key in output, f"Missing KL key: {key}"
+
+        # Without KL
+        collator_no_kl = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=False)
+        output_no_kl = collator_no_kl(make_examples())
+        assert "completion_input_ids" in output_no_kl
+        assert "KL_completion_input_ids" not in output_no_kl
+
+    def test_kl_cycling(self):
+        # The KL completion for example i must be the completion from example i-1 (cycled by +1).
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        image = Image.new("RGB", (16, 16))
+        # Two distinct completions so that cycling is detectable
+        examples = [
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Q1"}],
+                "completion": [{"role": "assistant", "content": "Answer one."}],
+                "label": True,
+            },
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Q2"}],
+                "completion": [{"role": "assistant", "content": "Answer two."}],
+                "label": False,
+            },
+        ]
+        output = collator(examples)
+        # KL completions are cycled: KL[0] = completion[-1], KL[1] = completion[0]
+        # They must differ from the matching main completion (unless both are identical strings, which they aren't here)
+        assert not torch.equal(output["completion_input_ids"][0], output["KL_completion_input_ids"][0])
+        assert not torch.equal(output["completion_input_ids"][1], output["KL_completion_input_ids"][1])
+
+
 class TestKTOTrainer(TrlTestCase):
     def setup_method(self):
         self.model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
@@ -314,116 +424,6 @@ class TestKTOTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-2]["eval_test"] == 0.0
-
-
-@require_vision
-class TestDataCollatorForVisionUnpairedPreference(TrlTestCase):
-    @pytest.mark.skipif(
-        Version(transformers.__version__) < Version("5.3.0"),
-        reason="mm_token_type_ids are returned by default since transformers-5.3.0 (see transformers#43972)",
-    )
-    def test_mm_token_type_ids_shape(self):
-        # Regression guard: when the processor returns mm_token_type_ids (Qwen2.5-VL after transformers#43972),
-        # the collator must produce a KL_completion_token_type_ids whose width matches KL_completion_input_ids,
-        # not the main completion's width (the two differ whenever their text lengths differ).
-        from PIL import Image
-        from transformers import AutoProcessor
-
-        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
-        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
-        image = Image.new("RGB", (16, 16))
-        examples = [
-            {
-                "images": [image],
-                "prompt": [{"role": "user", "content": "What is this?"}],
-                "completion": [{"role": "assistant", "content": "A red square."}],
-                "label": True,
-            },
-            {
-                "images": [image],
-                "prompt": [{"role": "user", "content": "Describe it."}],
-                "completion": [{"role": "assistant", "content": "An image."}],
-                "label": False,
-            },
-        ]
-        output = collator(examples)
-
-        assert "mm_token_type_ids" in output
-        assert output["mm_token_type_ids"].shape == output["completion_input_ids"].shape, (
-            f"mm_token_type_ids shape {output['mm_token_type_ids'].shape} != "
-            f"completion_input_ids shape {output['completion_input_ids'].shape}"
-        )
-        assert "KL_completion_mm_token_type_ids" in output
-        assert output["KL_completion_mm_token_type_ids"].shape == output["KL_completion_input_ids"].shape, (
-            f"KL_completion_mm_token_type_ids shape {output['KL_completion_mm_token_type_ids'].shape} != "
-            f"KL_completion_input_ids shape {output['KL_completion_input_ids'].shape}"
-        )
-
-    def test_output_keys(self):
-        from PIL import Image
-        from transformers import AutoProcessor
-
-        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
-        image = Image.new("RGB", (16, 16))
-
-        def make_examples():
-            return [
-                {
-                    "images": [image],
-                    "prompt": [{"role": "user", "content": "What is this?"}],
-                    "completion": [{"role": "assistant", "content": "A red square."}],
-                    "label": True,
-                },
-                {
-                    "images": [image],
-                    "prompt": [{"role": "user", "content": "Describe it."}],
-                    "completion": [{"role": "assistant", "content": "An image."}],
-                    "label": False,
-                },
-            ]
-
-        # With KL
-        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
-        output = collator(make_examples())
-        for key in ["completion_input_ids", "completion_attention_mask", "completion_mask", "pixel_values", "label"]:
-            assert key in output, f"Missing key: {key}"
-        for key in ["KL_completion_input_ids", "KL_completion_attention_mask", "KL_completion_mask"]:
-            assert key in output, f"Missing KL key: {key}"
-
-        # Without KL
-        collator_no_kl = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=False)
-        output_no_kl = collator_no_kl(make_examples())
-        assert "completion_input_ids" in output_no_kl
-        assert "KL_completion_input_ids" not in output_no_kl
-
-    def test_kl_cycling(self):
-        # The KL completion for example i must be the completion from example i-1 (cycled by +1).
-        from PIL import Image
-        from transformers import AutoProcessor
-
-        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
-        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
-        image = Image.new("RGB", (16, 16))
-        # Two distinct completions so that cycling is detectable
-        examples = [
-            {
-                "images": [image],
-                "prompt": [{"role": "user", "content": "Q1"}],
-                "completion": [{"role": "assistant", "content": "Answer one."}],
-                "label": True,
-            },
-            {
-                "images": [image],
-                "prompt": [{"role": "user", "content": "Q2"}],
-                "completion": [{"role": "assistant", "content": "Answer two."}],
-                "label": False,
-            },
-        ]
-        output = collator(examples)
-        # KL completions are cycled: KL[0] = completion[-1], KL[1] = completion[0]
-        # They must differ from the matching main completion (unless both are identical strings, which they aren't here)
-        assert not torch.equal(output["completion_input_ids"][0], output["KL_completion_input_ids"][0])
-        assert not torch.equal(output["completion_input_ids"][1], output["KL_completion_input_ids"][1])
 
 
 @require_vision

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -474,7 +474,7 @@ class TestKTOTrainerVLM(TrlTestCase):
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
-            per_device_train_batch_size=2,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             report_to="none",
         )
         trainer = KTOTrainer(model=model_id, args=training_args, train_dataset=dataset)
@@ -488,6 +488,9 @@ class TestKTOTrainerVLM(TrlTestCase):
         # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
+            # LLaVA & LLaVA-Next: vision_feature_layer=-2 leaves the last encoder layer (layers.1) and
+            # post_layernorm (pooler-only path) without gradient by design. Assert they stay frozen — if they
+            # ever start training, the feature-selection plumbing has likely regressed.
             if model_id in (
                 "trl-internal-testing/tiny-LlavaForConditionalGeneration",
                 "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
@@ -501,30 +504,9 @@ class TestKTOTrainerVLM(TrlTestCase):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
-            max_length=None,
-            per_device_train_batch_size=2,
-            max_steps=3,
+            max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             loss_type="apo_zero_unpaired",
-            report_to="none",
-        )
-        trainer = KTOTrainer(
-            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-            args=training_args,
-            train_dataset=dataset,
-        )
-        trainer.train()
-        assert trainer.state.log_history[-1]["train_loss"] is not None
-
-    def test_train_vlm_with_max_length(self):
-        # Regression test: mm_token_type_ids (and KL_completion_mm_token_type_ids) must be truncated alongside
-        # input_ids when max_length is set, otherwise a shape mismatch crashes the model forward pass.
-        # max_length=37 truncates 1 completion token (total_len=38) while keeping all image tokens (prompt_len=34) safe.
-        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
-        training_args = KTOConfig(
-            output_dir=self.tmp_dir,
-            max_length=37,  # total_len=38, prompt_len=34 — truncates completion, not image tokens
-            per_device_train_batch_size=2,
-            max_steps=3,
             report_to="none",
         )
         trainer = KTOTrainer(
@@ -547,11 +529,7 @@ class TestKTOTrainerVLM(TrlTestCase):
     )
     def test_train_vlm_text_only_data(self, model_id, dataset_config):
         dataset = load_dataset("trl-internal-testing/zen", dataset_config, split="train")
-        training_args = KTOConfig(
-            output_dir=self.tmp_dir,
-            max_steps=3,
-            report_to="none",
-        )
+        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none")
         trainer = KTOTrainer(
             model=model_id,
             args=training_args,
@@ -572,19 +550,24 @@ class TestKTOTrainerVLM(TrlTestCase):
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
-    def test_precompute_ref_log_probs_raises_for_vision(self):
+    def test_train_vlm_with_max_length(self):
+        # Regression test: mm_token_type_ids (and KL_completion_mm_token_type_ids) must be truncated alongside
+        # input_ids when max_length is set, otherwise a shape mismatch crashes the model forward pass.
+        # max_length=37 truncates 1 completion token (total_len=38) while keeping all image tokens (prompt_len=34) safe.
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
+            max_length=37,  # total_len=38, prompt_len=34 — truncates completion, not image tokens
+            per_device_train_batch_size=2,
             report_to="none",
-            precompute_ref_log_probs=True,
         )
-        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported for vision datasets"):
-            KTOTrainer(
-                model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-                args=training_args,
-                train_dataset=dataset,
-            )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
 
     def test_vision_dataset_with_text_model_raises(self):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
@@ -596,6 +579,16 @@ class TestKTOTrainerVLM(TrlTestCase):
                 train_dataset=dataset,
             )
 
+    def test_precompute_ref_log_probs_raises_for_vision(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported for vision datasets"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_liger_kernel
     def test_train_vlm_liger(self):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
@@ -603,7 +596,6 @@ class TestKTOTrainerVLM(TrlTestCase):
             output_dir=self.tmp_dir,
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
             per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
-            max_steps=3,
             use_liger_kernel=True,
             report_to="none",
         )

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -475,7 +475,6 @@ class TestKTOTrainerVLM(TrlTestCase):
             output_dir=self.tmp_dir,
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
             per_device_train_batch_size=2,
-            max_steps=3,
             report_to="none",
         )
         trainer = KTOTrainer(model=model_id, args=training_args, train_dataset=dataset)

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -523,7 +523,7 @@ class TestKTOTrainerVLM(TrlTestCase):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
-            max_length=37,
+            max_length=37,  # total_len=38, prompt_len=34 — truncates completion, not image tokens
             per_device_train_batch_size=2,
             max_steps=3,
             report_to="none",

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -517,12 +517,13 @@ class TestKTOTrainerVLM(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
     def test_train_vlm_with_max_length(self):
-        # Regression guard: mm_token_type_ids and KL_completion_mm_token_type_ids must be truncated alongside their
-        # corresponding input_ids when max_length is set, otherwise a shape mismatch crashes the model forward pass.
+        # Regression test: mm_token_type_ids (and KL_completion_mm_token_type_ids) must be truncated alongside
+        # input_ids when max_length is set, otherwise a shape mismatch crashes the model forward pass.
+        # max_length=37 truncates 1 completion token (total_len=38) while keeping all image tokens (prompt_len=34) safe.
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
-            max_length=64,
+            max_length=37,
             per_device_train_batch_size=2,
             max_steps=3,
             report_to="none",

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -15,13 +15,15 @@
 import multiprocess
 import pytest
 import torch
+import transformers
 from datasets import Dataset, load_dataset
+from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
-from trl.experimental.kto.kto_trainer import _get_kl_completion_ids
+from trl.experimental.kto.kto_trainer import DataCollatorForVisionUnpairedPreference, _get_kl_completion_ids
 
-from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
+from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft, require_vision
 
 
 class TestKTOTrainer(TrlTestCase):
@@ -312,3 +314,311 @@ class TestKTOTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-2]["eval_test"] == 0.0
+
+
+@require_vision
+class TestDataCollatorForVisionUnpairedPreference(TrlTestCase):
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.3.0"),
+        reason="mm_token_type_ids are returned by default since transformers-5.3.0 (see transformers#43972)",
+    )
+    def test_mm_token_type_ids_shape(self):
+        # Regression guard: when the processor returns mm_token_type_ids (Qwen2.5-VL after transformers#43972),
+        # the collator must produce a KL_completion_token_type_ids whose width matches KL_completion_input_ids,
+        # not the main completion's width (the two differ whenever their text lengths differ).
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        image = Image.new("RGB", (16, 16))
+        examples = [
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "What is this?"}],
+                "completion": [{"role": "assistant", "content": "A red square."}],
+                "label": True,
+            },
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Describe it."}],
+                "completion": [{"role": "assistant", "content": "An image."}],
+                "label": False,
+            },
+        ]
+        output = collator(examples)
+
+        assert "mm_token_type_ids" in output
+        assert output["mm_token_type_ids"].shape == output["completion_input_ids"].shape, (
+            f"mm_token_type_ids shape {output['mm_token_type_ids'].shape} != "
+            f"completion_input_ids shape {output['completion_input_ids'].shape}"
+        )
+        assert "KL_completion_mm_token_type_ids" in output
+        assert output["KL_completion_mm_token_type_ids"].shape == output["KL_completion_input_ids"].shape, (
+            f"KL_completion_mm_token_type_ids shape {output['KL_completion_mm_token_type_ids'].shape} != "
+            f"KL_completion_input_ids shape {output['KL_completion_input_ids'].shape}"
+        )
+
+    def test_output_keys(self):
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        image = Image.new("RGB", (16, 16))
+
+        def make_examples():
+            return [
+                {
+                    "images": [image],
+                    "prompt": [{"role": "user", "content": "What is this?"}],
+                    "completion": [{"role": "assistant", "content": "A red square."}],
+                    "label": True,
+                },
+                {
+                    "images": [image],
+                    "prompt": [{"role": "user", "content": "Describe it."}],
+                    "completion": [{"role": "assistant", "content": "An image."}],
+                    "label": False,
+                },
+            ]
+
+        # With KL
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        output = collator(make_examples())
+        for key in ["completion_input_ids", "completion_attention_mask", "completion_mask", "pixel_values", "label"]:
+            assert key in output, f"Missing key: {key}"
+        for key in ["KL_completion_input_ids", "KL_completion_attention_mask", "KL_completion_mask"]:
+            assert key in output, f"Missing KL key: {key}"
+
+        # Without KL
+        collator_no_kl = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=False)
+        output_no_kl = collator_no_kl(make_examples())
+        assert "completion_input_ids" in output_no_kl
+        assert "KL_completion_input_ids" not in output_no_kl
+
+    def test_kl_cycling(self):
+        # The KL completion for example i must be the completion from example i-1 (cycled by +1).
+        from PIL import Image
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration")
+        collator = DataCollatorForVisionUnpairedPreference(processor, calculate_kl=True)
+        image = Image.new("RGB", (16, 16))
+        # Two distinct completions so that cycling is detectable
+        examples = [
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Q1"}],
+                "completion": [{"role": "assistant", "content": "Answer one."}],
+                "label": True,
+            },
+            {
+                "images": [image],
+                "prompt": [{"role": "user", "content": "Q2"}],
+                "completion": [{"role": "assistant", "content": "Answer two."}],
+                "label": False,
+            },
+        ]
+        output = collator(examples)
+        # KL completions are cycled: KL[0] = completion[-1], KL[1] = completion[0]
+        # They must differ from the matching main completion (unless both are identical strings, which they aren't here)
+        assert not torch.equal(output["completion_input_ids"][0], output["KL_completion_input_ids"][0])
+        assert not torch.equal(output["completion_input_ids"][1], output["KL_completion_input_ids"][1])
+
+
+@require_vision
+class TestKTOTrainerVLM(TrlTestCase):
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ),
+            "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3VLForConditionalGeneration",
+                marks=[
+                    pytest.mark.skipif(
+                        Version(transformers.__version__) < Version("4.57.0"),
+                        reason="Qwen3-VL series were introduced in transformers-4.57.0",
+                    ),
+                ],
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+        ],
+    )
+    def test_train_vlm(self, model_id):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
+            per_device_train_batch_size=2,
+            max_steps=3,
+            report_to="none",
+        )
+        trainer = KTOTrainer(model=model_id, args=training_args, train_dataset=dataset)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if model_id in (
+                "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+                "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            ) and ("encoder.layers.1" in n or "post_layernorm" in n):
+                assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
+
+    def test_train_vlm_apo_zero_unpaired(self):
+        # apo_zero_unpaired does not need the KL term: verify that calculate_kl=False path works end-to-end.
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            max_length=None,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            loss_type="apo_zero_unpaired",
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    def test_train_vlm_with_max_length(self):
+        # Regression guard: mm_token_type_ids and KL_completion_mm_token_type_ids must be truncated alongside their
+        # corresponding input_ids when max_length is set, otherwise a shape mismatch crashes the model forward pass.
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            max_length=64,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "dataset_config",
+        ["conversational_unpaired_preference", "standard_unpaired_preference"],
+    )
+    def test_train_vlm_text_only_data(self, model_id, dataset_config):
+        dataset = load_dataset("trl-internal-testing/zen", dataset_config, split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            max_steps=3,
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model=model_id,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n.startswith("model.visual"):
+                torch.testing.assert_close(param, new_param, rtol=1e-12, atol=1e-12, msg=f"Param {n} is updated")
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
+
+    def test_precompute_ref_log_probs_raises_for_vision(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            report_to="none",
+            precompute_ref_log_probs=True,
+        )
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported for vision datasets"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    def test_vision_dataset_with_text_model_raises(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="vision-related.*vision-language model"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    @require_liger_kernel
+    def test_train_vlm_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            max_steps=3,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Param {n} is not updated"


### PR DESCRIPTION
Align KTO with DPO: Add VLM tests.

This PR significantly expands the test coverage for vision-language model (VLM) support in the KTOTrainer, introducing new tests for the `DataCollatorForVisionUnpairedPreference` and VLM training flows. The new tests ensure correct handling of multimodal token type IDs, KL completion cycling, and proper error handling for vision/text model mismatches. Additionally, the tests verify that model parameters are updated as expected and that edge cases (such as truncation and configuration options) are robustly handled.

Part of:
- #4786

### Changes

**New Vision-Language Model (VLM) Test Suite:**

* Added the `TestKTOTrainerVLM` class, which covers end-to-end VLM training for a variety of supported models, checks parameter updates, verifies correct behavior with/without KL loss, tests truncation edge cases, and asserts appropriate error handling for misconfigurations and unsupported options.

**Data Collator for Vision Unpaired Preference:**

* Introduced the `TestDataCollatorForVisionUnpairedPreference` class to validate the shape and presence of multimodal token type IDs, output keys for KL and non-KL paths, and correct cycling of KL completions.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications; CI may run heavier vision-dependent jobs when `require_vision` is satisfied.
> 
> **Overview**
> Adds **vision-language model (VLM) test coverage** for experimental `KTOTrainer`, mirroring DPO-style VLM tests (#4786).
> 
> **`TestDataCollatorForVisionUnpairedPreference`** exercises `DataCollatorForVisionUnpairedPreference`: `mm_token_type_ids` / `KL_completion_mm_token_type_ids` must match the width of their paired `input_ids` (transformers ≥5.3.0), required batch keys with and without KL, and KL completion cycling across batch items.
> 
> **`TestKTOTrainerVLM`** adds end-to-end training on `zen-image` for multiple tiny VLMs (version-gated where needed), checks trainable param updates (including LLaVA frozen layers), `apo_zero_unpaired` without KL, text-only data on a VLM (vision weights stay fixed), `max_length` truncation with multimodal tensors, `ValueError` for vision data + text-only model and for `precompute_ref_log_probs` on vision, plus Liger kernel training.
> 
> Test imports now pull in `DataCollatorForVisionUnpairedPreference`, `require_vision`, `transformers`, and `packaging.version` for skip conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9f738aa587d4102ed020c2d8ab591eb5c56243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->