### PR TITLE
Keep extra columns in unpair_preference_dataset

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -995,7 +995,7 @@ class TestUnpairPreferenceDataset(TrlTestCase):
         )
 
     def test_unpair_preference_dataset_extra_columns(self):
-        # Test that extra columns are dropped (not causing a length mismatch error)
+        # Test that extra columns are preserved and duplicated for chosen and rejected rows
         paired_dataset = Dataset.from_dict(
             {
                 "prompt": ["The sky is", "The sun is"],
@@ -1005,7 +1005,8 @@ class TestUnpairPreferenceDataset(TrlTestCase):
             }
         )
         unpaired_dataset = unpair_preference_dataset(paired_dataset)
-        assert unpaired_dataset.to_dict() == self.unpaired_dataset.to_dict()
+        expected = {**self.unpaired_dataset.to_dict(), "extra": [1, 2, 1, 2]}
+        assert unpaired_dataset.to_dict() == expected
 
     def test_unpair_preference_dataset_iterable(self):
         # Test that an IterableDataset with extra columns is correctly unpaired
@@ -1017,7 +1018,7 @@ class TestUnpairPreferenceDataset(TrlTestCase):
         ]
 
     def test_unpair_preference_dataset_iterable_extra_columns(self):
-        # Test that an IterableDataset with extra columns drops them without error
+        # Test that an IterableDataset with extra columns preserves and duplicates them
         paired_iterable = Dataset.from_dict(
             {
                 "prompt": ["The sky is", "The sun is"],
@@ -1027,9 +1028,9 @@ class TestUnpairPreferenceDataset(TrlTestCase):
             }
         ).to_iterable_dataset()
         unpaired_dataset = unpair_preference_dataset(paired_iterable)
+        expected = {**self.unpaired_dataset.to_dict(), "extra": [1, 2, 1, 2]}
         assert list(unpaired_dataset) == [
-            dict(zip(self.unpaired_dataset.column_names, vals, strict=False))
-            for vals in zip(*self.unpaired_dataset.to_dict().values(), strict=False)
+            dict(zip(expected.keys(), vals, strict=False)) for vals in zip(*expected.values(), strict=False)
         ]
 
     def test_unpair_preference_dataset_dict(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -404,6 +404,9 @@ def _unpair_row(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
     }
     if "prompt" in batch:
         new_batch["prompt"] = batch["prompt"] + batch["prompt"]
+    for k in batch:
+        if k not in ("chosen", "rejected", "prompt"):
+            new_batch[k] = batch[k] + batch[k]
     return new_batch
 
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -417,7 +417,8 @@ def unpair_preference_dataset(
     """
     Unpair a preference dataset.
 
-    The output contains only `"prompt"`, `"completion"`, and `"label"`; all other columns are dropped.
+    The output contains `"prompt"`, `"completion"`, and `"label"` plus any extra columns, which are duplicated for
+    each chosen and rejected row.
 
     Args:
         dataset ([`~datasets.Dataset`] or [`~datasets.DatasetDict`] or [`~datasets.IterableDataset`] or [`~datasets.IterableDatasetDict`]):


### PR DESCRIPTION
Keep extra column in `unpair_preference_dataset`.

This PR fixes unpair_preference_dataset to preserve extra columns instead of silently dropping them, e.g. `chat_template_kwargs`. 

Follow-up to:
- #6059

### Motivation

PR #6059 fixed a ValueError caused by a length mismatch: when a paired dataset had extra columns, those columns kept their original row count (N) after unpairing while "completion" and "label" grew to 2N rows. The fix at the time was to drop all columns with `remove_columns=column_names`, leaving only the function's output. However, this also silently discards valid user data such as `chat_template_kwargs`, breaking per-example tokenization in the KTO trainer.

### Solution

Preserve extra columns in `_unpair_row` by duplicating their values for the chosen and rejected rows, the same way "prompt" is already handled. This keeps all lengths consistent (2N) without discarding user data.

### Changes
- Update _unpair_row to duplicate extra columns alongside chosen and rejected rows
- Update unpair_preference_dataset docstring to reflect that extra columns are now preserved
- Update tests to assert extra columns are preserved rather than dropped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to dataset shaping with updated tests; restores metadata needed by KTO without touching auth or training core logic.
> 
> **Overview**
> **`unpair_preference_dataset`** no longer drops non-core columns when converting paired preference data to unpaired rows. **`_unpair_row`** now copies every column except `chosen` and `rejected` by concatenating each value list with itself (same pattern as `prompt`), so row counts stay at 2N for fields like `chat_template_kwargs`.
> 
> The public docstring and tests were updated to expect preserved, duplicated extras on both `Dataset` and iterable paths instead of silent removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc76c772abb819cf4f9b93feece825baffc2e821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->