### PR TITLE
Fix broken light-mode banner image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div style="text-align: center">
     <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/TRL%20banner%20light.png">
+        <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/trl_banner_light.png">
         <img src="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/trl_banner_dark.png" alt="TRL Banner">
     </picture>
 </div>


### PR DESCRIPTION
## Problem

The TRL banner renders as a broken-image icon at the top of the README on the default branch (it rendered fine back at `v0.29.1`).

## Cause

The banner was upgraded from a single `<img>` to a `<picture>` block for light/dark theme switching:

```html
<picture>
    <source media="(prefers-color-scheme: light)" srcset=".../TRL%20banner%20light.png">
    <img src=".../trl_banner_dark.png" alt="TRL Banner">
</picture>
```

A `<picture>` uses the **first matching `<source>`** and only falls back to the `<img>` when no source matches. GitHub renders the README in light theme by default, so `prefers-color-scheme: light` matches and the browser commits to the light source — `TRL%20banner%20light.png`, which **404s** on the Hub. Because a source matched, the working dark `<img>` fallback is never used, so the banner breaks.

Verified against the Hub (following CDN redirects):

| URL | Status |
|---|---|
| `TRL%20banner%20light.png` (current light source) | **404** |
| `trl_banner_dark.png` (img fallback) | 200 |
| `trl_banner_light.png` (correct name) | **200** |

## Fix

Point the light `<source>` at the real filename, `trl_banner_light.png`. Light theme now shows the light banner; dark theme falls through to the dark banner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change in README with no runtime, security, or data impact.
> 
> **Overview**
> Fixes the broken TRL banner at the top of **README.md** on GitHub’s default (light) theme.
> 
> The light `<source>` in the `<picture>` block pointed at `TRL%20banner%20light.png`, which **404s** on the Hub. When that media query matches, the browser never uses the working dark `<img>` fallback, so the banner showed as a broken image. The light `srcset` is updated to **`trl_banner_light.png`**, which exists, so light theme gets the light asset and dark theme still uses the dark banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb15b698bd1c594e642faaba1d3bda2a3aad5ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->