### PR TITLE
fix: load image-text policy for async grpo

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -14,34 +14,25 @@
 
 import itertools
 import queue
-from types import SimpleNamespace
-from unittest.mock import patch
 
 import numpy as np
 import pytest
 import torch
+import transformers
 from datasets import load_dataset
+from packaging.version import Version
 from transformers import AutoTokenizer
 from transformers.testing_utils import torch_device
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
-from trl.experimental.async_grpo import async_grpo_trainer as async_grpo_trainer_module
+from trl.experimental.async_grpo.async_grpo_trainer import _load_policy_model
 from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
 
-from ..testing_utils import TrlTestCase, is_ampere_or_newer
+from ..testing_utils import TrlTestCase, is_ampere_or_newer, require_vision
 
 
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
-
-
-class _DummyPolicy:
-    def __init__(self):
-        self.text = torch.nn.Parameter(torch.ones(1))
-        self.visual = torch.nn.Parameter(torch.ones(1))
-
-    def named_parameters(self):
-        return iter([("language_model.model.embed_tokens.weight", self.text), ("visual.blocks.0.weight", self.visual)])
 
 
 class _StubRolloutWorker:
@@ -104,42 +95,40 @@ class _StubRolloutWorker:
     reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
 )
 class TestAsyncGRPOTrainer(TrlTestCase):
-    def test_load_policy_model_keeps_text_models_on_causal_lm(self):
-        policy = _DummyPolicy()
-        config = SimpleNamespace(architectures=["Qwen2ForCausalLM"])
+    def test_load_policy_model_text(self):
+        # A text-only causal LM loads as-is, with every parameter trainable.
+        model = _load_policy_model("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        names = [n for n, _ in model.named_parameters()]
+        assert any(n.startswith("model.") for n in names)
+        assert all(p.requires_grad for _, p in model.named_parameters())
 
-        with (
-            patch.object(async_grpo_trainer_module.AutoConfig, "from_pretrained", return_value=config),
-            patch.object(
-                async_grpo_trainer_module.AutoModelForCausalLM, "from_pretrained", return_value=policy
-            ) as causal,
-            patch.object(async_grpo_trainer_module.AutoModelForImageTextToText, "from_pretrained") as image_text,
-        ):
-            model = async_grpo_trainer_module._load_policy_model("text-model")
-
-        assert model is policy
-        causal.assert_called_once_with("text-model", device_map=None, dtype=torch.float32)
-        image_text.assert_not_called()
-        assert policy.visual.requires_grad
-
-    def test_load_policy_model_uses_image_text_model_for_conditional_generation(self):
-        policy = _DummyPolicy()
-        config = SimpleNamespace(architectures=["Qwen3_5ForConditionalGeneration"])
-
-        with (
-            patch.object(async_grpo_trainer_module.AutoConfig, "from_pretrained", return_value=config),
-            patch.object(async_grpo_trainer_module.AutoModelForCausalLM, "from_pretrained") as causal,
-            patch.object(
-                async_grpo_trainer_module.AutoModelForImageTextToText, "from_pretrained", return_value=policy
-            ) as image_text,
-        ):
-            model = async_grpo_trainer_module._load_policy_model("vl-model")
-
-        assert model is policy
-        image_text.assert_called_once_with("vl-model", device_map=None, dtype=torch.float32)
-        causal.assert_not_called()
-        assert policy.text.requires_grad
-        assert not policy.visual.requires_grad
+    @require_vision
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+        ],
+    )
+    def test_load_policy_model_vlm_freezes_vision(self, model_id):
+        # Image-text policies must load through AutoModelForImageTextToText so the
+        # weight-sync namespace matches what vLLM serves, with the vision tower
+        # frozen so only the language side receives gradients.
+        model = _load_policy_model(model_id)
+        names = [n for n, _ in model.named_parameters()]
+        assert any("visual" in n or "vision" in n for n in names)  # the vision tower is present
+        assert any(p.requires_grad for _, p in model.named_parameters())  # the language side still trains
+        for n, p in model.named_parameters():
+            assert p.requires_grad != ("visual" in n or "vision" in n)
 
     def test_init_minimal(self):
         # Test that AsyncGRPOTrainer can be instantiated with only model, reward_model and train_dataset

--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -14,6 +14,8 @@
 
 import itertools
 import queue
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -23,6 +25,7 @@ from transformers import AutoTokenizer
 from transformers.testing_utils import torch_device
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
+from trl.experimental.async_grpo import async_grpo_trainer as async_grpo_trainer_module
 from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
 
 from ..testing_utils import TrlTestCase, is_ampere_or_newer
@@ -30,6 +33,15 @@ from ..testing_utils import TrlTestCase, is_ampere_or_newer
 
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
+
+
+class _DummyPolicy:
+    def __init__(self):
+        self.text = torch.nn.Parameter(torch.ones(1))
+        self.visual = torch.nn.Parameter(torch.ones(1))
+
+    def named_parameters(self):
+        return iter([("language_model.model.embed_tokens.weight", self.text), ("visual.blocks.0.weight", self.visual)])
 
 
 class _StubRolloutWorker:
@@ -92,6 +104,43 @@ class _StubRolloutWorker:
     reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
 )
 class TestAsyncGRPOTrainer(TrlTestCase):
+    def test_load_policy_model_keeps_text_models_on_causal_lm(self):
+        policy = _DummyPolicy()
+        config = SimpleNamespace(architectures=["Qwen2ForCausalLM"])
+
+        with (
+            patch.object(async_grpo_trainer_module.AutoConfig, "from_pretrained", return_value=config),
+            patch.object(
+                async_grpo_trainer_module.AutoModelForCausalLM, "from_pretrained", return_value=policy
+            ) as causal,
+            patch.object(async_grpo_trainer_module.AutoModelForImageTextToText, "from_pretrained") as image_text,
+        ):
+            model = async_grpo_trainer_module._load_policy_model("text-model")
+
+        assert model is policy
+        causal.assert_called_once_with("text-model", device_map=None, dtype=torch.float32)
+        image_text.assert_not_called()
+        assert policy.visual.requires_grad
+
+    def test_load_policy_model_uses_image_text_model_for_conditional_generation(self):
+        policy = _DummyPolicy()
+        config = SimpleNamespace(architectures=["Qwen3_5ForConditionalGeneration"])
+
+        with (
+            patch.object(async_grpo_trainer_module.AutoConfig, "from_pretrained", return_value=config),
+            patch.object(async_grpo_trainer_module.AutoModelForCausalLM, "from_pretrained") as causal,
+            patch.object(
+                async_grpo_trainer_module.AutoModelForImageTextToText, "from_pretrained", return_value=policy
+            ) as image_text,
+        ):
+            model = async_grpo_trainer_module._load_policy_model("vl-model")
+
+        assert model is policy
+        image_text.assert_called_once_with("vl-model", device_map=None, dtype=torch.float32)
+        causal.assert_not_called()
+        assert policy.text.requires_grad
+        assert not policy.visual.requires_grad
+
     def test_init_minimal(self):
         # Test that AsyncGRPOTrainer can be instantiated with only model, reward_model and train_dataset
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -27,7 +27,14 @@ from accelerate.logging import get_logger
 from datasets import Dataset, IterableDataset
 from torch.distributed._tensor import DTensor
 from torch.utils.data import DataLoader
-from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase, TrainerCallback
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoModelForImageTextToText,
+    AutoTokenizer,
+    PreTrainedTokenizerBase,
+    TrainerCallback,
+)
 from transformers.data.data_collator import DataCollatorMixin
 
 from ...trainer.base_trainer import _BaseTrainer
@@ -43,6 +50,33 @@ logger = get_logger(__name__)
 # completions, and additional arguments from the trainer (refer to the trainer's source for details). To ensure forward
 # compatibility, it should accept **kwargs.
 RewardFunc = Callable[..., list[float]]
+
+
+def _load_policy_model(model_name: str, model_init_kwargs: dict | None = None):
+    model_init_kwargs = dict(model_init_kwargs or {})
+    # FlashAttention is required: training runs in padding-free mode, where sequences are concatenated into a single
+    # row and `cu_seq_lens` are derived from `position_ids` resets. SDPA/eager can't handle this.
+    model_init_kwargs.setdefault("attn_implementation", "kernels-community/flash-attn3")
+    config = AutoConfig.from_pretrained(
+        model_name, trust_remote_code=model_init_kwargs.get("trust_remote_code", False)
+    )
+    architectures = getattr(config, "architectures", None) or []
+    is_image_text_model = any("ConditionalGeneration" in name or "ImageTextToText" in name for name in architectures)
+
+    if not is_image_text_model:
+        return AutoModelForCausalLM.from_pretrained(
+            model_name, device_map=None, dtype=torch.float32, **model_init_kwargs
+        )
+
+    # Image-text policies load through AutoModelForImageTextToText with the vision tower frozen: async GRPO only trains
+    # the language policy, and syncing vision weights would enlarge every weight transfer for no training signal.
+    model = AutoModelForImageTextToText.from_pretrained(
+        model_name, device_map=None, dtype=torch.float32, **model_init_kwargs
+    )
+    for name, parameter in model.named_parameters():
+        if "visual" in name or "vision" in name:
+            parameter.requires_grad = False
+    return model
 
 
 class _SupportsReset(Protocol):
@@ -296,9 +330,10 @@ class AsyncGRPOTrainer(_BaseTrainer):
         model (`str`):
             Model to be trained. Must be a string, being the *model id* of a pretrained model hosted inside a model
             repo on huggingface.co, or a path to a *directory* containing model weights saved using
-            [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
-            using [`~transformers.AutoModelForCausalLM.from_pretrained`]. The model name is also used to identify the
-            model on the vLLM server used for generation.
+            [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. Text models are loaded
+            using [`~transformers.AutoModelForCausalLM.from_pretrained`]; image-text and conditional generation models
+            use the matching image-text auto model so trainer weight names match the vLLM server. The model name is also
+            used to identify the model on the vLLM server used for generation.
         reward_funcs (`RewardFunc | list[RewardFunc]`):
             Reward functions to be used for computing the rewards. To compute the rewards, we call all the reward
             functions with the prompts and completions and sum the rewards. Can be either:
@@ -403,15 +438,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
         model_name = model
         model_init_kwargs = self.args.model_init_kwargs or {}
         model_init_kwargs.setdefault("trust_remote_code", self.args.trust_remote_code)
-        # FlashAttention is required: training runs in padding-free mode, where sequences are concatenated into a
-        # single row and `cu_seq_lens` are derived from `position_ids` resets. SDPA/eager can't handle this.
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            device_map=None,
-            dtype=torch.float32,
-            attn_implementation="kernels-community/flash-attn3",
-            **model_init_kwargs,
-        )
+        model = _load_policy_model(model_name, model_init_kwargs)
 
         if self.args.use_liger_kernel:
             raise NotImplementedError("`use_liger_kernel` is not supported yet.")


### PR DESCRIPTION
# What does this PR do?

Fixes #6028.

`AsyncGRPOTrainer` always loaded the policy with `AutoModelForCausalLM`. For image-text / conditional-generation checkpoints this gives the trainer `model.*` parameter names, while vLLM serves the same checkpoint with `language_model.model.*` and vision-tower keys. The first weight sync can then fail because the two sides do not agree on parameter names.

This PR keeps text models on the existing causal-LM path, but detects image-text / conditional-generation architectures from `AutoConfig.architectures` and loads them with `AutoModelForImageTextToText`. The vision tower parameters are frozen for the text-only RL use case described in the issue, so the trainer namespace matches the vLLM server while avoiding accidental vision-tower updates.

I also updated the trainer argument docs and added focused tests for both loader paths.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case: #6028.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

## To verify

- `python -m py_compile trl\experimental\async_grpo\async_grpo_trainer.py tests\experimental\test_async_grpo_trainer.py`
- `python -m ruff check trl\experimental\async_grpo\async_grpo_trainer.py tests\experimental\test_async_grpo_trainer.py`
- `python -m ruff format --check trl\experimental\async_grpo\async_grpo_trainer.py tests\experimental\test_async_grpo_trainer.py`
- `.\.venv\Scripts\python.exe -m pytest tests\experimental\test_async_grpo_trainer.py::TestAsyncGRPOTrainer::test_load_policy_model_keeps_text_models_on_causal_lm tests\experimental\test_async_grpo_trainer.py::TestAsyncGRPOTrainer::test_load_policy_model_uses_image_text_model_for_conditional_generation -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how policies are instantiated for async GRPO and affects weight-sync metadata for VLMs; text-only path is intentionally preserved but architecture detection must stay correct.
> 
> **Overview**
> **Fixes weight-sync mismatches** when `AsyncGRPOTrainer` is used with vision-language / conditional-generation checkpoints. Policy loading no longer always goes through `AutoModelForCausalLM`; it is centralized in `_load_policy_model`.
> 
> For **text-only** models, behavior is unchanged: causal LM load with Flash Attention defaults and all parameters trainable.
> 
> For **image-text** models (detected via `AutoConfig.architectures` containing `ConditionalGeneration` or `ImageTextToText`), the policy loads with `AutoModelForImageTextToText` so parameter names align with vLLM. **Vision tower weights are frozen** (`requires_grad=False` on `visual`/`vision` params) so only the language side is trained and weight transfers stay smaller.
> 
> Trainer docs for the `model` argument are updated accordingly. New tests cover the text path and several tiny VLMs (with `@require_vision` and a transformers version gate for Qwen3.5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5473dd1523199e38230f6775996c012187bcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->