### PR TITLE
Add support for vLLM 0.20.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.19.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.20.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.19.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.19.1",
+    "vllm>=0.12.0,<=0.20.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.19.0",
+    "vllm>=0.12.0,<=0.19.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.1")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.20.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.20.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.0")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
TRL's vLLM API surface (`LLM`, `SamplingParams`, `StructuredOutputsParams`, weight-sync via `collective_rpc`/`init_communicator`/`update_named_param`/`load_weights`) is untouched by v0.20.0's breaking changes. The only real risk is environmental: vllm 0.20 makes transformers v5 the baseline and bumps to torch 2.11 / CUDA 13. TRL already supports transformers v5, so that's fine. The deprecations (`LLM.reward`, `cprofile`, NVFP4, pooler renames) don't touch TRL.

```
$ pytest tests/test_vllm_client_server.py
======================================== test session starts =========================================
platform linux -- Python 3.13.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 51 items
tests/test_vllm_client_server.py ..................x..................sssssssss.....            [100%]

======================= 41 passed, 9 skipped, 1 xfailed in 515.10s (0:08:35) =========================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-boundary and dependency metadata only; no behavioral changes to TRL’s vLLM integration, though installing vLLM 0.20 may pull newer torch/CUDA/transformers stacks via upstream pins.
> 
> **Overview**
> Extends TRL’s **supported vLLM ceiling** from `0.19.1` to **`0.20.0`** everywhere users hit version policy: the vLLM integration doc warning, the `trl[vllm]` optional dependency in `pyproject.toml`, and the runtime check/warning in `is_vllm_available()` in `trl/import_utils.py`.
> 
> There are **no changes** to vLLM client/server code or trainer integration logic—only version bounds and messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f2ee8df9028dc5d7ca9fc282901f4d6f2ccb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->