### PR TITLE
Pin SHA instead of version tag for CI pre-commit/action

### DIFF
--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.12
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files
 


### PR DESCRIPTION
Pin SHA instead of version tag for CI pre-commit/action.

This PR updates the way the `pre-commit/action` GitHub Action is referenced in the workflow configuration files. Instead of using a version tag, the workflows now use a specific commit SHA for improved reliability and reproducibility.

Related to:
- #6097
- #6098
- #6099

### Changes

**CI workflow improvements:**

* Changed the `pre-commit/action` step to reference a specific commit SHA (`2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd`) instead of the version tag `v3.0.1`, ensuring consistent action behavior across workflow runs in:
  * `.github/workflows/tests-experimental.yml`
  * `.github/workflows/tests.yml`: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only pinning with no application or runtime changes; pre-commit behavior stays the same.
> 
> **Overview**
> Pins **`pre-commit/action`** in the **Check code quality** job from the **`v3.0.1`** tag to commit **`2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd`** (annotated as v3.0.1), in **`.github/workflows/tests.yml`** and **`.github/workflows/tests-experimental.yml`**.
> 
> Behavior is unchanged: **`extra_args: --all-files`** is still passed; only how the action is resolved is updated for reproducibility and supply-chain hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d98fb095dcf8b07e27b36b1432c8adb7eb25d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->