### PR TITLE
Remove redundant `.contiguous()` calls

### DIFF
--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1564,7 +1564,7 @@ class DistillationTrainer(_BaseTrainer):
 
         labels_mask = inputs["labels"] != -100
         masked_input_ids = torch.where(labels_mask, inputs["input_ids"], torch.full_like(inputs["input_ids"], -100))
-        true_labels = masked_input_ids[:, 1:].contiguous().reshape(-1)
+        true_labels = masked_input_ids[:, 1:].reshape(-1)
 
         student_head = unwrapped_student.get_output_embeddings()
         teacher_head = unwrapped_teacher.get_output_embeddings()

--- a/trl/experimental/gfpo/gfpo_trainer.py
+++ b/trl/experimental/gfpo/gfpo_trainer.py
@@ -313,8 +313,8 @@ class GFPOTrainer(_GRPOTrainer):
             group_global_indices = group_row_offsets + group_local_indices
             group_global_indices = group_global_indices.flatten()
 
-            rewards = rewards[group_global_indices].contiguous()
-            rewards_per_func = rewards_per_func[group_global_indices, :].contiguous()
+            rewards = rewards[group_global_indices]
+            rewards_per_func = rewards_per_func[group_global_indices, :]
 
             num_inputs_in_device = int(len(prompts) / self.num_generations * self.num_remains_in_group)
 
@@ -354,23 +354,23 @@ class GFPOTrainer(_GRPOTrainer):
                 prompts
             )  # step is length of prompts
 
-            prompt_ids = prompt_ids[local_input_indices_to_keep].contiguous()
-            prompt_mask = prompt_mask[local_input_indices_to_keep].contiguous()
-            completion_ids = completion_ids[local_input_indices_to_keep].contiguous()
-            completion_mask = completion_mask[local_input_indices_to_keep].contiguous()
-            attention_mask = attention_mask[local_input_indices_to_keep].contiguous()
+            prompt_ids = prompt_ids[local_input_indices_to_keep]
+            prompt_mask = prompt_mask[local_input_indices_to_keep]
+            completion_ids = completion_ids[local_input_indices_to_keep]
+            completion_mask = completion_mask[local_input_indices_to_keep]
+            attention_mask = attention_mask[local_input_indices_to_keep]
             completion_lengths = completion_mask.sum(1)
             agg_completion_lengths = self.accelerator.gather(completion_lengths)
             num_items_in_batch = agg_completion_lengths.sum()
 
             if sampling_per_token_logps is not None:
-                sampling_per_token_logps = sampling_per_token_logps[local_input_indices_to_keep].contiguous()
+                sampling_per_token_logps = sampling_per_token_logps[local_input_indices_to_keep]
             if old_per_token_logps is not None:
-                old_per_token_logps = old_per_token_logps[local_input_indices_to_keep].contiguous()
+                old_per_token_logps = old_per_token_logps[local_input_indices_to_keep]
             if ref_per_token_logps is not None:
-                ref_per_token_logps = ref_per_token_logps[local_input_indices_to_keep].contiguous()
+                ref_per_token_logps = ref_per_token_logps[local_input_indices_to_keep]
             if self.use_vllm and self.vllm_importance_sampling_correction:
-                importance_sampling_ratio = importance_sampling_ratio[local_input_indices_to_keep].contiguous()
+                importance_sampling_ratio = importance_sampling_ratio[local_input_indices_to_keep]
 
         # Calculate mean reward per function, but only for samples where the function was applied (non-NaN values)
         for i, reward_func_name in enumerate(self.reward_func_names):

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -1725,7 +1725,7 @@ class GOLDTrainer(SFTTrainer):
                 masked_input_ids = torch.where(
                     labels_mask, inputs["input_ids"], torch.full_like(inputs["input_ids"], -100)
                 )
-                true_labels = masked_input_ids[:, 1:].contiguous().reshape(-1)
+                true_labels = masked_input_ids[:, 1:].reshape(-1)
 
                 student_head = unwrapped_student.get_output_embeddings()
                 teacher_head = unwrapped_teacher.get_output_embeddings()

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1305,8 +1305,8 @@ def patch_chunked_lm_head(model: torch.nn.Module, chunk_size: int, temperature: 
         labels = labels[:, 1:]  # [B, S-1]
 
         b, s, h = hidden_states.shape
-        hidden_flat = hidden_states.reshape(b * s, h).contiguous()
-        targets_flat = labels.reshape(b * s).contiguous()
+        hidden_flat = hidden_states.reshape(b * s, h)
+        targets_flat = labels.reshape(b * s)
 
         # Filter to completion tokens only to avoid expensive matmuls on prompt tokens and tool results
         valid_mask = None


### PR DESCRIPTION
Drops `.contiguous()` calls that are provably no-ops, in cases where the surrounding code already guarantees a contiguous result:

- **After advanced indexing**: integer/boolean indexing (`x[index_tensor]`) already returns a fresh contiguous tensor.
- **Before `.reshape(...)`**: `reshape` copies to a contiguous layout itself when the input is non-contiguous, so a preceding `.contiguous()` is dead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only cleanup with no logic changes; behavior should match prior code while slightly reducing unnecessary copies in training loops.
> 
> **Overview**
> This PR strips **redundant `.contiguous()`** calls across several training hot paths where they do not change tensor layout or memory behavior.
> 
> In **distillation** and **GOLD** Liger JSD paths, `true_labels` is built with `masked_input_ids[:, 1:].reshape(-1)` only—dropping `.contiguous()` before reshape because reshape already handles non-contiguous inputs when needed.
> 
> In **GFPO**, after group filtering via integer indexing (`group_global_indices`, `local_input_indices_to_keep`), `.contiguous()` is removed from rewards, per-token logprob tensors, and prompt/completion batches because advanced indexing already yields contiguous views.
> 
> In **`trl/trainer/utils.py`**, flattened hidden states and label targets for chunked logprob computation no longer call `.contiguous()` immediately before `.reshape()`.
> 
> **No algorithm or API changes**—only fewer redundant memory copies in loss and rollout scoring code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27cf0a4b198c80db6fbbd53a97a30e4796c7e666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->