### PR TITLE
Drop vLLM 0.12 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.13.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.19.0",
+    "vllm>=0.13.0,<=0.19.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.0")):
+        if not (Version("0.13.0") <= Version(_vllm_version) <= Version("0.19.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.13.0 to 0.19.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
Raise the minimum supported vLLM version from `0.12.0` to `0.13.0` (pyproject, `is_vllm_available` range check + warning, and docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-policy and documentation-only changes with no runtime logic beyond stricter version warnings; users on vLLM 0.12.x will need to upgrade.
> 
> **Overview**
> Raises the **minimum supported vLLM version** from `0.12.0` to `0.13.0`; the upper bound (`0.19.0`) is unchanged.
> 
> The `trl[vllm]` optional dependency in `pyproject.toml`, the supported-range check and warning in `is_vllm_available()`, and the compatibility note in `docs/source/vllm_integration.md` are all updated so installs and runtime behavior align on **0.13.0–0.19.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a9f433e6dc55760f8bca5df6b5889366ac2579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->