### PR TITLE
async_grpo: inject the environment_factory reset() observation into the prompt

### DIFF
--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -313,8 +313,34 @@ class _AsyncRolloutLoop:
                 self._heartbeat_value.value = time.time()
                 while free_slots and not stop_event.is_set():
                     group_id, row = next(work_iter)
+                    slot = free_slots.pop()
+                    # Reset the env BEFORE building the prompt and capture its initial observation (e.g. a
+                    # task instruction). The reset() return was previously discarded, so an
+                    # environment_factory whose task lives in the observation (not the dataset prompt) was
+                    # generated against the bare prompt. Mirror GRPOTrainer: fold the observation into the
+                    # last prompt message. It is task-level (identical across the group's generations), so
+                    # inject it once, when the group is first created.
+                    observation = self.environments[slot].reset(**row) if self.environments is not None else None
+
                     if group_id not in pending_groups:
                         prompt = row["prompt"]
+                        if observation is not None:
+                            last = prompt[-1]
+                            if isinstance(last["content"], str) and isinstance(observation, str):
+                                content = last["content"] + observation
+                            else:
+                                obs = (
+                                    observation
+                                    if isinstance(observation, list)
+                                    else [{"type": "text", "text": observation}]
+                                )
+                                base = (
+                                    last["content"]
+                                    if isinstance(last["content"], list)
+                                    else [{"type": "text", "text": last["content"]}]
+                                )
+                                content = base + obs
+                            prompt = prompt[:-1] + [{**last, "content": content}]
                         prompt_ids = self.tokenizer.apply_chat_template(
                             prompt,
                             return_dict=False,
@@ -341,10 +367,6 @@ class _AsyncRolloutLoop:
                             model_version=self.model_version,
                         )
                         pending_completed[group_id] = 0
-
-                    slot = free_slots.pop()
-                    if self.environments is not None:
-                        self.environments[slot].reset(**row)
 
                     task = asyncio.create_task(
                         self._generate_one(pending_groups[group_id].prompt, tool_dict=self._sync_tool_dicts[slot])


### PR DESCRIPTION
Closes #6067.

`AsyncGRPOTrainer`'s rollout worker called `env.reset(**row)` but discarded its return value, so an `environment_factory` whose task is delivered via the initial observation (rather than the dataset `prompt` column) was generated against the bare prompt — if that prompt is empty, the policy sees no task and trains on irrelevant completions. `GRPOTrainer` already folds `reset()`'s observation into the prompt (`prompt[-1]["content"] += observation`); this mirrors that in the async rollout worker: reset the env before building the prompt, and fold the observation into the last prompt message once per group (it is task-level, identical across the group's generations).

**TITO-safe.** This only affects the turn-0 prompt, which is tokenized once via the training chat template. It does not decode-then-re-encode any sampled tokens — the running buffer (`prompt_ids = prompt_ids + turn_ids + suffix_ids`), `parse_response`-for-dispatch, and the tool-response delta are all unchanged. The policy is still trained on the exact tokens it sampled; it just samples them in response to the actual task instead of an empty prompt.

**Verified end-to-end.** An `environment_factory` (the Harbor data-agent suite) that earns reward under `GRPOTrainer` previously earned 0 under `AsyncGRPOTrainer` (the agent flailed with "no task description") and now earns reward with the same config after this change.

Happy to add a unit test if you have a preferred harness for the async rollout loop.

Related: #6027, #6028 (other async `environment_factory` gaps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Turn-0 prompt assembly only in the async rollout child; no auth or training-token path changes beyond fixing missing task text for env-based tasks.
> 
> **Overview**
> **Async GRPO rollout** now matches **GRPOTrainer** for `environment_factory` setups where the task text comes from `reset()` rather than the dataset `prompt` column.
> 
> In `_generate_loop`, the worker **resets the env before** building `prompt_ids`, **keeps** the `reset(**row)` return value, and **merges** that observation into the last chat message when a new rollout group is created (once per group, not per generation). String and multimodal-style list content are both handled.
> 
> Previously `reset()` ran after slot assignment but its return was ignored, so generation could run on an empty or incomplete prompt and earn no reward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b158e15c69b0557ddc83c8ffa5223d5ebd9c3bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->