### PR TITLE
Align KTO with DPO: Move all metrics computation from log to _compute_loss

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1250,6 +1250,11 @@ class KTOTrainer(_BaseTrainer):
                 self.accelerator.gather_for_metrics(rejected_logits_sum.nansum()).nansum().item() / all_num_rejected
             )
 
+        if all_num_chosen > 0 and all_num_rejected > 0:
+            self._metrics[mode]["rewards/margins"].append(
+                self._metrics[mode]["rewards/chosen"][-1] - self._metrics[mode]["rewards/rejected"][-1]
+            )
+
         return loss
 
     def _compute_loss(self, model, inputs, return_outputs):
@@ -1401,6 +1406,11 @@ class KTOTrainer(_BaseTrainer):
                 self.accelerator.gather_for_metrics(policy_rejected_logits.nansum()).nansum().item() / all_num_rejected
             )
 
+        if all_num_chosen > 0 and all_num_rejected > 0:
+            self._metrics[mode]["rewards/margins"].append(
+                self._metrics[mode]["rewards/chosen"][-1] - self._metrics[mode]["rewards/rejected"][-1]
+            )
+
         loss = losses.nanmean()
         if self.aux_loss_enabled:
             loss += self.aux_loss_coef * aux_loss
@@ -1451,8 +1461,6 @@ class KTOTrainer(_BaseTrainer):
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"
         metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}  # average the metrics
-        if "rewards/chosen" in metrics and "rewards/rejected" in metrics:
-            metrics["rewards/margins"] = metrics["rewards/chosen"] - metrics["rewards/rejected"]
         # This method can be called both in training and evaluation. When called in evaluation, the keys in `logs`
         # start with "eval_". We need to add the prefix "eval_" to the keys in `metrics` to match the format.
         if mode == "eval":


### PR DESCRIPTION
This PR moves the `rewards/margins` computation out of `log()` and into `_compute_loss`, storing it in `self._metrics[mode]` exactly as DPO does, so the two log() bodies become identical.

Part of:
- #4786

### Changes

**Reward margin tracking improvements:**

* In both `_compute_loss_liger` and `_compute_loss`, the code now appends the difference between the latest chosen and rejected rewards to the `rewards/margins` metric for each batch, enabling more detailed per-batch margin tracking.

**Logging simplification:**

* The calculation of average reward margins in the `log` method has been removed, since margins are now tracked per batch and averaged directly, avoiding redundant computation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only refactor in KTO logging; no change to loss computation or training behavior beyond how reward margin is aggregated for logs.
> 
> **Overview**
> **`rewards/margins` is now recorded in the loss path** (both `_compute_loss` and `_compute_loss_liger`), matching how DPO tracks metrics and supporting the goal of unifying `log()` across trainers (#4786).
> 
> After each step’s chosen/rejected reward metrics are appended, the trainer also appends a per-step margin when the batch has at least one desirable and one undesirable example: the difference between the latest `rewards/chosen` and `rewards/rejected` entries for that step.
> 
> **`log()` no longer derives margins** from the averaged chosen and rejected rewards at log time; it only averages whatever was appended to `self._metrics`, including `rewards/margins` when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbb90f7c75644a55472b2aaae228cabf8fa2eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->