### PR TITLE
fix: don't re-flatten vLLM server completion_ids in Online DPO

### DIFF
--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 from datasets import Dataset, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
@@ -406,6 +409,40 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert trainer.reward_weights is not None
         assert round(abs(trainer.reward_weights[0].item() - 0.7), 5) == 0
         assert round(abs(trainer.reward_weights[1].item() - 0.3), 5) == 0
+
+    def test_generate_vllm_server_preserves_completion_token_lists(self, monkeypatch):
+        # Regression test for #5514. VLLMClient.generate returns completion_ids as a list[list[int]] with one
+        # token-id list per completion (the same shape the colocate path produces), so _generate_vllm_server must
+        # pass each completion through unchanged. Previously it re-flattened the list, turning every token into its
+        # own single-token "completion".
+        monkeypatch.setattr("trl.experimental.online_dpo.online_dpo_trainer.gather_object", lambda x: x)
+        monkeypatch.setattr(
+            "trl.experimental.online_dpo.online_dpo_trainer.broadcast_object_list",
+            lambda x, from_process=0: x,
+        )
+
+        server_completion_ids = [[101, 102, 103], [201, 202]]
+
+        trainer = OnlineDPOTrainer.__new__(OnlineDPOTrainer)
+        trainer.accelerator = SimpleNamespace(is_main_process=True, process_index=0)
+        trainer.state = SimpleNamespace(global_step=0)
+        trainer._last_loaded_step = 0  # equal to global_step, so no vLLM weight reload is triggered
+        trainer.num_generations = 2
+        trainer.repetition_penalty = 1.0
+        trainer.temperature = 1.0
+        trainer.top_p = 1.0
+        trainer.top_k = None
+        trainer.min_p = None
+        trainer.generation_config = SimpleNamespace(max_tokens=16)
+        trainer.args = SimpleNamespace(generation_kwargs={})
+        trainer.processing_class = lambda **kwargs: {"input_ids": torch.tensor([[5, 6, 7]])}
+        trainer.vllm_client = SimpleNamespace(generate=lambda **kwargs: {"completion_ids": server_completion_ids})
+
+        completion_ids, _ = trainer._generate_vllm_server(["a plain prompt"])
+
+        # Each completion keeps its full token-id list instead of being exploded into one single-token entry per
+        # token (which was the bug).
+        assert completion_ids == server_completion_ids
 
 
 @require_vision

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -673,8 +673,6 @@ class OnlineDPOTrainer(_BaseTrainer):
                 else None,
                 generation_kwargs=self.args.generation_kwargs,
             )["completion_ids"]
-            # Flatten: each prompt generates 2 completions
-            completion_ids = [[comp_id] for prompt_completions in completion_ids for comp_id in prompt_completions]
         else:
             completion_ids = [None] * (len(all_prompts) * 2)
 


### PR DESCRIPTION
Fixes #5514

## What

`OnlineDPOTrainer._generate_vllm_server` re-flattened the vLLM client's `completion_ids`:

```python
completion_ids = [[comp_id] for prompt_completions in completion_ids for comp_id in prompt_completions]
```

`VLLMClient.generate(...)["completion_ids"]` already returns a `list[list[int]]` with one token-id list per completion (the same shape the colocate path produces, and that GRPO uses). The comprehension iterates over every completion *and* every token, so a completion like `[101, 102, 103]` becomes three separate single-token "completions" `[101], [102], [103]`. Downstream this makes `completion_mask` `[1, 0, 0, ...]` for every row and throws off the per-process row count. The colocate path (`_generate_vllm_colocate`) and `GRPOTrainer` never apply this extra flatten, so server-mode Online DPO was the only inconsistent path.

## Fix

Remove the re-flatten so `completion_ids` is passed through as the `list[list[int]]` the client already returns.

## Test

Added `test_generate_vllm_server_preserves_completion_token_lists` (CPU-only; mocks the vLLM client and the distributed gather/broadcast) asserting each completion keeps its full token-id list. Fails before this change, passes after.

---

Note: there is an existing draft #5516 proposing the same one-line removal, but it has been a WIP with no activity since April. I commented on the issue a couple of days ago offering this tested fix and asking whether to open a fresh PR or revive #5516, did not hear back, and the bug is still live on `main`, so I am opening this clean, tested PR. Happy to defer to #5516 if its author would like to finish it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Online DPO generation on the vLLM server path, which directly affects training data shape and loss; scope is a one-line behavioral fix with a targeted test.
> 
> **Overview**
> Fixes a bug in **vLLM server** mode for Online DPO where `_generate_vllm_server` incorrectly re-flattened `completion_ids` from the vLLM client.
> 
> The client already returns `list[list[int]]` (one full token sequence per completion, matching colocate and GRPO). The removed comprehension treated each **token** as its own completion, breaking `completion_mask`, row counts, and training semantics for server-mode users only.
> 
> The fix is to **pass `completion_ids` through unchanged** after `VLLMClient.generate`. A CPU regression test mocks the client and distributed gather/broadcast to assert multi-token completions stay intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9f32a0ae0d373cf303666c15008a71d94da688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->