### PR TITLE
Add GMPO (Geometric-Mean Policy Optimization) experimental trainer

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -109,6 +109,8 @@
     title: GFPO
   - local: gkd_trainer
     title: GKD
+  - local: gmpo
+    title: GMPO
   - local: gold_trainer
     title: GOLD
   - local: grpo_with_replay_buffer
@@ -144,3 +146,4 @@
   - local: xpo_trainer
     title: XPO
   title: Experimental
+  isExpanded: false

--- a/docs/source/gmpo.md
+++ b/docs/source/gmpo.md
@@ -1,0 +1,36 @@
+# GMPO
+
+In the paper [Geometric-Mean Policy Optimization](https://huggingface.co/papers/2507.20673), the authors propose a GRPO variant that maximizes the *geometric* mean of the token-level importance ratios instead of the arithmetic mean. Because the geometric mean is far less sensitive to outlier ratios, the policy update is more stable and tolerates a much wider clipping range. Clipping is applied per token, in log space, and one-sided per the advantage sign (the standard PPO trust region) — crucially, *before* the geometric mean is taken.
+
+To use GMPO, you can use the [`GMPOTrainer`] class in `trl.experimental.gmpo`.
+
+## Usage
+
+```python
+from trl.experimental.gmpo import GMPOConfig, GMPOTrainer
+
+training_args = GMPOConfig(
+    epsilon=0.4,  # log-space clip range -> ratios clipped to (exp(-0.4), exp(0.4)); paper, Sec. 4
+    beta=0.0,
+)
+trainer = GMPOTrainer(
+    model="Qwen/Qwen3-0.6B",
+    reward_funcs=...,
+    train_dataset=...,
+    args=training_args,
+)
+trainer.train()
+```
+
+In GMPO, clipping is applied to the per-token *log*-importance ratios (i.e. in log space) before the geometric mean is taken, so `epsilon` and `epsilon_high` are expressed in log space: the effective ratio clipping range is `(exp(-epsilon), exp(epsilon_high))`. The paper recommends a markedly wider range than GRPO/DAPO, `(exp(-0.4), exp(0.4))`, to encourage exploration.
+
+## GMPOTrainer
+
+[[autodoc]] experimental.gmpo.GMPOTrainer
+    - train
+    - save_model
+    - push_to_hub
+
+## GMPOConfig
+
+[[autodoc]] experimental.gmpo.GMPOConfig

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -123,6 +123,31 @@ $$
 
 This token-level ratio is then combined with a shared advantage  \\( \hat{A}_i \\), and the GRPO objective clips and optimizes each token independently across the sequence.
 
+### Geometric-Mean Policy Optimization
+
+**📜 Paper**: https://huggingface.co/papers/2507.20673
+
+Geometric-Mean Policy Optimization (GMPO) is a GRPO variant that maximizes the *geometric* mean of the token-level importance ratios instead of the arithmetic mean. The geometric mean is far less sensitive to outlier ratios, so the policy update is more stable and tolerates a much wider clipping range. Clipping is applied per token, in log space, and is one-sided per the advantage sign (the standard PPO trust region) — crucially, *before* the geometric mean is taken. This is what distinguishes GMPO from GSPO (`importance_sampling_level="sequence"`), which clips the sequence-level ratio *after* averaging.
+
+The GMPO objective replaces GRPO's per-token arithmetic mean with the geometric mean of the (clipped) token ratios:
+
+$$
+\mathcal{J}_{\text{GMPO}}(\theta) = \mathbb{E}_{q, \{o_i\}} \left[ \frac{1}{G} \sum_{i=1}^{G} \left( \prod_{t=1}^{|o_i|} \min\left[ w_{i,t}(\theta)^{\operatorname{sgn}(\hat{A}_i)},\ \operatorname{clip}\left(w_{i,t}(\theta)^{\operatorname{sgn}(\hat{A}_i)}, \epsilon_1, \epsilon_2\right) \right]^{\operatorname{sgn}(\hat{A}_i)} \right)^{\frac{1}{|o_i|}} \hat{A}_i \right]
+$$
+
+where  \\( w_{i,t}(\theta) \\) is the per-token importance ratio. In practice the product and clipping are computed in log space for numerical stability, and the clip range  \\( (\epsilon_1, \epsilon_2) = (e^{-0.4}, e^{0.4}) \\) is markedly wider than GRPO/DAPO to encourage exploration.
+
+TRL provides an experimental implementation, available through the `trl.experimental.gmpo` module:
+
+```python
+from trl.experimental.gmpo import GMPOConfig, GMPOTrainer
+
+training_args = GMPOConfig(
+    epsilon=0.4,  # log-space clip range -> ratios clipped to (exp(-0.4), exp(0.4)); paper, Sec. 4
+    beta=0.0,
+)
+```
+
 ### DAPO: An Open-Source LLM Reinforcement Learning System at Scale
 
 **📜 Paper**: https://huggingface.co/papers/2503.14476

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -137,7 +137,7 @@ $$
 
 where  \\( w_{i,t}(\theta) \\) is the per-token importance ratio. In practice the product and clipping are computed in log space for numerical stability, and the clip range  \\( (\epsilon_1, \epsilon_2) = (e^{-0.4}, e^{0.4}) \\) is markedly wider than GRPO/DAPO to encourage exploration.
 
-TRL provides an experimental implementation, available through the `trl.experimental.gmpo` module:
+TRL provides an experimental implementation, see [Experimental - GMPO](gmpo):
 
 ```python
 from trl.experimental.gmpo import GMPOConfig, GMPOTrainer

--- a/tests/experimental/test_gmpo_trainer.py
+++ b/tests/experimental/test_gmpo_trainer.py
@@ -1,0 +1,118 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from datasets import load_dataset
+
+from trl.experimental.gmpo import GMPOConfig, GMPOTrainer
+
+from ..testing_utils import TrlTestCase
+
+
+class TestGMPOConfig:
+    def test_default_epsilon_is_log_space(self):
+        # GMPO expresses the clip range in log space; default is the paper's (exp(-0.4), exp(0.4)).
+        args = GMPOConfig("dummy")
+        assert args.epsilon == 0.4
+        # epsilon_high is inherited from GRPOConfig and defaults to None, so the range is symmetric.
+        assert args.epsilon_high is None
+
+
+class TestGMPOTrainer(TrlTestCase):
+    def test_train(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GMPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            num_iterations=2,  # the importance sampling weights won't be 0 in this case
+            report_to="none",
+        )
+        trainer = GMPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
+    def test_train_conversational(self, config_name):
+        dataset = load_dataset("trl-internal-testing/zen", config_name, split="train")
+
+        training_args = GMPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            num_iterations=2,  # the importance sampling weights won't be 0 in this case
+            report_to="none",
+        )
+        trainer = GMPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    def test_train_with_kl(self):
+        # GMPO sequence-averages the KL when beta > 0; exercise that path.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GMPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            beta=0.1,  # enable KL regularization toward the reference model
+            report_to="none",
+        )
+        trainer = GMPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        assert "kl" in trainer.state.log_history[-1]  # KL is logged when beta > 0
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."

--- a/trl/experimental/gmpo/__init__.py
+++ b/trl/experimental/gmpo/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .gmpo_config import GMPOConfig
+from .gmpo_trainer import GMPOTrainer
+

--- a/trl/experimental/gmpo/__init__.py
+++ b/trl/experimental/gmpo/__init__.py
@@ -14,4 +14,3 @@
 
 from .gmpo_config import GMPOConfig
 from .gmpo_trainer import GMPOTrainer
-

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 
 from ...trainer.grpo_config import GRPOConfig
 
+
 @dataclass
 class GMPOConfig(GRPOConfig):
     # docstyle-ignore

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -1,0 +1,46 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from ...trainer.grpo_config import GRPOConfig
+
+@dataclass
+class GMPOConfig(GRPOConfig):
+    # docstyle-ignore
+    r"""
+    Configuration class for the [`GMPOTrainer`].
+
+    [`GMPOConfig`] inherits every parameter from [`GRPOConfig`]; it only changes the meaning and default of the
+    clipping range. In GMPO, clipping is applied to the per-token *log*-importance ratios (i.e. in log space) before
+    the geometric mean is taken, so `epsilon` and `epsilon_high` are expressed in log space: the effective ratio
+    clipping range is `(exp(-epsilon), exp(epsilon_high))`. The [GMPO paper](https://huggingface.co/papers/2507.20673)
+    recommends a markedly wider range than GRPO/DAPO, `(exp(-0.4), exp(0.4))`, to encourage exploration.
+
+    Parameters:
+        epsilon (`float`, *optional*, defaults to `0.4`):
+            Lower-bound clipping value, expressed in log space. The lower bound of the per-token importance ratio is
+            `exp(-epsilon)`.
+        epsilon_high (`float`, *optional*):
+            Upper-bound clipping value, expressed in log space. If `None`, it defaults to the value of `epsilon`. The
+            upper bound of the per-token importance ratio is `exp(epsilon_high)`.
+    """
+
+    epsilon: float = field(
+        default=0.4,
+        metadata={
+            "help": "Lower-bound clipping value, expressed in log space. The lower bound of the per-token importance "
+            "ratio is exp(-epsilon). GMPO recommends 0.4."
+        },
+    )

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -31,7 +31,7 @@ class GMPOTrainer(GRPOTrainer):
     syncing, metric logging) is inherited unchanged
     """
 
-    _tag_names = ['trl', 'gmpo']
+    _tag_names = ["trl", "gmpo"]
 
     def __init__(self, model, reward_funcs, args=None, **kwargs):
         if args is None:
@@ -39,14 +39,14 @@ class GMPOTrainer(GRPOTrainer):
             args = GMPOConfig(f"{model_name.split('/')[-1]}-GMPO")
 
         super().__init__(model, reward_funcs, args=args, **kwargs)
-    
+
     def _compute_loss(self, model, inputs):
-        # compute the per-token log probabilities for the model
-        prompt_ids, prompt_mask = inputs['prompt_ids'], inputs['prompt_mask']
-        completion_ids, completion_mask = inputs['completion_ids'], inputs['completion_mask']
+        # Compute the per-token log probabilities for the model
+        prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
+        completion_ids, completion_mask = inputs["completion_ids"], inputs["completion_mask"]
         input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
-        logits_to_keep = completion_ids.size(1) # we only need to complete the logits for the completion tokens
+        logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
         mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
 
         # Compute the per_token_logps and the entropy at each position in the completion
@@ -71,15 +71,15 @@ class GMPOTrainer(GRPOTrainer):
         else:
             entropy_mask = None
 
-        advantages = inputs['advantages']
+        advantages = inputs["advantages"]
         # When num_iterations == 1 and steps_per_generation <= gradient_accumulation_steps,
         # old_per_token_logps == per_token_logps, so we skip its computation and use per_token_logps.detach() instead.
         old_per_token_logps = inputs.get("old_per_token_logps")
         old_per_token_logps = per_token_logps.detach() if old_per_token_logps is None else old_per_token_logps
 
         # GMPO Objective
-        # Per-token log importance ratio 
-        log_ratio = per_token_logps - old_per_token_logps 
+        # Per-token log importance ratio
+        log_ratio = per_token_logps - old_per_token_logps
 
         # Token-level clipping, performed in *log space* for numerical stability. The clip range in
         # ratio space is (exp(-epsilon_low), exp(epsilon_high)); the paper recommends exp(±0.4), markedly wider than
@@ -102,17 +102,16 @@ class GMPOTrainer(GRPOTrainer):
         log_importance_weights = (clipped_log_ratio * seq_mask).sum(-1) / seq_mask.sum(-1).clamp(min=1.0)  # (B,)
         coef = torch.exp(log_importance_weights)  # (B,) sequence-level (geometric-mean) importance weight
 
-        per_sequence_loss = -coef * advantages # (B,)
+        per_sequence_loss = -coef * advantages  # (B,)
 
         # KL regularization toward the reference model (optional; sequence-averaged to match GMPO's sequence-level
         # objective). Disabled by default (beta == 0)
-
         if self.beta != 0.0:
-            ref_per_token_logps = inputs['ref_per_token_logps']
+            ref_per_token_logps = inputs["ref_per_token_logps"]
             per_token_kl = (
                 torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
             )
-            seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0) # (B,)
+            seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
             per_sequence_loss = per_sequence_loss + self.beta * seq_kl
 
         # GMPO aggregates with a plain mean over sequences, per token-norm
@@ -149,5 +148,5 @@ class GMPOTrainer(GRPOTrainer):
         self._metrics[mode]["clip_ratio/high_max"].append(nanmax(gathered_high_clip).item())
         gathered_clip_ratio = self.accelerator.gather(clip_ratio)
         self._metrics[mode]["clip_ratio/region_mean"].append(gathered_clip_ratio.nanmean().item())
-        
+
         return loss

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -1,0 +1,153 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from ...trainer.grpo_trainer import GRPOTrainer
+from ...trainer.utils import get_config_model_id, nanmax, nanmin
+from .gmpo_config import GMPOConfig
+
+
+class GMPOTrainer(GRPOTrainer):
+    """
+    Trainer for Geometric-Mean Policy Optimization (GMPO).
+
+    GMPO (https://huggingface.co/papers/2507.20673) is a GRPO variant that maximizes the *geometric* mean of the
+    token-level importance ratios instead of the arithmetic mean. Because the geometric mean is far less sensitive to
+    outlier ratios, the policy update is more stable and a much wider clipping range can be used.
+
+    The only change w.r.t. [`GRPOTrainer`] is `_compute_loss`. Everything else (generation, reward computation, weight
+    syncing, metric logging) is inherited unchanged
+    """
+
+    _tag_names = ['trl', 'gmpo']
+
+    def __init__(self, model, reward_funcs, args=None, **kwargs):
+        if args is None:
+            model_name = model if isinstance(model, str) else get_config_model_id(model.config)
+            args = GMPOConfig(f"{model_name.split('/')[-1]}-GMPO")
+
+        super().__init__(model, reward_funcs, args=args, **kwargs)
+    
+    def _compute_loss(self, model, inputs):
+        # compute the per-token log probabilities for the model
+        prompt_ids, prompt_mask = inputs['prompt_ids'], inputs['prompt_mask']
+        completion_ids, completion_mask = inputs['completion_ids'], inputs['completion_mask']
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+        logits_to_keep = completion_ids.size(1) # we only need to complete the logits for the completion tokens
+        mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
+
+        # Compute the per_token_logps and the entropy at each position in the completion
+        per_token_logps, entropies = self._get_per_token_logps_and_entropies(
+            model,
+            input_ids,
+            attention_mask,
+            logits_to_keep,
+            compute_entropy=True,
+            pixel_values=inputs.get("pixel_values"),
+            image_grid_thw=inputs.get("image_grid_thw"),
+            num_images=inputs.get("num_images"),
+            pixel_attention_mask=inputs.get("pixel_attention_mask"),
+            image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
+            mm_token_type_ids=inputs.get("mm_token_type_ids"),
+            image_position_ids=inputs.get("image_position_ids"),
+        )
+
+        if self.top_entropy_quantile < 1.0:
+            entropy_mask = self.get_high_entropy_mask(entropies, mask, 1 - self.top_entropy_quantile)
+        else:
+            entropy_mask = None
+
+        advantages = inputs['advantages']
+        # When num_iterations == 1 and steps_per_generation <= gradient_accumulation_steps,
+        # old_per_token_logps == per_token_logps, so we skip its computation and use per_token_logps.detach() instead.
+        old_per_token_logps = inputs.get("old_per_token_logps")
+        old_per_token_logps = per_token_logps.detach() if old_per_token_logps is None else old_per_token_logps
+
+        # GMPO Objective
+        # Per-token log importance ratio 
+        log_ratio = per_token_logps - old_per_token_logps 
+
+        # Token-level clipping, performed in *log space* for numerical stability. The clip range in
+        # ratio space is (exp(-epsilon_low), exp(epsilon_high)); the paper recommends exp(±0.4), markedly wider than
+        # GRPO/DAPO, to encourage exploration.
+        clamped_log_ratio = torch.clamp(log_ratio, min=-self.epsilon_low, max=self.epsilon_high)
+
+        # sign-aware, one-sided clipping = PPO's trust-region "min" trick written in log-spaces:
+        advantages_col = advantages.unsqueeze(1)
+        clipped_log_ratio = torch.where(
+            advantages_col > 0,
+            torch.minimum(log_ratio, clamped_log_ratio),
+            torch.maximum(log_ratio, clamped_log_ratio),
+        )
+
+        # Optionally drop low-entropy tokens from the geometric mean
+        seq_mask = mask * entropy_mask if entropy_mask is not None else mask
+
+        # Geometric mean of the clipped token ratios = exp(mean of clipped log-ratios over valid tokens). The 1/|o_i|
+        # exponent is the geometric-mean normalization; the paper's ablation shows it is essential.
+        log_importance_weights = (clipped_log_ratio * seq_mask).sum(-1) / seq_mask.sum(-1).clamp(min=1.0)  # (B,)
+        coef = torch.exp(log_importance_weights)  # (B,) sequence-level (geometric-mean) importance weight
+
+        per_sequence_loss = -coef * advantages # (B,)
+
+        # KL regularization toward the reference model (optional; sequence-averaged to match GMPO's sequence-level
+        # objective). Disabled by default (beta == 0)
+
+        if self.beta != 0.0:
+            ref_per_token_logps = inputs['ref_per_token_logps']
+            per_token_kl = (
+                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
+            )
+            seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0) # (B,)
+            per_sequence_loss = per_sequence_loss + self.beta * seq_kl
+
+        # GMPO aggregates with a plain mean over sequences, per token-norm
+        # already lives inside the geometric mean.
+        mode = "train" if self.model.training else "eval"
+        loss = per_sequence_loss.mean()
+        normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
+        loss = loss / normalizer
+
+        # logging
+        completion_token_count = mask.sum().clamp(min=1.0)
+
+        if self.beta != 0.0:
+            mean_kl = (per_token_kl * mask).sum() / completion_token_count
+            self._metrics[mode]["kl"].append(self.accelerator.gather(mean_kl).nanmean().item())
+
+        mean_entropy = (entropies * mask).sum() / completion_token_count
+        self._metrics[mode]["entropy"].append(self.accelerator.gather(mean_entropy).nanmean().item())
+
+        # Fraction of the tokens pushed into the clipped region, in log-space.
+        is_high_clipped = (log_ratio > self.epsilon_high) & (advantages_col > 0)
+        is_low_clipped = (log_ratio < -self.epsilon_low) & (advantages_col < 0)
+        is_region_clipped = is_high_clipped | is_low_clipped
+
+        low_clip = (is_low_clipped.float() * mask).sum() / completion_token_count
+        high_clip = (is_high_clipped.float() * mask).sum() / completion_token_count
+        clip_ratio = (is_region_clipped.float() * mask).sum() / completion_token_count
+
+        gathered_low_clip = self.accelerator.gather(low_clip)
+        self._metrics[mode]["clip_ratio/low_mean"].append(gathered_low_clip.nanmean().item())
+        self._metrics[mode]["clip_ratio/low_min"].append(nanmin(gathered_low_clip).item())
+        gathered_high_clip = self.accelerator.gather(high_clip)
+        self._metrics[mode]["clip_ratio/high_mean"].append(gathered_high_clip.nanmean().item())
+        self._metrics[mode]["clip_ratio/high_max"].append(nanmax(gathered_high_clip).item())
+        gathered_clip_ratio = self.accelerator.gather(clip_ratio)
+        self._metrics[mode]["clip_ratio/region_mean"].append(gathered_clip_ratio.nanmean().item())
+        
+        return loss


### PR DESCRIPTION
Implements GMPO (https://huggingface.co/papers/2507.20673) as a self-contained experimental trainer under trl/experimental/gmpo/, following the GSPO-token pattern (a GRPOTrainer subclass overriding _compute_loss). GMPO maximizes the geometric mean of the per-token importance ratios instead of the arithmetic mean, applying one-sided token-level clipping in log space before averaging. Adds a paper_index.md section as required for paper implementations.

Fix #6056.

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ X] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect the new experimental module and docs; the custom `_compute_loss` path is numerically sensitive but isolated from core `GRPOTrainer` behavior.
> 
> **Overview**
> Adds **Geometric-Mean Policy Optimization (GMPO)** as an experimental GRPO variant under `trl.experimental.gmpo`, following the same pattern as other `GRPOTrainer` subclasses that only override `_compute_loss`.
> 
> **`GMPOTrainer`** replaces GRPO’s per-token arithmetic mean of importance ratios with a **sequence-level geometric mean** (mean of clipped log-ratios, then `exp`). Clipping is **one-sided by advantage sign** and applied in **log space** before averaging; optional **sequence-averaged KL** when `beta > 0`. **`GMPOConfig`** subclasses `GRPOConfig` and sets the paper’s default **`epsilon=0.4`** (log-space clip → ratio range about `exp(±0.4)`).
> 
> Documentation adds **`gmpo.md`**, a **paper index** section (vs GSPO), and a **toctree** entry (Experimental section collapsed with `isExpanded: false`). **Tests** cover default config, training (standard/conversational), and KL logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c512b84bfcb60491637bf3abaa755118484b1451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->