### PR TITLE
Drop vLLM 0.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.13.0,<=0.22.1",
+    "vllm>=0.14.0,<=0.22.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.13.0") <= Version(_vllm_version) <= Version("0.22.1")):
+        if not (Version("0.14.0") <= Version(_vllm_version) <= Version("0.22.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.13.0 to 0.22.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.14.0 to 0.22.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
vLLM v0.13.0 was released 2025-12-19 (~6 months ago).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and version-check-only change; users on vLLM 0.13.x will see warnings and won't satisfy the optional extra pin.
> 
> **Overview**
> Raises the **minimum supported vLLM version from 0.14.0** (previously 0.13.0); the upper bound **0.23.0** is unchanged.
> 
> The `vllm` optional extra in `pyproject.toml` and `is_vllm_available()` in `trl/import_utils.py` now enforce that range and emit the updated compatibility warning when an installed version falls outside it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8099f8781ec8042a4a3b092f3c3c21ba624ee276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->