### PR TITLE
fix(gold): preserve vllm prompt special tokens

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -429,7 +429,7 @@ def test_generate_on_policy_for_slices_uses_prompt_attention_mask_for_vllm_promp
     assert trainer.vllm_generation.sync_calls == 1
     assert captured["completion_ids"] == [[42]]
     assert captured["prompt_ids_list"] == [[5, 9, 6]]
-    assert captured["prompts_text"] == ["A B"]
+    assert captured["prompts_text"] == ["A <eos> B"]
 
 
 def test_generate_on_policy_for_slices_reconstructs_prompt_with_special_tokens():
@@ -506,7 +506,7 @@ def test_generate_on_policy_for_slices_reconstructs_prompt_with_special_tokens()
     assert torch.equal(buffered_inputs["labels"], torch.tensor([[-100, -100, -100, 42]], dtype=torch.long))
     assert buffered_inputs["original_prompt_text"] == ["A <special> B"]
     assert buffered_inputs["original_completion_text"] == ["C"]
-    assert trainer._buffered_text_logs[0] == (["A B"], ["C"])
+    assert trainer._buffered_text_logs[0] == (["A <special> B"], ["C"])
 
 
 def test_on_policy_prompt_text_reflects_truncated_prompt():

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -1139,7 +1139,7 @@ class GOLDTrainer(SFTTrainer):
 
         prompts_text = self.processing_class.batch_decode(
             prompt_ids_list,
-            skip_special_tokens=True,
+            skip_special_tokens=False,
         )
 
         if not self.use_vllm:


### PR DESCRIPTION
## What changed

GOLD's vLLM on-policy path now decodes the prompt text with `skip_special_tokens=False`.

The current main branch already passes prompt token ids to vLLM, so the model-side generation path keeps the templated tokens. The remaining mismatch was the prompt text recorded and passed through the completion buffer: it still decoded with `skip_special_tokens=True`, so chat-template markers such as `<|im_start|>` / `<|im_end|>` could disappear from the prompt text associated with the generated completion.

This keeps the token-id path unchanged and aligns the text side with the existing `original_prompt_text` reconstruction, which already preserves special tokens.

Fixes #5241.

## To verify

```bash
python -m pytest tests/experimental/test_gold_trainer.py -k "prompt_attention_mask_for_vllm_prompts or reconstructs_prompt_with_special_tokens" -q
python -m ruff check trl/experimental/gold/gold_trainer.py tests/experimental/test_gold_trainer.py
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single decode-flag change on the experimental GOLD vLLM path; behavior is narrowed to preserving template tokens in text metadata with test coverage.
> 
> **Overview**
> GOLD’s vLLM on-policy path now decodes masked prompt token ids with **`skip_special_tokens=False`** when building `prompts_text` for the completion buffer and logs.
> 
> Previously that decode stripped chat-template / pad markers (e.g. `<eos>`, `<|im_start|>`) even though vLLM still received the full id sequence and `original_prompt_text` already kept specials after truncation. **Prompt text attached to generated completions now matches the token path**, which matters for teacher re-encoding and ULD alignment (fixes #5241).
> 
> Tests were updated so `prompts_text` and `_buffered_text_logs` expect specials in the reconstructed prompt strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767765d813076a54c4e919f97da10cde1656893b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->