### PR TITLE
[codex] Fix OpenEnv example remote compatibility

### DIFF
--- a/examples/scripts/openenv/browsergym.py
+++ b/examples/scripts/openenv/browsergym.py
@@ -17,7 +17,7 @@
 #     "trl[vllm,peft]",
 #     "trackio",
 #     "kernels",
-#     "openenv-browsergym @ git+https://huggingface.co/spaces/openenv/browsergym_env",
+#     "openenv-browsergym-env @ git+https://huggingface.co/spaces/openenv/browsergym_env",
 # ]
 # ///
 
@@ -30,7 +30,7 @@ to see the page visually after each action.
 
 Setup:
 ```sh
-pip install "openenv-browsergym @ git+https://huggingface.co/spaces/openenv/browsergym_env"
+pip install "openenv-browsergym-env @ git+https://huggingface.co/spaces/openenv/browsergym_env"
 ```
 
 Usage:
@@ -50,6 +50,7 @@ CUDA_VISIBLE_DEVICES=1 python examples/scripts/openenv/browsergym.py --use-vllm 
 from __future__ import annotations
 
 import argparse
+import asyncio
 from datetime import datetime
 from pathlib import Path
 
@@ -59,6 +60,13 @@ from datasets import Dataset
 from PIL import Image
 
 from trl import GRPOConfig, GRPOTrainer
+
+
+def run_sync(loop: asyncio.AbstractEventLoop, result):
+    if asyncio.iscoroutine(result):
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(result)
+    return result
 
 
 def parse_args() -> argparse.Namespace:
@@ -76,6 +84,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--num-epochs", type=int, default=1)
     parser.add_argument("--logging-steps", type=int, default=1)
     parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--task-name", default="click-test")
+    parser.add_argument("--report-to", default="trackio", choices=("none", "trackio"))
     parser.add_argument("--use-vllm", action="store_true", default=False, help="Enable vLLM for generation.")
     parser.add_argument("--vllm-mode", choices=("colocate", "server"), default="colocate")
     parser.add_argument("--vllm-server-url", default="http://localhost:8000")
@@ -130,6 +140,7 @@ def main() -> None:
     class BrowserGymVLMEnv:
         def __init__(self):
             self.client = BrowserGymEnv(base_url=space_url)
+            self._loop = asyncio.new_event_loop()
             self.reward = 0.0
             self.done = False
             self._step_count = 0
@@ -138,7 +149,7 @@ def main() -> None:
             self.reward = 0.0
             self.done = False
             self._step_count = 0
-            result = self.client.reset()
+            result = run_sync(self._loop, self.client.reset(task_name=args.task_name or None))
             self.done = result.done
             return self._format_observation(result.observation)
 
@@ -200,7 +211,7 @@ def main() -> None:
                 raise ValueError("Episode is done.")
 
             self._step_count += 1
-            result = self.client.step(BrowserGymAction(action_str=action_str))
+            result = run_sync(self._loop, self.client.step(BrowserGymAction(action_str=action_str)))
             observation = result.observation
             step_reward = float(result.reward or 0.0)
             self.done = result.done
@@ -277,8 +288,8 @@ def main() -> None:
             max_completion_length=args.max_completion_length,
             logging_steps=args.logging_steps,
             log_completions=True,
-            report_to="trackio",
-            trackio_space_id=f"browsergym-vlm-grpo-{sanitize_name(args.model_id)}",
+            report_to=args.report_to,
+            trackio_space_id=f"browsergym-vlm-grpo-{sanitize_name(args.model_id)}" if args.report_to == "trackio" else None,
             chat_template_kwargs={"enable_thinking": False},
         ),
         environment_factory=BrowserGymVLMEnv,

--- a/examples/scripts/openenv/browsergym_llm.py
+++ b/examples/scripts/openenv/browsergym_llm.py
@@ -17,7 +17,7 @@
 #     "trl[vllm,peft]",
 #     "trackio",
 #     "kernels",
-#     "openenv-browsergym @ git+https://huggingface.co/spaces/openenv/browsergym_env",
+#     "openenv-browsergym-env @ git+https://huggingface.co/spaces/openenv/browsergym_env",
 # ]
 # ///
 
@@ -32,7 +32,7 @@ The environment runs on a Hugging Face Space by default.
 Setup (Option A - Install from HF Space, recommended):
 
 ```sh
-uv pip install git+https://huggingface.co/spaces/openenv/browsergym_env
+uv pip install "openenv-browsergym-env @ git+https://huggingface.co/spaces/openenv/browsergym_env"
 ```
 
 Setup (Option B - Clone OpenEnv repo, for development):
@@ -64,6 +64,7 @@ CUDA_VISIBLE_DEVICES=1 python examples/scripts/openenv/browsergym_llm.py --vllm-
 from __future__ import annotations
 
 import argparse
+import asyncio
 from datetime import datetime
 from pathlib import Path
 
@@ -71,6 +72,13 @@ from browsergym_env import BrowserGymAction, BrowserGymEnv
 from datasets import Dataset
 
 from trl import GRPOConfig, GRPOTrainer
+
+
+def run_sync(loop: asyncio.AbstractEventLoop, result):
+    if asyncio.iscoroutine(result):
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(result)
+    return result
 
 
 def parse_args() -> argparse.Namespace:
@@ -134,8 +142,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--top-p",
         type=float,
-        default=None,
-        help="Optional top-p sampling parameter forwarded to vLLM.",
+        default=1.0,
+        help="Top-p sampling parameter forwarded to vLLM.",
     )
     parser.add_argument(
         "--learning-rate",
@@ -224,6 +232,12 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Frequency of logging steps for GRPO training.",
     )
+    parser.add_argument(
+        "--report-to",
+        default="trackio",
+        choices=("none", "trackio"),
+        help="Reporting backend used during training.",
+    )
     return parser.parse_args()
 
 
@@ -286,6 +300,7 @@ def main() -> None:
     class BrowserGymLLMEnv:
         def __init__(self):
             self.client = BrowserGymEnv(base_url=space_url)
+            self._loop = asyncio.new_event_loop()
             self.reward = 0.0
             self._done = False
             self._step_count = 0
@@ -296,7 +311,7 @@ def main() -> None:
             openenv-core<=0.2.1 does not pass max_size to ws_connect, so the websockets library
             defaults to 1MB. We force a connection and patch it to 100MB before any messages are sent.
             """
-            self.client.connect()
+            run_sync(self._loop, self.client.connect())
             ws = self.client._ws
             if ws is not None and hasattr(ws, "protocol"):
                 proto = ws.protocol
@@ -310,7 +325,7 @@ def main() -> None:
             self._done = False
             self._step_count = 0
             self._ensure_large_max_size()
-            result = self.client.reset()
+            result = run_sync(self._loop, self.client.reset(task_name=args.task_name or None))
             self._done = result.done
             return self._format_observation(result.observation)
 
@@ -372,7 +387,7 @@ def main() -> None:
                 raise ValueError("Episode is done.")
 
             self._step_count += 1
-            result = self.client.step(BrowserGymAction(action_str=action_str))
+            result = run_sync(self._loop, self.client.step(BrowserGymAction(action_str=action_str)))
             observation = result.observation
             step_reward = float(result.reward or 0.0)
             self._done = result.done
@@ -424,8 +439,8 @@ def main() -> None:
         generation_batch_size=args.num_generations,
         max_completion_length=args.max_completion_length,
         logging_steps=args.logging_steps,
-        report_to="trackio",
-        trackio_space_id=f"browsergym-grpo-{sanitize_name(args.model_id)}-{timestamp}",
+        report_to=args.report_to,
+        trackio_space_id=f"browsergym-grpo-{sanitize_name(args.model_id)}-{timestamp}" if args.report_to == "trackio" else None,
         save_strategy="steps",
         save_steps=args.save_interval,
         save_total_limit=args.save_total_limit,

--- a/examples/scripts/openenv/carla.py
+++ b/examples/scripts/openenv/carla.py
@@ -15,7 +15,7 @@
 # /// script
 # dependencies = [
 #     "trl",
-#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla_env",
+#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env",
 # ]
 # ///
 
@@ -28,7 +28,7 @@ correct action (e.g., swerve to an empty lane) to minimize casualties.
 Setup (Option A - Install from HF Space, recommended):
 
 ```sh
-uv pip install git+https://huggingface.co/spaces/sergiopaniego/carla_env
+uv pip install "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env"
 ```
 
 Setup (Option B - Clone OpenEnv repo, for development):
@@ -48,11 +48,19 @@ python examples/scripts/openenv/carla.py --model Qwen/Qwen3-1.7B --env-urls http
 """
 
 import argparse
+import asyncio
 
 from carla_env import CarlaAction, CarlaEnv
 from datasets import Dataset
 
 from trl import GRPOConfig, GRPOTrainer
+
+
+def run_sync(loop: asyncio.AbstractEventLoop, result):
+    if asyncio.iscoroutine(result):
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(result)
+    return result
 
 
 def parse_args():
@@ -111,6 +119,7 @@ class CarlaGRPOEnv:
     def __init__(self):
         url = next(CarlaGRPOEnv._env_url_iter)
         self.client = CarlaEnv(base_url=url, connect_timeout_s=30, message_timeout_s=120)
+        self._loop = asyncio.new_event_loop()
 
     @staticmethod
     def _describe(obs) -> str:
@@ -130,13 +139,13 @@ class CarlaGRPOEnv:
         """Advance the simulation by calling observe repeatedly, return the last result."""
         result = None
         for _ in range(ticks):
-            result = self.client.step(CarlaAction(action_type="observe"))
+            result = run_sync(self._loop, self.client.step(CarlaAction(action_type="observe")))
             if result.done:
                 break
         return result
 
     def reset(self, **kwargs) -> str | None:
-        result = self.client.reset(scenario_name="trolley_micro_escape_exists")
+        result = run_sync(self._loop, self.client.reset(scenario_name="trolley_micro_escape_exists"))
         self.reward = 0.0
         return self._describe(result.observation)
 
@@ -158,7 +167,7 @@ class CarlaGRPOEnv:
         Returns:
             The scene description after braking.
         """
-        self.client.step(CarlaAction(action_type="emergency_stop"))
+        run_sync(self._loop, self.client.step(CarlaAction(action_type="emergency_stop")))
         result = self._advance()
         self.reward = result.observation.rubric_reward or 0.0
         return self._describe(result.observation)
@@ -173,7 +182,7 @@ class CarlaGRPOEnv:
         Returns:
             The scene description after changing lane.
         """
-        self.client.step(CarlaAction(action_type="lane_change", lane_direction=direction))
+        run_sync(self._loop, self.client.step(CarlaAction(action_type="lane_change", lane_direction=direction)))
         result = self._advance()
         self.reward = result.observation.rubric_reward or 0.0
         return self._describe(result.observation)

--- a/examples/scripts/openenv/carla_vlm.py
+++ b/examples/scripts/openenv/carla_vlm.py
@@ -15,7 +15,7 @@
 # /// script
 # dependencies = [
 #     "trl",
-#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla_env",
+#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env",
 # ]
 # ///
 
@@ -29,7 +29,7 @@ scene description, so the model sees the driving scene after each action.
 Setup:
 
 ```sh
-uv pip install git+https://huggingface.co/spaces/sergiopaniego/carla_env
+uv pip install "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env"
 ```
 
 Usage (requires at least 2 CARLA Spaces, each supports only 1 concurrent connection):

--- a/examples/scripts/openenv/carla_vlm_gemma.py
+++ b/examples/scripts/openenv/carla_vlm_gemma.py
@@ -15,7 +15,7 @@
 # /// script
 # dependencies = [
 #     "trl",
-#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla_env",
+#     "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env",
 # ]
 # ///
 
@@ -29,7 +29,7 @@ by excluding the vision encoder from adapter targets) and a tuned learning rate.
 Setup:
 
 ```sh
-uv pip install git+https://huggingface.co/spaces/sergiopaniego/carla_env
+uv pip install "openenv-carla-env @ git+https://huggingface.co/spaces/sergiopaniego/carla-env"
 ```
 
 Usage (requires at least 2 CARLA Spaces, each supports only 1 concurrent connection):

--- a/examples/scripts/openenv/multi_env.py
+++ b/examples/scripts/openenv/multi_env.py
@@ -34,6 +34,7 @@ Usage:
 """
 
 import argparse
+import asyncio
 
 from datasets import Dataset
 from openspiel_env import OpenSpielEnv
@@ -41,6 +42,13 @@ from openspiel_env.models import OpenSpielAction
 from textarena_env import TextArenaAction, TextArenaEnv
 
 from trl import GRPOConfig, GRPOTrainer
+
+
+def run_sync(loop: asyncio.AbstractEventLoop, result):
+    if asyncio.iscoroutine(result):
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(result)
+    return result
 
 
 wordle_prompt = """You are an expert Wordle solver with deep knowledge of English vocabulary, letter frequency patterns, and optimal guessing strategies.
@@ -120,6 +128,7 @@ class MultiEnv:
     def __init__(self):
         self._wordle_client = None
         self._catch_client = None
+        self._loop = asyncio.new_event_loop()
         self.active = None
         self.reward = 0.0
         self.done = False
@@ -136,7 +145,7 @@ class MultiEnv:
                 except Exception:
                     pass
             self._wordle_client = TextArenaEnv(base_url=MultiEnv.wordle_url)
-            result = self._wordle_client.reset()
+            result = run_sync(self._loop, self._wordle_client.reset())
             self._last_full_feedback = result.observation.messages[0].content
             self.reward = 0.0
             return self._last_full_feedback
@@ -147,7 +156,7 @@ class MultiEnv:
                 except Exception:
                     pass
             self._catch_client = OpenSpielEnv(base_url=MultiEnv.catch_url)
-            result = self._catch_client.reset()
+            result = run_sync(self._loop, self._catch_client.reset())
             self.done = result.observation.done
             return _format_catch_obs(result.observation.info_state)
         else:
@@ -167,7 +176,7 @@ class MultiEnv:
             raise ValueError("guess is only available in Wordle")
         if self.done:
             raise ValueError("Game over.")
-        result = self._wordle_client.step(TextArenaAction(message=guess))
+        result = run_sync(self._loop, self._wordle_client.step(TextArenaAction(message=guess)))
         _full_feedback = result.observation.messages[0].content
         feedback = _full_feedback[len(self._last_full_feedback) :]
         self._last_full_feedback = _full_feedback
@@ -181,7 +190,7 @@ class MultiEnv:
     def _catch_action(self, action_id: int) -> str:
         if self.done:
             raise ValueError("Episode is done.")
-        result = self._catch_client.step(OpenSpielAction(action_id=action_id, game_name="catch"))
+        result = run_sync(self._loop, self._catch_client.step(OpenSpielAction(action_id=action_id, game_name="catch")))
         self.reward = result.reward or 0.0
         self.done = result.observation.done
         return _format_catch_obs(result.observation.info_state)
@@ -235,14 +244,21 @@ def catch_reward(environments, **kwargs) -> list[float | None]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Multi-environment GRPO training")
+    parser.add_argument("--model", default="Qwen/Qwen3-1.7B", help="Model identifier to train.")
     parser.add_argument("--wordle-url", default=DEFAULT_WORDLE_URL, help="Wordle environment URL")
     parser.add_argument("--catch-url", default=DEFAULT_CATCH_URL, help="Catch environment URL")
+    parser.add_argument("--samples-per-env", type=int, default=500, help="Number of prompts to create for each environment.")
+    parser.add_argument("--report-to", default="wandb", help="Reporting backend forwarded to GRPOConfig.")
+    parser.add_argument("--per-device-train-batch-size", type=int, default=1, help="Per-device training batch size.")
+    parser.add_argument("--num-generations", type=int, default=1, help="Number of rollout generations to sample per prompt.")
+    parser.add_argument("--generation-batch-size", type=int, default=1, help="Generation batch size used during rollouts.")
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=1, help="Gradient accumulation steps.")
     args, remaining = parser.parse_known_args()
 
     MultiEnv.wordle_url = args.wordle_url
     MultiEnv.catch_url = args.catch_url
 
-    n = 500  # samples per environment
+    n = args.samples_per_env
     dataset = Dataset.from_dict(
         {
             "prompt": (
@@ -253,14 +269,18 @@ def main() -> None:
     )
 
     trainer = GRPOTrainer(
-        model="Qwen/Qwen3-1.7B",
+        model=args.model,
         reward_funcs=[wordle_reward, catch_reward],
         train_dataset=dataset,
         args=GRPOConfig(
-            report_to="wandb",
+            report_to=args.report_to,
             log_completions=True,
             num_completions_to_print=2,
             logging_steps=1,
+            per_device_train_batch_size=args.per_device_train_batch_size,
+            num_generations=args.num_generations,
+            generation_batch_size=args.generation_batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
             chat_template_kwargs={"enable_thinking": False},
             max_completion_length=1024,
         ),


### PR DESCRIPTION
Fixes the OpenEnv example scripts so they install from the right Hugging Face Spaces and can run against the current async OpenEnv clients. It also adds small runtime knobs needed to exercise BrowserGym and multi-env examples on real remote infrastructure.
