### PR TITLE
fix: address 4 remaining GMPO bugs from code review

### DIFF
--- a/tests/experimental/test_gmpo_trainer.py
+++ b/tests/experimental/test_gmpo_trainer.py
@@ -29,6 +29,12 @@ class TestGMPOConfig:
         # epsilon_high is inherited from GRPOConfig and defaults to None, so the range is symmetric.
         assert args.epsilon_high is None
 
+    def test_default_loss_type_is_grpo(self):
+        # GMPO always uses per-sequence-mean / grad-accum normalization, so loss_type should default to "grpo"
+        # rather than inheriting the parent's "dapo" default, which would be misleading.
+        args = GMPOConfig("dummy")
+        assert args.loss_type == "grpo"
+
 
 class TestGMPOTrainer(TrlTestCase):
     def test_train(self):

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -45,3 +45,11 @@ class GMPOConfig(GRPOConfig):
             "ratio is exp(-epsilon). GMPO recommends 0.4."
         },
     )
+
+    loss_type: str = field(
+        default="grpo",
+        metadata={
+            "help": "Ignored in GMPO. GMPO always uses per-sequence-mean / grad-accum normalization, regardless of "
+            "the value of this parameter."
+        },
+    )

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -89,13 +89,31 @@ class GMPOTrainer(GRPOTrainer):
         # sign-aware, one-sided clipping = PPO's trust-region "min" trick written in log-spaces:
         advantages_col = advantages.unsqueeze(1)
         clipped_log_ratio = torch.where(
-            advantages_col > 0,
+            advantages_col >= 0,
             torch.minimum(log_ratio, clamped_log_ratio),
             torch.maximum(log_ratio, clamped_log_ratio),
         )
 
         # Optionally drop low-entropy tokens from the geometric mean
         seq_mask = mask * entropy_mask if entropy_mask is not None else mask
+
+        # Off-policy sequence masking (DeepSeek-V3.2, Eq 9): masks out tokens with high KL divergence for
+        # negative-advantage sequences. Applied to seq_mask so masked tokens are excluded from the geometric mean.
+        if self.off_policy_mask_threshold is not None:
+            sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
+            off_policy_mask = self.get_off_policy_mask(
+                advantages=advantages,
+                per_token_logps=per_token_logps,
+                sampling_per_token_logps=sampling_per_token_logps,
+                mask=mask,
+                off_policy_threshold=self.off_policy_mask_threshold,
+            )
+            seq_mask = seq_mask * off_policy_mask
+
+        # vLLM importance sampling correction: apply per-token IS ratio as weights inside the geometric mean.
+        # This is the sequence-level equivalent of GRPO's per-token loss * IS ratio.
+        if self.use_vllm and self.vllm_importance_sampling_correction:
+            seq_mask = seq_mask * inputs["importance_sampling_ratio"]
 
         # Geometric mean of the clipped token ratios = exp(mean of clipped log-ratios over valid tokens). The 1/|o_i|
         # exponent is the geometric-mean normalization; the paper's ablation shows it is essential.


### PR DESCRIPTION
Closes #6056

Fixes 4 issues in `GMPOTrainer._compute_loss` and `GMPOConfig` flagged during the review of PR #6078:

1. **Zero-advantage edge case**: Changed `advantages_col > 0` to `>= 0` so zero-advantage tokens don't hit the inflating `torch.maximum` branch.

2. **Off-policy sequence masking**: Added the same `get_off_policy_mask` call from parent `GRPOTrainer._compute_loss` (DeepSeek-V3.2, Eq 9), applied to `seq_mask` to exclude off-policy tokens from the geometric mean.

3. **vLLM importance sampling correction**: Added `inputs["importance_sampling_ratio"]` as per-token weights inside the geometric mean, matching GRPO's `per_token_loss * IS ratio` at the sequence level.

4. **`loss_type` default mismatch**: Overrode in `GMPOConfig` to default to `"grpo"` (GMPO's fixed aggregation) instead of inheriting `"dapo"` from `GRPOConfig`, which was silently ignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the training objective for zero-advantage tokens and when off-policy or vLLM IS options are enabled; incorrect masking would skew GMPO updates but scope is limited to experimental GMPO.
> 
> **Overview**
> Aligns **GMPO** loss computation and config defaults with behaviors already present on **GRPO**, fixing four review findings.
> 
> In `GMPOTrainer._compute_loss`, log-space clipping now treats **zero advantage** like non-negative (`>= 0`) so those tokens use the minimum branch instead of inflating via `maximum`. When `off_policy_mask_threshold` is set, **off-policy sequence masking** (same `get_off_policy_mask` as GRPO) is applied to `seq_mask` before the geometric mean. With vLLM importance sampling enabled, **per-token IS ratios** from `inputs["importance_sampling_ratio"]` are folded into `seq_mask`, mirroring GRPO’s token-level correction at sequence level.
> 
> `GMPOConfig` now defaults **`loss_type` to `"grpo"`** and documents that the field is ignored, instead of inheriting `"dapo"` from `GRPOConfig`. A unit test asserts that default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874add2b14a967955f8d6b23d67c8e1bcabcff61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->