### PR TITLE
fix(sft): reject transformed datasets during preparation

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn.functional as F
 import transformers
 from accelerate.utils.memory import release_memory
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from packaging.version import Version
 from packaging.version import parse as parse_version
 from transformers import (
@@ -1099,6 +1099,21 @@ class TestSFTTrainer(TrlTestCase):
         assert isinstance(trainer.data_collator, DataCollatorForLanguageModeling)
         assert trainer.data_collator.max_length == 16
         assert trainer.data_collator.truncation_mode == "keep_end"
+
+    def test_dataset_with_transform_requires_skip_prepare_dataset(self):
+        dataset = Dataset.from_dict({"text": ["hello world"]})
+
+        def add_suffix(batch):
+            batch["text"] = [text + " <AUG>" for text in batch["text"]]
+            return batch
+
+        dataset = dataset.with_transform(add_suffix)
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+
+        with pytest.raises(ValueError, match=r"Dataset\.with_transform\(\).*skip_prepare_dataset"):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+            )
 
     def test_padding_free_without_packing_and_max_length_raises(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:2]")

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1110,7 +1110,10 @@ class TestSFTTrainer(TrlTestCase):
         dataset = dataset.with_transform(add_suffix)
         training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
 
-        with pytest.raises(ValueError, match=r"Dataset\.with_transform\(\).*skip_prepare_dataset"):
+        with pytest.raises(
+            ValueError,
+            match=r"Dataset\.with_transform\(\).*skip_prepare_dataset.*trainer-ready",
+        ):
             SFTTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
             )

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1421,8 +1421,9 @@ class SFTTrainer(_BaseTrainer):
             raise ValueError(
                 "SFTTrainer cannot prepare a dataset that uses `Dataset.with_transform()`. The preparation pipeline "
                 "calls `Dataset.map()`, which reads through the transform and can bake a random or stateful transform "
-                "into the tokenized columns. Pass `dataset_kwargs={'skip_prepare_dataset': True}` and provide already "
-                "tokenized examples, or materialize the transform with `Dataset.map()` before constructing the trainer."
+                "into the tokenized columns. Pass `dataset_kwargs={'skip_prepare_dataset': True}` and make the "
+                "transform return trainer-ready examples, including tokenized fields, or materialize deterministic "
+                "transforms with `Dataset.map()` before constructing the trainer."
             )
 
         # If the dataset is already preprocessed (tokenized), skip the processing steps.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1417,6 +1417,14 @@ class SFTTrainer(_BaseTrainer):
         formatting_func: Callable[[dict], str] | None,
         dataset_name: str,
     ) -> Dataset | IterableDataset:
+        if isinstance(dataset, Dataset) and dataset.format["type"] == "custom":
+            raise ValueError(
+                "SFTTrainer cannot prepare a dataset that uses `Dataset.with_transform()`. The preparation pipeline "
+                "calls `Dataset.map()`, which reads through the transform and can bake a random or stateful transform "
+                "into the tokenized columns. Pass `dataset_kwargs={'skip_prepare_dataset': True}` and provide already "
+                "tokenized examples, or materialize the transform with `Dataset.map()` before constructing the trainer."
+            )
+
         # If the dataset is already preprocessed (tokenized), skip the processing steps.
         column_names = get_dataset_column_names(dataset)
         is_processed = "input_ids" in column_names


### PR DESCRIPTION
Fixes #6039.

SFTTrainer currently lets `Dataset.with_transform()` datasets enter the automatic preparation pipeline. That path calls `Dataset.map()` for EOS insertion and tokenization, and `map()` reads rows through the active custom transform. For stateful or random transforms, that can bake one transform realization into the prepared Arrow columns while later accesses still run a different transform.

This PR adds a guard before SFT dataset preparation: if the dataset has a custom transform, fail with a clear error explaining why automatic preparation is unsafe and pointing users to either `dataset_kwargs={"skip_prepare_dataset": True}` with already-tokenized examples, or materializing the transform with `Dataset.map()` before constructing the trainer.

I kept this as the conservative fix from the issue. It does not attempt lazy transform composition or packing support in this PR.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. #6039
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Tests

- `python -m ruff check trl\\trainer\\sft_trainer.py tests\\test_sft_trainer.py`
- `.\\.venv\\Scripts\\python.exe -m py_compile trl\\trainer\\sft_trainer.py tests\\test_sft_trainer.py`
- `.\\.venv\\Scripts\\python.exe -m pytest tests\\test_sft_trainer.py::TestSFTTrainer::test_dataset_with_transform_requires_skip_prepare_dataset -q`

One nearby skip-prepare test was also attempted in this local Windows venv, but it fails before reaching trainer logic because the current CPU-only environment rejects the default bf16 settings. I did not change existing tests to hide that environment issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, early validation in the dataset prep path; only blocks an unsafe pattern and does not change successful training flows.
> 
> **Overview**
> **SFTTrainer** now refuses datasets created with **`Dataset.with_transform()`** when automatic dataset preparation runs. Preparation uses **`Dataset.map()`**, which materializes rows through the lazy transform and can freeze one random or stateful augmentation into Arrow columns while later reads still apply a different transform.
> 
> At the start of **`_prepare_dataset`**, the trainer checks for a custom dataset format and raises **`ValueError`** with guidance to use **`dataset_kwargs={'skip_prepare_dataset': True}`** with trainer-ready (e.g. tokenized) examples from the transform, or to **`map()`** deterministic transforms before building the trainer.
> 
> A regression test asserts that **`SFTTrainer`** construction fails on a **`with_transform`** dataset with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27def356a338de514eeb1b370cf45ca8df2b495a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->