### PR TITLE
Align KTO with DPO: Support pad_to_multiple_of

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -19,9 +19,44 @@ from datasets import Dataset, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
-from trl.experimental.kto.kto_trainer import _get_kl_completion_ids
+from trl.experimental.kto.kto_trainer import DataCollatorForUnpairedPreference, _get_kl_completion_ids
 
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft
+
+
+class TestDataCollatorForUnpairedPreference(TrlTestCase):
+    def test_with_pad_to_multiple_of(self):
+        collator = DataCollatorForUnpairedPreference(pad_token_id=0, pad_to_multiple_of=5)
+        examples = [
+            {"prompt_ids": [1], "completion_ids": [2], "KL_completion_ids": [3], "label": True},
+            {"prompt_ids": [4, 5], "completion_ids": [6, 7], "KL_completion_ids": [8, 9], "label": False},
+        ]
+        result = collator(examples)
+
+        expected_completion_input_ids = torch.tensor(
+            [
+                [1, 2, 0, 0, 0],  # prompt + completion (example 1, padded to multiple of 5)
+                [4, 5, 6, 7, 0],  # prompt + completion (example 2)
+            ]
+        )
+        expected_kl_completion_input_ids = torch.tensor(
+            [
+                [1, 3, 0, 0, 0],  # prompt + KL completion (example 1, padded to multiple of 5)
+                [4, 5, 8, 9, 0],  # prompt + KL completion (example 2)
+            ]
+        )
+
+        assert set(result.keys()) == {
+            "completion_input_ids",
+            "completion_attention_mask",
+            "completion_mask",
+            "KL_completion_input_ids",
+            "KL_completion_attention_mask",
+            "KL_completion_mask",
+            "label",
+        }
+        torch.testing.assert_close(result["completion_input_ids"], expected_completion_input_ids)
+        torch.testing.assert_close(result["KL_completion_input_ids"], expected_kl_completion_input_ids)
 
 
 class TestKTOTrainer(TrlTestCase):

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -110,12 +110,15 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
             Token ID to use for padding `input_ids` sequences.
         max_length (`int`, *optional*):
             Maximum sequence length after assembly. Sequences longer than `max_length` are truncated from the end.
+        pad_to_multiple_of (`int`, *optional*):
+            If set, the sequences will be padded to a multiple of this value.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
     """
 
     pad_token_id: int
     max_length: int | None = None
+    pad_to_multiple_of: int | None = None
     return_tensors: str = "pt"
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
@@ -141,16 +144,19 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
                 [torch.tensor(ids, dtype=torch.int64) for ids in full_ids_list],
                 padding_value=self.pad_token_id,
                 padding_side="right",
+                pad_to_multiple_of=self.pad_to_multiple_of,
             )
             batch[f"{prefix}_attention_mask"] = pad(
                 [torch.ones(len(ids), dtype=torch.int64) for ids in full_ids_list],
                 padding_value=0,
                 padding_side="right",
+                pad_to_multiple_of=self.pad_to_multiple_of,
             )
             batch[f"{prefix}_mask"] = pad(
                 [torch.tensor(m, dtype=torch.int64) for m in completion_mask_list],
                 padding_value=0,
                 padding_side="right",
+                pad_to_multiple_of=self.pad_to_multiple_of,
             )
 
         if "ref_logps" in examples[0]:


### PR DESCRIPTION
Align KTO with DPO: Support `pad_to_multiple_of`.

This PR adds support for padding to a specified multiple in the `DataCollatorForUnpairedPreference` class and introduces a new test to verify this behavior. The main focus is on improving how input sequences are padded during batch collation.

Part of:
- #4786

### Changes

**Enhancements to Data Collation:**

* `KTOTrainer`: Added a new `pad_to_multiple_of` parameter to `DataCollatorForUnpairedPreference`, allowing sequences to be padded to a specified multiple. The padding logic in the `torch_call` method has been updated to use this parameter. 

**Testing Improvements:**

* `test_kto_trainer.py`: Added the `TestDataCollatorForUnpairedPreference` test class to verify that the collator correctly pads sequences to the specified multiple when `pad_to_multiple_of` is set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional collator parameter with default `None` preserves prior padding; change is localized to collation and covered by a new test.
> 
> **Overview**
> Adds optional **`pad_to_multiple_of`** to KTO’s `DataCollatorForUnpairedPreference`, matching DPO-style batch padding for tensor-core / sequence-parallel setups.
> 
> When set, completion and KL-completion **`input_ids`**, **`attention_mask`**, and **`completion_mask`** are padded via the shared `pad()` helper so batch sequence length rounds up to that multiple (not only to the longest example). Docstring documents the new field.
> 
> A unit test **`test_with_pad_to_multiple_of`** checks that short sequences (e.g. length 2) pad to length 5 when `pad_to_multiple_of=5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe333116debc9d58ac3d41c15f4365c12fb02df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->