### PR TITLE
Raise a clear error when PPO value/reward model is not a PreTrainedModel

### DIFF
--- a/tests/experimental/test_ppo_trainer.py
+++ b/tests/experimental/test_ppo_trainer.py
@@ -827,3 +827,21 @@ class TestPPOTrainer(TrlTestCase):
 
         assert critic_weights_updated, "Critic weights were not updated during training"
         assert policy_weights_updated, "Policy LoRA weights were not updated during training"
+
+    @pytest.mark.parametrize("bad_arg", ["value_model", "reward_model"])
+    def test_plain_nn_module_raises_clear_error(self, bad_arg):
+        """Passing a plain `nn.Module` as `value_model`/`reward_model` should raise a clear `TypeError` instead of a
+        cryptic `AttributeError: ... has no attribute 'base_model_prefix'` (see #1977)."""
+        training_args = PPOConfig(output_dir=self.tmp_dir, report_to="none")
+        kwargs = {
+            "args": training_args,
+            "processing_class": self.tokenizer,
+            "model": self.model,
+            "ref_model": self.ref_model,
+            "reward_model": self.reward_model,
+            "value_model": self.value_model,
+            "train_dataset": self.raw_dataset["train"],
+        }
+        kwargs[bad_arg] = torch.nn.Module()  # plain nn.Module, lacks `base_model_prefix`
+        with pytest.raises(TypeError, match="base_model_prefix"):
+            PPOTrainer(**kwargs)

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -37,6 +37,7 @@ from transformers import (
     DataCollatorWithPadding,
     FeatureExtractionMixin,
     GenerationConfig,
+    PreTrainedModel,
     PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
@@ -317,12 +318,16 @@ class PPOTrainer(_BaseTrainer):
             Model to be trained. This is the policy model.
         ref_model (`torch.nn.Module`, *optional*):
             Reference model used to compute the KL divergence. If `None`, a copy of the policy model is created.
-        reward_model (`torch.nn.Module`):
-            Reward model used to compute the rewards.
+        reward_model ([`~transformers.PreTrainedModel`]):
+            Reward model used to compute the rewards. Must be a sequence-classification model (e.g. loaded with
+            [`~transformers.AutoModelForSequenceClassification`]), since the trainer relies on its `base_model_prefix`
+            attribute and `score` head.
         train_dataset ([`~datasets.Dataset`]):
             Dataset for training.
-        value_model (`torch.nn.Module`):
-            Value model used to predict the value of a state.
+        value_model ([`~transformers.PreTrainedModel`]):
+            Value model used to predict the value of a state. Must be a sequence-classification model (e.g. loaded with
+            [`~transformers.AutoModelForSequenceClassification`]), since the trainer relies on its `base_model_prefix`
+            attribute and `score` head.
         data_collator ([`~transformers.DataCollatorWithPadding`], *optional*):
             Data collator to batch and pad samples from the dataset. If `None`, a default data collator is created
             using the `processing_class`.
@@ -360,9 +365,9 @@ class PPOTrainer(_BaseTrainer):
         processing_class: PreTrainedTokenizerBase | BaseImageProcessor | FeatureExtractionMixin | ProcessorMixin,
         model: nn.Module,
         ref_model: nn.Module | None,
-        reward_model: nn.Module,
+        reward_model: PreTrainedModel,
         train_dataset: Dataset,
-        value_model: nn.Module,
+        value_model: PreTrainedModel,
         data_collator: DataCollatorWithPadding | None = None,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
         # less commonly used
@@ -450,6 +455,18 @@ class PPOTrainer(_BaseTrainer):
             self.ref_model = None
         else:
             self.ref_model = create_reference_model(self.policy_model)
+
+        # The trainer relies on the transformers `base_model_prefix` attribute and a `score` head, so `value_model`
+        # and `reward_model` must be `PreTrainedModel` instances (typically loaded with
+        # `AutoModelForSequenceClassification`). A plain `nn.Module` would otherwise fail later with a cryptic
+        # `AttributeError: ... has no attribute 'base_model_prefix'` (see #1977).
+        for name, module in [("value_model", value_model), ("reward_model", reward_model)]:
+            if not isinstance(module, PreTrainedModel):
+                raise TypeError(
+                    f"`{name}` must be a `transformers.PreTrainedModel` exposing a `base_model_prefix` attribute and "
+                    f"a `score` head (e.g. a model loaded with `AutoModelForSequenceClassification.from_pretrained(...)`), "
+                    f"but got `{type(module).__name__}`. A plain `nn.Module` is not supported."
+                )
 
         self.reward_model = reward_model
         self.train_dataset = train_dataset


### PR DESCRIPTION
# What does this PR do?

Fixes #1977.

Passing a plain `nn.Module` as `value_model` or `reward_model` to the experimental `PPOTrainer` failed with a cryptic `AttributeError: '<Class>' object has no attribute 'base_model_prefix'` — both at construction (`PolicyAndValueWrapper`) and during training (`get_reward`).

As @qgallouedec confirmed in the issue, `value_model`/`reward_model` must expose a transformers-style `base_model_prefix` and a `score` head, i.e. be `PreTrainedModel` instances (typically loaded with `AutoModelForSequenceClassification`).

This PR:
- Adds an `isinstance(..., PreTrainedModel)` guard in `PPOTrainer.__init__` that raises an actionable `TypeError` for both models before they are used. A single up-front check covers both crash sites, since training cannot start without passing `__init__`.
- Updates the `reward_model`/`value_model` type hints and docstrings from `torch.nn.Module` to `PreTrainedModel` (the issue also asked for clearer type annotations/documentation).
- Adds a parametrized regression test (`test_plain_nn_module_raises_clear_error`).

Scoped to `trl.experimental.ppo` as suggested. The modern `RLOOTrainer` already guards reward models with `isinstance(reward_func, PreTrainedModel)`, so no change is needed there.

Per `AGENTS.md`, this uses `isinstance` rather than `hasattr`/`getattr`, mirroring the existing `isinstance(peft_config, PeftConfig)` guard in the same `__init__`.

Verified on CPU (Apple Silicon, no GPU): reproduced the original `AttributeError`, confirmed the new `TypeError`, and the existing `test_basic_training` still passes.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #1977
- [x] Did you make sure to update the documentation with your changes? (updated the `reward_model`/`value_model` type hints and docstrings)
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constructor-only validation and docs; valid usage with AutoModelForSequenceClassification is unchanged.
> 
> **Overview**
> Experimental **`PPOTrainer`** now rejects plain `torch.nn.Module` instances passed as **`value_model`** or **`reward_model`**, raising an actionable **`TypeError`** in **`__init__`** instead of a later **`AttributeError`** on missing **`base_model_prefix`** (fixes #1977).
> 
> **`reward_model`** and **`value_model`** signatures and docstrings are updated from **`nn.Module`** to **`PreTrainedModel`**, documenting the expected sequence-classification setup (**`base_model_prefix`** + **`score`** head). A parametrized test asserts **`TypeError`** when either argument is a bare **`nn.Module`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90c65984908cdd7ffa72e4d019c803391917278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->