### PR TITLE
Fix broken doc links in paper_index (experimental page was split)

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -95,7 +95,7 @@ training_args = GRPOConfig(
 
 Note that this method only has an effect when training goes slightly off-policy—for example, when `steps_per_generation > gradient_accumulation_steps` or `num_iterations > 1`. Otherwise, it is effectively equivalent to no modification.
 
-TRL also provide an experimental implementation of GSPO-token, see [Experimental - GSPO-Token](experimental#gspo-token).
+TRL also provide an experimental implementation of GSPO-token, see [Experimental - GSPO-Token](gspo_token).
 
 #### Policy ratio: GRPO vs. GSPO
 
@@ -408,7 +408,7 @@ TRL exposes the Importance Sampling granularity level through the `vllm_importan
 
 **📜 Paper**: https://huggingface.co/papers/2508.09726
 
-See [Experimental - GFPO](experimental#gfpo).
+See [Experimental - GFPO](gfpo).
 
 ### Perception-Aware Policy Optimization for Multimodal Reasoning
 
@@ -1717,7 +1717,7 @@ trainer = MiniLLMTrainer(
 trainer.train()
 ```
 
-For more details, see the [MiniLLM Trainer documentation](minillm) documentation.
+For more details, see the [MiniLLM Trainer documentation](minillm_trainer).
 
 ### Reinforcement Learning via Self-Distillation
 


### PR DESCRIPTION
## What does this PR do?

Fixes three broken relative links in `docs/source/paper_index.md`. The former single `experimental` doc page has since been split into per-method pages (`gspo_token`, `gfpo`, `minillm_trainer` per `_toctree.yml`), but `paper_index.md` still pointed at the old `experimental#…` anchors (and `minillm`):

| Reference | Before | After |
|-----------|--------|-------|
| GSPO-Token | `](experimental#gspo-token)` | `](gspo_token)` |
| GFPO | `](experimental#gfpo)` | `](gfpo)` |
| MiniLLM | `](minillm)` | `](minillm_trainer)` |

All three target pages (`gspo_token.md`, `gfpo.md`, `minillm_trainer.md`) exist; the `experimental` page no longer does, so these currently 404 in the built docs. The MiniLLM sentence also dropped a duplicated trailing "documentation".

Docs-only — no code change.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes broken documentation links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording fixes with no code or build-config changes.
> 
> **Overview**
> Updates **`docs/source/paper_index.md`** so cross-references match the current Sphinx layout after the monolithic `experimental` page was removed and methods moved to dedicated pages in `_toctree.yml`.
> 
> **GSPO-Token** and **GFPO** links now target `gspo_token` and `gfpo` instead of `experimental#gspo-token` and `experimental#gfpo`. The **MiniLLM** blurb points at `minillm_trainer` (replacing `minillm`) and drops a duplicated trailing “documentation” in the link text.
> 
> Docs-only; no runtime or API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554af9b950dec6683e49df91e04609a5bee5ad27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->