### PR TITLE
Add support for vLLM 0.19.1

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.19.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.19.0",
+    "vllm>=0.12.0,<=0.19.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.0")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
Nothing special in the [release note](https://github.com/vllm-project/vllm/releases/tag/v0.19.1) (expect for the transformers v5 compatibility!!), and the tests are passing:

```
$ pytest tests/test_vllm_client_server.py
==================================== test session starts ====================================
platform linux -- Python 3.13.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 51 items                                                                                                                                                                         

tests/test_vllm_client_server.py ..................x..................sssssssss.....    [100%]

==================== 41 passed, 9 skipped, 1 xfailed in 511.74s (0:08:31) ====================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-cap changes only; no training or vLLM integration logic was modified.
> 
> **Overview**
> Extends TRL’s supported vLLM window from **0.19.0** to **0.19.1** so installs and runtime checks treat the new patch release as compatible.
> 
> The upper bound is updated in the optional `vllm` extra in `pyproject.toml`, in the vLLM integration docs warning, and in `is_vllm_available()` in `trl/import_utils.py` (version range check and user-facing warning text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8759b40dd28cc69c7e47514ea0cbd67edb815b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->