### PR TITLE
Auto-load `processing_class` in BCO trainer when omitted

### DIFF
--- a/tests/experimental/test_bco_trainer.py
+++ b/tests/experimental/test_bco_trainer.py
@@ -81,6 +81,30 @@ class TestBCOTrainer(TrlTestCase):
                 assert not torch.equal(param.cpu(), new_param.cpu())
 
     @require_sklearn
+    def test_train_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be
+        # auto-loaded from the model, consistent with DPOTrainer / RewardTrainer.
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+        ref_model = AutoModelForCausalLM.from_pretrained(model_id)
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        training_args = BCOConfig(
+            output_dir=self.tmp_dir,
+            remove_unused_columns=False,
+            learning_rate=0.1,
+            report_to="none",
+        )
+        trainer = BCOTrainer(
+            model=model,
+            ref_model=ref_model,
+            args=training_args,
+            train_dataset=dataset,
+        )
+        assert trainer.processing_class is not None
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @require_sklearn
     def test_train_with_precompute(self):
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -40,6 +40,7 @@ from torch import autocast
 from torch.utils.data import DataLoader, SequentialSampler
 from transformers import (
     AutoModelForCausalLM,
+    AutoTokenizer,
     BaseImageProcessor,
     DataCollator,
     FeatureExtractionMixin,
@@ -59,7 +60,12 @@ from ...data_utils import maybe_apply_chat_template, maybe_extract_prompt, maybe
 from ...import_utils import is_joblib_available
 from ...models.utils import prepare_deepspeed
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import disable_dropout_in_model, log_table_to_comet_experiment, selective_log_softmax
+from ...trainer.utils import (
+    disable_dropout_in_model,
+    get_config_model_id,
+    log_table_to_comet_experiment,
+    selective_log_softmax,
+)
 from ..utils import DPODataCollatorWithPadding, create_reference_model, pad_to_length, peft_module_casting_to_bf16
 from .bco_config import BCOConfig
 
@@ -567,9 +573,7 @@ class BCOTrainer(_BaseTrainer):
             self.ref_model = create_reference_model(model)
 
         if processing_class is None:
-            raise ValueError(
-                "max_length or a processing_class must be specified when using the default DPODataCollatorWithPadding"
-            )
+            processing_class = AutoTokenizer.from_pretrained(get_config_model_id(model.config))
         if args.max_length is None:
             logger.warning(
                 "When using DPODataCollatorWithPadding, you should set `max_length` in the `BCOConfig`. "


### PR DESCRIPTION
## What does this PR do?

`BCOTrainer` (under `trl.experimental`) documents `processing_class` as *optional* and defaults it to `None` in its signature, but raises when it is omitted:

```python
if processing_class is None:
    raise ValueError(
        "max_length or a processing_class must be specified when using the default DPODataCollatorWithPadding"
    )
```

The other preference trainers handle `processing_class=None` by auto-loading it from the model:

- `RewardTrainer` → `AutoTokenizer.from_pretrained(get_config_model_id(model.config))`
- `KTOTrainer` (BCO's closest sibling) → `AutoProcessor.from_pretrained(get_config_model_id(model.config))`
- `DPOTrainer` → `AutoProcessor.from_pretrained(...)`

This PR makes `BCOTrainer` do the same. BCO is text-only (it treats `processing_class` as a tokenizer when building the default `DPODataCollatorWithPadding`), so it mirrors `RewardTrainer` and loads a tokenizer:

```python
if processing_class is None:
    processing_class = AutoTokenizer.from_pretrained(get_config_model_id(model.config))
```

By this point the model has already been instantiated (the reference model is created from it just above), so `model.config` is available. When `max_length` is also unset the existing warning path still applies (it defaults to 512), so passing just a model works as the `*optional*` docstring promises.

A regression test is added that constructs the trainer without `processing_class` and runs training.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [ ] Was this discussed/approved via a GitHub issue? _(N/A — small consistency fix aligning `BCOTrainer` with the other preference trainers.)_
- [ ] Did you make sure to update the documentation with your changes? _(N/A — the `processing_class` docstring already says *optional*; this makes the behavior match it.)_
- [x] Did you write any new necessary tests? _(Regression test added.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral alignment in experimental BCO init; no auth or training-algorithm changes beyond removing a spurious error.
> 
> **Overview**
> **`BCOTrainer` no longer raises when `processing_class` is omitted.** It now loads a tokenizer from the model config via `AutoTokenizer.from_pretrained(get_config_model_id(model.config))`, matching **`RewardTrainer`** and other preference trainers whose docs already treat `processing_class` as optional.
> 
> A regression test constructs the trainer without a tokenizer, asserts `processing_class` is set, and runs a short training step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19788d38eca7fa6d5127cb6127de69b89abaaa5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->