### PR TITLE
Update distributed SFT test after default chunked_nll loss

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -98,7 +98,7 @@ class TestDistributed(TrlTestCase):
             "fsdp2",
         ],
     )
-    def test_sft_chunked_nll(self, config, get_config_path):
+    def test_sft_nll_loss(self, config, get_config_path):
         # fmt: off
         run_command(
             [
@@ -107,7 +107,7 @@ class TestDistributed(TrlTestCase):
                 "--model_name_or_path", "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
                 "--dataset_name", "trl-internal-testing/zen",
                 "--dataset_config", "standard_language_modeling",
-                "--loss_type", "chunked_nll",
+                "--loss_type", "nll",
             ],
             os.environ.copy(),
         )


### PR DESCRIPTION
Update distributed SFT test after default chunked_nll loss.

Follow-up to:
- #5873 
- #5846

This PR updates the distributed test suite, specifically renaming a test and updating a parameter to reflect the use of the standard `nll` (Negative Log-Likelihood) loss type instead of `chunked_nll` once the latter became the default value.

### Changes

- Test renaming:
  * Renamed the test method from `test_sft_chunked_nll` to `test_sft_nll_loss` in `tests/distributed/test_distributed.py` to better reflect its purpose.

- Test parameter update:
  * Changed the `--loss_type` argument from `"chunked_nll"` to `"nll"` in the test command, aligning the test with the standard NLL loss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only rename and CLI flag change; no production training or loss logic is modified.
> 
> **Overview**
> Updates the distributed SFT integration test so it still exercises the **non-default** `nll` loss path after `chunked_nll` became the default in recent SFT changes (follow-up to #5873 / #5846).
> 
> Renames `test_sft_chunked_nll` to **`test_sft_nll_loss`** and changes the launched `trl/scripts/sft.py` CLI from `--loss_type chunked_nll` to **`--loss_type nll`**. The same accelerate configs (ddp, zero2, zero3, fsdp2) and xfail marks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8039907da92eb1ef1bd7e5e6f6b7e16b7bb5c87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->