### PR TITLE
fix(async-grpo): support partial and callable reward functions

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 import itertools
 import queue
 
@@ -23,13 +24,33 @@ from transformers import AutoTokenizer
 from transformers.testing_utils import torch_device
 
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
-from trl.experimental.async_grpo.async_rollout_worker import RolloutSample
+from trl.experimental.async_grpo.async_rollout_worker import RolloutSample, _get_callable_name
 
 from ..testing_utils import TrlTestCase, is_ampere_or_newer
 
 
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
+
+
+def _partial_compatible_reward(completions, **kwargs):
+    return [1.0] * len(completions)
+
+
+class _CallableReward:
+    def __call__(self, completions, **kwargs):
+        return [1.0] * len(completions)
+
+
+@pytest.mark.parametrize(
+    ("reward_func", "expected_name"),
+    [
+        (partial(_partial_compatible_reward), "_partial_compatible_reward"),
+        (_CallableReward(), "_CallableReward"),
+    ],
+)
+def test_get_callable_name_supports_picklable_reward_callables(reward_func, expected_name):
+    assert _get_callable_name(reward_func) == expected_name
 
 
 class _StubRolloutWorker:

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -23,6 +23,7 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
+from functools import partial
 from multiprocessing.queues import Queue as MPQueue
 from multiprocessing.sharedctypes import Synchronized as MPValue
 from multiprocessing.synchronize import Event as MPEvent
@@ -49,6 +50,17 @@ logger = get_logger(__name__)
 Messages: TypeAlias = list[dict[str, str]]
 
 _RETRYABLE_HTTP_ERRORS = (aiohttp.ClientError, asyncio.TimeoutError, TimeoutError, ConnectionResetError)
+
+
+def _get_callable_name(func: Callable) -> str:
+    """Return a stable metric name for a supported picklable callable."""
+    while isinstance(func, partial):
+        func = func.func
+
+    if inspect.isfunction(func) or inspect.ismethod(func):
+        return func.__name__
+
+    return type(func).__name__
 
 
 async def _retry_on_http_error(coro_factory: Callable[[], Awaitable], *, label: str, max_attempts: int = 1):
@@ -204,7 +216,7 @@ class _AsyncRolloutLoop:
         self.dataset = dataset
         self._dataset_iter = iter(dataset)
         self.reward_funcs = reward_funcs
-        self.reward_func_names = [f.__name__ for f in reward_funcs]
+        self.reward_func_names = [_get_callable_name(f) for f in reward_funcs]
         self.tokenizer = add_response_schema(processing_class)
         self.rollout_buffer = rollout_buffer  # shared mp.Queue
         self._model_version_value = model_version_value  # shared mp.Value


### PR DESCRIPTION
Fixes #6133 

## What does this PR do?

AsyncGRPO documents support for picklable reward callables such as `functools.partial` objects and callable class instances.

The spawned rollout worker currently builds reward metric names through `f.__name__`. Since these supported callable forms generally do not expose `__name__`, training can fail during rollout-worker initialization with an `AttributeError`.

This PR resolves callable names as follows:

* Regular functions and methods keep their existing names.
* `functools.partial` values use the wrapped function name.
* Callable instances use their class name.

The change is intentionally limited to reward functions. The worker’s tool-name handling is not changed because tool names may also affect model-facing schemas.

## Test plan

Added CPU-only regression coverage for:

* `functools.partial` reward functions
* Callable class-instance reward functions

Ran:

```bash
python -m pytest -q tests/experimental/test_async_grpo_trainer.py -k picklable_reward
python -m pre_commit run --files \
  trl/experimental/async_grpo/async_rollout_worker.py \
  tests/experimental/test_async_grpo_trainer.py
```

## AI writing disclosure

* [x] AI-assisted: some parts were suggested by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized naming fix at worker init with regression tests; no change to reward computation or tool schemas.
> 
> **Overview**
> Fixes rollout worker startup when reward functions are **`functools.partial`** or **callable class instances** (documented as picklable), which often lack **`__name__`** and previously caused **`AttributeError`** during **`reward_func_names`** initialization.
> 
> Adds **`_get_callable_name`**: unwraps partials to the wrapped function name, keeps function/method **`__name__`**, and uses the **class name** for other callables. **`_AsyncRolloutLoop`** now uses this for per-reward metric keys (`rewards/{name}`); tool naming is unchanged.
> 
> Adds parametrized tests for partial and callable-instance reward naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7cff3a228adc71bc2eb86cfaaf72f9fb1654b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->