### PR TITLE
Warn when sequence-level importance sampling is combined with a token-summed loss type

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1724,10 +1724,10 @@ class TestGRPOTrainer(TrlTestCase):
         expected_warning = "All reward functions returned None for the following kwargs:"
         assert expected_warning in caplog.text
 
-    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo"])
+    @pytest.mark.parametrize("loss_type",["grpo", "bnpo", "dr_grpo", "dapo", "cispo"])
     def test_warning_raised_sequence_level_with_token_summed_loss(self, caplog, loss_type):
         """Test that a warning is raised when sequence-level importance sampling is combined with a loss type that
-        sums per-token contributions, as it length-weights each sequence instead of following the GSPO objective."""
+        sums per-token contributions (length-weighting each sequence instead of following the GSPO objective)."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         def dummy_reward_func(completions, **kwargs):
@@ -1751,34 +1751,7 @@ class TestGRPOTrainer(TrlTestCase):
             )
 
         expected_warning = "weights each sequence by its completion length"
-        assert expected_warning in caplog.text
-
-    def test_no_warning_raised_sequence_level_with_grpo_loss(self, caplog):
-        """Test that no warning is raised for the recommended GSPO setup (sequence-level sampling + grpo loss)."""
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-
-        def dummy_reward_func(completions, **kwargs):
-            return [0.0] * len(completions)
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            importance_sampling_level="sequence",
-            loss_type="grpo",
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=8,  # reduce the completion length to reduce memory usage
-            report_to="none",
-        )
-        with caplog.at_level("WARNING", logger="trl.trainer.grpo_trainer"):
-            GRPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                reward_funcs=dummy_reward_func,
-                args=training_args,
-                train_dataset=dataset,
-            )
-
-        unexpected_warning = "weights each sequence by its completion length"
-        assert unexpected_warning not in caplog.text
+        assert (expected_warning in caplog.text) == (loss_type != "grpo")
 
     def test_train_num_generations_larger_than_batch_size(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1724,6 +1724,62 @@ class TestGRPOTrainer(TrlTestCase):
         expected_warning = "All reward functions returned None for the following kwargs:"
         assert expected_warning in caplog.text
 
+    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo"])
+    def test_warning_raised_sequence_level_with_token_summed_loss(self, caplog, loss_type):
+        """Test that a warning is raised when sequence-level importance sampling is combined with a loss type that
+        sums per-token contributions, as it length-weights each sequence instead of following the GSPO objective."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def dummy_reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            importance_sampling_level="sequence",
+            loss_type=loss_type,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        with caplog.at_level("WARNING", logger="trl.trainer.grpo_trainer"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=dummy_reward_func,
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+        expected_warning = "weights each sequence by its completion length"
+        assert expected_warning in caplog.text
+
+    def test_no_warning_raised_sequence_level_with_grpo_loss(self, caplog):
+        """Test that no warning is raised for the recommended GSPO setup (sequence-level sampling + grpo loss)."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def dummy_reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            importance_sampling_level="sequence",
+            loss_type="grpo",
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        with caplog.at_level("WARNING", logger="trl.trainer.grpo_trainer"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=dummy_reward_func,
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+        unexpected_warning = "weights each sequence by its completion length"
+        assert unexpected_warning not in caplog.text
+
     def test_train_num_generations_larger_than_batch_size(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1724,7 +1724,7 @@ class TestGRPOTrainer(TrlTestCase):
         expected_warning = "All reward functions returned None for the following kwargs:"
         assert expected_warning in caplog.text
 
-    @pytest.mark.parametrize("loss_type",["grpo", "bnpo", "dr_grpo", "dapo", "cispo"])
+    @pytest.mark.parametrize("loss_type", ["grpo", "bnpo", "dr_grpo", "dapo", "cispo"])
     def test_warning_raised_sequence_level_with_token_summed_loss(self, caplog, loss_type):
         """Test that a warning is raised when sequence-level importance sampling is combined with a loss type that
         sums per-token contributions (length-weighting each sequence instead of following the GSPO objective)."""

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -592,6 +592,15 @@ class SDPOTrainer(_BaseTrainer):
         self.model_accepts_loss_kwargs = False
 
         self.importance_sampling_level = args.importance_sampling_level
+
+        if args.importance_sampling_level == "sequence" and args.loss_type in ["bnpo", "dr_grpo", "dapo"]:
+            logger.warning(
+                f"When using `importance_sampling_level='sequence'`, the `'{args.loss_type}'` loss sums per-token "
+                "contributions, which effectively weights each sequence by its completion length instead of "
+                "optimizing the per-sequence objective. To reproduce the GSPO paper's setup, set `loss_type='grpo'` "
+                "(see https://huggingface.co/docs/trl/main/en/paper_index#group-sequence-policy-optimization)."
+            )
+
         self.scale_rewards = args.scale_rewards
         self.epsilon_low = args.epsilon
         self.epsilon_high = args.epsilon_high

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -592,6 +592,10 @@ class SDPOTrainer(_BaseTrainer):
         self.model_accepts_loss_kwargs = False
 
         self.importance_sampling_level = args.importance_sampling_level
+        self.scale_rewards = args.scale_rewards
+        self.epsilon_low = args.epsilon
+        self.epsilon_high = args.epsilon_high
+        self.beta = args.beta
 
         if args.importance_sampling_level == "sequence" and args.loss_type in ["bnpo", "dr_grpo", "dapo"]:
             logger.warning(
@@ -600,11 +604,6 @@ class SDPOTrainer(_BaseTrainer):
                 "optimizing the per-sequence objective. To reproduce the GSPO paper's setup, set `loss_type='grpo'` "
                 "(see https://huggingface.co/docs/trl/main/en/paper_index#group-sequence-policy-optimization)."
             )
-
-        self.scale_rewards = args.scale_rewards
-        self.epsilon_low = args.epsilon
-        self.epsilon_high = args.epsilon_high
-        self.beta = args.beta
 
         if not isinstance(reward_funcs, list):
             reward_funcs = [reward_funcs]

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -616,6 +616,14 @@ class GRPOTrainer(_BaseTrainer):
                 "set to `'token'` (the default)."
             )
 
+        if args.importance_sampling_level == "sequence" and args.loss_type in ["bnpo", "dr_grpo", "dapo", "cispo"]:
+            logger.warning(
+                f"When using `importance_sampling_level='sequence'`, the `'{args.loss_type}'` loss sums per-token "
+                "contributions, which effectively weights each sequence by its completion length instead of "
+                "optimizing the per-sequence objective. To reproduce the GSPO paper's setup, set `loss_type='grpo'` "
+                "(see https://huggingface.co/docs/trl/main/en/paper_index#group-sequence-policy-optimization)."
+            )
+
         if self.loss_type == "vespo" and self.use_vllm and self.vllm_importance_sampling_correction:
             if self.vllm_importance_sampling_mode not in ["token_truncate", "token_mask"]:
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Fixes #3823.

Combining `importance_sampling_level="sequence"` (the GSPO setup) with a loss type that
sums per-token contributions (`bnpo`, `dr_grpo`, `cispo`, or the default `dapo`) silently
length-weights each sequence's loss instead of applying the per-sequence objective GSPO
prescribes.

This PR adds the warning suggested in
https://github.com/huggingface/trl/issues/3823#issuecomment-4539808557, placed right
after the existing `luspo`/`vespo` mismatch checks in `GRPOTrainer.__init__` and
mirroring their style. It points users to `loss_type="grpo"`, matching the GSPO recipe in
the paper index. The experimental `PAPOTrainer` reuses `GRPOTrainer.__init__`, so it
inherits the check.

One thing that turned up while testing: the existing
`test_train_sequence_importance_sampling` itself uses the footgun combo (sequence-level
importance sampling with the default `dapo`), so the new warning now fires during its
setup. I left it unchanged to keep the diff minimal — happy to switch it to
`loss_type="grpo"` if preferred.

Tests: a parametrized test asserting the warning fires for all four affected loss types
(fails on `main` without the fix), and a negative test asserting the recommended GSPO
combo stays silent. Also ran the other warning tests and `test_train_loss_types` locally
(CPU).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (#3823)
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

The fix and tests were developed with Claude Code and verified by running the test suite locally.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only validation at init; no change to loss computation or training behavior.
> 
> **Overview**
> Adds **init-time warnings** when `importance_sampling_level="sequence"` (GSPO-style) is paired with loss types that **sum per-token terms** (`bnpo`, `dr_grpo`, `dapo`, `cispo`). That combo length-weights each sequence instead of matching the per-sequence GSPO objective; the message recommends `loss_type="grpo"` and links the paper index.
> 
> The check is added in **`GRPOTrainer.__init__`** next to the existing `luspo`/`vespo` config warnings, and the same logic is mirrored in **`SDPOTrainer`**.
> 
> A parametrized test asserts the warning appears for the four affected loss types and stays off for `grpo` with sequence-level IS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe6e118c4836bf76a2366c6e6a8dbe6306697e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->