### PR TITLE
Align KTO with DPO: Add VLM multi-image test

### DIFF
--- a/scripts/generate_zen_multi_image_dataset.py
+++ b/scripts/generate_zen_multi_image_dataset.py
@@ -234,6 +234,37 @@ def main(test_size, push_to_hub, repo_id):
     conversational_preference_dataset = conversational_preference_dataset.train_test_split(test_size=test_size, shuffle=False)
     if push_to_hub:
         conversational_preference_dataset.push_to_hub(repo_id, config_name="conversational_preference")
+
+    completion = [
+        [{"role": "assistant", "content": [{"type": "text", "text": "Beautiful."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Explicit."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Simple."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Very complicated."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Flat."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Sparse."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Readability."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Yes, special cases are special enough to break the rules."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Practicality."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Warnings."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "When explicitly silenced."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Give up."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "One, and preferably only one."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "French."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Some day."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Yes, often."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "It means it's a bad idea."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "It means it may be a good idea."}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "Namespaces are one honking great idea."}]}],
+    ]
+    label = [True, True, True, False, True, True, True, False, True, False, True, False, True, False, False, True, True, True, True]
+    # Create the images
+    number_of_images = [sum(1 for part in row[0]["content"] if part.get("type") == "image") for row in prompt]
+    sizes = [np.random.randint(32, 64, size=(num_images, 2)) for num_images in number_of_images]
+    images = [[np.random.uniform(low=0.0, high=255.0, size=(h, w, 3)).astype(np.uint8) for h, w in s] for s in sizes]
+    conversational_unpaired_preference_dataset = Dataset.from_dict({"prompt": prompt, "completion": completion, "label": label, "images": images}, features=Features(prompt=Message, completion=Message, label=Value("bool"), images=List(Image())))
+    conversational_unpaired_preference_dataset = conversational_unpaired_preference_dataset.train_test_split(test_size=test_size, shuffle=False)
+    if push_to_hub:
+        conversational_unpaired_preference_dataset.push_to_hub(repo_id, config_name="conversational_unpaired_preference")
     # fmt: on
 
 

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -18,6 +18,7 @@ import torch
 import transformers
 from datasets import Dataset, load_dataset
 from packaging.version import Version
+from packaging.version import parse as parse_version
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.kto import KTOConfig, KTOTrainer
@@ -702,6 +703,46 @@ class TestKTOTrainerVLM(TrlTestCase):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+        ],
+    )
+    @pytest.mark.xfail(
+        parse_version(transformers.__version__) < parse_version("4.57.0"),
+        reason="Mixing text-only and image+text examples is only supported in transformers >= 4.57.0",
+        strict=False,
+    )
+    def test_train_vlm_multi_image(self, model_id):
+        dataset = load_dataset(
+            "trl-internal-testing/zen-multi-image", "conversational_unpaired_preference", split="train"
+        )
+
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
+            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            report_to="none",
+        )
+        trainer = KTOTrainer(
+            model=model_id,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
     def test_train_vlm_apo_zero_unpaired(self):
         # apo_zero_unpaired does not need the KL term: verify that calculate_kl=False path works end-to-end.

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -1133,7 +1133,7 @@ class TestKTOTrainerVLM(TrlTestCase):
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             max_length=None,  # for VLMs, truncating can remove image tokens, leading to errors
-            per_device_train_batch_size=1,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
             report_to="none",
         )
         trainer = KTOTrainer(


### PR DESCRIPTION
Align KTO with DPO: Add VLM multi-image test.

Part of:
- #4786

This PR introduces support for testing vision-language model (VLM) training with datasets containing multiple images per example, and adds a new dataset generation step for this use case. The main changes include a new test for multi-image VLM training, enhancements to dataset generation to include multi-image examples, and minor dependency improvements.

TODO:
- [x] Once validated, run script to generate and push the new config dataset to the Hub

### Changes

### Vision-language model (VLM) multi-image support

* Added a new test method `test_train_vlm_multi_image` to `tests/experimental/test_kto_trainer.py` that verifies VLM training works with examples containing multiple images, using the `"trl-internal-testing/zen-multi-image"` dataset. The test is only run for `transformers` versions >= 4.57.0, where this feature is supported.
* In `scripts/generate_zen_multi_image_dataset.py`, added logic to generate a `conversational_unpaired_preference_dataset` containing prompts, completions, labels, and a variable number of randomly generated images per example, supporting the new multi-image training scenario.

### Dependency and import improvements

* Imported `parse` from `packaging.version` as `parse_version` to simplify version comparisons in the tests.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and synthetic dataset generation only; no changes to KTO training logic or production paths.
> 
> **Overview**
> Adds **KTO** coverage for vision-language training on multi-image, mixed text-only and image+text batches, aligned with the existing DPO multi-image test.
> 
> `scripts/generate_zen_multi_image_dataset.py` now builds and optionally Hub-pushes a **`conversational_unpaired_preference`** config: same multi-image prompts as other zen-multi-image splits, plus `completion`, boolean `label`, and per-row random images.
> 
> `tests/experimental/test_kto_trainer.py` adds **`test_train_vlm_multi_image`** for tiny Qwen2.5-VL on `trl-internal-testing/zen-multi-image` / `conversational_unpaired_preference`, with **`xfail`** when `transformers` &lt; 4.57.0 (mixed modalities). The test checks training loss and that weights update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d67c92372a7ce0e314f73999b12d3f11952996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->