### PR TITLE
Fix signature of _unpair_row

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -396,15 +396,15 @@ def maybe_apply_chat_template(
         return example
 
 
-def _unpair_row(examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
-    batch_size = len(examples["chosen"])
-    new_rows = {
-        "completion": examples["chosen"] + examples["rejected"],
+def _unpair_row(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
+    batch_size = len(batch["chosen"])
+    new_batch = {
+        "completion": batch["chosen"] + batch["rejected"],
         "label": [True] * batch_size + [False] * batch_size,
     }
-    if "prompt" in examples:
-        new_rows["prompt"] = examples["prompt"] + examples["prompt"]
-    return new_rows
+    if "prompt" in batch:
+        new_batch["prompt"] = batch["prompt"] + batch["prompt"]
+    return new_batch
 
 
 def unpair_preference_dataset(

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -396,7 +396,7 @@ def maybe_apply_chat_template(
         return example
 
 
-def _unpair_row(examples: list[dict[str, list[dict[str, str]]]]) -> list[dict[str, list[dict[str, str]]]]:
+def _unpair_row(examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
     batch_size = len(examples["chosen"])
     new_rows = {
         "completion": examples["chosen"] + examples["rejected"],


### PR DESCRIPTION
Fix type hint in `_unpair_row`.

This PR refactors the `_unpair_row` function in `trl/data_utils.py` to improve clarity and type correctness. The function signature is updated, and variable names are made more descriptive for easier understanding.

### Changes

**Refactoring and code clarity:**

* Changed the `_unpair_row` function signature to accept a dictionary (`batch`) instead of a list, and updated type annotations for better accuracy.
* Renamed variables from `examples`/`new_rows` to `batch`/`new_batch` for clearer intent and readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only typing and rename in a small helper with no logic changes.
> 
> **Overview**
> Corrects the type annotations and naming for **`_unpair_row`**, the batched callback used by **`unpair_preference_dataset`** when calling `dataset.map(..., batched=True)`.
> 
> The parameter and return types are updated from a misleading `list[dict[...]]` to **`dict[str, list[Any]]`**, matching the column-oriented batch dict Hugging Face `datasets` passes to batched map functions. Locals are renamed from `examples` / `new_rows` to **`batch`** / **`new_batch`** for clarity. **Unpairing logic is unchanged** (chosen/rejected still become completion rows with matching labels and duplicated prompts when present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c6b23354f6448ffbe0b0cd598a5617b40178fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->