### PR TITLE
feat(ppo): add save_value_model flag to PPOConfig

### DIFF
--- a/trl/experimental/ppo/ppo_config.py
+++ b/trl/experimental/ppo/ppo_config.py
@@ -111,6 +111,10 @@ class PPOConfig(_BaseConfig):
             This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for generation,
             improving generation speed. However, disabling this option allows training models that exceed the VRAM
             capacity of a single GPU, albeit at the cost of slower generation.
+        save_value_model (`bool`, *optional*, defaults to `False`):
+            Whether to save the value model (critic) alongside the policy when calling :meth:`save_model` or at each
+            checkpoint. When enabled, the value model is written to a ``value_model/`` sub-directory inside the
+            checkpoint directory. Useful for inference-time quality estimation, continued critic training, and research.
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
@@ -276,5 +280,13 @@ class PPOConfig(_BaseConfig):
             "help": "This setting applies to DeepSpeed ZeRO-3. If enabled, the policy model weights are gathered for "
             "generation, improving generation speed. However, disabling this option allows training models that "
             "exceed the VRAM capacity of a single GPU, albeit at the cost of slower generation."
+        },
+    )
+    save_value_model: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to save the value model (critic) alongside the policy when calling `save_model` or "
+            "at each checkpoint. When enabled the value model is written to a `value_model/` sub-directory inside "
+            "the checkpoint directory."
         },
     )

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -605,6 +605,17 @@ class PPOTrainer(_BaseTrainer):
 
         super().save_model(output_dir, _internal_call)
 
+        if self.args.save_value_model and hasattr(backup_model, "value_model"):
+            # Save the value model (critic) to a `value_model/` sub-directory.
+            value_model_dir = os.path.join(
+                output_dir if output_dir is not None else self.args.output_dir,
+                "value_model",
+            )
+            self.model = backup_model.value_model
+            if self.is_deepspeed_enabled:
+                self.deepspeed = self.model
+            super().save_model(value_model_dir, _internal_call)
+
         self.model = backup_model
         if self.is_deepspeed_enabled:
             self.deepspeed = backup_deepspeed


### PR DESCRIPTION
Adds a new `save_value_model: bool = False` field to `PPOConfig`. When enabled, `PPOTrainer.save_model()` writes the value model (critic) to a `value_model/` sub-directory alongside the policy checkpoint, making critic checkpointing and faithful RLHF run resumption possible.

Fixes #3293

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure
- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is off by default and only extends checkpoint I/O on an explicit flag; no training-loop or inference path changes.
> 
> **Overview**
> Adds an opt-in **`save_value_model`** flag on **`PPOConfig`** (default **`False`**) so PPO checkpoints can include the critic, not just the policy.
> 
> When enabled, **`PPOTrainer.save_model()`** still writes the policy as today, then saves **`backup_model.value_model`** under a **`value_model/`** subfolder in the same output/checkpoint directory, including the same DeepSpeed swap pattern used for the policy save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482546f32142449f3283256cc832c18d15437c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->