### PR TITLE
fix(sft): raise clear ValueError when Dataset.with_transform is passed to SFTTrainer

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2013,6 +2013,33 @@ class TestSFTTrainer(TrlTestCase):
                 raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
 
 
+    def test_with_transform_raises_clear_error(self):
+        """SFTTrainer must raise ValueError (not silently corrupt) when Dataset.with_transform is used.
+
+        Regression test for https://github.com/huggingface/trl/issues/6039 — before the fix,
+        _prepare_dataset would silently bake in stale randomness and freeze input_ids to a single
+        draw made during map-based tokenization.
+        """
+        import random
+        from datasets import Dataset
+
+        random.seed(42)
+        ds = Dataset.from_dict({"text": ["hello world"] * 4})
+
+        def augment(batch):
+            batch["text"] = [t + f" <TAG{random.randint(0, 999)}>" for t in batch["text"]]
+            return batch
+
+        ds_with_transform = ds.with_transform(augment)
+
+        with pytest.raises(ValueError, match="with_transform"):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                train_dataset=ds_with_transform,
+                args=SFTConfig(output_dir=self.tmp_dir, report_to="none", use_cpu=True, bf16=False),
+            )
+
+
 @pytest.mark.slow
 @require_torch_accelerator
 @require_peft

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1417,6 +1417,52 @@ class SFTTrainer(_BaseTrainer):
         formatting_func: Callable[[dict], str] | None,
         dataset_name: str,
     ) -> Dataset | IterableDataset:
+        # Reject datasets that use Dataset.with_transform before any map-based prep runs.
+        # `with_transform` (format_type == "custom") defers augmentation to access time, but every
+        # `dataset.map` call also reads its input *through* the transform.  That means each
+        # successive map step (add_eos, tokenize, …) fires the augmentation on an already-mutated
+        # row, baking stale randomness into the stored columns and making the final `input_ids`
+        # unrelated to the user's intended augmentation.
+        #
+        # Three failure modes result (all silent by default):
+        #   1. Multi-step map prep stacks transform invocations, producing garbled stored data.
+        #   2. `Trainer._remove_unused_columns` removes the raw text column, leaving the transform
+        #      with no data to read → `KeyError` at batch time.
+        #   3. Even with `remove_unused_columns=False`, `input_ids` is frozen to a single
+        #      random draw made during tokenization, so augmentation appears live on `text` but
+        #      the model always trains on the same garbled sequence.
+        #
+        # The correct approach is to include add-EOS and tokenization inside the user's own
+        # transform and skip `_prepare_dataset` entirely via
+        # `SFTConfig(dataset_kwargs={"skip_prepare_dataset": True})`.
+        if isinstance(dataset, Dataset) and dataset._format_type == "custom":
+            transform_fn = dataset._format_kwargs.get("transform")
+            if transform_fn is not None:
+                raise ValueError(
+                    f"The {dataset_name} dataset has a custom transform applied via "
+                    "`Dataset.with_transform(...)`. `SFTTrainer._prepare_dataset` uses "
+                    "`Dataset.map` internally, which reads input rows *through* the transform "
+                    "before writing them back — causing the transform to fire multiple times "
+                    "on already-mutated data and freezing `input_ids` to a single random draw "
+                    "made at prep time. In the worst case the raw text column is later removed "
+                    "by `Trainer._remove_unused_columns`, leaving the transform with no data to "
+                    "read and raising a `KeyError` at training time.\n\n"
+                    "To fix this, move add-EOS and tokenization inside your transform and pass "
+                    "`dataset_kwargs={'skip_prepare_dataset': True}` to `SFTConfig` so that "
+                    "`_prepare_dataset` is skipped entirely:\n\n"
+                    "    from transformers import AutoTokenizer\n"
+                    "    tok = AutoTokenizer.from_pretrained(...)\n\n"
+                    "    def my_transform(batch):\n"
+                    "        # your augmentation here\n"
+                    "        batch['text'] = [t + tok.eos_token for t in batch['text']]\n"
+                    "        return tok(batch['text'], truncation=True)\n\n"
+                    "    ds = ds.with_transform(my_transform)\n"
+                    "    trainer = SFTTrainer(\n"
+                    "        ...,\n"
+                    "        args=SFTConfig(dataset_kwargs={'skip_prepare_dataset': True}),\n"
+                    "    )\n"
+                )
+
         # If the dataset is already preprocessed (tokenized), skip the processing steps.
         column_names = get_dataset_column_names(dataset)
         is_processed = "input_ids" in column_names


### PR DESCRIPTION
## What does this PR do?

Fixes **silent data corruption** when a `Dataset.with_transform`-decorated dataset is passed to `SFTTrainer`.

### Root cause

`_prepare_dataset` calls `Dataset.map` for add-EOS, schema normalisation, and tokenisation. `Dataset.map` reads each row *through* the dataset's format transform before writing the result back — so when the user's augmentation transform is active, it fires **once per map step, each time on an already-mutated row**. Three failure modes result, all silent:

| # | Failure mode |
|---|---|
| 1 | Multi-step map stacks transform invocations. EOS lands inside the augmented string; `input_ids` is tokenised from a stale draw unrelated to what `text` shows on later access. |
| 2 | `Trainer._remove_unused_columns` drops the raw `text` column; the live transform then has nothing to read → `KeyError: 'text'` at batch time. |
| 3 | Even with `remove_unused_columns=False`, `input_ids` is frozen to a single draw made during the tokenise map step. `text` re-randomises on each access but the model always trains on the same corrupted sequence. |

None of these raise a meaningful error — users see garbled data or a cryptic `KeyError` with no pointer to the root cause.

### Fix

At the top of `_prepare_dataset`, detect `dataset._format_type == "custom"` (the sentinel `Dataset.with_transform` sets) and raise a descriptive `ValueError` that:
- names all three failure modes
- shows the correct workaround (`skip_prepare_dataset=True` + include tokenisation in the user's transform)

### Example output after this fix

```
ValueError: The train dataset has a custom transform applied via `Dataset.with_transform(...)`.
`SFTTrainer._prepare_dataset` uses `Dataset.map` internally, which reads input rows *through*
the transform and can corrupt or freeze the augmented data.

To fix this, move add-EOS and tokenization inside your transform and pass
`dataset_kwargs={'skip_prepare_dataset': True}` to `SFTConfig` so that
`_prepare_dataset` is skipped entirely:

    from transformers import AutoTokenizer
    tok = AutoTokenizer.from_pretrained(...)

    def my_transform(batch):
        # your augmentation here
        batch['text'] = [t + tok.eos_token for t in batch['text']]
        return tok(batch['text'], truncation=True)

    ds = ds.with_transform(my_transform)
    trainer = SFTTrainer(
        ...,
        args=SFTConfig(dataset_kwargs={'skip_prepare_dataset': True}),
    )
```

Closes #6039

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Guardrail-only change at dataset prep time with no effect on normal datasets; slightly relies on datasets internal `_format_type`/`_format_kwargs` API.
> 
> **Overview**
> **`SFTTrainer`** now **fails fast** when the train/eval dataset was built with **`Dataset.with_transform`**, instead of letting **`_prepare_dataset`**’s internal **`map`** steps interact badly with the live transform (silent corruption, frozen **`input_ids`**, or **`KeyError`** on **`text`**).
> 
> At the start of **`_prepare_dataset`**, it checks for Hugging Face **`datasets`** custom format (`_format_type == "custom"`) and raises a **`ValueError`** that explains why **`map`** + **`with_transform`** clash and points users to **`SFTConfig(dataset_kwargs={"skip_prepare_dataset": True})`** with EOS/tokenization inside their own transform.
> 
> A regression test **`test_with_transform_raises_clear_error`** asserts construction raises with a message mentioning **`with_transform`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8bfd44c214ca611d0af99a45ae5287181fba125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->