### PR TITLE
fix: address 4 remaining GMPO bugs from code review

### DIFF
--- a/tests/experimental/test_gmpo_trainer.py
+++ b/tests/experimental/test_gmpo_trainer.py
@@ -29,6 +29,12 @@ class TestGMPOConfig:
         # epsilon_high is inherited from GRPOConfig and defaults to None, so the range is symmetric.
         assert args.epsilon_high is None
 
+    def test_default_loss_type_is_grpo(self):
+        # GMPO always uses per-sequence-mean / grad-accum normalization, so loss_type should default to "grpo"
+        # rather than inheriting the parent's "dapo" default, which would be misleading.
+        args = GMPOConfig("dummy")
+        assert args.loss_type == "grpo"
+
 
 class TestGMPOTrainer(TrlTestCase):
     def test_train(self):

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -45,3 +45,11 @@ class GMPOConfig(GRPOConfig):
             "ratio is exp(-epsilon). GMPO recommends 0.4."
         },
     )
+
+    loss_type: str = field(
+        default="grpo",
+        metadata={
+            "help": "Ignored in GMPO. GMPO always uses per-sequence-mean / grad-accum normalization, regardless of "
+            "the value of this parameter."
+        },
+    )

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -89,7 +89,7 @@ class GMPOTrainer(GRPOTrainer):
         # sign-aware, one-sided clipping = PPO's trust-region "min" trick written in log-spaces:
         advantages_col = advantages.unsqueeze(1)
         clipped_log_ratio = torch.where(
-            advantages_col > 0,
+            advantages_col >= 0,
             torch.minimum(log_ratio, clamped_log_ratio),
             torch.maximum(log_ratio, clamped_log_ratio),
         )
@@ -97,12 +97,49 @@ class GMPOTrainer(GRPOTrainer):
         # Optionally drop low-entropy tokens from the geometric mean
         seq_mask = mask * entropy_mask if entropy_mask is not None else mask
 
+        # Off-policy sequence masking (DeepSeek-V3.2, Eq 9): masks out tokens with high KL divergence for
+        # negative-advantage sequences. Applied to seq_mask so masked tokens are excluded from the geometric mean.
+        if self.off_policy_mask_threshold is not None:
+            sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
+            off_policy_mask = self.get_off_policy_mask(
+                advantages=advantages_col,  # parent unsqueezes before calling, pass 2D to avoid broadcast bug
+                per_token_logps=per_token_logps,
+                sampling_per_token_logps=sampling_per_token_logps,
+                mask=mask,
+                off_policy_threshold=self.off_policy_mask_threshold,
+            )
+            seq_mask = seq_mask * off_policy_mask
+
+        # vLLM importance sampling correction: match GRPO's per-token loss * IS ratio at the sequence level.
+        # Token-level modes (token_truncate, token_mask): IS ratio is (B, T), apply as weights in the geometric mean.
+        # Sequence-level modes (sequence_truncate, sequence_mask): IS ratio is (B, 1), constant per sequence so it
+        # would cancel in a weighted geometric mean — multiply into per_sequence_loss instead.
+        if self.use_vllm and self.vllm_importance_sampling_correction:
+            is_ratio = inputs["importance_sampling_ratio"]
+            if is_ratio.size(1) == 1:
+                # Sequence-level IS: multiply directly into per_sequence_loss after the geometric mean
+                seq_is_ratio = is_ratio.squeeze(-1)  # (B,)
+            else:
+                # Token-level IS: apply as weights in the geometric mean
+                seq_mask = seq_mask * is_ratio
+                seq_is_ratio = None
+        else:
+            seq_is_ratio = None
+
         # Geometric mean of the clipped token ratios = exp(mean of clipped log-ratios over valid tokens). The 1/|o_i|
         # exponent is the geometric-mean normalization; the paper's ablation shows it is essential.
-        log_importance_weights = (clipped_log_ratio * seq_mask).sum(-1) / seq_mask.sum(-1).clamp(min=1.0)  # (B,)
+        seq_token_count = seq_mask.sum(-1)  # (B,)
+        log_importance_weights = (clipped_log_ratio * seq_mask).sum(-1) / seq_token_count.clamp(min=1.0)  # (B,)
         coef = torch.exp(log_importance_weights)  # (B,) sequence-level (geometric-mean) importance weight
 
         per_sequence_loss = -coef * advantages  # (B,)
+
+        # Apply sequence-level vLLM IS correction (saved earlier) to per_sequence_loss
+        if seq_is_ratio is not None:
+            per_sequence_loss = per_sequence_loss * seq_is_ratio
+
+        # Zero out loss for sequences with no valid tokens after masking (off-policy mask + entropy mask + vLLM IS)
+        per_sequence_loss = torch.where(seq_token_count > 0, per_sequence_loss, 0.0)
 
         # KL regularization toward the reference model (optional; sequence-averaged to match GMPO's sequence-level
         # objective). Disabled by default (beta == 0)


### PR DESCRIPTION
# What does this PR do?

Fixes 4 issues in `GMPOTrainer._compute_loss` and `GMPOConfig` flagged during the review of PR #6078 but never resolved before merge.

**Zero-advantage edge case**: Changed `advantages_col > 0` to `>= 0` so zero-advantage tokens don't hit the inflating `torch.maximum` branch.

**Off-policy sequence masking**: Added the same `get_off_policy_mask` call from parent `GRPOTrainer._compute_loss` (DeepSeek-V3.2, Eq 9), applied to `seq_mask` to exclude off-policy tokens from the geometric mean.

**vLLM importance sampling correction**: Added `inputs["importance_sampling_ratio"]` as per-token weights inside the geometric mean, matching GRPO's `per_token_loss * IS ratio` at the sequence level.

**`loss_type` default mismatch**: Overrode in `GMPOConfig` to default to `"grpo"` (GMPO's fixed aggregation) instead of inheriting `"dapo"` from `GRPOConfig`, which was silently ignored.

Fixes #6056

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #6056
- [x] Did you write any new necessary tests? Added `test_default_loss_type_is_grpo` to verify the loss_type override.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RL training loss math for GMPO (clipping edge case, masking, vLLM IS), which can shift gradients when those features are enabled, though scope is limited to experimental GMPO.
> 
> **Overview**
> **GMPO `_compute_loss`** is brought in line with review fixes that were missing after the initial GMPO merge.
> 
> Log-space clipping now treats **zero advantage** like non-negative (`>= 0`) so those tokens use the minimum branch instead of the inflating maximum path. **Off-policy sequence masking** (`off_policy_mask_threshold`) is wired through `get_off_policy_mask` into `seq_mask`, excluding high-KL tokens on negative-advantage sequences from the geometric mean. **vLLM importance sampling** applies token-level ratios as weights in the geometric mean and sequence-level `(B, 1)` ratios on `per_sequence_loss` after aggregation. Sequences with no valid tokens after masking get **zero loss**.
> 
> **`GMPOConfig`** overrides `loss_type` to default `"grpo"` (documented as ignored) instead of inheriting `"dapo"` from `GRPOConfig`. A test asserts that default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4655d7923d17af49b02d253321be7a832bd0c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->