### PR TITLE
fix(data): correct extract_prompt index for divergence at start and prefix completions

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1145,6 +1145,34 @@ class TestExtractPrompt(TrlTestCase):
         example_extracted_prompt = maybe_extract_prompt(self.example_explicit_prompt_standard)
         assert example_extracted_prompt == self.example_explicit_prompt_standard, "The prompt should remain unchanged."
 
+    def test_extract_prompt_diverge_at_start(self):
+        # Chosen and rejected diverge at the very first token: there is no shared prompt. A trailing space in chosen
+        # must not be mistaken for a space before the prompt (which previously wrapped the index to -1).
+        example = {"chosen": "Paris ", "rejected": "London"}
+        assert extract_prompt(example) == {"prompt": "", "chosen": "Paris ", "rejected": "London"}
+
+    def test_extract_prompt_chosen_is_prefix_of_rejected(self):
+        # When chosen is a prefix of rejected, the whole chosen is the shared prompt.
+        example = {
+            "chosen": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "rejected": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+                {"role": "user", "content": "Are you sure?"},
+            ],
+        }
+        assert extract_prompt(example) == {
+            "prompt": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "chosen": [],
+            "rejected": [{"role": "user", "content": "Are you sure?"}],
+        }
+
 
 class TestPackDatasetWrapped(TrlTestCase):
     def test_with_dataset(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -584,11 +584,15 @@ def extract_prompt(example: dict[str, Sequence]) -> dict[str, Sequence]:
      'rejected': [{'role': 'assistant', 'content': 'It is green.'}]}
     ```
     """
-    for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
-        if example["chosen"][idx] != example["rejected"][idx]:
-            if example["chosen"][idx - 1] == " ":  # remove space before the prompt
-                idx -= 1
+    # Find the first index where the chosen and rejected completions diverge. If one is a prefix of the other (no
+    # divergence within the common length), the prompt is the whole common part.
+    idx = min(len(example["chosen"]), len(example["rejected"]))
+    for i in range(idx):
+        if example["chosen"][i] != example["rejected"][i]:
+            idx = i
             break
+    if idx > 0 and example["chosen"][idx - 1] == " ":  # remove space before the prompt
+        idx -= 1
     return {
         "prompt": example["chosen"][:idx],
         "chosen": example["chosen"][idx:],


### PR DESCRIPTION
## What

`extract_prompt` finds the shared prefix between `chosen` and `rejected` by walking until they diverge. Two edge cases produce wrong (sometimes corrupt) output.

1. **Divergence at index 0 with a trailing space in `chosen`.** When the two completions differ at the very first element, `idx` is `0`, so the space check reads `example["chosen"][idx - 1]` which is `chosen[-1]`, the *last* element. If that happens to be a space, `idx` becomes `-1` and the slices wrap around. Example:

   ```python
   extract_prompt({"chosen": "Paris ", "rejected": "London"})
   # current:  {'prompt': 'Paris', 'chosen': ' ', 'rejected': 'n'}
   # expected: {'prompt': '',      'chosen': 'Paris ', 'rejected': 'London'}
   ```

2. **`chosen` is a prefix of `rejected` (or equal).** When no divergence is found within the common length, the loop never breaks and `idx` keeps the loop variable's last value, `min(len) - 1`, instead of `min(len)`. The last shared element leaks into both completions:

   ```python
   extract_prompt({
       "chosen":   [{"role": "user", "content": "Q"}, {"role": "assistant", "content": "A"}],
       "rejected": [{"role": "user", "content": "Q"}, {"role": "assistant", "content": "A"},
                    {"role": "user", "content": "more"}],
   })
   # current 'chosen' is [A] and 'rejected' still contains A; expected 'chosen' is [] and the prompt is the full [Q, A]
   ```

## Fix

Initialize `idx` to the common length, set it to the first mismatching position when one is found, and guard the space-trim with `idx > 0`. Behavior for all normally-diverging cases is unchanged (byte-identical).

## Verification

```
python -m pytest tests/test_data_utils.py::TestExtractPrompt -q   # 8 passed
ruff check trl/data_utils.py tests/test_data_utils.py             # All checks passed!
```

Added two tests to `TestExtractPrompt` (divergence at start, and chosen-is-prefix-of-rejected). Both fail on current `main` and pass with the fix; the existing cases keep passing.

使用 Claude Code 辅助

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect prompt splitting can mislabel preference training data, but the change is localized to `extract_prompt` with targeted tests and unchanged behavior for normal cases.
> 
> **Overview**
> Fixes **`extract_prompt`** so implicit preference examples split into `prompt` / `chosen` / `rejected` correctly in two edge cases.
> 
> The divergence index now starts at the **full common length** and only moves to the first mismatch; when **`chosen` is a prefix of `rejected`**, the entire shared part becomes the prompt instead of leaving the last shared element in the completions. The trailing-space trim before the split runs only when **`idx > 0`**, so first-token divergence (e.g. `"Paris "` vs `"London"`) no longer reads `chosen[-1]` and corrupts slices.
> 
> **`TestExtractPrompt`** gains regression tests for both scenarios; typical diverging cases stay byte-identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae449ca0f95e402377e1f4e158b7a12ea2cc093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->