### PR TITLE
Add support for vLLM 0.22.1

### DIFF
--- a/docs/source/harbor.md
+++ b/docs/source/harbor.md
@@ -18,11 +18,10 @@ pip install trl[harbor]
 ```
 
 > [!IMPORTANT]
-> Harbor drives generation through vLLM and uses `environment_factory`, which requires `vllm>=0.22.0` and `transformers>=5.2.0`. The `trl[vllm]` extra currently pins `vllm<=0.19` (which in turn pins `transformers<5`), so install these explicitly. Their constraints conflict, so install vLLM first and then force-install transformers:
+> Harbor drives generation through vLLM and uses `environment_factory`, which requires `vllm>=0.22.0` and `transformers>=5.2.0`.
 >
 > ```bash
 > pip install 'vllm>=0.22.0'
-> pip install 'transformers>=5.2.0' --no-deps
 > ```
 
 This installs the `harbor` framework (Python >= 3.12). The integration imports `harbor` lazily and runs it **in-process**, so users who don't touch `trl.experimental.harbor` aren't affected.

--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.12.0` to `0.19.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.12.0` to `0.22.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.12.0,<=0.19.0",
+    "vllm>=0.12.0,<=0.22.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -115,7 +115,7 @@ def is_vllm_available(min_version: str | None = None) -> bool:
     if _vllm_available:
         if not (Version("0.13.0") <= Version(_vllm_version) <= Version("0.22.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.22.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.19.0")):
+        if not (Version("0.12.0") <= Version(_vllm_version) <= Version("0.22.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.12.0 to 0.19.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.12.0 to 0.22.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
Raises the supported vLLM range from `X–0.19.0` to `X–0.22.1` (warning in `import_utils.py`, `trl[vllm]` extra, and docs).

I verified 0.22.1 installs and imports on our cluster, and checked the 0.20→0.22 release notes: none of TRL's vLLM touchpoints (`collective_rpc`, the `model_executor.driver_worker.model_runner.model` chain, `StatelessProcessGroup`, `PyNcclCommunicator`, `logprobs_mode`, `StructuredOutputsParams`, `external_launcher`, `worker_extension_cls`, sleep/wake) were removed or renamed.

```
pytest tests/test_vllm_client_server.py
======================================= test session starts ========================================
platform linux -- Python 3.13.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 51 items

tests/test_vllm_client_server.py ..................x..................sssssssss.....           [100%]
======================= 41 passed, 9 skipped, 1 xfailed in 768.72s (0:12:48) ========================
```

I could **not** install 0.20.x / 0.21.x to test them: their only wheels require glibc ≥2.34 (or are CUDA 13 builds), while our cluster is glibc 2.31 / CUDA 12.9. Since no recent vLLM release has broken TRL, I suggest we assume these untestable intermediate versions are fine and bump straight to 0.22.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bound and documentation updates only; no runtime integration logic changes.
> 
> **Overview**
> Raises TRL’s supported vLLM ceiling from **0.20.0** to **0.22.1** in `is_vllm_available()` (version check + warning text), the **`trl[vllm]`** extra in `pyproject.toml`, and the vLLM integration docs.
> 
> Harbor install notes are simplified: they still require `vllm>=0.22.0` and `transformers>=5.2.0`, but the workaround for installing transformers with `--no-deps` after a conflicting `trl[vllm]` pin is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d92df6b65cbd1f3cdc44246f0d2b5286c1aafca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->