### PR TITLE
Add vision requirement marker to Idefics3 test parameter

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -579,7 +579,9 @@ class TestIsChatTemplateStopTokenTrained:
             ),
         ),
         pytest.param("trl-internal-testing/tiny-GptOssForCausalLM", id="gptoss"),
-        pytest.param("trl-internal-testing/tiny-Idefics3ForConditionalGeneration", id="idefics3"),
+        pytest.param(
+            "trl-internal-testing/tiny-Idefics3ForConditionalGeneration", id="idefics3", marks=require_vision
+        ),
         pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-3", id="llama3"),
         pytest.param("trl-internal-testing/tiny-LlavaForConditionalGeneration", id="llava", marks=require_vision),
         pytest.param(


### PR DESCRIPTION
Forgot in https://github.com/huggingface/trl/pull/5871

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only gating change; no production code or runtime behavior affected.
> 
> **Overview**
> Adds the **`require_vision`** pytest marker to the **`tiny-Idefics3ForConditionalGeneration`** case in **`TestGetTrainingChatTemplate`**, matching other vision models in the same parametrized list (e.g. Gemma3, Llava, Qwen-VL).
> 
> That case loads an **`AutoProcessor`** and runs VLM-specific paths, so it should be skipped in CI or local runs without vision support—same follow-up as PR #5871.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d63f205f8cde74686f2e841ec2bfecfc89c2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->