### PR TITLE
Align format of code examples in docstrings

### DIFF
--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -72,12 +72,12 @@ def clone_chat_template(
 
     Example:
     ```python
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-    from trl import clone_chat_template
+    >>> from transformers import AutoModelForCausalLM, AutoTokenizer
+    >>> from trl import clone_chat_template
 
-    model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B")
-    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
-    model, tokenizer, added_tokens = clone_chat_template(model, tokenizer, "Qwen/Qwen3-0.6B")
+    >>> model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B")
+    >>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
+    >>> model, tokenizer, added_tokens = clone_chat_template(model, tokenizer, "Qwen/Qwen3-0.6B")
     ```
     """
     # Load the source tokenizer containing the desired chat template

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -278,18 +278,18 @@ class AsyncGRPOTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl.experimental.async_grpo import AsyncGRPOTrainer
-    from trl.rewards import accuracy_reward
-    from datasets import load_dataset
+    >>> from trl.experimental.async_grpo import AsyncGRPOTrainer
+    >>> from trl.rewards import accuracy_reward
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
+    >>> dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
 
-    trainer = AsyncGRPOTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        reward_funcs=accuracy_reward,
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = AsyncGRPOTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     reward_funcs=accuracy_reward,
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/experimental/bema_for_ref_model/callback.py
+++ b/trl/experimental/bema_for_ref_model/callback.py
@@ -119,9 +119,9 @@ class BEMACallback(_BEMACallback):
     Example:
 
     ```python
-    from trl import BEMACallback
+    >>> from trl import BEMACallback
 
-    trainer = Trainer(..., callbacks=[BEMACallback()])
+    >>> trainer = Trainer(..., callbacks=[BEMACallback()])
     ```
     """
 

--- a/trl/experimental/harbor/__init__.py
+++ b/trl/experimental/harbor/__init__.py
@@ -19,9 +19,9 @@ Train on Harbor agentic task suites with `GRPOTrainer` via `environment_factory`
 imported lazily so this module imports without it.
 
 ```python
-from trl.experimental.harbor import HarborSpec
+>>> from trl.experimental.harbor import HarborSpec
 
-spec = HarborSpec("AdithyaSK/data_agent_rl_environment_train", agent="bash", num_tasks=64)
+>>> spec = HarborSpec("AdithyaSK/data_agent_rl_environment_train", agent="bash", num_tasks=64)
 ```
 """
 

--- a/trl/experimental/harbor/_spec.py
+++ b/trl/experimental/harbor/_spec.py
@@ -18,19 +18,19 @@ Construct **one** ``HarborSpec`` and read three properties off it — ``.train_d
 ``.reward_funcs`` — each plugging into the matching ``GRPOTrainer`` kwarg:
 
 ```python
-from trl import GRPOConfig, GRPOTrainer
-from trl.experimental.harbor import HarborSpec
+>>> from trl import GRPOConfig, GRPOTrainer
+>>> from trl.experimental.harbor import HarborSpec
 
-spec = HarborSpec("AdithyaSK/data_agent_rl_environment_train", agent="bash", num_tasks=64)
+>>> spec = HarborSpec("AdithyaSK/data_agent_rl_environment_train", agent="bash", num_tasks=64)
 
-trainer = GRPOTrainer(
-    model="Qwen/Qwen3.5-4B",
-    args=GRPOConfig(num_generations=8, max_steps=50, max_tool_calling_iterations=25),
-    train_dataset=spec.train_dataset,
-    environment_factory=spec.environment_factory,
-    reward_funcs=spec.reward_funcs,
-)
-trainer.train()
+>>> trainer = GRPOTrainer(
+...     model="Qwen/Qwen3.5-4B",
+...     args=GRPOConfig(num_generations=8, max_steps=50, max_tool_calling_iterations=25),
+...     train_dataset=spec.train_dataset,
+...     environment_factory=spec.environment_factory,
+...     reward_funcs=spec.reward_funcs,
+... )
+>>> trainer.train()
 ```
 
 A Harbor *task* is a directory (``instruction.md`` + ``task.toml`` + ``environment/`` + ``tests/``); the dataset is a

--- a/trl/experimental/merge_model_callback.py
+++ b/trl/experimental/merge_model_callback.py
@@ -308,11 +308,11 @@ class MergeModelCallback(TrainerCallback):
     Example:
 
     ```python
-    from trl.experimental.merge_model_callback import MergeConfig, MergeModelCallback
+    >>> from trl.experimental.merge_model_callback import MergeConfig, MergeModelCallback
 
-    config = MergeConfig()
-    merge_callback = MergeModelCallback(config)
-    trainer = DPOTrainer(..., callbacks=[merge_callback])
+    >>> config = MergeConfig()
+    >>> merge_callback = MergeModelCallback(config)
+    >>> trainer = DPOTrainer(..., callbacks=[merge_callback])
     ```
     """
 

--- a/trl/experimental/minillm/minillm_trainer.py
+++ b/trl/experimental/minillm/minillm_trainer.py
@@ -53,17 +53,17 @@ class MiniLLMTrainer(GRPOTrainer):
     Example:
 
     ```python
-    from datasets import load_dataset
-    from trl.experimental.minillm import MiniLLMTrainer
+    >>> from datasets import load_dataset
+    >>> from trl.experimental.minillm import MiniLLMTrainer
 
-    dataset = load_dataset("trl-lib/tldr", split="train")
+    >>> dataset = load_dataset("trl-lib/tldr", split="train")
 
-    trainer = MiniLLMTrainer(
-        model="Qwen/Qwen3-0.6B",
-        teacher_model="Qwen/Qwen3-1.7B",
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = MiniLLMTrainer(
+    ...     model="Qwen/Qwen3-0.6B",
+    ...     teacher_model="Qwen/Qwen3-1.7B",
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -19,19 +19,19 @@ three properties off of it — ``.train_dataset``, ``.environment_factory``, ``.
 directly into the matching ``GRPOTrainer`` kwarg:
 
 ```python
-from trl import GRPOConfig, GRPOTrainer
-from trl.experimental.openreward import OpenRewardSpec
+>>> from trl import GRPOConfig, GRPOTrainer
+>>> from trl.experimental.openreward import OpenRewardSpec
 
-spec = OpenRewardSpec("Eigent/SETA", num_tasks=64)
+>>> spec = OpenRewardSpec("Eigent/SETA", num_tasks=64)
 
-trainer = GRPOTrainer(
-    model="Qwen/Qwen3-4B",
-    args=GRPOConfig(num_generations=2, max_steps=5, max_tool_calling_iterations=20),
-    train_dataset=spec.train_dataset,
-    environment_factory=spec.environment_factory,
-    reward_funcs=spec.reward_funcs,
-)
-trainer.train()
+>>> trainer = GRPOTrainer(
+...     model="Qwen/Qwen3-4B",
+...     args=GRPOConfig(num_generations=2, max_steps=5, max_tool_calling_iterations=20),
+...     train_dataset=spec.train_dataset,
+...     environment_factory=spec.environment_factory,
+...     reward_funcs=spec.reward_funcs,
+... )
+>>> trainer.train()
 ```
 
 Backed by the official ``openreward`` SDK (lazy-imported); install with ``pip install trl[openreward]``.

--- a/trl/experimental/papo/papo_trainer.py
+++ b/trl/experimental/papo/papo_trainer.py
@@ -39,39 +39,38 @@ class PAPOTrainer(GRPOTrainer):
     Example:
 
     ```python
-    from datasets import load_dataset
-    from trl.experimental.papo import PAPOTrainer, PAPOConfig
+    >>> from datasets import load_dataset
+    >>> from trl.experimental.papo import PAPOTrainer, PAPOConfig
 
-    dataset = load_dataset("your-vlm-dataset", split="train")
-
-
-    def reward_func(completions, **kwargs):
-        # Your reward function for multimodal reasoning
-        return [compute_reward(c) for c in completions]
+    >>> dataset = load_dataset("your-vlm-dataset", split="train")
 
 
+    >>> def reward_func(completions, **kwargs):
+    ...     # Your reward function for multimodal reasoning
+    ...     return [compute_reward(c) for c in completions]
     # PAPO-G
-    config = PAPOConfig(
-        loss_type="grpo",  # Use GRPO as base
-        perception_loss_weight=0.1,
-        mask_ratio=0.3,
-    )
 
+    >>> config = PAPOConfig(
+    ...     loss_type="grpo",  # Use GRPO as base
+    ...     perception_loss_weight=0.1,
+    ...     mask_ratio=0.3,
+    ... )
     # PAPO-G
-    config = PAPOConfig(
-        loss_type="dapo",  # Use DAPO as base
-        perception_loss_weight=0.1,
-        mask_ratio=0.3,
-    )
 
-    trainer = PAPOTrainer(
-        model="Qwen/Qwen2-VL-2B-Instruct",
-        reward_funcs=reward_func,
-        args=config,
-        train_dataset=dataset,
-    )
+    >>> config = PAPOConfig(
+    ...     loss_type="dapo",  # Use DAPO as base
+    ...     perception_loss_weight=0.1,
+    ...     mask_ratio=0.3,
+    ... )
 
-    trainer.train()
+    >>> trainer = PAPOTrainer(
+    ...     model="Qwen/Qwen2-VL-2B-Instruct",
+    ...     reward_funcs=reward_func,
+    ...     args=config,
+    ...     train_dataset=dataset,
+    ... )
+
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/experimental/sdft/teacher_sync.py
+++ b/trl/experimental/sdft/teacher_sync.py
@@ -74,13 +74,13 @@ class PEFTAdapterEMACallback(TrainerCallback):
 
     Usage:
         ```python
-        trainer.add_callback(
-            PEFTAdapterEMACallback(
-                model=model,
-                teacher_adapter_name="teacher",
-                update_rate=0.05,
-            )
-        )
+        >>> trainer.add_callback(
+        ...     PEFTAdapterEMACallback(
+        ...         model=model,
+        ...         teacher_adapter_name="teacher",
+        ...         update_rate=0.05,
+        ...     )
+        ... )
         ```
     """
 

--- a/trl/experimental/sdpo/teacher_sync.py
+++ b/trl/experimental/sdpo/teacher_sync.py
@@ -74,13 +74,13 @@ class PEFTAdapterEMACallback(TrainerCallback):
 
     Usage:
         ```python
-        trainer.add_callback(
-            PEFTAdapterEMACallback(
-                model=model,
-                teacher_adapter_name="teacher",
-                update_rate=0.05,
-            )
-        )
+        >>> trainer.add_callback(
+        ...     PEFTAdapterEMACallback(
+        ...         model=model,
+        ...         teacher_adapter_name="teacher",
+        ...         update_rate=0.05,
+        ...     )
+        ... )
         ```
     """
 

--- a/trl/extras/profiling.py
+++ b/trl/extras/profiling.py
@@ -147,17 +147,17 @@ def profiling_context(trainer: Trainer, name: str) -> ProfilingContext:
 
     Example:
     ```python
-    from transformers import Trainer
-    from trl.extras.profiling import profiling_context
+    >>> from transformers import Trainer
+    >>> from trl.extras.profiling import profiling_context
 
 
-    class MyTrainer(Trainer):
-        def some_method(self):
-            A = np.random.rand(1000, 1000)
-            B = np.random.rand(1000, 1000)
-            with profiling_context(self, "matrix_multiplication"):
-                # Code to profile: simulate a computationally expensive operation
-                result = A @ B  # Matrix multiplication
+    >>> class MyTrainer(Trainer):
+    ...     def some_method(self):
+    ...         A = np.random.rand(1000, 1000)
+    ...         B = np.random.rand(1000, 1000)
+    ...         with profiling_context(self, "matrix_multiplication"):
+    ...             # Code to profile: simulate a computationally expensive operation
+    ...             result = A @ B  # Matrix multiplication
     ```
     """
     context_name = f"{trainer.__class__.__name__}.{name}"
@@ -187,17 +187,17 @@ def profiling_decorator(func: Callable) -> Callable:
 
     Example:
     ```python
-    from transformers import Trainer
-    from trl.extras.profiling import profiling_decorator
+    >>> from transformers import Trainer
+    >>> from trl.extras.profiling import profiling_decorator
 
 
-    class MyTrainer(Trainer):
-        @profiling_decorator
-        def some_method(self):
-            A = np.random.rand(1000, 1000)
-            B = np.random.rand(1000, 1000)
-            # Code to profile: simulate a computationally expensive operation
-            result = A @ B
+    >>> class MyTrainer(Trainer):
+    ...     @profiling_decorator
+    ...     def some_method(self):
+    ...         A = np.random.rand(1000, 1000)
+    ...         B = np.random.rand(1000, 1000)
+    ...         # Code to profile: simulate a computationally expensive operation
+    ...         result = A @ B
     ```
     """
 

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -112,10 +112,10 @@ class VLLMClient:
         There are several ways to initialize the client:
 
         ```python
-        VLLMClient(base_url="http://localhost:8000")
-        VLLMClient(base_url="http://192.168.1.100:8000")
-        VLLMClient(host="localhost", server_port=8000)
-        VLLMClient(host="192.168.1.100", server_port=8000)
+        >>> VLLMClient(base_url="http://localhost:8000")
+        >>> VLLMClient(base_url="http://192.168.1.100:8000")
+        >>> VLLMClient(host="localhost", server_port=8000)
+        >>> VLLMClient(host="192.168.1.100", server_port=8000)
         ```
     """
 

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -126,8 +126,8 @@ def _unwrap_model_for_generation(
 
     Example:
     ```python
-    with _unwrap_model_for_generation(model, accelerator) as unwrapped_model:
-        generated_outputs = unwrapped_model.generate(input_ids)
+    >>> with _unwrap_model_for_generation(model, accelerator) as unwrapped_model:
+    ...     generated_outputs = unwrapped_model.generate(input_ids)
     ```
     """
     unwrapped_model = accelerator.unwrap_model(model)

--- a/trl/rewards/other_rewards.py
+++ b/trl/rewards/other_rewards.py
@@ -102,12 +102,12 @@ def get_soft_overlong_punishment(max_completion_len: int, soft_punish_cache: int
 
     Example:
     ```python
-    from trl.rewards import get_soft_overlong_punishment
+    >>> from trl.rewards import get_soft_overlong_punishment
 
-    soft_overlong_punishment = get_soft_overlong_punishment(max_completion_len=100, soft_punish_cache=20)
-    completion_ids = [[1] * 90]  # simulating a completion with 90 tokens. 90 is between 80 and 100.
-    rewards = soft_overlong_punishment(completion_ids)
-    print(rewards)  # [-0.5]
+    >>> soft_overlong_punishment = get_soft_overlong_punishment(max_completion_len=100, soft_punish_cache=20)
+    >>> completion_ids = [[1] * 90]  # simulating a completion with 90 tokens. 90 is between 80 and 100.
+    >>> rewards = soft_overlong_punishment(completion_ids)
+    >>> print(rewards)  # [-0.5]
     ```
     """
     return _SoftOverlongPunishment(max_completion_len, soft_punish_cache)

--- a/trl/rewards/other_rewards.py
+++ b/trl/rewards/other_rewards.py
@@ -106,8 +106,8 @@ def get_soft_overlong_punishment(max_completion_len: int, soft_punish_cache: int
 
     >>> soft_overlong_punishment = get_soft_overlong_punishment(max_completion_len=100, soft_punish_cache=20)
     >>> completion_ids = [[1] * 90]  # simulating a completion with 90 tokens. 90 is between 80 and 100.
-    >>> rewards = soft_overlong_punishment(completion_ids)
-    >>> print(rewards)  # [-0.5]
+    >>> soft_overlong_punishment(completion_ids)
+    >>> [-0.5]
     ```
     """
     return _SoftOverlongPunishment(max_completion_len, soft_punish_cache)

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -416,15 +416,12 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
 
     Example:
     ```python
-    from trl import DatasetMixtureConfig, get_dataset
-    from trl.scripts.utils import DatasetConfig
+    >>> from trl import DatasetMixtureConfig, get_dataset
+    >>> from trl.scripts.utils import DatasetConfig
 
-    mixture_config = DatasetMixtureConfig(datasets=[DatasetConfig(path="trl-lib/tldr")])
-    dataset = get_dataset(mixture_config)
-    print(dataset)
-    ```
-
-    ```
+    >>> mixture_config = DatasetMixtureConfig(datasets=[DatasetConfig(path="trl-lib/tldr")])
+    >>> dataset = get_dataset(mixture_config)
+    >>> print(dataset)
     DatasetDict({
         train: Dataset({
             features: ['prompt', 'completion'],

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -420,8 +420,7 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
     >>> from trl.scripts.utils import DatasetConfig
 
     >>> mixture_config = DatasetMixtureConfig(datasets=[DatasetConfig(path="trl-lib/tldr")])
-    >>> dataset = get_dataset(mixture_config)
-    >>> print(dataset)
+    >>> get_dataset(mixture_config)
     DatasetDict({
         train: Dataset({
             features: ['prompt', 'completion'],

--- a/trl/skills/skills.py
+++ b/trl/skills/skills.py
@@ -84,15 +84,17 @@ def resolve_target_path(target: str | Path, scope: str = "project") -> Path:
 
     Example:
         ```python
-        from trl.skills import resolve_target_path
+        >>> from trl.skills import resolve_target_path
 
-        # Resolve agent name with scope
-        path = resolve_target_path("claude", "global")
-        print(path)  # /home/user/.claude/skills
+        >>> # Resolve agent name with scope
+        >>> path = resolve_target_path("claude", "global")
+        >>> print(path)
+        /home/user/.claude/skills
 
-        # Resolve custom path
-        path = resolve_target_path("/custom/skills")
-        print(path)  # /custom/skills
+        >>> # Resolve custom path
+        >>> path = resolve_target_path("/custom/skills")
+        >>> print(path)
+        /custom/skills
         ```
     """
     if isinstance(target, Path):
@@ -148,19 +150,22 @@ def list_skills(target: str | Path | None = None, scope: str = "project") -> lis
 
     Example:
         ```python
-        from trl.skills import list_skills
+        >>> from trl.skills import list_skills
 
-        # List TRL's built-in skills
-        skills = list_skills()
-        print(skills)  # ['trl-training']
+        >>> # List TRL's built-in skills
+        >>> skills = list_skills()
+        >>> print(skills)
+        ['trl-training']
 
-        # List skills installed for Claude globally
-        installed = list_skills(target="claude", scope="global")
-        print(installed)  # ['trl-training', 'custom-skill']
+        >>> # List skills installed for Claude globally
+        >>> installed = list_skills(target="claude", scope="global")
+        >>> print(installed)
+        ['trl-training', 'custom-skill']
 
-        # List skills in custom directory
-        custom = list_skills(target="/path/to/skills")
-        print(custom)  # [...]
+        >>> # List skills in custom directory
+        >>> custom = list_skills(target="/path/to/skills")
+        >>> print(custom)
+        [...]
         ```
     """
     if target is None:
@@ -270,16 +275,16 @@ def install_skill(
 
     Example:
         ```python
-        from trl.skills import install_skill
+        >>> from trl.skills import install_skill
 
-        # Install to Claude's global skills directory
-        install_skill("trl-training", target="claude", scope="global")
+        >>> # Install to Claude's global skills directory
+        >>> install_skill("trl-training", target="claude", scope="global")
 
-        # Install to custom directory
-        install_skill("trl-training", target="/path/to/skills")
+        >>> # Install to custom directory
+        >>> install_skill("trl-training", target="/path/to/skills")
 
-        # Overwrite existing installation
-        install_skill("trl-training", target="claude", force=True)
+        >>> # Overwrite existing installation
+        >>> install_skill("trl-training", target="claude", force=True)
         ```
     """
     target_dir = resolve_target_path(target, scope)
@@ -340,13 +345,13 @@ def uninstall_skill(skill_name: str, target: str | Path, scope: str = "project")
 
     Example:
         ```python
-        from trl.skills import uninstall_skill
+        >>> from trl.skills import uninstall_skill
 
-        # Uninstall from Claude's global directory
-        uninstall_skill("trl-training", target="claude", scope="global")
+        >>> # Uninstall from Claude's global directory
+        >>> uninstall_skill("trl-training", target="claude", scope="global")
 
-        # Uninstall from custom directory
-        uninstall_skill("trl-training", target="/path/to/skills")
+        >>> # Uninstall from custom directory
+        >>> uninstall_skill("trl-training", target="/path/to/skills")
         ```
     """
     target_dir = resolve_target_path(target, scope)

--- a/trl/skills/skills.py
+++ b/trl/skills/skills.py
@@ -87,13 +87,11 @@ def resolve_target_path(target: str | Path, scope: str = "project") -> Path:
         >>> from trl.skills import resolve_target_path
 
         >>> # Resolve agent name with scope
-        >>> path = resolve_target_path("claude", "global")
-        >>> print(path)
+        >>> resolve_target_path("claude", "global")
         /home/user/.claude/skills
 
         >>> # Resolve custom path
-        >>> path = resolve_target_path("/custom/skills")
-        >>> print(path)
+        >>> resolve_target_path("/custom/skills")
         /custom/skills
         ```
     """
@@ -153,18 +151,15 @@ def list_skills(target: str | Path | None = None, scope: str = "project") -> lis
         >>> from trl.skills import list_skills
 
         >>> # List TRL's built-in skills
-        >>> skills = list_skills()
-        >>> print(skills)
+        >>> list_skills()
         ['trl-training']
 
         >>> # List skills installed for Claude globally
-        >>> installed = list_skills(target="claude", scope="global")
-        >>> print(installed)
+        >>> list_skills(target="claude", scope="global")
         ['trl-training', 'custom-skill']
 
         >>> # List skills in custom directory
-        >>> custom = list_skills(target="/path/to/skills")
-        >>> print(custom)
+        >>> list_skills(target="/path/to/skills")
         [...]
         ```
     """

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -257,9 +257,9 @@ class LogCompletionsCallback(TrainerCallback):
 
     Usage:
     ```python
-    trainer = DPOTrainer(...)
-    completions_callback = LogCompletionsCallback(trainer=trainer)
-    trainer.add_callback(completions_callback)
+    >>> trainer = DPOTrainer(...)
+    >>> completions_callback = LogCompletionsCallback(trainer=trainer)
+    >>> trainer.add_callback(completions_callback)
     ```
 
     Args:
@@ -628,9 +628,9 @@ class BEMACallback(TrainerCallback):
     Example:
 
     ```python
-    from trl import BEMACallback
+    >>> from trl import BEMACallback
 
-    trainer = Trainer(..., callbacks=[BEMACallback()])
+    >>> trainer = Trainer(..., callbacks=[BEMACallback()])
     ```
     """
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -412,16 +412,16 @@ class DPOTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl import DPOTrainer
-    from datasets import load_dataset
+    >>> from trl import DPOTrainer
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train")
+    >>> dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train")
 
-    trainer = DPOTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = DPOTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -141,18 +141,18 @@ class GRPOTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl import GRPOTrainer
-    from trl.rewards import accuracy_reward
-    from datasets import load_dataset
+    >>> from trl import GRPOTrainer
+    >>> from trl.rewards import accuracy_reward
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
+    >>> dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
 
-    trainer = GRPOTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        reward_funcs=accuracy_reward,
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = GRPOTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     reward_funcs=accuracy_reward,
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -236,16 +236,16 @@ class RewardTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl import RewardTrainer
-    from datasets import load_dataset
+    >>> from trl import RewardTrainer
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train")
+    >>> dataset = load_dataset("trl-lib/ultrafeedback_binarized", split="train")
 
-    trainer = RewardTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = RewardTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -111,18 +111,18 @@ class RLOOTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl import RLOOTrainer
-    from trl.rewards import accuracy_reward
-    from datasets import load_dataset
+    >>> from trl import RLOOTrainer
+    >>> from trl.rewards import accuracy_reward
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
+    >>> dataset = load_dataset("trl-lib/DeepMath-103K", split="train")
 
-    trainer = RLOOTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        reward_funcs=accuracy_reward,
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = RLOOTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     reward_funcs=accuracy_reward,
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -822,16 +822,16 @@ class SFTTrainer(_BaseTrainer):
     Example:
 
     ```python
-    from trl import SFTTrainer
-    from datasets import load_dataset
+    >>> from trl import SFTTrainer
+    >>> from datasets import load_dataset
 
-    dataset = load_dataset("roneneldan/TinyStories", split="train[:1%]")
+    >>> dataset = load_dataset("roneneldan/TinyStories", split="train[:1%]")
 
-    trainer = SFTTrainer(
-        model="Qwen/Qwen2.5-0.5B-Instruct",
-        train_dataset=dataset,
-    )
-    trainer.train()
+    >>> trainer = SFTTrainer(
+    ...     model="Qwen/Qwen2.5-0.5B-Instruct",
+    ...     train_dataset=dataset,
+    ... )
+    >>> trainer.train()
     ```
 
     Args:


### PR DESCRIPTION
Align format of code examples in docstrings.


This PR updates the code examples in docstrings throughout the codebase to use the interactive Python prompt style (`>>>`) for improved clarity and consistency. The changes affect a wide range of files, especially those related to training utilities, experimental trainers, skills management, and reward functions.

### Changes

**Documentation and Example Formatting Updates:**

* Updated all code examples in docstrings to use the `>>>` interactive prompt style, making them clearer and more consistent for users. This affects functions, classes, and usage examples across multiple modules, including `trl/experimental`, `trl/skills/skills.py`, `trl/rewards/other_rewards.py`, `trl/generation/vllm_client.py`, and others.

No functional or behavioral changes are introduced; all updates are strictly to improve documentation and user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits with no changes to executable code paths or configuration defaults.
> 
> **Overview**
> **Documentation-only:** docstring code examples across TRL are reformatted to use interactive Python / doctest conventions (`>>>` on executable lines, `...` for continued blocks) instead of plain script-style snippets.
> 
> The sweep covers trainers (`GRPOTrainer`, `DPOTrainer`, `SFTTrainer`, experimental trainers), callbacks, Harbor/OpenReward specs, skills helpers, profiling utilities, vLLM client docs, and similar API docstrings. A few examples also drop redundant `print()` calls in favor of showing expression results directly (e.g. in `other_rewards.py` and `scripts/utils.py`).
> 
> No runtime, API, or training behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8878c01d386bf6a89343cdc8fbca3645c819d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->