### PR TITLE
Fix broken light-mode banner image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div style="text-align: center">
     <picture>
-        <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/TRL%20banner%20light.png">
+        <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/trl_banner_light.png">
         <img src="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/trl_banner_dark.png" alt="TRL Banner">
     </picture>
 </div>


### PR DESCRIPTION
# What does this PR do?

Fixes the broken TRL banner image at the top of the README (it renders as a broken-image icon on the default branch, though it rendered fine at `v0.29.1`).

The banner was changed from a single `<img>` to a `<picture>` block for light/dark theme switching. A `<picture>` uses the **first matching `<source>`** and only falls back to the `<img>` when no source matches. GitHub renders the README in light theme by default, so `prefers-color-scheme: light` matches and the browser commits to the light source — `TRL%20banner%20light.png`, which **404s** on the Hub. Because a source matched, the working dark `<img>` fallback is never reached, so the banner breaks.

Verified against the Hub (following CDN redirects):

| URL | Status |
|---|---|
| `TRL%20banner%20light.png` (current light source) | **404** |
| `trl_banner_dark.png` (img fallback) | 200 |
| `trl_banner_light.png` (correct name) | **200** |

The fix points the light `<source>` at the real filename, `trl_banner_light.png`. Light theme now shows the light banner; dark theme falls through to the dark banner.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change in README.md with no impact on code, security, or data handling.
> 
> **Overview**
> Fixes the **broken README banner** in light theme by updating the `<picture>` light `<source>` `srcset` from the non-existent `TRL%20banner%20light.png` to **`trl_banner_light.png`**, which matches the asset on the Hub.
> 
> GitHub’s default light rendering was selecting that source and never falling back to the working dark `<img>`, so the header showed a broken image. No runtime or library code is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb15b698bd1c594e642faaba1d3bda2a3aad5ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->