### PR TITLE
Align KTO with DPO: Support config pad_to_multiple_of

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -48,6 +48,8 @@ class KTOConfig(_BaseConfig):
         max_length (`int` or `None`, *optional*, defaults to `1024`):
             Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left.
             If `None`, no truncation is applied.
+        pad_to_multiple_of (`int`, *optional*):
+            If set, the sequences will be padded to a multiple of this value.
         precompute_ref_log_probs (`bool`, *optional*, defaults to `False`):
             Whether to precompute the reference model log probabilities for the entire training dataset before
             training. This allows to save memory during training, as the reference model does not need to be kept in
@@ -129,6 +131,10 @@ class KTOConfig(_BaseConfig):
             "help": "Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from "
             "the left. If `None`, no truncation is applied."
         },
+    )
+    pad_to_multiple_of: int | None = field(
+        default=None,
+        metadata={"help": "If set, the sequences will be padded to a multiple of this value."},
     )
     precompute_ref_log_probs: bool = field(
         default=False,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -198,6 +198,8 @@ class DataCollatorForVisionUnpairedPreference(DataCollatorMixin):
             Maximum sequence length. Sequences longer than `max_length` are truncated.
         calculate_kl (`bool`, *optional*, defaults to `True`):
             Whether to produce KL sequences by cycling completions within the batch.
+        pad_to_multiple_of (`int`, *optional*):
+            If set, the sequences will be padded to a multiple of this value.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Only `"pt"` is supported.
     """
@@ -205,9 +207,15 @@ class DataCollatorForVisionUnpairedPreference(DataCollatorMixin):
     processor: ProcessorMixin
     max_length: int | None = None
     calculate_kl: bool = True
+    pad_to_multiple_of: int | None = None
     return_tensors: str = "pt"
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
+        if self.pad_to_multiple_of is not None:
+            raise NotImplementedError(
+                "Padding to a multiple of a value is not yet implemented for vision-language modeling and "
+                "prompt-completion data."
+            )
         if "image" in examples[0]:
             for example in examples:
                 example["images"] = [example.pop("image")]

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -576,12 +576,14 @@ class KTOTrainer(_BaseTrainer):
             data_collator = DataCollatorForUnpairedPreference(
                 pad_token_id=self._tokenizer.pad_token_id,
                 max_length=args.max_length,
+                pad_to_multiple_of=args.pad_to_multiple_of,
             )
         elif data_collator is None and self._is_vision_dataset:
             data_collator = DataCollatorForVisionUnpairedPreference(
                 processor=processing_class,
                 max_length=args.max_length,
                 calculate_kl=calculate_kl,
+                pad_to_multiple_of=args.pad_to_multiple_of,
             )
 
         # Training arguments


### PR DESCRIPTION
Align KTO with DPO: Support config `pad_to_multiple_of`.

Part of:
- #4786

This PR introduces support for a new padding option, `pad_to_multiple_of`, in the KTO configuration and trainer. This option allows sequences to be padded to a specified multiple, improving compatibility with certain models and hardware. However, for vision-language modeling, the option is added but not yet implemented, and raises an error if used.

### Changes

**Padding configuration enhancements:**

* Added a `pad_to_multiple_of` parameter to the `KTOConfig` class, allowing users to specify that sequences should be padded to a multiple of a given value.
* Updated the initialization of `DataCollatorForUnpairedPreference` and `DataCollatorForVisionUnpairedPreference` to accept and pass through the `pad_to_multiple_of` argument.

**Vision-language modeling limitation:**

* In `DataCollatorForVisionUnpairedPreference`, added the `pad_to_multiple_of` parameter but explicitly raise a `NotImplementedError` if it is set, clarifying that this feature is not yet supported for vision-language or prompt-completion data.

These changes lay the groundwork for improved padding control, with clear messaging around current limitations for vision-language tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional padding config with default `None`; only affects batch tensor shapes for text KTO, and VLM paths error explicitly if misconfigured.
> 
> **Overview**
> Adds **`pad_to_multiple_of`** to `KTOConfig` and documents it alongside existing preprocessing options, mirroring DPO (#4786).
> 
> `KTOTrainer` now passes `args.pad_to_multiple_of` into the default **`DataCollatorForUnpairedPreference`** (text), so batch padding can round sequence length up to a hardware-friendly multiple via the existing `pad()` helper.
> 
> The vision collator **`DataCollatorForVisionUnpairedPreference`** accepts the same argument for API parity but **raises `NotImplementedError`** at collation time if it is set, so VLM KTO runs fail fast instead of silently ignoring the option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a624714477aa11ee4ad32d40510af4a223eaba0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->