### PR TITLE
Pin SHA instead of version tag for CI actions/setup-python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "Version is ${{ steps.get_version.outputs.version }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  #v6.2.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.13
       - uses: pre-commit/action@v3.0.1
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.13
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.12
       - uses: pre-commit/action@v3.0.1
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -167,7 +167,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -218,7 +218,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -275,7 +275,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -29,7 +29,7 @@ jobs:
         with: { ref: v1.6-release }
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Pin SHA instead of version tag for CI actions/setup-python.

This PR updates the GitHub Actions workflows to use a specific commit hash for the `actions/setup-python` action instead of the generic `@v6` tag. This change ensures greater reproducibility and security by pinning the action version across all workflows.

Related to:
- #6097
- #6098

### Changes

**Workflow updates for reproducibility and security:**

* Replace all instances of `actions/setup-python@v6`  with `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0) in:.
  * `.github/workflows/publish.yml`
  * `.github/workflows/tests.yml`
  * `.github/workflows/tests-experimental.yml`
  * `.github/workflows/tests_latest.yml`
  * `.github/workflows/tests_transformers_branch.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only action pinning with no application or runtime behavior changes.
> 
> **Overview**
> Pins **`actions/setup-python`** across CI from the floating **`@v6`** tag to commit **`a309ff8b426b58ec0e2a45f0f869d46889d02405`** (annotated as **v6.2.0**), so every Python setup step runs the same action revision.
> 
> The update applies to all **`Set up Python`** steps in **`publish.yml`**, **`tests.yml`**, **`tests-experimental.yml`**, **`tests_latest.yml`**, and **`tests_transformers_branch.yml`**. Python version matrices and job logic are unchanged; only the action reference is hardened for reproducibility and supply-chain pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6e0e85af430671644d747cf03462508e1ac51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->