### PR TITLE
Fix broken import in GOLD trainer docs (GOLD is experimental)

### DIFF
--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -60,7 +60,7 @@ A more explicit setup might look like this when you need to customise model load
 
 ```python
 from datasets import load_dataset
-from trl import GOLDConfig, GOLDTrainer
+from trl.experimental.gold import GOLDConfig, GOLDTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 student_name = "meta-llama/Llama-3.2-1B-Instruct"


### PR DESCRIPTION
## What does this PR do?

Fixes a broken import in the GOLD trainer docs. The "more explicit setup" example used:

```python
from trl import GOLDConfig, GOLDTrainer
```

but GOLD is experimental — `GOLDConfig` / `GOLDTrainer` are not exported from the top-level `trl` package, so this raises `ImportError: cannot import name 'GOLDConfig' from 'trl'`. They live in `trl.experimental.gold`, which the earlier quick-start example in the same file already imports correctly (`from trl.experimental.gold import GOLDConfig, GOLDTrainer`). This makes the second example consistent with the first.

Docs-only — no code change.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a broken code example in the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single import line; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the **advanced / explicit setup** code block in `gold_trainer.md` so it imports `GOLDConfig` and `GOLDTrainer` from `trl.experimental.gold` instead of `from trl import ...`.
> 
> That matches the quick-start example above it and avoids a copy-paste `ImportError`, since GOLD types are not re-exported from the top-level `trl` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41fddc21c4aaae71636156a40f43bd5be74b410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->