### PR TITLE
Fix GRPOTrainer crash with environment_factory on partial batches

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2400,6 +2400,60 @@ class TestGRPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.2.0"),
+        reason="Environment factory support is not available in transformers versions below 5.2.0",
+        strict=True,
+    )
+    @require_jmespath
+    @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
+    def test_evaluate_with_environment_factory_partial_batch(self):
+        # Regression test for #6129. `self.environments` has `generation_batch_size` entries, but the final
+        # batch of an eval (or of training on a non-divisible dataset) can be partial, i.e.
+        # `len(prompts) < generation_batch_size`. Here `num_generations_eval=1` with a single eval example
+        # yields one prompt against two environments, which previously raised
+        # `ValueError: zip() argument 2 is longer than argument 1` in `_generate_and_score_completions`.
+        # `evaluate()` must now complete.
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+
+        class DummyEnvironment:
+            def reset(self, **kwargs):
+                self._counter = 0
+
+            def increment(self, step: int) -> int:
+                """
+                Increment the internal counter.
+
+                Args:
+                    step: Value to add to the counter.
+
+                Returns:
+                    The updated counter value.
+                """
+                self._counter += step
+                return self._counter
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            per_device_eval_batch_size=2,
+            num_generations=2,
+            num_generations_eval=1,  # eval batch yields fewer prompts than the environment list
+            max_completion_length=8,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+            eval_dataset=dataset.select(range(1)),  # 1 example -> partial final eval batch
+            environment_factory=DummyEnvironment,
+        )
+
+        metrics = trainer.evaluate()
+        assert metrics["eval_loss"] is not None
+
+    @pytest.mark.xfail(
         condition=Version(transformers.__version__) < Version("5.0.0"),
         reason="Tool parsing is not supported in transformers versions below 5.0.0",
         strict=True,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1930,7 +1930,12 @@ class GRPOTrainer(_BaseTrainer):
         prompts = [x["prompt"] for x in inputs]
 
         if self.environments:
-            for prompt, environment, reset_kwargs in zip(prompts, self.environments, inputs, strict=True):
+            # `self.environments` has `generation_batch_size` entries, but the final batch of an eval (or of
+            # training on a non-divisible dataset) can be partial, i.e. `len(prompts) < generation_batch_size`.
+            # Slice to the live batch so the strict zip holds on partial batches (see issue #6129).
+            for prompt, environment, reset_kwargs in zip(
+                prompts, self.environments[: len(prompts)], inputs, strict=True
+            ):
                 observation = environment.reset(**reset_kwargs)
                 if observation is None:
                     continue


### PR DESCRIPTION
## What does this PR do?

`GRPOTrainer` builds a fixed list of `generation_batch_size` environments once in `__init__`
(`generation_batch_size = per_device_train_batch_size * steps_per_generation`). In
`_generate_and_score_completions`, each batch resets them with a strict zip:

```python
for prompt, environment, reset_kwargs in zip(prompts, self.environments, inputs, strict=True):
```

This assumes every batch has exactly `generation_batch_size` prompts. The final batch of an evaluation is
partial whenever `len(eval_dataset)` is not a multiple of the batch (for example with
`num_generations_eval < num_generations`), so `len(prompts) < generation_batch_size` and `strict=True`
raises `ValueError: zip() argument 2 is longer than argument 1`. The same would break training on a
non-divisible final batch.

**Fix:** slice the environments to the live batch (`self.environments[: len(prompts)]`). `prompts` and
`inputs` are always equal length, so the strict zip stays meaningful; on a full batch the slice is a no-op.

**Test:** added `test_evaluate_with_environment_factory_partial_batch`, which reproduces the crash via a
partial eval batch (`num_generations_eval=1` with a single eval example) and asserts `evaluate()` completes.
It fails on `main` and passes with this change.

One observation left out of this PR: `_calculate_rewards` also passes the full `self.environments` to
synchronous reward functions. There the list intentionally has a different length from the
`num_generations`-expanded completions, so the same `[: len(prompts)]` slice would not be correct and I did
not want to guess at the intended alignment. Happy to look at it separately if you think it needs handling.

Fixes #6129

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #6129
- [ ] Did you make sure to update the documentation with your changes? (not applicable, bug fix)
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow batch-alignment fix in environment reset; full batches unchanged and covered by a targeted regression test.
> 
> **Overview**
> Fixes a crash when **GRPOTrainer** uses **`environment_factory`** and a batch has fewer prompts than **`generation_batch_size`** (typical on the last eval batch or a non-divisible train set). **`_generate_and_score_completions`** now zips prompts with **`self.environments[: len(prompts)]`** instead of the full environment list, so **`strict=True`** zip no longer raises when eval uses **`num_generations_eval`** smaller than train generations.
> 
> Adds **`test_evaluate_with_environment_factory_partial_batch`** to assert **`evaluate()`** completes with a single eval example and partial batch (regression for #6129).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32494f3e157b91f97c2004cb1143466446eb59a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->