### PR TITLE
Fix broken example link in BCO trainer docs

### DIFF
--- a/docs/source/bco_trainer.md
+++ b/docs/source/bco_trainer.md
@@ -4,7 +4,7 @@
 
 TRL supports the Binary Classifier Optimization (BCO).
 The [BCO](https://huggingface.co/papers/2404.04656) authors train a binary classifier whose logit serves as a reward so that the classifier maps {prompt, chosen completion} pairs to 1 and {prompt, rejected completion} pairs to 0.
-For a full example have a look at  [`examples/scripts/bco.py`].
+For a full example have a look at [`examples/scripts/bco.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/bco.py).
 
 ## Expected dataset type
 


### PR DESCRIPTION
## What does this PR do?

Fixes a broken link in the BCO trainer docs. The intro line referenced the example script as a bare code span with no URL:

```
For a full example have a look at  [`examples/scripts/bco.py`].
```

Since there's no `(...)` target, it rendered as un-clickable `[examples/scripts/bco.py]` text. This adds the GitHub link (matching how the same script is linked from `example_overview.md` and other trainer docs) and drops a stray double-space:

```
For a full example have a look at [`examples/scripts/bco.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/bco.py).
```

Docs-only — no code change.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a broken documentation link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation link fix with no code or behavioral impact.
> 
> **Overview**
> Fixes the intro link to **`examples/scripts/bco.py`** in **`bco_trainer.md`**: it was a bare code span with no URL, so readers saw non-clickable text. The line now uses the same GitHub **`blob/main`** target as **`example_overview.md`** and other trainer docs, and a stray double space before the link is removed.
> 
> Docs-only; no runtime or training behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fe5d63a3d168e94605e6de47f932f73ad2fbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->