### PR TITLE
Fix `unpair_preference_dataset` dropping extra columns

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -994,6 +994,44 @@ class TestUnpairPreferenceDataset(TrlTestCase):
             "The paired dataset should be converted to unpaired."
         )
 
+    def test_unpair_preference_dataset_extra_columns(self):
+        # Test that extra columns are dropped (not causing a length mismatch error)
+        paired_dataset = Dataset.from_dict(
+            {
+                "prompt": ["The sky is", "The sun is"],
+                "chosen": [" blue.", " in the sky."],
+                "rejected": [" green.", " in the sea."],
+                "extra": [1, 2],
+            }
+        )
+        unpaired_dataset = unpair_preference_dataset(paired_dataset)
+        assert unpaired_dataset.to_dict() == self.unpaired_dataset.to_dict()
+
+    def test_unpair_preference_dataset_iterable(self):
+        # Test that an IterableDataset with extra columns is correctly unpaired
+        paired_dataset = self.paired_dataset.to_iterable_dataset()
+        unpaired_dataset = unpair_preference_dataset(paired_dataset)
+        assert list(unpaired_dataset) == [
+            dict(zip(self.unpaired_dataset.column_names, vals, strict=False))
+            for vals in zip(*self.unpaired_dataset.to_dict().values(), strict=False)
+        ]
+
+    def test_unpair_preference_dataset_iterable_extra_columns(self):
+        # Test that an IterableDataset with extra columns drops them without error
+        paired_iterable = Dataset.from_dict(
+            {
+                "prompt": ["The sky is", "The sun is"],
+                "chosen": [" blue.", " in the sky."],
+                "rejected": [" green.", " in the sea."],
+                "extra": [1, 2],
+            }
+        ).to_iterable_dataset()
+        unpaired_dataset = unpair_preference_dataset(paired_iterable)
+        assert list(unpaired_dataset) == [
+            dict(zip(self.unpaired_dataset.column_names, vals, strict=False))
+            for vals in zip(*self.unpaired_dataset.to_dict().values(), strict=False)
+        ]
+
     def test_unpair_preference_dataset_dict(self):
         # Test that a paired dataset dict is correctly converted to unpaired
         paired_dataset_dict = DatasetDict({"abc": self.paired_dataset})

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -414,6 +414,8 @@ def unpair_preference_dataset(
     """
     Unpair a preference dataset.
 
+    The output contains only `"prompt"`, `"completion"`, and `"label"`; all other columns are dropped.
+
     Args:
         dataset ([`~datasets.Dataset`] or [`~datasets.DatasetDict`] or [`~datasets.IterableDataset`] or [`~datasets.IterableDatasetDict`]):
             Preference dataset to unpair. The dataset must have columns `"chosen"`, `"rejected"` and optionally
@@ -447,7 +449,13 @@ def unpair_preference_dataset(
     {'prompt': 'The sky is', 'completion': ' blue.', 'label': True}
     ```
     """
-    return dataset.map(_unpair_row, batched=True, remove_columns=["chosen", "rejected"], **map_kwargs)
+    if isinstance(dataset, DatasetDict):
+        column_names = next(iter(dataset.values())).column_names
+    elif isinstance(dataset, Dataset):
+        column_names = dataset.column_names
+    else:  # IterableDataset
+        column_names = dataset.column_names or list(next(iter(dataset)).keys())
+    return dataset.map(_unpair_row, batched=True, remove_columns=column_names, **map_kwargs)
 
 
 def maybe_unpair_preference_dataset(


### PR DESCRIPTION
Fix `unpair_preference_dataset` dropping extra columns.

This pull request improves the robustness of the `unpair_preference_dataset` function by ensuring that any extra columns in the input dataset are dropped when converting from paired to unpaired format. It also adds comprehensive tests to verify correct behavior for both regular and iterable datasets, even when extra columns are present.

Fix #2351.

### Motivation

`unpair_preference_dataset` uses `batched=True` mapping, so `_unpair_row` doubles the row count (N → 2N). The previous `remove_columns=["chosen", "rejected"]` only removed those two columns, leaving any extra column in the dataset at its original N-row length — causing an `ArrowInvalid` length mismatch when PyArrow merged the results.

### Solution

The fix computes `column_names` from the dataset before calling map and passes all of them to `remove_columns`, so only the columns produced by `_unpair_row` (prompt, completion, label) survive. The docstring is updated to document that extra columns are dropped.

### Changes

**Functionality improvements:**

* Updated `unpair_preference_dataset` to dynamically remove all columns from the input dataset, not just `"chosen"` and `"rejected"`, ensuring only `"prompt"`, `"completion"`, and `"label"` remain in the output. This prevents errors from extra columns and standardizes output.
* Clarified the docstring for `unpair_preference_dataset` to specify that all columns except `"prompt"`, `"completion"`, and `"label"` are dropped.

**Testing improvements:**

* Added tests to verify that extra columns are dropped for both regular and iterable datasets, and that no errors occur due to length mismatches or unexpected columns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized data-prep fix with tests; standard paired datasets behave the same aside from intentionally dropping previously retained extra columns.
> 
> **Overview**
> Fixes **`ArrowInvalid`** length mismatches when paired preference data has columns beyond `prompt` / `chosen` / `rejected`. Batched `_unpair_row` doubles row count (N → 2N); removing only `chosen` and `rejected` left extra columns at length N during the merge.
> 
> **`unpair_preference_dataset`** now resolves **all** input column names (including **`DatasetDict`** and **`IterableDataset`**, peeking one row when `column_names` is missing) and passes them to **`remove_columns`**, so the result is only **`prompt`**, **`completion`**, and **`label`**. The docstring states that other columns are dropped.
> 
> Tests cover extra columns on **`Dataset`** and **`IterableDataset`**, plus iterable unpairing without extras.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29a8cb8995dd875adb4a97d4bbd929b2d3d94e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->