### PR TITLE
Fix chunked_nll mixed Tensor/DTensor error under FSDP2 + PEFT

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -237,7 +237,9 @@ def _chunked_cross_entropy_loss(
     return loss, correct, entropy_sum, n_valid_tensor
 
 
-def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: bool = False) -> None:
+def _patch_chunked_ce_lm_head(
+    model: torch.nn.Module, chunk_size: int, is_vlm: bool = False, with_peft: bool = False
+) -> None:
     """
     Patch `model.forward` to compute the LM loss via [`_chunked_cross_entropy_loss`].
 
@@ -309,16 +311,26 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         )
         hidden_states = outputs.last_hidden_state
 
+        lm_head_weight = lm_head.weight
+        lm_head_bias = lm_head.bias
+        # Under FSDP2 + PEFT, the outer FSDP module wraps PeftModel while lm_head.weight
+        # belongs to the nested causal-LM FSDP module, which is never entered directly inside
+        # _chunked_ce_forward. The weight therefore stays in Shard(0) placement; full_tensor()
+        # all-gathers the shards into the complete weight before the chunked matmul.
+        if with_peft and isinstance(lm_head_weight, torch.distributed.tensor.DTensor):
+            lm_head_weight = lm_head_weight.full_tensor()
+            if lm_head_bias is not None:
+                lm_head_bias = lm_head_bias.full_tensor()
         loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
             hidden_states,
-            lm_head.weight,
+            lm_head_weight,
             chunk_size,
             labels=labels,
             shift_labels=shift_labels,
             num_items_in_batch=num_items_in_batch,
             logit_scale=logit_scale,
             final_logit_softcapping=final_logit_softcapping,
-            lm_head_bias=lm_head.bias,
+            lm_head_bias=lm_head_bias,
         )
 
         aux_loss = None
@@ -1307,7 +1319,9 @@ class SFTTrainer(_BaseTrainer):
                             "`lm_head` from `target_modules`, or switch to `loss_type='nll'`. If this is a real use "
                             "case for you, please open an issue at https://github.com/huggingface/trl/issues."
                         )
-                _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
+                _patch_chunked_ce_lm_head(
+                    target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm, with_peft=is_peft_model(model)
+                )
             else:
                 raise ValueError(
                     f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "


### PR DESCRIPTION
Fix `chunked_nll` mixed Tensor/DTensor error under FSDP2 + PEFT.

Fix #6064.

This PR fixes the chunked cross-entropy loss computation in SFTTrainer` to better support PEFT models when used with FSDP2. The main changes ensure that tensor types are compatible when running under these advanced distributed training setups.

### Motivation

After #5846 defaulted `loss_type` to `chunked_nll`, the `test_sft_peft[fsdp2]` distributed smoke test started failing:
> RuntimeError: aten.mm.default got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!

**Root cause** 

Under FSDP2 + PEFT, LoRA's internal dtype cast (`x = x.to(lora_A.weight.dtype)`) strips the `DTensor(Replicate)` wrapper from activations inside the backbone. `hidden_states` therefore exits the backbone as a plain tensor, while `lm_head.weight`, gathered by the outer FSDP2 module (which wraps `PeftModel`), remains a `DTensor(Replicate)`. Handing both to `_chunked_cross_entropy_loss` produces the mixed-type error when the chunked matmul runs.

In non-PEFT FSDP2 (where the outer FSDP2 module wraps the causal LM directly) this does not occur: `hidden_states` stays `DTensor(Replicate)` throughout the backbone, so both operands of the matmul are consistently `DTensor(Replicate)`.

### Solution

Add a `with_peft: bool = False` parameter to `_patch_chunked_ce_lm_head`. When `with_peft=True` and `lm_head.weight` is a `DTensor` (the FSDP2 runtime indicator), `full_tensor()` is called to all-gather the shards into the complete weight matrix before passing it to `_chunked_cross_entropy_loss`. This mirrors the approach used in `_maybe_gather_lm_head_ctx` for ZeRO-3. This restores the type consistency that non-PEFT FSDP2 has naturally. 

The `with_peft` guard is intentional: a bare `isinstance(DTensor)` check would incorrectly convert the weight in non-PEFT FSDP2, where `hidden_states` is still a `DTensor(Replicate)` and both operands must remain `DTensor` for the matmul to dispatch correctly.

### Changes

Model compatibility improvements:

* Updated `_patch_chunked_ce_lm_head` to accept a new `with_peft` argument, allowing it to handle PEFT-specific logic when patching the model's forward method. 
* In `_chunked_ce_forward`, added logic to convert `lm_head.weight` and `lm_head.bias` from `DTensor(Replicate)` to local tensors if PEFT is enabled, ensuring type consistency with `hidden_states` under FSDP2 + PEFT.

These changes improve stability and correctness when training with LoRA/PEFT adapters in distributed FSDP2 environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed training loss computation for the default chunked_nll path; behavior change is gated to PEFT + DTensor lm_head, but incorrect guarding could affect FSDP2 matmul dispatch.
> 
> **Overview**
> Fixes **`loss_type='chunked_nll'`** failing under **FSDP2 + PEFT** when LoRA dtype casts leave **`hidden_states`** as plain tensors while **`lm_head.weight`** stays a **`DTensor`**, which breaks the chunked matmul.
> 
> **`_patch_chunked_ce_lm_head`** gains a **`with_peft`** flag. In the patched forward, when **`with_peft=True`** and the head weight is a **`DTensor`**, **`full_tensor()`** all-gathers **`lm_head.weight`** (and bias) before **`_chunked_cross_entropy_loss`**, matching the ZeRO-3 gather pattern in **`_maybe_gather_lm_head_ctx`**. **`SFTTrainer`** passes **`with_peft=is_peft_model(model)`** so non-PEFT FSDP2 paths keep both operands as **`DTensor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2755b64a2a7714500a3f627fd5ae70471238e07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->