### PR TITLE
fix(gold): preserve vllm prompt special tokens

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -429,7 +429,7 @@ def test_generate_on_policy_for_slices_uses_prompt_attention_mask_for_vllm_promp
     assert trainer.vllm_generation.sync_calls == 1
     assert captured["completion_ids"] == [[42]]
     assert captured["prompt_ids_list"] == [[5, 9, 6]]
-    assert captured["prompts_text"] == ["A B"]
+    assert captured["prompts_text"] == ["A <eos> B"]
 
 
 def test_generate_on_policy_for_slices_reconstructs_prompt_with_special_tokens():
@@ -506,7 +506,7 @@ def test_generate_on_policy_for_slices_reconstructs_prompt_with_special_tokens()
     assert torch.equal(buffered_inputs["labels"], torch.tensor([[-100, -100, -100, 42]], dtype=torch.long))
     assert buffered_inputs["original_prompt_text"] == ["A <special> B"]
     assert buffered_inputs["original_completion_text"] == ["C"]
-    assert trainer._buffered_text_logs[0] == (["A B"], ["C"])
+    assert trainer._buffered_text_logs[0] == (["A <special> B"], ["C"])
 
 
 def test_on_policy_prompt_text_reflects_truncated_prompt():

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -1139,7 +1139,7 @@ class GOLDTrainer(SFTTrainer):
 
         prompts_text = self.processing_class.batch_decode(
             prompt_ids_list,
-            skip_special_tokens=True,
+            skip_special_tokens=False,
         )
 
         if not self.use_vllm:


### PR DESCRIPTION
# What does this PR do?

GOLD's vLLM on-policy path now preserves chat-template special tokens when it reconstructs prompt text for the completion buffer and text logs.

The model-side generation path already receives the original prompt token IDs. The remaining mismatch was `prompts_text`, which decoded the same IDs with `skip_special_tokens=True`; markers such as `<|im_start|>` and `<|im_end|>` could therefore disappear before teacher re-encoding and ULD alignment. This change keeps the token path unchanged and makes the recorded text consistent with the existing `original_prompt_text` reconstruction.

Fixes #5241.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in this PR.

## Validation

```bash
python -m pytest tests/experimental/test_gold_trainer.py -k "prompt_attention_mask_for_vllm_prompts or reconstructs_prompt_with_special_tokens" -q -p no:cacheprovider
python -m ruff check trl/experimental/gold/gold_trainer.py tests/experimental/test_gold_trainer.py
git diff --check
```

Result: 2 passed, 23 deselected; ruff and diff check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-flag change in one decode call on the GOLD vLLM on-policy path; behavior is narrowed to more faithful prompt strings with tests covering the regression.
> 
> **Overview**
> GOLD’s vLLM on-policy path now decodes masked prompt token IDs with **`skip_special_tokens=False`** when building `prompts_text` in `_generate_on_policy_for_slices`, instead of stripping chat-template markers (e.g. `<|im_start|>`, EOS/pad-as-special) before they reach the completion buffer and text logs.
> 
> vLLM still gets the same prompt ID lists; only the string reconstruction changes so **`prompts_text` and `_buffered_text_logs` match `original_prompt_text`**, which was already decoded with special tokens preserved (including after truncation). That keeps teacher re-encoding and ULD byte alignment consistent with the tokens the student actually sees.
> 
> Tests were updated to assert pad/EOS and custom special tokens appear in captured `prompts_text` and buffered logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47550bc1209f92b3d3154ba808ae48217db8a92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->