### PR TITLE
Fix AsyncGRPO reward names for partial and callable rewards

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -13,23 +13,34 @@
 # limitations under the License.
 
 import itertools
+import multiprocessing as mp
 import queue
+from functools import partial
 
 import numpy as np
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from transformers import AutoTokenizer
 from transformers.testing_utils import torch_device
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
-from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
+from trl.experimental.async_grpo.async_rollout_worker import RolloutSample, _AsyncRolloutLoop
 
 from ..testing_utils import TrlTestCase, is_ampere_or_newer
 
 
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
+
+
+def offset_reward_func(completions, offset=0.0, **kwargs):
+    return [offset] * len(completions)
+
+
+class CallableRewardFunc:
+    def __call__(self, completions, **kwargs):
+        return [0.0] * len(completions)
 
 
 class _StubRolloutWorker:
@@ -85,6 +96,41 @@ class _StubRolloutWorker:
 
     def check_health(self, stale_after_s):
         pass
+
+
+def _make_rollout_loop(reward_funcs):
+    ctx = mp.get_context("spawn")
+    tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+    dataset = Dataset.from_list([{"prompt": [{"role": "user", "content": "Hello"}]}])
+    return _AsyncRolloutLoop(
+        model_name="dummy-model",
+        dataset=dataset,
+        reward_funcs=reward_funcs,
+        processing_class=tokenizer,
+        rollout_buffer=ctx.Queue(),
+        model_version_value=ctx.Value("i", 0),
+        heartbeat_value=ctx.Value("d", 0.0),
+        failed_event=ctx.Event(),
+        exception_info_queue=ctx.Queue(maxsize=1),
+        num_generations=1,
+        max_inflight_tasks=1,
+    )
+
+
+def test_async_rollout_loop_names_partial_reward_func():
+    rollout_loop = _make_rollout_loop([partial(offset_reward_func, offset=1.0)])
+    try:
+        assert rollout_loop.reward_func_names == ["offset_reward_func"]
+    finally:
+        rollout_loop._loop.close()
+
+
+def test_async_rollout_loop_names_callable_instance_reward_func():
+    rollout_loop = _make_rollout_loop([CallableRewardFunc()])
+    try:
+        assert rollout_loop.reward_func_names == ["CallableRewardFunc"]
+    finally:
+        rollout_loop._loop.close()
 
 
 @pytest.mark.skipif(

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -23,6 +23,7 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
+from functools import partial
 from multiprocessing.queues import Queue as MPQueue
 from multiprocessing.sharedctypes import Synchronized as MPValue
 from multiprocessing.synchronize import Event as MPEvent
@@ -133,6 +134,12 @@ def _spawn_stop_watcher(rollout_loop: "_AsyncRolloutLoop", stop_event: MPEvent) 
     threading.Thread(target=_watch, daemon=True, name="grpo-mp-stop-watcher").start()
 
 
+def _reward_func_name(reward_func: Callable[..., list[float]]) -> str:
+    if isinstance(reward_func, partial):
+        return _reward_func_name(reward_func.func)
+    return getattr(reward_func, "__name__", reward_func.__class__.__name__)
+
+
 def _child_main(
     loop_kwargs: dict[str, Any],
     samples_queue: MPQueue,
@@ -204,7 +211,7 @@ class _AsyncRolloutLoop:
         self.dataset = dataset
         self._dataset_iter = iter(dataset)
         self.reward_funcs = reward_funcs
-        self.reward_func_names = [f.__name__ for f in reward_funcs]
+        self.reward_func_names = [_reward_func_name(f) for f in reward_funcs]
         self.tokenizer = add_response_schema(processing_class)
         self.rollout_buffer = rollout_buffer  # shared mp.Queue
         self._model_version_value = model_version_value  # shared mp.Value


### PR DESCRIPTION
## Summary

Fixes #6133.

AsyncGRPO documents that rollout-worker reward functions may be module-level functions, `functools.partial` objects, or callable class instances. `_AsyncRolloutLoop` still assumed each reward callable had `__name__`, which crashes for documented `partial` and callable-instance rewards before scoring begins.

## Changes

- Add a small reward-name helper for AsyncGRPO rollout metrics.
- Preserve normal function/method names.
- Recursively unwrap `functools.partial` and use the wrapped callable name.
- Use the class name for callable reward instances.
- Add focused regression coverage for partial and callable-instance reward functions.

## Testing/Verification

- `python -m ruff check trl/experimental/async_grpo/async_rollout_worker.py tests/experimental/test_async_grpo_trainer.py`
- AST/source compile check for the changed files with Python `compile(..., "exec")`
- Dependency-free semantic check of the new helper for normal functions, partials, nested partials, and callable instances

I also attempted the targeted pytest command:

```bash
python -m pytest tests/experimental/test_async_grpo_trainer.py::test_async_rollout_loop_names_partial_reward_func tests/experimental/test_async_grpo_trainer.py::test_async_rollout_loop_names_callable_instance_reward_func -q
```

but this local environment is missing core test dependencies before collection (`ModuleNotFoundError: No module named 'torch'`; `datasets` and `transformers` are also absent).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case: #6133
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed; this aligns implementation with the existing documented contract.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow initialization/metrics labeling fix with no changes to reward scoring or training logic; covered by new unit tests.
> 
> **Overview**
> Fixes a startup crash when AsyncGRPO rollout workers use **`functools.partial`** or **callable class instances** as reward functions—types already documented as supported but previously broken because `_AsyncRolloutLoop` read **`__name__`** directly.
> 
> A new **`_reward_func_name`** helper builds **`reward_func_names`**: it recursively unwraps partials to the underlying callable’s name and falls back to the class name when **`__name__`** is missing. Per-reward rollout metrics (`rewards/{name}`) now label correctly for those reward types.
> 
> Regression tests construct **`_AsyncRolloutLoop`** with a partial and a callable instance and assert the expected names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0f120df203ed8f40bb760881d189c43b37e787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->