### PR TITLE
Standardize model_init_kwargs type documentation across trainer configs

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -36,7 +36,7 @@ class DPOConfig(_BaseConfig):
     Parameters:
         > Parameters that control the model
 
-        model_init_kwargs (`dict[str, Any]`, *optional*):
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`DPOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -36,7 +36,7 @@ class GRPOConfig(_BaseConfig):
     Parameters:
         > Parameters that control the model and reference model
 
-        model_init_kwargs (`str`, `dict[str, Any]`, *optional*):
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`GRPOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -36,7 +36,7 @@ class RewardConfig(_BaseConfig):
     Parameters:
         > Parameters that control the model
 
-        model_init_kwargs (`dict[str, Any]`, *optional*):
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`RewardTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -36,7 +36,7 @@ class RLOOConfig(_BaseConfig):
     Parameters:
         > Parameters that control the model and reference model
 
-        model_init_kwargs (`str`, `dict[str, Any]`, *optional*):
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`RLOOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -36,7 +36,7 @@ class SFTConfig(_BaseConfig):
     Parameters:
         > Parameters that control the model
 
-        model_init_kwargs (`dict[str, Any]`, *optional*):
+        model_init_kwargs (`dict[str, Any]` or `str`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
             argument of the [`SFTTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
The model_init_kwargs field is typed `dict[str, Any] | str | None` in all trainer configs, but the docstrings were inconsistent: DPOConfig, RewardConfig, and SFTConfig documented only `dict[str, Any]` (omitting the accepted `str`), while GRPOConfig and RLOOConfig used a non-standard comma-separated format.

Align all five to ``dict[str, Any]` or `str`, *optional*`, matching the actual type annotation and the repo's existing `x or y` docstring convention (e.g. lr_scheduler_kwargs in base_config.py).

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits with no behavior, API, or training logic changes.
> 
> **Overview**
> Aligns **`model_init_kwargs`** docstrings in **DPO**, **Reward**, **SFT**, **GRPO**, and **RLOO** config classes so they all document **`dict[str, Any]` or `str`**, matching the existing field type (`dict[str, Any] | str | None`) and the repo’s **`x or y`** doc convention (e.g. `lr_scheduler_kwargs` in `base_config.py`).
> 
> Some configs previously listed only a dict type (omitting CLI/json **str** parsing); GRPO/RLOO used a comma-separated type list. **No runtime or type annotation changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f2c4fb950bd22ce60b7830eb771cb7ee61eb88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->