### PR TITLE
Hotfix CI: Temporarily pin deepspeed < 0.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ bco = [
     "joblib"
 ]
 deepspeed = [
-    "deepspeed>=0.14.4",
+    "deepspeed>=0.14.4,<0.19.2",  # temporary hotfix for #6089
     "transformers!=5.1.0",  # see transformers#43780
 ]
 kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
@@ -103,7 +103,7 @@ dev = [
     "scikit-learn",
     "joblib",
     # deepspeed
-    "deepspeed>=0.14.4",
+    "deepspeed>=0.14.4,<0.19.2",  # temporary hotfix for #6089
     # kernels: transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0


### PR DESCRIPTION
Hotfix CI: Temporarily pin deepspeed < 0.19.2.

Hotfix for:
- #6089

This PR applies a temporary hotfix to the `deepspeed` dependency in the `pyproject.toml` file by restricting its version to below `0.19.2` for both the `deepspeed` and `dev` dependency groups. This is to address issue #6089.

### Changes

Dependency version restriction:

* Updated the `deepspeed` dependency in both the `deepspeed` and `dev` groups to require a version greater than or equal to `0.14.4` but less than `0.19.2`, with a comment referencing issue #6089. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only constraint in packaging metadata; no application logic changes, though installs are blocked from DeepSpeed 0.19.2+ until the pin is removed.
> 
> **Overview**
> Temporarily caps the optional **`deepspeed`** dependency at **`<0.19.2`** (still **`>=0.14.4`**) in both the **`deepspeed`** and **`dev`** optional dependency groups in `pyproject.toml`, with a comment pointing at issue **#6089**. This is a CI hotfix to avoid breakage from newer DeepSpeed releases; no runtime library code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55d89d6996c00d40b6060c10c272563404ae5f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->