### PR TITLE
docs(rloo): add clarifying comment on KL penalty formula divergence from GRPO

### DIFF
--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1303,6 +1303,10 @@ class RLOOTrainer(_BaseTrainer):
 
         # Include the KL penalty in the reward
         if self.beta != 0.0:
+            # RLOO uses the first-order log ratio for the per-token KL estimate, following the original RLOO paper
+            # (Ahmadian et al., 2024, https://huggingface.co/papers/2405.14782). Unlike GRPOTrainer's Schulman
+            # approximation (always >= 0), this can be negative per token. The divergence is intentional: RLOO applies
+            # KL as a reward penalty (summed across tokens per sequence), while GRPO adds it to the per-token loss.
             per_token_kl = old_per_token_logps - ref_per_token_logps
             # Apply sequence-level KL penalty to rewards (sum KL across tokens first, then apply to each sequence)
             kl = (per_token_kl * completion_mask).sum(-1)


### PR DESCRIPTION
## What does this PR do?

Adds a clarifying comment to the KL penalty computation in RLOOTrainer explaining `per_token_kl = old_per_token_logps - ref_per_token_logps`.

### Background

The original RLOO paper (Ahmadian et al., 2024) uses the first-order log ratio for the per-token KL estimate. Unlike GRPOTrainer's Schulman approximation (always >= 0), this can be negative per token. The divergence is intentional: RLOO applies KL as a reward penalty (summed across tokens per sequence), while GRPO adds it to the per-token loss.

Fixes #5889

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue? #5889
- [ ] Did you write any new necessary tests? No functional change.
- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or training logic modifications.
> 
> **Overview**
> Adds an inline comment above the KL penalty block in `RLOOTrainer._generate_and_score_completions` where `per_token_kl = old_per_token_logps - ref_per_token_logps` is computed.
> 
> The comment documents that RLOO follows the first-order log-ratio KL estimate from Ahmadian et al. (2024), which can be **negative per token**, unlike **GRPOTrainer**’s Schulman approximation (non-negative). It also states that the difference is intentional: RLOO subtracts sequence-summed KL from **rewards**, while GRPO adds KL to the **per-token loss**.
> 
> No behavior, tests, or config changes—documentation only (addresses #5889).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641682a40cb486a471cec79337e8971227447c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->