### PR TITLE
Fix broken section anchors in docs (slug mismatches, renamed/removed sections)

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -94,7 +94,7 @@ When using the teacher server:
 
 ### Expected dataset type
 
-The dataset should be formatted as a [conversational](dataset_formats#conversational) [language modeling](dataset_formats#language_modeling) dataset:
+The dataset should be formatted as a [conversational](dataset_formats#conversational) [language modeling](dataset_formats#language-modeling) dataset:
 
 ```python
 {"messages": [{"role": "user", "content": "What color is the sky?"},

--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -105,7 +105,7 @@ trainer.train()
 
 ### Expected dataset type
 
-GOLD requires a [conversational](dataset_formats#conversational) [language modeling](dataset_formats#language_modeling) dataset, e.g.:
+GOLD requires a [conversational](dataset_formats#conversational) [language modeling](dataset_formats#language-modeling) dataset, e.g.:
 
 ```python
 {"messages": [{"role": "user", "content": "What color is the sky?"},

--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -208,7 +208,7 @@ run_uv_job(
 
 </hfoption>
 </hfoptions>
-See the full list of examples in [Maintained examples](example_overview#maintained-examples).
+See the full list of examples in [Maintained examples](example_overview).
 
 ### Docker Images
 

--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -208,7 +208,8 @@ run_uv_job(
 
 </hfoption>
 </hfoptions>
-See the full list of examples in [Maintained examples](example_overview).
+
+See the full list of examples in [Maintained examples](example_overview#scripts).
 
 ### Docker Images
 

--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -209,7 +209,7 @@ run_uv_job(
 </hfoption>
 </hfoptions>
 
-See the full list of examples in [Maintained examples](example_overview#scripts).
+See the full list of examples in [Example Scripts](example_overview#scripts).
 
 ### Docker Images
 

--- a/docs/source/openenv.md
+++ b/docs/source/openenv.md
@@ -186,7 +186,7 @@ def reward_func(environments, **kwargs) -> list[float]:
     return [env.reward for env in environments]
 ```
 
-For more information on reward functions, see the [GRPO - Custom Reward Functions](grpo_trainer#custom-reward-functions).
+For more information on reward functions, see the [GRPO - Custom Reward Functions](grpo_trainer#using-a-custom-reward-function).
 
 ### Tips for reward functions
 

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -271,7 +271,7 @@ training_args = GRPOConfig(
 )
 ```
 
-Note that when using gradient accumulation, the loss is aggregated over the total number of tokens in the batch, but not over the accumulated batch. For more details, see the [GRPO Trainer - Loss types](grpo_trainer#loss_types).
+Note that when using gradient accumulation, the loss is aggregated over the total number of tokens in the batch, but not over the accumulated batch. For more details, see the [GRPO Trainer - Loss types](grpo_trainer#loss-types).
 
 ### Truncated Importance Sampling
 


### PR DESCRIPTION
## What does this PR do?

Fixes five broken in-page section links (`page#anchor`) across the docs. These are a different class from the file-level links fixed in #6070 — here the target *page* exists but the `#anchor` doesn't resolve, so the links silently 404 in the built docs.

| File | Before | After | Cause |
|------|--------|-------|-------|
| `distillation_trainer.md` | `dataset_formats#language_modeling` | `dataset_formats#language-modeling` | slug uses `-`, not `_` |
| `gold_trainer.md` | `dataset_formats#language_modeling` | `dataset_formats#language-modeling` | slug uses `-`, not `_` |
| `paper_index.md` | `grpo_trainer#loss_types` | `grpo_trainer#loss-types` | slug uses `-`, not `_` |
| `openenv.md` | `grpo_trainer#custom-reward-functions` | `grpo_trainer#using-a-custom-reward-function` | section renamed |
| `jobs_training.md` | `example_overview#maintained-examples` | `example_overview` | section no longer exists; link to the page |

The three underscore cases are slug mismatches — the doc-builder generates hyphenated anchors from headings (`## Language modeling` → `language-modeling`), so `#language_modeling` never resolves. I verified each corrected anchor (`language-modeling`, `loss-types`, `using-a-custom-reward-function`) is a live heading on its target page.

Docs-only — no code change.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes broken documentation links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link corrections with no runtime or training behavior changes.
> 
> **Overview**
> Fixes **five broken `page#anchor` links** in the TRL docs so built documentation resolves the intended sections instead of silent 404s.
> 
> **Slug fixes (underscore → hyphen):** `distillation_trainer.md` and `gold_trainer.md` now point to `dataset_formats#language-modeling`; `paper_index.md` points to `grpo_trainer#loss-types`.
> 
> **Renamed / removed targets:** `openenv.md` links to `grpo_trainer#using-a-custom-reward-function` instead of the old custom-reward anchor; `jobs_training.md` points to `example_overview#scripts` instead of the removed `maintained-examples` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf752b52fd8b14da8137690b8ef633466186816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->