### PR TITLE
Align KTO with DPO: Add evaluate() override

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -348,6 +348,23 @@ class TestKTOTrainer(TrlTestCase):
         )
         assert type(trainer.model).__name__ == "RemoteForCausalLM"
 
+    @pytest.mark.parametrize("precompute_ref_log_probs", [False, True])
+    def test_evaluate_with_raw_dataset(self, precompute_ref_log_probs):
+        # `evaluate` should accept the same (unprocessed) dataset types as the trainer, e.g. a held-out test set
+        # passed directly to `evaluate`. With `precompute_ref_log_probs=True`, the reference log-probs must also be
+        # precomputed for the freshly-passed dataset. See https://github.com/huggingface/trl/issues/6115.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir, precompute_ref_log_probs=precompute_ref_log_probs, report_to="none"
+        )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        metrics = trainer.evaluate(eval_dataset=dataset)
+        assert metrics["eval_loss"] is not None
+
     def test_kto_trainer_with_ref_model_is_model(self):
         training_args = KTOConfig(
             output_dir=self.tmp_dir,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1407,6 +1407,39 @@ class KTOTrainer(_BaseTrainer):
 
         return (loss, outputs) if return_outputs else loss
 
+    def evaluate(
+        self,
+        eval_dataset: Dataset | dict[str, Dataset] | None = None,
+        ignore_keys: list[str] | None = None,
+        metric_key_prefix: str = "eval",
+    ) -> dict[str, float]:
+        # When a dataset is passed directly to `evaluate` (e.g. a held-out test set), preprocess it the same way
+        # `__init__` does, so that `evaluate` accepts the same dataset types as the trainer. `_prepare_dataset` is
+        # idempotent: it skips datasets that are already tokenized. A `str` selects a dataset that was already prepared
+        # at init time, so it's left untouched.
+        if not self._is_vision_dataset and eval_dataset is not None and not isinstance(eval_dataset, str):
+            if isinstance(eval_dataset, dict):
+                eval_dataset = {
+                    key: self._prepare_dataset(dataset, self.processing_class, self.args, key)
+                    for key, dataset in eval_dataset.items()
+                }
+            else:
+                eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
+            # With `precompute_ref_log_probs`, `_compute_loss` reads the reference log-probs from the batch, so they
+            # must be precomputed here as well, mirroring `__init__`.
+            if self.precompute_ref_logps:
+                batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
+                if isinstance(eval_dataset, dict):
+                    eval_dataset = {
+                        name: self._precompute_ref_logps(dataset, name, batch_size)
+                        for name, dataset in eval_dataset.items()
+                    }
+                else:
+                    eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
+        return super().evaluate(
+            eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
+        )
+
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         try:
             if self.use_liger_kernel:


### PR DESCRIPTION
This PR adds an `evaluate()` override to `KTOTrainer`, porting it word-for-word from `DPOTrainer`, so that a raw (untokenized) dataset passed at call time is preprocessed identically to what `__init__` does.

Part of:
- #4786

Follow-up to:
- #6116

### Changes

- Add `evaluate()` override to `KTOTrainer`, ported from `DPOTrainer`: prepares any raw dataset passed at call time via `_prepare_dataset`, then optionally precomputes reference log-probs when `precompute_ref_log_probs=True`, mirroring `__init__` behavior
- Add `test_evaluate_with_raw_dataset` to `TestKTOTrainer`, parametrized over `precompute_ref_log_probs=[False, True]`, mirroring the analogous DPO test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral fix aligned with existing DPO/Reward trainer patterns; limited to eval-time dataset preparation and optional ref log-prob caching, covered by a new integration test.
> 
> **Overview**
> **`KTOTrainer.evaluate()`** now mirrors **`DPOTrainer`**: when you pass a raw (untokenized) eval set at call time—e.g. a held-out test split not wired in at init—it runs **`_prepare_dataset`** first so eval accepts the same dataset shapes as training. Vision datasets and **`str`** eval keys (already-prepared splits) are unchanged.
> 
> If **`precompute_ref_log_probs=True`**, reference log-probs are also precomputed on that call-time dataset before delegating to **`super().evaluate()`**, since **`_compute_loss`** expects **`ref_logps`** on the batch.
> 
> Adds **`test_evaluate_with_raw_dataset`**, parametrized over **`precompute_ref_log_probs`**, asserting **`eval_loss`** is returned when evaluating the raw zen unpaired preference split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1f44f99eb47fd0e97b5596f8e46eb137882c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->