### PR TITLE
Pin SHA instead of version tag for CI astral-sh/setup-uv

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -36,7 +36,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -83,7 +83,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |

--- a/.github/workflows/sync-huggingface-skills.yml
+++ b/.github/workflows/sync-huggingface-skills.yml
@@ -46,7 +46,7 @@ jobs:
           path: skills-repo
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Copy generated files
         run: cp trl/skills/trl-training/SKILL.md skills-repo/skills/trl-training/

--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -53,7 +53,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -120,7 +120,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -176,7 +176,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -227,7 +227,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -284,7 +284,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -38,7 +38,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -40,7 +40,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |
@@ -96,7 +96,7 @@ jobs:
           apt-get update && apt-get install -y make git curl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: Create Python virtual environment
         run: |


### PR DESCRIPTION
Pin SHA instead of version tag for CI astral-sh/setup-uv.

This PR updates the GitHub Actions workflows to pin the `astral-sh/setup-uv` action to a specific commit hash instead of a version tag. This change improves the security and reliability of the CI pipelines by ensuring that the exact same code is used every time the workflow runs.

Related to:
- #6097

### Changes

**CI Workflow dependency pinning:**

* Updated the `Install uv` step to use `astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39` (commit hash for v8.2.0) instead of the version tag in the following workflow files:
  * `.github/workflows/slow-tests.yml`
  * `.github/workflows/sync-huggingface-skills.yml`
  *  `.github/workflows/tests.yml`
  * `.github/workflows/tests-experimental.yml`
  * `.github/workflows/tests_latest.yml`
  * `.github/workflows/tests_transformers_branch.yml`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only supply-chain hardening with no runtime or application code changes; behavior should match the same v8.2.0 action release.
> 
> **Overview**
> **Pins `astral-sh/setup-uv` to commit `fac544c07dec837d0ccb6301d7b5580bf5edae39`** (still v8.2.0) everywhere it installs uv, replacing the floating `@v8.2.0` tag.
> 
> Touched workflows: `slow-tests.yml`, `sync-huggingface-skills.yml`, `tests.yml`, `tests-experimental.yml`, `tests_latest.yml`, and `tests_transformers_branch.yml`. In `sync-huggingface-skills.yml` the pin was already on that SHA; only the comment spacing was normalized.
> 
> No changes to test commands, Python versions, or dependency install logic—only how the setup-uv action is referenced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb4406487c2c66618e842f60c1b28f3b8f9f235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->