### PR TITLE
Replace parse_version with Version

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -17,7 +17,6 @@ import torch
 import transformers
 from datasets import load_dataset
 from packaging.version import Version
-from packaging.version import parse as parse_version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import torch_device
 from transformers.utils import is_peft_available
@@ -1175,7 +1174,7 @@ class TestDPOTrainerVLM(TrlTestCase):
         ],
     )
     @pytest.mark.xfail(
-        parse_version(transformers.__version__) < parse_version("4.57.0"),
+        Version(transformers.__version__) < Version("4.57.0"),
         reason="Mixing text-only and image+text examples is only supported in transformers >= 4.57.0",
         strict=False,
     )

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -25,7 +25,6 @@ import transformers
 from accelerate.utils.memory import release_memory
 from datasets import Dataset, load_dataset
 from packaging.version import Version
-from packaging.version import parse as parse_version
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
@@ -733,7 +732,7 @@ class TestSFTTrainer(TrlTestCase):
                 tokenizer_name_or_path="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             )
         elif peft_type == "prefix_tuning":
-            if parse_version(peft.__version__) <= Version("0.17.1"):
+            if Version(peft.__version__) <= Version("0.17.1"):
                 pytest.xfail(
                     "Prefix tuning with device_map='auto' is broken in peft 0.17.1 and below. See "
                     "https://github.com/huggingface/peft/issues/2821"
@@ -1881,7 +1880,7 @@ class TestSFTTrainer(TrlTestCase):
         ],
     )
     @pytest.mark.xfail(
-        parse_version(transformers.__version__) < parse_version("4.57.0"),
+        Version(transformers.__version__) < Version("4.57.0"),
         reason="Mixing text-only and image+text examples is only supported in transformers >= 4.57.0",
         strict=False,
     )


### PR DESCRIPTION
Replace parse_version with Version.

This PR refactors version comparison logic in the test files by replacing the use of `parse_version` with direct usage of the `Version` class from the `packaging.version` module. This simplifies the code and removes an unnecessary import.

### Changes

**Refactoring version comparison:**

* Replaced `parse_version(transformers.__version__) < parse_version("4.57.0")` with `Version(transformers.__version__) < Version("4.57.0")` in `test_dpo_trainer.py` and `test_sft_trainer.py` to directly use the `Version` class for version checks. 
* Replaced `parse_version(peft.__version__) <= Version("0.17.1")` with `Version(peft.__version__) <= Version("0.17.1")` in `test_sft_trainer.py`.

**Code cleanup:**

* Removed the unused import of `parse as parse_version` from `packaging.version` in both `test_dpo_trainer.py` and `test_sft_trainer.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test import and version-comparison style changed; no production code or test logic altered.
> 
> **Overview**
> Test-only cleanup in `test_dpo_trainer.py` and `test_sft_trainer.py`: version gates for transformers/peft now call `Version(...)` directly instead of wrapping strings with `parse_version`, and the redundant `parse as parse_version` import is removed.
> 
> Behavior of skip/xfail conditions (e.g. transformers ≥ 4.57.0 for multi-image VLM tests, peft ≤ 0.17.1 for prefix tuning) is unchanged; this aligns those spots with the rest of the test suite, which already uses `Version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e87e5f7a9fb9696ae86ee6e4acdff3e96e4552f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->