### PR TITLE
Align KTO with DPO: Add tests for text data collator

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -19,9 +19,112 @@ from datasets import Dataset, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
-from trl.experimental.kto.kto_trainer import _get_kl_completion_ids
+from trl.experimental.kto.kto_trainer import DataCollatorForUnpairedPreference, _get_kl_completion_ids
 
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
+
+
+class TestDataCollatorForUnpairedPreference(TrlTestCase):
+    def test_padding_and_masks(self):
+        collator = DataCollatorForUnpairedPreference(pad_token_id=0)
+        examples = [
+            {"prompt_ids": [1, 2, 3], "completion_ids": [4, 5], "KL_completion_ids": [6], "label": True},
+            {"prompt_ids": [7, 8], "completion_ids": [9, 10], "KL_completion_ids": [11, 12, 13], "label": False},
+        ]
+        result = collator(examples)
+
+        expected_completion_input_ids = torch.tensor(
+            [
+                [1, 2, 3, 4, 5],  # prompt + completion (example 1)
+                [7, 8, 9, 10, 0],  # prompt + completion (example 2, padded)
+            ]
+        )
+        expected_completion_attention_mask = torch.tensor(
+            [
+                [1, 1, 1, 1, 1],
+                [1, 1, 1, 1, 0],
+            ]
+        )
+        expected_completion_mask = torch.tensor(
+            [
+                [0, 0, 0, 1, 1],  # completion (example 1)
+                [0, 0, 1, 1, 0],  # completion (example 2, padded)
+            ]
+        )
+        expected_kl_completion_input_ids = torch.tensor(
+            [
+                [1, 2, 3, 6, 0],  # prompt + KL completion (example 1, padded)
+                [7, 8, 11, 12, 13],  # prompt + KL completion (example 2)
+            ]
+        )
+        expected_kl_completion_attention_mask = torch.tensor(
+            [
+                [1, 1, 1, 1, 0],
+                [1, 1, 1, 1, 1],
+            ]
+        )
+        expected_kl_completion_mask = torch.tensor(
+            [
+                [0, 0, 0, 1, 0],  # KL completion (example 1, padded)
+                [0, 0, 1, 1, 1],  # KL completion (example 2)
+            ]
+        )
+
+        assert set(result.keys()) == {
+            "completion_input_ids",
+            "completion_attention_mask",
+            "completion_mask",
+            "KL_completion_input_ids",
+            "KL_completion_attention_mask",
+            "KL_completion_mask",
+            "label",
+        }
+        torch.testing.assert_close(result["completion_input_ids"], expected_completion_input_ids)
+        torch.testing.assert_close(result["completion_attention_mask"], expected_completion_attention_mask)
+        torch.testing.assert_close(result["completion_mask"], expected_completion_mask)
+        torch.testing.assert_close(result["KL_completion_input_ids"], expected_kl_completion_input_ids)
+        torch.testing.assert_close(result["KL_completion_attention_mask"], expected_kl_completion_attention_mask)
+        torch.testing.assert_close(result["KL_completion_mask"], expected_kl_completion_mask)
+        assert result["label"] == [True, False]
+
+    def test_optional_reference_logps(self):
+        collator = DataCollatorForUnpairedPreference(pad_token_id=0)
+        examples = [
+            {
+                "prompt_ids": [1, 2],
+                "completion_ids": [3],
+                "KL_completion_ids": [4],
+                "ref_logps": 0.1,
+                "ref_KL_logps": 0.2,
+                "label": True,
+            },
+            {
+                "prompt_ids": [5],
+                "completion_ids": [6, 7],
+                "KL_completion_ids": [8, 9],
+                "ref_logps": 0.3,
+                "ref_KL_logps": 0.4,
+                "label": False,
+            },
+        ]
+        result = collator(examples)
+
+        expected_ref_logps = torch.tensor([0.1, 0.3])
+        expected_ref_kl_logps = torch.tensor([0.2, 0.4])
+
+        assert set(result.keys()) == {
+            "completion_input_ids",
+            "completion_attention_mask",
+            "completion_mask",
+            "KL_completion_input_ids",
+            "KL_completion_attention_mask",
+            "KL_completion_mask",
+            "ref_logps",
+            "ref_KL_logps",
+            "label",
+        }
+        torch.testing.assert_close(result["ref_logps"], expected_ref_logps)
+        torch.testing.assert_close(result["ref_KL_logps"], expected_ref_kl_logps)
 
 
 class TestKTOTrainer(TrlTestCase):


### PR DESCRIPTION
Align KTO with DPO: Add tests for text data collator.

This PR adds comprehensive unit tests for the `DataCollatorForUnpairedPreference` class of the `KTOTrainer. These tests verify the correct handling of padding, masks, and optional log-probability fields, ensuring that the data collator processes input examples as expected.

Part of:
- #4786

### Changes

**New tests for data collation:**

* Added the `TestDataCollatorForUnpairedPreference` test class to validate the behavior of `DataCollatorForUnpairedPreference`, including correct padding, attention masks, and mask generation for both completion and KL completion sequences.
* Added tests to verify that optional fields `ref_logps` and `ref_KL_logps` are correctly handled and included in the collated output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime or trainer logic modified.
> 
> **Overview**
> Adds **`TestDataCollatorForUnpairedPreference`** in `tests/experimental/test_kto_trainer.py`, mirroring DPO’s collator unit tests as part of KTO/DPO alignment (#4786). The import is extended to pull in **`DataCollatorForUnpairedPreference`** alongside `_get_kl_completion_ids`.
> 
> **`test_padding_and_masks`** exercises batch collation with mismatched sequence lengths: prompt+completion and prompt+KL completion are padded to the batch max, with expected **`completion_*`** and **`KL_completion_*`** tensors for `input_ids`, attention masks, completion masks (1 only on completion tokens), and **`label`**.
> 
> **`test_optional_reference_logps`** checks that when every example includes **`ref_logps`** and **`ref_KL_logps`**, the collator adds those keys as stacked float tensors without changing the rest of the batch layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f15c8a77195f3a09409b0a317a4f52816f0767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->