### PR TITLE
[fix] GLM-4-MoE template: turn-terminating token to the turn itself

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -735,7 +735,13 @@ class TestGetTrainingChatTemplate:
         before = tokenizer.apply_chat_template(messages, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-        assert before == after
+        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
+            # GLM's native template doesn't terminate an assistant turn with an end-of-turn token; the turn is ended
+            # by the following message's role marker. The training template appends that terminator to the final
+            # assistant turn so the stop token is trained — here the `<|user|>` that would open the next turn.
+            assert after == before + "<|user|>"
+        else:
+            assert before == after
 
     def test_behavior_unchanged_final_assistant_with_reasoning_content(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
@@ -753,7 +759,13 @@ class TestGetTrainingChatTemplate:
         before = tokenizer.apply_chat_template(messages, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-        assert before == after
+        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
+            # GLM's native template doesn't terminate an assistant turn with an end-of-turn token; the turn is ended
+            # by the following message's role marker. The training template appends that terminator to the final
+            # assistant turn so the stop token is trained — here the `<|user|>` that would open the next turn.
+            assert after == before + "<|user|>"
+        else:
+            assert before == after
 
     def test_behavior_unchanged_final_assistant_with_existing_think_tags(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
@@ -770,7 +782,13 @@ class TestGetTrainingChatTemplate:
         before = tokenizer.apply_chat_template(messages, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-        assert before == after
+        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
+            # GLM's native template doesn't terminate an assistant turn with an end-of-turn token; the turn is ended
+            # by the following message's role marker. The training template appends that terminator to the final
+            # assistant turn so the stop token is trained — here the `<|user|>` that would open the next turn.
+            assert after == before + "<|user|>"
+        else:
+            assert before == after
 
     def test_behavior_unchanged_assistant_with_tool_calls(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)
@@ -791,7 +809,13 @@ class TestGetTrainingChatTemplate:
         before = tokenizer.apply_chat_template(messages_before, tokenize=False)
         new_chat_template = get_training_chat_template(tokenizer)
         after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=new_chat_template)
-        assert before == after
+        if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
+            # GLM's native template doesn't terminate an assistant turn with an end-of-turn token; the turn is ended
+            # by the following message's role marker. The training template appends that terminator to the final
+            # assistant turn so the stop token is trained — here `<|observation|>`, which closes a tool call.
+            assert after == before + "<|observation|>"
+        else:
+            assert before == after
 
     def test_behavior_unchanged_with_tools_with_and_without_system_message(self, tokenizer_name):
         tokenizer = self._load(tokenizer_name)

--- a/trl/chat_templates/glm4moe_training.jinja
+++ b/trl/chat_templates/glm4moe_training.jinja
@@ -93,7 +93,7 @@ For each function call, output the function name and arguments within the follow
 {{- m.content }}
 {{- '\n</tool_response>' }}
 {%- else -%}
-<|observation|>{% for tr in m.content %}
+{{- '<|observation|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}{% for tr in m.content %}
 
 <tool_response>
 {{ tr.output if tr.output is defined else tr }}

--- a/trl/chat_templates/glm4moe_training.jinja
+++ b/trl/chat_templates/glm4moe_training.jinja
@@ -1,14 +1,3 @@
-{#- Training variant of the GLM-4-MoE chat template (see glm4moe.jinja for the original).
-    Modifications vs the original:
-    - {%- if '</think>' in content %} → {%- if '<think>' in content and '</think>' in content %}
-      Always check for both tags to avoid edge cases where the model generates only one tag.
-    - Added {% generation %} / {% endgeneration %} around assistant message output to support
-      assistant-only loss masking in SFT training.
-    - The role marker of the message following an assistant turn (<|user|>/<|observation|>/...) is the
-      inference-time stop token that closes the turn, so it is emitted inside the assistant's generation
-      block (and suppressed at the start of the following message) to include it in the loss mask. The
-      rendered text is unchanged.
--#}
 [gMASK]<sop>
 {%- if tools -%}
 <|system|>
@@ -54,8 +43,8 @@ For each function call, output the function name and arguments within the follow
 {%- endfor %}
 {% for m in messages %}
 {%- if m.role == 'user' -%}
-{{- '<|user|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
-{{ visible_text(m.content) }}
+{%- if loop.first or messages[loop.index0 - 1].role != 'assistant' -%}<|user|>{%- endif -%}
+{{ '\n' + visible_text(m.content) }}
 {{- '/nothink' if (enable_thinking is defined and not enable_thinking and not visible_text(m.content).endswith("/nothink")) else '' -}}
 {%- elif m.role == 'assistant' -%}
 <|assistant|>
@@ -64,12 +53,12 @@ For each function call, output the function name and arguments within the follow
 {%- if m.reasoning_content is string %}
     {%- set reasoning_content = m.reasoning_content %}
 {%- else %}
-    {%- if '<think>' in content and '</think>' in content %}
+    {%- if '</think>' in content %}
         {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
         {%- set content = content.split('</think>')[-1].lstrip('\n') %}
     {%- endif %}
 {%- endif %}
-{%- generation %}
+{% generation %}
 {%- if loop.index0 > ns.last_user_index and reasoning_content -%}
 {{ '\n<think>' + reasoning_content.strip() +  '</think>'}}
 {%- else -%}
@@ -89,33 +78,32 @@ For each function call, output the function name and arguments within the follow
 <arg_key>{{ k }}</arg_key>
 <arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>
 {% endfor %}
-</tool_call>{% endfor %}
-{% endif %}
-{%- if not loop.last and messages[loop.index0 + 1].role != 'assistant' %}
-{%- set next_role = messages[loop.index0 + 1].role %}
-{{- '<|user|>' if next_role == 'user' else '<|observation|>' if next_role == 'tool' else '<|system|>' }}
+</tool_call>{% endfor %}<|observation|>
+{%- elif loop.last -%}
+{{- '<|user|>' }}
+{%- elif messages[loop.index0 + 1].role == 'system' -%}
+{{- '<|system|>' }}
+{%- else -%}
+{{- '<|user|>' }}
 {%- endif %}
-{%- endgeneration %}
+{% endgeneration %}
 {%- elif m.role == 'tool' -%}
 {%- if m.content is string -%}
-{%- if loop.first or (messages[loop.index0 - 1].role not in ["tool", "assistant"]) %}
-    {{- '<|observation|>' }}
-{%- endif %}
 {{- '\n<tool_response>\n' }}
 {{- m.content }}
 {{- '\n</tool_response>' }}
 {%- else -%}
-{{- '<|observation|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}{% for tr in m.content %}
+<|observation|>{% for tr in m.content %}
 
 <tool_response>
 {{ tr.output if tr.output is defined else tr }}
 </tool_response>{% endfor -%}
 {% endif -%}
 {%- elif m.role == 'system' -%}
-{{- '<|system|>' if loop.first or messages[loop.index0 - 1].role != 'assistant' }}
-{{ visible_text(m.content) }}
+{%- if loop.first or messages[loop.index0 - 1].role != 'assistant' -%}<|system|>{%- endif -%}
+{{ '\n' + visible_text(m.content) }}
 {%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}
     <|assistant|>{{- '\n<think></think>' if (enable_thinking is defined and not enable_thinking) else '' -}}
-{%- endif -%}
+{%- endif -%}


### PR DESCRIPTION
GLM's chat format does **not** terminate an assistant turn with an end-of-turn token. We should consider this as a bug in the chat template. A rendeered conversation should always terminate with a EOS.

The turn is closed by the *next* message's role marker (`<|user|>`, `<|observation|>`, …), and these markers are exactly the tokens GLM lists as `eos_token_id` in its `generation_config`.

```diff
- [gMASK]<sop><|user|>\nWhat color is the sky?<|assistant|>\n<think></think>\nIt is blue.
+ [gMASK]<sop><|user|>\nWhat color is the sky?<|assistant|>\n<think></think>\nIt is blue.<|user|>
```

```diff
- [gMASK]<sop><|user|>\nWhat color is the sky?<|assistant|>\n<think></think>\nIt is blue.<|user|>Thanks!.
+ [gMASK]<sop><|user|>\nWhat color is the sky?<|assistant|>\n<think></think>\nIt is blue.<|user|>Thanks!<|assistant|>
```

If there is no stop token at the end of the assistant turn, the model is never trained to end its turn and at inference it keeps generating past where it should stop.

Another issue is that, when getting the tool suffix ids in the GRPO multi-turn generation loop (`_get_tool_suffix_ids`), the tool suffix is computed as the difference between the tool-call turn and that same turn followed by the tool response. Since the original template closes the assistant tool-call turn on `</tool_call>` and only emits `<|observation|>` from the following tool message, the `<|observation|>` token — which is the stop token that actually closes a tool-call turn — ends up in the tool suffix rather than in the model-generated completion.

This PR makes the GLM-4-MoE *training* template attribute the turn-terminating token to the turn itself

## Changes

### `trl/chat_templates/glm4moe_training.jinja`

Every assistant turn now emits its end-of-turn token at the end of its `{% generation %}` block:

- a **tool-call** turn → `<|observation|>`
- any **other** turn → the following message's role marker (`<|user|>` / `<|system|>`), or `<|user|>` when it is the final turn.

The leading role marker (`<|user|>` / `<|system|>` / `<|observation|>`) is **suppressed at the start of the following message** when the previous message was an assistant — it has already been emitted by the assistant turn. This is the same "move the marker to the previous turn" trick already used for `<|observation|>`, generalized to all role markers.

**Behavior for intermediate turns is unchanged** — the marker is merely relocated, so the rendered text is byte-for-byte identical.

**The final assistant turn now ends on its stop token** (this is the intended change):

```python
msgs = [
    {"role": "user", "content": "What color is the sky?"},
    {"role": "assistant", "content": "It is blue."},
]
# before: '...<|assistant|>\n<think></think>\nIt is blue.'
# after : '...<|assistant|>\n<think></think>\nIt is blue.<|user|>'
```

```python
msgs = [
    {"role": "user", "content": "w?"},
    {"role": "assistant", "content": "", "tool_calls": [
        {"type": "function", "function": {"name": "get_weather", "arguments": {"location": "Paris"}}}]},
]
# before: '...</tool_call>'
# after : '...</tool_call><|observation|>'
```

Minor cleanups in the same file: reverted the reasoning-extraction guard from `'<think>' in content and '</think>' in content` back to `'</think>' in content` (consistency with the upstream template).

## Testing / impact on existing tests

Because the final assistant turn now intentionally ends with a stop token, the `TestGetTrainingChatTemplate::test_behavior_unchanged_*` cases: 

```python
before = tokenizer.apply_chat_template(messages, tokenize=False)
after = tokenizer.apply_chat_template(messages, tokenize=False, chat_template=get_training_chat_template(tokenizer))
if tokenizer_name == "trl-internal-testing/tiny-Glm4MoeForCausalLM":
    # GLM's native template doesn't terminate an assistant turn with an end-of-turn token; the training
    # template appends the terminator that would open the next turn so the stop token is trained.
    assert after == before + "<|user|>"        # plain final turn
    # assert after == before + "<|observation|>"  # the tool-call case
else:
    assert before == after
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the GLM-4-MoE training Jinja and test expectations, but it alters tokenization/loss masks for SFT and GRPO multi-turn tool flows—wrong terminator logic would mis-train stop behavior.
> 
> **Overview**
> Updates **`glm4moe_training.jinja`** so each assistant turn’s **`{% generation %}`** block ends with the GLM stop token (`<|user|>`, `<|observation|>`, or `<|system|>`), instead of leaving the turn open until the next message’s role marker. Leading role markers on the following user/system/tool message are skipped when the prior turn was assistant, so **multi-turn rendered text stays the same**; only the **final** assistant turn gains an explicit terminator (e.g. `...It is blue.<|user|>`), which is what SFT loss masking and GRPO tool-suffix logic need.
> 
> Tool-call turns append **`<|observation|>`** right after `</tool_call>` inside generation. Reasoning extraction is aligned with upstream again (**`'</think>' in content`** only). Tests for **`tiny-Glm4MoeForCausalLM`** now expect **`after == before + "<|user|>"`** (or **`+<|observation|>`** for final tool-call turns) instead of strict equality with the native template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c65eb7d86a41add906014a69ccf677d3d2f56f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->