### PR TITLE
Auto-load `processing_class` in CPO/ORPO trainers when omitted

### DIFF
--- a/tests/experimental/test_cpo_trainer.py
+++ b/tests/experimental/test_cpo_trainer.py
@@ -90,6 +90,26 @@ class TestCPOTrainer(TrlTestCase):
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
 
+    def test_cpo_trainer_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be
+        # auto-loaded from the model, consistent with DPOTrainer / RewardTrainer.
+        training_args = CPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            remove_unused_columns=False,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
+        trainer = CPOTrainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=dataset["train"],
+        )
+        assert trainer.processing_class is not None
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
     @pytest.mark.parametrize(
         "config_name",
         [

--- a/tests/experimental/test_orpo_trainer.py
+++ b/tests/experimental/test_orpo_trainer.py
@@ -85,6 +85,27 @@ class TestORPOTrainer(TrlTestCase):
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
 
+    def test_orpo_trainer_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be
+        # auto-loaded from the model, consistent with DPOTrainer / RewardTrainer.
+        training_args = ORPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            remove_unused_columns=False,
+            beta=0.1,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference")
+        trainer = ORPOTrainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=dataset["train"],
+        )
+        assert trainer.processing_class is not None
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
     @pytest.mark.parametrize(
         "config_name",
         [

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -35,6 +35,7 @@ from torch import autocast
 from torch.utils.data import DataLoader
 from transformers import (
     AutoModelForCausalLM,
+    AutoTokenizer,
     BaseImageProcessor,
     DataCollator,
     FeatureExtractionMixin,
@@ -50,7 +51,12 @@ from transformers.utils import is_peft_available, is_torch_fx_proxy
 
 from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import disable_dropout_in_model, log_table_to_comet_experiment, selective_log_softmax
+from ...trainer.utils import (
+    disable_dropout_in_model,
+    get_config_model_id,
+    log_table_to_comet_experiment,
+    selective_log_softmax,
+)
 from ..utils import (
     DPODataCollatorWithPadding,
     add_bos_token_if_needed,
@@ -255,7 +261,7 @@ class CPOTrainer(_BaseTrainer):
             self.pad_token_id = model.config.pad_token_id
 
         if processing_class is None:
-            raise ValueError("processing_class must be specified to tokenize a CPO dataset.")
+            processing_class = AutoTokenizer.from_pretrained(get_config_model_id(model.config))
         if args.max_length is None:
             logger.warning(
                 "`max_length` is not set in the CPOConfig's init"

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -35,6 +35,7 @@ from torch import autocast
 from torch.utils.data import DataLoader
 from transformers import (
     AutoModelForCausalLM,
+    AutoTokenizer,
     BaseImageProcessor,
     DataCollator,
     FeatureExtractionMixin,
@@ -51,7 +52,12 @@ from transformers.utils import is_peft_available, is_torch_fx_proxy
 
 from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import disable_dropout_in_model, log_table_to_comet_experiment, selective_log_softmax
+from ...trainer.utils import (
+    disable_dropout_in_model,
+    get_config_model_id,
+    log_table_to_comet_experiment,
+    selective_log_softmax,
+)
 from ..utils import (
     DPODataCollatorWithPadding,
     add_bos_token_if_needed,
@@ -264,7 +270,7 @@ class ORPOTrainer(_BaseTrainer):
             self.pad_token_id = model.config.pad_token_id
 
         if processing_class is None:
-            raise ValueError("processing_class must be specified to tokenize a ORPO dataset.")
+            processing_class = AutoTokenizer.from_pretrained(get_config_model_id(model.config))
         if args.max_length is None:
             logger.warning(
                 "`max_length` is not set in the ORPOConfig's init"


### PR DESCRIPTION
# What does this PR do?

`CPOTrainer` and `ORPOTrainer` (under `trl.experimental`) document `processing_class` as *optional* and accept `processing_class=None`, but they raise an error instead of handling that case:

```python
if processing_class is None:
    raise ValueError("processing_class must be specified to tokenize a CPO dataset.")
```

This is inconsistent with the non-experimental preference trainers, which auto-load `processing_class` from the model when it is omitted:

- `RewardTrainer` → `AutoTokenizer.from_pretrained(get_config_model_id(model.config))`
- `DPOTrainer` → `AutoProcessor.from_pretrained(...)`

This PR makes CPO/ORPO mirror `RewardTrainer` (they are text-only preference trainers), so passing just a model works as the `*optional*` docstring already promises:

```python
if processing_class is None:
    processing_class = AutoTokenizer.from_pretrained(get_config_model_id(model.config))
```

A regression test is added for each trainer that constructs the trainer without `processing_class` and runs a few training steps.

Validated locally on an RTX 4080: the two new tests pass and the existing CPO/ORPO suites stay green (22 passed).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? (No change needed — the `processing_class` docstring already says *optional*; this makes the behavior match it.)
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small initializer behavior change and tests only; mirrors an existing TRL pattern and does not alter training loss logic.
> 
> **Overview**
> **CPOTrainer** and **ORPOTrainer** now load a tokenizer when `processing_class` is omitted, instead of raising `ValueError`. Both use `AutoTokenizer.from_pretrained(get_config_model_id(model.config))`, aligning with **RewardTrainer** and the trainers’ optional `processing_class` docs.
> 
> Regression tests **`test_cpo_trainer_processing_class_autoloaded`** and **`test_orpo_trainer_processing_class_autoloaded`** construct each trainer without a tokenizer, assert `processing_class` is set, and run a short training step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f99f3b864271425b3d3ba0d2d44a5742adf705a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

