### PR TITLE
Align KTO with DPO: Support sync_ref_model

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -367,6 +367,35 @@ class TestKTOTrainer(TrlTestCase):
                 train_dataset=dataset,
             )
 
+    def test_train_with_sync_ref_model(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            sync_ref_model=True,
+            ref_model_sync_steps=2,  # reduce sync steps to ensure a sync happens
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        assert trainer.ref_model is not None
+        previous_ref_params = {n: param.clone() for n, param in trainer.ref_model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+            new_ref_param = trainer.ref_model.get_parameter(n)
+            assert not torch.equal(previous_ref_params[n], new_ref_param), f"Ref Parameter {n} has not changed."
+
     def test_tokenize_and_process_tokens(self):
         # Pytest/CI often starts background threads before tests run. Under Python 3.12+,
         # using "fork" in a multi-threaded process emits a DeprecationWarning and may deadlock.

--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -81,6 +81,18 @@ class KTOConfig(_BaseConfig):
             Undesirable losses are weighed by this factor to counter unequal number of desirable and undesirable pairs.
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
+        sync_ref_model (`bool`, *optional*, defaults to `False`):
+            Whether to synchronize the reference model with the active model every `ref_model_sync_steps` steps, using
+            the `ref_model_mixup_alpha` parameter. This synchronization originates from the
+            [TR-DPO](https://huggingface.co/papers/2404.09656) paper. `sync_ref_model=True` is not yet compatible with
+            PEFT or `precompute_ref_log_probs=True`.
+        ref_model_mixup_alpha (`float`, *optional*, defaults to `0.6`):
+            α parameter from the TR-DPO paper, which controls the mix between the current policy and the previous
+            reference policy during updates. The reference policy is updated according to the equation: `π_ref = α *
+            π_θ + (1 - α) * π_ref_prev`. To use this parameter, you must set `sync_ref_model=True`.
+        ref_model_sync_steps (`int`, *optional*, defaults to `512`):
+            τ parameter from the TR-DPO paper, which determines how frequently the current policy is synchronized with
+            the reference policy. To use this parameter, you must set `sync_ref_model=True`.
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.
@@ -196,4 +208,28 @@ class KTOConfig(_BaseConfig):
     activation_offloading: bool = field(
         default=False,
         metadata={"help": "Whether to offload the activations to the CPU."},
+    )
+    sync_ref_model: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to synchronize the reference model with the active model every `ref_model_sync_steps` "
+            "steps, using the `ref_model_mixup_alpha` parameter. This synchronization originates from the "
+            "[TR-DPO](https://huggingface.co/papers/2404.09656) paper. `sync_ref_model=True` is not yet compatible "
+            "with PEFT or `precompute_ref_log_probs=True`."
+        },
+    )
+    ref_model_mixup_alpha: float = field(
+        default=0.6,
+        metadata={
+            "help": "α parameter from the TR-DPO paper, which controls the mix between the current policy and the "
+            "previous reference policy during updates. The reference policy is updated according to the equation: "
+            "`π_ref = α * π_θ + (1 - α) * π_ref_prev`. To use this parameter, you must set `sync_ref_model=True`."
+        },
+    )
+    ref_model_sync_steps: int = field(
+        default=512,
+        metadata={
+            "help": "τ parameter from the TR-DPO paper, which determines how frequently the current policy is "
+            "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
+        },
     )

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -54,6 +54,7 @@ from ...import_utils import is_liger_kernel_available
 from ...models import get_act_offloading_ctx_manager
 from ...models.utils import disable_gradient_checkpointing, prepare_deepspeed, prepare_fsdp
 from ...trainer.base_trainer import _BaseTrainer
+from ...trainer.callbacks import SyncRefModelCallback
 from ...trainer.utils import (
     create_model_from_path,
     disable_dropout_in_model,
@@ -733,6 +734,25 @@ class KTOTrainer(_BaseTrainer):
                 self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
+
+        if args.sync_ref_model:
+            if is_peft_model(self.model):
+                raise NotImplementedError(
+                    "You passed `sync_ref_model=True` while using a PEFT model, which is currently not supported. "
+                    "With PEFT, KTOTrainer does not keep a separate reference model in memory; instead, it recovers "
+                    "reference behavior by temporarily disabling the adapter. As a result, there is no standalone "
+                    "`ref_model` instance to synchronize. Use `sync_ref_model=False`, or opt for full fine-tuning if "
+                    "you need a synced reference model. If you need `sync_ref_model` to work with PEFT, please open a "
+                    "feature request at https://github.com/huggingface/trl/issues."
+                )
+            if args.precompute_ref_log_probs:
+                raise ValueError(
+                    "You cannot use `sync_ref_model=True` together with `precompute_ref_log_probs=True`. "
+                    "`precompute_ref_log_probs=True` assumes a fixed reference model, but with `sync_ref_model=True` "
+                    "the reference model is periodically updated during training, making any precomputed reference "
+                    "log-probs stale. Set `precompute_ref_log_probs=False` or disable `sync_ref_model`."
+                )
+            self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
 
         self.use_liger_kernel = args.use_liger_kernel
         # Import Liger kernel if enabled


### PR DESCRIPTION
Align KTO with DPO: Support sync_ref_model.

This PR introduces support for synchronizing the reference model with the active model during KTO training, aligning with DPO. It adds new configuration options to control synchronization behavior, updates the trainer to handle these options, and includes a test to verify the new functionality. The changes also ensure that synchronization is not used with incompatible features such as PEFT or precomputed reference log-probs.

Part of:
- #4786

### Changes

**Reference model synchronization (TR-DPO):**

* Added `sync_ref_model`, `ref_model_mixup_alpha`, and `ref_model_sync_steps` options to `KTOConfig`, allowing users to enable and configure periodic reference model synchronization as in DPO. These options are documented and include appropriate defaults and usage notes. 
* Updated `KTOTrainer` to register the `SyncRefModelCallback` when `sync_ref_model` is enabled, and to raise clear errors if used with PEFT or `precompute_ref_log_probs`, which are currently incompatible with reference model synchronization.

**Testing:**

* Added a new test, `test_train_with_sync_ref_model`, to verify that enabling reference model synchronization updates both the model and reference model parameters during training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reference-policy behavior during KTO (affecting loss/KL terms) and reuses the shared sync callback; mitigated by default-off config and explicit errors for PEFT/precomputed ref logprobs.
> 
> **Overview**
> KTO training can now **periodically update the reference model** from the active policy, matching DPO’s TR-DPO-style behavior instead of keeping a fixed `ref_model` for the whole run.
> 
> `KTOConfig` gains **`sync_ref_model`**, **`ref_model_mixup_alpha`**, and **`ref_model_sync_steps`**. When sync is on, `KTOTrainer` registers the shared **`SyncRefModelCallback`** and **rejects PEFT** and **`precompute_ref_log_probs=True`**, since neither path has a stable in-memory reference to mix.
> 
> A new integration test **`test_train_with_sync_ref_model`** checks that both policy and reference weights move after training with a short sync interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472c7f9c924674c0ced18bc608a737191466334f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->