### PR TITLE
Fix broken internal doc link to GKD Trainer in MiniLLM docs

### DIFF
--- a/docs/source/minillm_trainer.md
+++ b/docs/source/minillm_trainer.md
@@ -49,7 +49,7 @@ training_args = MiniLLMConfig(
 )
 ```
 
-\\( L_{\text{MiniLLM}} \\) becomes the reverse KLD version of the GKD loss as in [GKD Trainer](./gkd_trainer.md):
+\\( L_{\text{MiniLLM}} \\) becomes the reverse KLD version of the GKD loss as in [GKD Trainer](gkd_trainer):
 
 $$
 L_{\text{GKD-RKL}}=\mathbb{E}_{x\sim \pi_{\theta}} \text{KL}\left[\pi_\theta(\cdot|x_{1..t})||\pi_{\text{teacher}}(\cdot | x_{1..t})\right].


### PR DESCRIPTION
The cross-reference used `(./gkd_trainer.md)`, which breaks on the rendered docs site. HF doc-builder expects bare page names; this was the only internal link in the docs using a `.md` extension. Aligns it with the convention used by all other internal links (e.g. index.md).

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or API impact.
> 
> **Overview**
> Fixes a broken cross-link in **MiniLLM Trainer** docs by changing the GKD reference from `(./gkd_trainer.md)` to `(gkd_trainer)`, matching how other TRL docs link internally (bare page names for Hugging Face doc-builder).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204a3617b2b3321f54726bf7311d240295857696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->