### PR TITLE
fix: pass AsyncGRPO environment rewards

### DIFF
--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -13,18 +13,24 @@
 # limitations under the License.
 
 import asyncio
+from dataclasses import dataclass
 
 from accelerate.state import PartialState
 
 from trl.experimental.async_grpo.async_rollout_worker import RolloutGroup, _AsyncRolloutLoop
 
 
-def test_score_group_passes_environment_reward():
+@dataclass
+class EnvSnapshot:
+    reward: float
+
+
+def test_score_group_passes_environments():
     captured = {}
 
-    def reward_func(completions, environment_reward, **kwargs):
-        captured["environment_reward"] = environment_reward
-        return environment_reward
+    def reward_func(completions, environments, **kwargs):
+        captured["environments"] = environments
+        return [env.reward for env in environments]
 
     rollout_loop = _AsyncRolloutLoop.__new__(_AsyncRolloutLoop)
     rollout_loop.reward_funcs = [reward_func]
@@ -35,7 +41,7 @@ def test_score_group_passes_environment_reward():
         prompt=[{"role": "user", "content": "hi"}],
         prompt_ids=[1, 2],
         reward_kwargs={},
-        env_rewards=[0.25, 0.75],
+        environments=[EnvSnapshot(0.25), EnvSnapshot(0.75)],
         completions=[
             [{"role": "assistant", "content": "left"}],
             [{"role": "assistant", "content": "right"}],
@@ -50,5 +56,5 @@ def test_score_group_passes_environment_reward():
 
     samples = asyncio.run(rollout_loop._score_group(group))
 
-    assert captured["environment_reward"] == [0.25, 0.75]
+    assert [env.reward for env in captured["environments"]] == [0.25, 0.75]
     assert [sample.metrics["reward"] for sample in samples] == [0.25, 0.75]

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -1,0 +1,54 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from accelerate.state import PartialState
+
+from trl.experimental.async_grpo.async_rollout_worker import RolloutGroup, _AsyncRolloutLoop
+
+
+def test_score_group_passes_environment_reward():
+    captured = {}
+
+    def reward_func(completions, environment_reward, **kwargs):
+        captured["environment_reward"] = environment_reward
+        return environment_reward
+
+    rollout_loop = _AsyncRolloutLoop.__new__(_AsyncRolloutLoop)
+    rollout_loop.reward_funcs = [reward_func]
+    rollout_loop.reward_func_names = ["reward_func"]
+    PartialState()
+
+    group = RolloutGroup(
+        prompt=[{"role": "user", "content": "hi"}],
+        prompt_ids=[1, 2],
+        reward_kwargs={},
+        env_rewards=[0.25, 0.75],
+        completions=[
+            [{"role": "assistant", "content": "left"}],
+            [{"role": "assistant", "content": "right"}],
+        ],
+        completions_ids=[[3], [4]],
+        completions_logprobs=[[-0.1], [-0.2]],
+        tool_mask=[[1], [1]],
+        tool_call_counts=[0, 0],
+        tool_failure_counts=[0, 0],
+        model_version=7,
+    )
+
+    samples = asyncio.run(rollout_loop._score_group(group))
+
+    assert captured["environment_reward"] == [0.25, 0.75]
+    assert [sample.metrics["reward"] for sample in samples] == [0.25, 0.75]

--- a/tests/experimental/test_async_rollout_worker.py
+++ b/tests/experimental/test_async_rollout_worker.py
@@ -13,19 +13,34 @@
 # limitations under the License.
 
 import asyncio
-from dataclasses import dataclass
+import copy
 
 from accelerate.state import PartialState
 
 from trl.experimental.async_grpo.async_rollout_worker import RolloutGroup, _AsyncRolloutLoop
 
 
-@dataclass
-class EnvSnapshot:
-    reward: float
+class CounterEnv:
+    """Environment mirroring the documented `environment_factory` contract: a `reset` method plus a
+    public tool method that mutates state the reward function reads back via `env.reward`.
+    """
+
+    def __init__(self):
+        self.reward = 0.0
+
+    def reset(self, **kwargs):
+        self.reward = 0.0
+        return "Counter reset."
+
+    def increment(self, step: float) -> float:
+        self.reward += step
+        return self.reward
 
 
-def test_score_group_passes_environments():
+def test_score_group_scores_per_completion_environment_snapshots():
+    # The worker keeps one environment instance per slot and reuses it across groups. Each finished
+    # completion is scored against a `copy.copy` snapshot taken at completion time, so resetting the
+    # instance for the next rollout must not corrupt rewards already captured for earlier completions.
     captured = {}
 
     def reward_func(completions, environments, **kwargs):
@@ -37,11 +52,24 @@ def test_score_group_passes_environments():
     rollout_loop.reward_func_names = ["reward_func"]
     PartialState()
 
+    # One reused environment instance produces two completions with different rewards; snapshot each
+    # exactly as the rollout loop does when a completion finishes.
+    env = CounterEnv()
+    snapshots = []
+    for step in (0.25, 0.75):
+        env.reset()
+        env.increment(step)
+        snapshots.append(copy.copy(env))
+
+    # Reusing/resetting the live instance for the next rollout must leave the snapshots untouched.
+    env.reset()
+    env.increment(99.0)
+
     group = RolloutGroup(
         prompt=[{"role": "user", "content": "hi"}],
         prompt_ids=[1, 2],
         reward_kwargs={},
-        environments=[EnvSnapshot(0.25), EnvSnapshot(0.75)],
+        environments=snapshots,
         completions=[
             [{"role": "assistant", "content": "left"}],
             [{"role": "assistant", "content": "right"}],

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -69,6 +69,7 @@ class RolloutGroup:
     prompt: Messages
     prompt_ids: list[int]
     reward_kwargs: dict[str, list[Any]]
+    env_rewards: list[Any]
     completions: list[Messages]
     completions_ids: list[list[int]]
     completions_logprobs: list[list[float]]
@@ -332,6 +333,7 @@ class _AsyncRolloutLoop:
                             prompt=prompt,
                             prompt_ids=prompt_ids,
                             reward_kwargs=reward_kwargs,
+                            env_rewards=[],
                             completions=[],
                             completions_ids=[],
                             completions_logprobs=[],
@@ -382,6 +384,9 @@ class _AsyncRolloutLoop:
                     group.tool_mask.append(tool_mask)
                     group.tool_call_counts.append(tool_call_count)
                     group.tool_failure_counts.append(tool_failure_count)
+                    if self.environments is not None:
+                        env = self.environments[slot]
+                        group.env_rewards.append(await asyncio.to_thread(lambda env=env: env.reward))
                     self._total_completion_tokens += sum(tool_mask)
                     pending_completed[group_id] += 1
 
@@ -598,6 +603,8 @@ class _AsyncRolloutLoop:
             completion_ids=group.completions_ids,
             **group.reward_kwargs,
         )
+        if group.env_rewards:
+            kwargs["environment_reward"] = group.env_rewards
         all_rewards = await asyncio.gather(
             *[
                 reward_func(**kwargs)

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import inspect
 import multiprocessing as mp
 import os
@@ -69,7 +70,7 @@ class RolloutGroup:
     prompt: Messages
     prompt_ids: list[int]
     reward_kwargs: dict[str, list[Any]]
-    env_rewards: list[Any]
+    environments: list[object]
     completions: list[Messages]
     completions_ids: list[list[int]]
     completions_logprobs: list[list[float]]
@@ -333,7 +334,7 @@ class _AsyncRolloutLoop:
                             prompt=prompt,
                             prompt_ids=prompt_ids,
                             reward_kwargs=reward_kwargs,
-                            env_rewards=[],
+                            environments=[],
                             completions=[],
                             completions_ids=[],
                             completions_logprobs=[],
@@ -385,8 +386,7 @@ class _AsyncRolloutLoop:
                     group.tool_call_counts.append(tool_call_count)
                     group.tool_failure_counts.append(tool_failure_count)
                     if self.environments is not None:
-                        env = self.environments[slot]
-                        group.env_rewards.append(await asyncio.to_thread(lambda env=env: env.reward))
+                        group.environments.append(copy.copy(self.environments[slot]))
                     self._total_completion_tokens += sum(tool_mask)
                     pending_completed[group_id] += 1
 
@@ -603,8 +603,8 @@ class _AsyncRolloutLoop:
             completion_ids=group.completions_ids,
             **group.reward_kwargs,
         )
-        if group.env_rewards:
-            kwargs["environment_reward"] = group.env_rewards
+        if group.environments:
+            kwargs["environments"] = group.environments
         all_rewards = await asyncio.gather(
             *[
                 reward_func(**kwargs)


### PR DESCRIPTION
# What does this PR do?

Fixes #6027.

`AsyncGRPOTrainer` can build environments through `environment_factory`, but the rollout worker only passed dataset-derived kwargs to `reward_funcs`. As a result, rewards computed by an environment were never visible to reward functions.

This adds a per-group `env_rewards` list, captures each completed environment's `reward` before the slot is reused, and forwards it to reward functions as `environment_reward`. The change is additive: runs without environments keep the existing kwargs.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. Issue: #6027.
- [x] Did you make sure to update the documentation with your changes? Not needed; this preserves the existing experimental API and fixes missing reward plumbing.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Tests

- `python -m py_compile trl\\experimental\\async_grpo\\async_rollout_worker.py tests\\experimental\\test_async_grpo_trainer.py tests\\experimental\\test_async_rollout_worker.py`
- `python -m ruff check trl\\experimental\\async_grpo\\async_rollout_worker.py tests\\experimental\\test_async_grpo_trainer.py tests\\experimental\\test_async_rollout_worker.py`
- `python -m ruff format --check trl\\experimental\\async_grpo\\async_rollout_worker.py tests\\experimental\\test_async_grpo_trainer.py tests\\experimental\\test_async_rollout_worker.py`
- `git diff --check`
- `.\\.venv\\Scripts\\python.exe -m pytest tests\\experimental\\test_async_rollout_worker.py -q`

## Who can review?

Anyone familiar with the experimental AsyncGRPO rollout worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental rollout scoring and reward kwargs; behavior change is limited to the environment_factory path and is covered by a new unit test.
> 
> **Overview**
> Fixes environment-backed rewards in the async GRPO rollout worker: when `environment_factory` is used, reward functions now receive a per-completion **`environments`** list instead of only dataset kwargs.
> 
> Each finished generation appends a **`copy.copy`** snapshot of the slot’s environment to the rollout group (before the slot is reset for the next rollout), and **`_score_group`** passes that list into reward funcs when non-empty. Runs without environments are unchanged.
> 
> A new test asserts that reused slots and later resets do not corrupt rewards for earlier completions in the same group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6143e0f575b2f6fdaca925f92b30f4879c6c6de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->