### PR TITLE
Add support for vLLM 0.23.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.13.0` to `0.22.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.13.0` to `0.23.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.13.0,<=0.22.1",
+    "vllm>=0.13.0,<=0.23.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.13.0") <= Version(_vllm_version) <= Version("0.22.1")):
+        if not (Version("0.13.0") <= Version(_vllm_version) <= Version("0.23.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.13.0 to 0.23.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
## Upgrade on the cluster

```bash
pip install --no-deps https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl
```

Checked the v0.23.0 release notes against the vLLM surface TRL actually uses: **No breaking changes.**

## Relevant

- **Transformers v5 compatibility**: v0.23.0 now targets Transformers v5. TRL's pin is already `transformers>=4.56.2, !=5.1.0` (supports v5), so upgrading vLLM aligns with a transformers-v5 TRL env. Most relevant change.
- **Sparse NCCL weight transfer for in-place updates (#40096)**: touches the weight-sync path. TRL drives its own sync via `collective_rpc`/the vLLM client, so not breaking, but the area to watch if weight-sync regresses.
- **Config validation now rejects 0/negative knobs** (vllm#43794, vllm#44057, vllm#44207, incl. `max_num_scheduled_tokens`). TRL passes `max_num_batched_tokens` etc. Hard-errors now if any resolve to 0 (TRL doesn't pass zeros today).

## Not relevant / unaffected

- Structured outputs (`Parser.parse()` unification) — server-side reasoning/tool-call parsing, not the `StructuredOutputsParams` regex path TRL uses.
- `sleep`/`wake_up`/`reset_prefix_cache`/`collective_rpc`: untouched APIs.
- Bulk of release (DeepSeek-V4, Gemma 4, MRv2, ROCm/XPU/TPU kernels, KV offloading) doesn't intersect TRL.

**Net:** safe to upgrade; mainly compelling if moving to transformers v5.

```
$ pytest tests/test_vllm_client_server.py
========================================== test session starts ===========================================
platform linux -- Python 3.13.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.13.0, datadir-1.8.0, xdist-3.8.0, rerunfailures-15.1, cov-7.1.0
collected 51 items                                                                                       

tests/test_vllm_client_server.py ..................x..................sssssssss.....               [100%]

============================================ warnings summary ============================================
trl/generation/__init__.py:22
  /fsx/qgallouedec/trl/trl/generation/__init__.py:22: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

trl/generation/vllm_client.py:40
  /fsx/qgallouedec/trl/trl/generation/vllm_client.py:40: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

trl/generation/vllm_generation.py:42
  /fsx/qgallouedec/trl/trl/generation/vllm_generation.py:42: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

tests/testing_utils.py:66
  /fsx/qgallouedec/trl/tests/testing_utils.py:66: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    require_vllm = pytest.mark.skipif(not is_vllm_available(), reason="test requires vllm")

tests/test_vllm_client_server.py:39
  /fsx/qgallouedec/trl/tests/test_vllm_client_server.py:39: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_int
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_string
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_torch_device
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_with_token_ids_and_image
  /fsx/qgallouedec/trl/trl/generation/vllm_client.py:132: UserWarning: TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version 0.23.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if not is_vllm_available():

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 41 passed, 9 skipped, 1 xfailed, 12 warnings in 777.08s (0:12:57) ====================

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and documentation-only changes; no logic changes to training or vLLM integration paths.
> 
> **Overview**
> Extends TRL’s supported vLLM range from **0.22.1** to **0.23.0** so installs and runtime checks accept the newer release.
> 
> The cap is updated in the optional `trl[vllm]` dependency in `pyproject.toml`, in `is_vllm_available()` version bounds and warning text in `trl/import_utils.py`, and in the supported-version warning in `docs/source/vllm_integration.md`. No trainer or vLLM client code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8516842371efc04be62506fced85a040b0dcdc12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->