### PR TITLE
Fix style of optional parameters in docstrings

### DIFF
--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -489,7 +489,7 @@ def first_true_indices(bools: torch.Tensor, dtype=torch.long) -> torch.Tensor:
     Args:
         bools (`torch.Tensor`):
             An N-dimensional boolean tensor.
-        dtype (`torch.dtype`, optional):
+        dtype (`torch.dtype`, *optional*):
             The desired data type of the output tensor. Defaults to `torch.long`.
 
     Returns:

--- a/trl/scripts/_hf_argparser.py
+++ b/trl/scripts/_hf_argparser.py
@@ -101,18 +101,19 @@ def HfArg(
     ```
 
     Args:
-        aliases (Union[str, list[str]], optional):
+        aliases (Union[str, list[str]], *optional*):
             Single string or list of strings of aliases to pass on to argparse, e.g. `aliases=["--example", "-e"]`.
             Defaults to None.
-        help (str, optional): Help string to pass on to argparse that can be displayed with --help. Defaults to None.
-        default (Any, optional):
+        help (str, *optional*):
+            Help string to pass on to argparse that can be displayed with --help. Defaults to None.
+        default (Any, *optional*):
             Default value for the argument. If not default or default_factory is specified, the argument is required.
             Defaults to dataclasses.MISSING.
-        default_factory (Callable[[], Any], optional):
+        default_factory (Callable[[], Any], *optional*):
             The default_factory is a 0-argument function called to initialize a field's value. It is useful to provide
             default values for mutable types, e.g. lists: `default_factory=list`. Mutually exclusive with `default=`.
             Defaults to dataclasses.MISSING.
-        metadata (dict, optional): Further metadata to pass on to `dataclasses.field`. Defaults to None.
+        metadata (dict, *optional*): Further metadata to pass on to `dataclasses.field`. Defaults to None.
 
     Returns:
         Field: A `dataclasses.Field` with the desired properties.

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -76,7 +76,7 @@ def _generate_completions(
         tokenizer (PreTrainedTokenizerBase): The tokenizer to be used for encoding and decoding.
         accelerator (Accelerator): The accelerator to be used for model execution.
         generation_config (GenerationConfig): Configuration for text generation.
-        batch_size (int, optional): The number of prompts to process in each batch. Default is 1.
+        batch_size (int, *optional*): The number of prompts to process in each batch. Default is 1.
 
     Returns:
         list[str]: A list of generated text completions corresponding to the input prompts.

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -240,9 +240,9 @@ class DataCollatorForVisionPreference(DataCollatorMixin):
             Maximum sequence length. Sequences longer than `max_length` are truncated before padding, which avoids
             allocating oversized tensors for batches containing very long sequences. Only `"keep_start"` truncation
             applies to vision datasets; `"keep_end"` is rejected upstream.
-        pad_to_multiple_of (`int` or `None`, optional, defaults to `None`):
+        pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
-        return_tensors (`str`, optional, defaults to `"pt"`):
+        return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
 
     Example:

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -60,7 +60,7 @@ class SFTConfig(_BaseConfig):
         eos_token (`str`, *optional*):
             Token used to indicate the end of a turn or sequence. If `None`, it defaults to
             `processing_class.eos_token`.
-        max_length (`int` or `None`, *optional*, defaults to `1024`):
+        max_length (`int`, *optional*, defaults to `1024`):
             Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left
             or right depending on `truncation_mode`. If `None`, no truncation is applied. When packing is enabled,
             this value sets the sequence length.

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -60,7 +60,7 @@ class SFTConfig(_BaseConfig):
         eos_token (`str`, *optional*):
             Token used to indicate the end of a turn or sequence. If `None`, it defaults to
             `processing_class.eos_token`.
-        max_length (`int`, *optional*, defaults to `1024`):
+        max_length (`int` or `None`, *optional*, defaults to `1024`):
             Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left
             or right depending on `truncation_mode`. If `None`, no truncation is applied. When packing is enabled,
             this value sets the sequence length.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -619,17 +619,17 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
         processor ([`~transformers.ProcessorMixin`]):
             The processor used to tokenize text and process images. It must be a subclass of
             [`~transformers.ProcessorMixin`] and include a `tokenizer` with a defined `pad_token_id`.
-        max_length (`int` or `None`, optional, defaults to `None`):
+        max_length (`int`, *optional*):
             Maximum sequence length for input tokens. If `None`, no truncation is applied.
         completion_only_loss (`bool`, *optional*, defaults to `False`):
             Whether to compute loss only on the completion part of the sequence. When `True`, the labels for the prompt
             part are set to -100. It requires the dataset type to be prompt-completion.
-        pad_to_multiple_of (`int` or `None`, optional, defaults to `None`):
+        pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
-        dataset_text_field (`str`, optional, defaults to `"text"`):
+        dataset_text_field (`str`, *optional*, defaults to `"text"`):
             Name of the column that contains text data in the dataset. This parameter is only relevant for [standard
             datasets format](dataset_formats#standard).
-        return_tensors (`str`, optional, defaults to `"pt"`):
+        return_tensors (`str`, *optional*, defaults to `"pt"`):
             The tensor type to return. Currently, only `"pt"` (PyTorch tensors) is supported.
 
     Example:


### PR DESCRIPTION


Fix style of optional parameters in docstrings.

This PR standardizes the docstring formatting for optional parameters across multiple files by marking them as `*optional*` and ensuring consistent style. These changes improve code readability and maintain consistent documentation for users and contributors.

### Changes

**Docstring formatting improvements:**

* Marked all optional parameters with "*optional*" in their docstrings for clarity and consistency in the following files and classes/functions:
  - `trl/experimental/utils.py`: `first_true_indices` function
  - `trl/scripts/_hf_argparser.py`: `Args` class
  - `trl/trainer/callbacks.py`: `_generate_completions` function
  - `trl/trainer/dpo_trainer.py`: `DataCollatorForVisionPreference` class
  - `trl/trainer/sft_config.py`: `SFTConfig` class
  - `trl/trainer/sft_trainer.py`: `DataCollatorForVisionLanguageModeling` class

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, training, or security impact.
> 
> **Overview**
> This PR **only updates docstrings** so optional parameters follow a consistent HuggingFace-style convention.
> 
> Optional parameters are marked with **`*optional*`** instead of mixed forms such as `optional`, `optional, defaults to ...`, or `int or None, optional`. Affected spots include `first_true_indices` in `experimental/utils.py`, `HfArg` in `scripts/_hf_argparser.py`, `_generate_completions` in `trainer/callbacks.py`, and collator/config docs in `dpo_trainer.py`, `sft_config.py`, and `sft_trainer.py`. Default values and parameter descriptions are unchanged aside from formatting (e.g. multi-line `help` for `HfArg`).
> 
> There are **no functional or API changes**—documentation alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde7bf1191a90f7221d828f975a7b157defe9a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->