### PR TITLE
fix: share frozen layers with reference model instead of duplicating in memory

### DIFF
--- a/tests/experimental/test_modeling_value_head.py
+++ b/tests/experimental/test_modeling_value_head.py
@@ -97,3 +97,16 @@ class TestReferenceModel(TrlTestCase):
 
         # other layers in optimized model change
         assert not (second_layer_before == second_layer_after).all()
+
+    def test_shared_layers_share_memory(self):
+        # Shared layers must reference the same storage as the source model, not a `deepcopy` duplicate,
+        # so they are held in memory only once (see issue #2904).
+        layer_0 = self.layer_format.format(layer=0)
+        layer_1 = self.layer_format.format(layer=1)
+
+        ref_model = create_reference_model(self.model, num_shared_layers=1)
+
+        # the shared layer points at the same storage as the source model
+        assert ref_model.get_parameter(layer_0).data_ptr() == self.model.get_parameter(layer_0).data_ptr()
+        # an unshared layer is an independent copy
+        assert ref_model.get_parameter(layer_1).data_ptr() != self.model.get_parameter(layer_1).data_ptr()

--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -735,7 +735,8 @@ def create_reference_model(
     Args:
         model ([`nn.Module`]): The model to be copied.
         num_shared_layers (`int`, *optional*):
-            The number of initial layers that are shared between both models and kept frozen.
+            The number of initial layers that are shared between both models and kept frozen. Shared layers reference
+            the same storage as the source model, so they are not duplicated in memory.
         pattern (`str`, *optional*): The shared layers are selected with a string pattern
             (e.g. "transformer.h.{layer}" for GPT2) and if a custom pattern is necessary it can be passed here.
 
@@ -783,12 +784,16 @@ def create_reference_model(
         else:
             unshared_param_list.append(name)
 
-    # create reference of the original parameter if they are shared
+    # Freeze the shared layers in the source model, then point the reference parameter at the same
+    # storage instead of keeping the `deepcopy` duplicate. The shared (frozen) layers are thus held in
+    # memory only once; because they are frozen in the model, the reference stays static during training.
     for param_name in shared_param_list:
         param = model.get_parameter(param_name)
         param.requires_grad = False
 
-        _ref_param = ref_model.get_parameter(param_name)
+        ref_param = ref_model.get_parameter(param_name)
+        ref_param.data = param.data
+        ref_param.requires_grad = False
 
     # for all other parameters just make sure they don't use gradients
     for param_name in unshared_param_list:


### PR DESCRIPTION
## What

`create_reference_model` (`trl/experimental/utils.py`) builds the reference with `ref_model = deepcopy(model)`, which copies **every** parameter. When `num_shared_layers` is set, the shared-layer loop then did:

```python
param = model.get_parameter(param_name)
param.requires_grad = False
_ref_param = ref_model.get_parameter(param_name)   # fetched, never assigned
```

`_ref_param` was a dead local — it was never assigned back — so the "shared" frozen layers kept their `deepcopy` duplicate and were held in memory **twice** (`data_ptr()` differed between model and reference).

## Fix

Point the reference parameter at the source parameter's storage so shared layers are stored once:

```python
param = model.get_parameter(param_name)
param.requires_grad = False

ref_param = ref_model.get_parameter(param_name)
ref_param.data = param.data
ref_param.requires_grad = False
```

This keeps the existing contract (shared layers frozen in both the model and the reference) and only affects the `num_shared_layers` path — the default `create_reference_model(model)` path (used by all current trainers) is unchanged.

## Verification

- Added `test_shared_layers_share_memory` asserting the shared layer shares storage (`data_ptr()` identity) while an unshared layer remains an independent copy. It fails on the previous code and passes with the fix.
- All three `TestReferenceModel` tests pass.
- `ruff check`, `ruff format`, and the pinned `doc-builder` style check are clean.

Resolves #2904

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Aliasing parameter tensors between the training model and reference can affect correctness if shared layers were ever updated on one side only; the change is scoped to the `num_shared_layers` path and relies on freezing shared weights in the source model.
> 
> **Overview**
> When `create_reference_model` is called with **`num_shared_layers`**, shared frozen weights no longer stay as separate **`deepcopy`** tensors on the reference model. The reference’s shared parameters are now wired to the source model’s storage via **`ref_param.data = param.data`**, so those layers are held in memory once while remaining frozen on both sides.
> 
> The default **`create_reference_model(model)`** path (no shared layers) is unchanged. Docs for **`num_shared_layers`** describe the shared-storage behavior.
> 
> A new test **`test_shared_layers_share_memory`** checks **`data_ptr()`** equality for a shared layer and inequality for an unshared layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe7a6d0d48fc113f111219e35c599952e643d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->