### PR TITLE
feat(`grpo_trainer.py`): STARE — Surprisal-guided Token-Level Advantage Reweighting

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -683,6 +683,40 @@ training_args = GRPOConfig(
 )
 ```
 
+
+### STARE: Surprisal-Guided Token-Level Advantage Reweighting for Policy Entropy Stability
+
+**📜 Paper**: https://huggingface.co/papers/2606.19236
+
+STARE addresses policy entropy collapse in PPO/GRPO-style RL on language models. A first-order analysis of per-token entropy dynamics shows that the change in entropy is proportional to the product of a token's advantage and an entropy-sensitivity term that grows with the token's surprisal \\( s_{i,t} = -\log \pi_\theta(o_{i,t}) \\) — so updates on high-surprisal tokens dominate how fast the policy loses (or keeps) exploration. STARE identifies the *entropy-critical token subset* via a top-fraction-by-surprisal selection within each advantage-sign partition and reweights the per-token PG loss of those tokens, gated by a closed-loop target-entropy signal.
+
+The STARE objective wraps the standard GRPO dual-clip surrogate with a token-level reweighting factor \\( \omega_{i,t} \\):
+
+$$
+\mathcal{J}_{\text{STARE}}(\theta) = \mathbb{E}_{q, \{o_i\}} \left[ \frac{1}{\sum_i |o_i|} \sum_{i=1}^{G} \sum_{t=1}^{|o_i|} \omega_{i,t} \cdot \min\left( w_{i,t}(\theta) \hat{A}_{i,t},\ \operatorname{clip}(w_{i,t}(\theta), 1-\epsilon, 1+\epsilon)\, \hat{A}_{i,t} \right) \right]
+$$
+
+with \\( w_{i,t}(\theta) = \pi_\theta(o_{i,t} \mid q, o_{i,<t}) / \pi_{\text{old}}(o_{i,t} \mid q, o_{i,<t}) \\) the per-token importance ratio. The reweighting factor is
+
+$$
+\omega_{i,t} = \begin{cases} W > 1 & \text{if } (i,t) \in L^+ \text{ (positive-advantage critical tokens)} \\ M < 1 & \text{if } (i,t) \in L^- \text{ and variant } = C2 \\ 1 & \text{otherwise} \end{cases}
+$$
+
+active only when the closed-loop gate is open: \\( \mathbb{1}[\bar{H}_k < H_{\text{tgt}}] \\), where \\( \bar{H}_k \\) is the batch-mean policy entropy and \\( H_{\text{tgt}} \\) is the target floor. When the gate stays closed, all weights revert to 1 and STARE degrades to vanilla GRPO.
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    loss_type="stare",
+    stare_variant="O1",  # "O1" (one-sided amplification, default) or "C2" (dual-sided regulation)
+    stare_top_p_ratio=0.1,  # paper Section 4.1 default
+    stare_reweight_w=1.1,  # multiplicative weight for L+ (positive-advantage critical tokens)
+    stare_reweight_m=0.9,  # multiplicative weight for L- (only active when variant="C2")
+    stare_target_entropy=0.3,  # closed-loop gate floor (paper Section 4.3)
+)
+```
+
 ## Optimal Advantage Regression
 
 Papers relating to the [`experimental.a2po.A2POTrainer`].

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -540,6 +540,10 @@ class TestGRPOTrainer(TrlTestCase):
     @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
     @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo", "stare"])
     def test_train_loss_types(self, loss_type, use_liger_kernel):
+        if loss_type == "stare" and use_liger_kernel:
+            pytest.skip(
+                "STARE is not yet supported with use_liger_kernel=True (validated by test_stare_rejects_liger_kernel)"
+            )
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -571,6 +575,24 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_stare_rejects_liger_kernel(self):
+        # STARE's per-token reweighting is not implemented in the fused Liger GRPO loss, so the combination must
+        # raise early rather than silently bypass the STARE objective.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        with pytest.raises(ValueError, match="STARE loss is not yet supported with `use_liger_kernel=True`"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=GRPOConfig(
+                    output_dir=self.tmp_dir,
+                    loss_type="stare",
+                    use_liger_kernel=True,
+                    report_to="none",
+                ),
+                train_dataset=dataset,
+            )
 
     def test_train_with_eval(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -160,6 +160,150 @@ class TestGetHighEntropyMask(TrlTestCase):
         torch.testing.assert_close(entropy_mask, expected_mask)
 
 
+class TestComputeStareTokenWeights(TrlTestCase):
+    """Math properties of STARE per-token PG-loss reweighting (paper Sections 4.1-4.3)."""
+
+    def _logps(self, probs):
+        return torch.log(torch.tensor(probs, dtype=torch.float32))
+
+    def _low_entropy(self, shape):
+        # Far below the default target_entropy=0.3 → closed-loop gate opens.
+        return torch.full(shape, 0.01)
+
+    def _high_entropy(self, shape):
+        # Above target_entropy=0.3 → gate stays closed.
+        return torch.full(shape, 0.5)
+
+    def test_gate_closed_returns_unit_weights(self):
+        # When batch-mean entropy >= target, all weights revert to 1 and STARE degrades to vanilla GRPO.
+        logps = self._logps([[-0.1, -0.2, -3.0, -4.0]])
+        advantages = torch.tensor([[1.0, 1.0, 1.0, 1.0]])
+        mask = torch.ones_like(advantages)
+        weights, stats = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._high_entropy(logps.shape),
+            mask=mask,
+            target_entropy=0.3,
+        )
+        torch.testing.assert_close(weights, torch.ones_like(weights))
+        assert stats["stare/gate_on"] == 0.0
+
+    def test_variant_o1_reweights_only_positive_critical_tokens(self):
+        # Two positive-advantage tokens; the higher-surprisal one is in L+ and gets reweight_w.
+        logps = self._logps([[-0.1, -3.0]])  # surprisal: [0.1, 3.0] → token 1 is critical
+        advantages = torch.tensor([[1.0, 1.0]])
+        mask = torch.ones_like(advantages)
+        weights, stats = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape),
+            mask=mask,
+            variant="O1",
+            top_p_ratio=0.5,  # 50% → ceil(2*0.5)=1 critical token per partition
+            reweight_w=1.5,
+            reweight_m=0.9,
+        )
+        torch.testing.assert_close(weights, torch.tensor([[1.0, 1.5]]))
+        assert stats["stare/gate_on"] == 1.0
+
+    def test_variant_o1_ignores_negative_advantage_tokens(self):
+        # O1 should leave negative-advantage tokens at weight 1 regardless of surprisal.
+        logps = self._logps([[-3.0, -3.0]])
+        advantages = torch.tensor([[1.0, -1.0]])  # one positive, one negative
+        mask = torch.ones_like(advantages)
+        weights, _ = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape),
+            mask=mask,
+            variant="O1",
+            top_p_ratio=1.0,
+            reweight_w=1.5,
+            reweight_m=0.5,
+        )
+        # Positive-advantage token reweighted by W; negative-advantage token untouched.
+        torch.testing.assert_close(weights, torch.tensor([[1.5, 1.0]]))
+
+    def test_variant_c2_reweights_both_partitions(self):
+        # C2 also damps negative-advantage critical tokens.
+        logps = self._logps([[-3.0, -3.0]])
+        advantages = torch.tensor([[1.0, -1.0]])
+        mask = torch.ones_like(advantages)
+        weights, _ = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape),
+            mask=mask,
+            variant="C2",
+            top_p_ratio=1.0,
+            reweight_w=1.5,
+            reweight_m=0.5,
+        )
+        torch.testing.assert_close(weights, torch.tensor([[1.5, 0.5]]))
+
+    def test_mask_excludes_padded_tokens(self):
+        # Padded positions must be excluded from candidate sets even when they have high surprisal.
+        logps = self._logps([[-0.1, -3.0, -5.0]])  # token 2 has highest surprisal but is padded
+        advantages = torch.tensor([[1.0, 1.0, 1.0]])
+        mask = torch.tensor([[1.0, 1.0, 0.0]])  # last token padded
+        weights, stats = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape) * mask,
+            mask=mask,
+            variant="O1",
+            top_p_ratio=0.5,  # ceil(2*0.5)=1 critical token out of 2 valid candidates
+            reweight_w=1.5,
+        )
+        # Token 1 (surprisal 3.0) is the highest-surprisal *valid* candidate.
+        torch.testing.assert_close(weights, torch.tensor([[1.0, 1.5, 1.0]]))
+        # Padded token contributes 0 to the reweight-ratio denominator.
+        assert stats["stare/positive_reweight_ratio"] == 0.5
+
+    def test_top_p_ratio_selects_correct_count(self):
+        # 4 positive-advantage tokens, top_p_ratio=0.5 → ceil(4*0.5)=2 critical tokens.
+        logps = self._logps([[-0.1, -0.2, -3.0, -4.0]])  # tokens 2, 3 have highest surprisal
+        advantages = torch.tensor([[1.0, 1.0, 1.0, 1.0]])
+        mask = torch.ones_like(advantages)
+        weights, _ = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape),
+            mask=mask,
+            variant="O1",
+            top_p_ratio=0.5,
+            reweight_w=1.5,
+        )
+        torch.testing.assert_close(weights, torch.tensor([[1.0, 1.0, 1.5, 1.5]]))
+
+    def test_rejects_invalid_variant(self):
+        logps = self._logps([[-0.5]])
+        advantages = torch.tensor([[1.0]])
+        mask = torch.ones_like(advantages)
+        with pytest.raises(ValueError, match="Unsupported STARE variant"):
+            GRPOTrainer.compute_stare_token_weights(
+                per_token_logps=logps,
+                advantages=advantages,
+                entropies=self._low_entropy(logps.shape),
+                mask=mask,
+                variant="X1",
+            )
+
+    def test_rejects_invalid_top_p_ratio(self):
+        logps = self._logps([[-0.5]])
+        advantages = torch.tensor([[1.0]])
+        mask = torch.ones_like(advantages)
+        with pytest.raises(ValueError, match="stare_top_p_ratio"):
+            GRPOTrainer.compute_stare_token_weights(
+                per_token_logps=logps,
+                advantages=advantages,
+                entropies=self._low_entropy(logps.shape),
+                mask=mask,
+                top_p_ratio=1.5,
+            )
+
+
 class TestGRPORolloutDispatch:
     def _make_trainer(self):
         trainer = object.__new__(GRPOTrainer)
@@ -394,7 +538,7 @@ class TestGRPOTrainer(TrlTestCase):
         assert type(trainer.model).__name__ == "RemoteForCausalLM"
 
     @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
-    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo"])
+    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo", "stare"])
     def test_train_loss_types(self, loss_type, use_liger_kernel):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -277,6 +277,33 @@ class TestComputeStareTokenWeights(TrlTestCase):
         )
         torch.testing.assert_close(weights, torch.tensor([[1.0, 1.0, 1.5, 1.5]]))
 
+    def test_top_p_ratio_is_per_sequence_not_batch_pooled(self):
+        # Two rows, both positive-advantage. Row 0 has uniformly higher surprisal than row 1. Under a
+        # batch-global topk with top_p_ratio=0.5, k=ceil(8*0.5)=4 slots all land in row 0 and row 1
+        # gets nothing (paper Section 4.2 explicitly selects per-response). Verify each row receives
+        # its own ceil(4*0.5)=2 critical tokens.
+        logps = self._logps(
+            [
+                [-3.0, -3.1, -3.2, -3.3],  # row 0: high surprisal
+                [-0.1, -0.2, -0.3, -0.4],  # row 1: low surprisal
+            ]
+        )
+        advantages = torch.tensor([[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]])
+        mask = torch.ones_like(advantages)
+        weights, _ = GRPOTrainer.compute_stare_token_weights(
+            per_token_logps=logps,
+            advantages=advantages,
+            entropies=self._low_entropy(logps.shape),
+            mask=mask,
+            variant="O1",
+            top_p_ratio=0.5,
+            reweight_w=1.5,
+        )
+        row0_selected = int((weights[0] > 1.0).sum().item())
+        row1_selected = int((weights[1] > 1.0).sum().item())
+        assert row0_selected == 2, f"row 0 expected 2 critical tokens, got {row0_selected}"
+        assert row1_selected == 2, f"row 1 expected 2 critical tokens, got {row1_selected} (batch-pooled regression?)"
+
     def test_rejects_invalid_variant(self):
         logps = self._logps([[-0.5]])
         advantages = torch.tensor([[1.0]])

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -212,6 +212,23 @@ class GRPOConfig(_BaseConfig):
             lambda parameter for negative advantages, it is the exponential decay factor in the VESPO loss. Controls
             how aggressively we down-weight samples with high importance weights (when the importance sampling ratio >
             1).
+        stare_variant (`str`, *optional*, defaults to `"O1"`):
+            STARE token-reweighting variant. `"O1"` (default, paper Section 4.2) amplifies positive-advantage
+            entropy-critical tokens only. `"C2"` additionally damps negative-advantage entropy-critical tokens.
+            Introduced in the [STARE paper](https://huggingface.co/papers/2606.19236).
+        stare_top_p_ratio (`float`, *optional*, defaults to `0.1`):
+            Fraction of highest-surprisal tokens (within each advantage-sign partition) treated as entropy-critical
+            and reweighted by STARE. Paper Section 4.1 default is `0.1`.
+        stare_reweight_w (`float`, *optional*, defaults to `1.1`):
+            Multiplicative weight `W > 1` applied to the per-token PG loss of positive-advantage entropy-critical
+            tokens (the set L+). Paper Section 4.2 default is `1.1`.
+        stare_reweight_m (`float`, *optional*, defaults to `0.9`):
+            Multiplicative weight `M < 1` applied to the per-token PG loss of negative-advantage entropy-critical
+            tokens (the set L-). Only active when `stare_variant="C2"`. Paper Section 4.2 default is `0.9`.
+        stare_target_entropy (`float`, *optional*, defaults to `0.3`):
+            Target policy entropy floor for STARE's closed-loop gate (paper Section 4.3). The gate opens
+            (reweighting is active) when the batch-mean policy entropy falls below this value; otherwise weights
+            revert to 1 and STARE degrades to vanilla GRPO. Paper default is `0.3`.
         importance_sampling_level (`str`, *optional*, defaults to `"token"`):
             Controls whether importance sampling ratios are computed at the `"token"` or `"sequence"` level. `"token"`
             keeps the raw per-token log-probability ratios (one weight per token). `"sequence"` averages the
@@ -272,6 +289,10 @@ class GRPOConfig(_BaseConfig):
             - `"vespo"`: Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth,
               asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in
               the [VESPO paper](https://huggingface.co/papers/2602.10693).
+            - `"stare"`: Surprisal-Guided Token-Level Advantage Reweighting for Policy Entropy Stability. Wraps the
+              GRPO dual-clip surrogate and reweights the per-token PG loss of entropy-critical tokens (the
+              highest-surprisal tokens within each advantage-sign partition), gated by a closed-loop target-entropy
+              signal. Introduced in the [STARE paper](https://huggingface.co/papers/2606.19236).
         mask_truncated_completions (`bool`, *optional*, defaults to `False`):
             When enabled, truncated completions are excluded from the loss calculation, preventing them from being
             incorrectly penalized and introducing noise during training. According to the
@@ -750,6 +771,44 @@ class GRPOConfig(_BaseConfig):
             "sampling ratio > 1)."
         },
     )
+    stare_variant: str = field(
+        default="O1",
+        metadata={
+            "help": "STARE token-reweighting variant. `'O1'` (default, paper Section 4.2) amplifies positive-advantage "
+            "entropy-critical tokens only. `'C2'` additionally damps negative-advantage entropy-critical tokens. "
+            "Introduced in the [STARE paper](https://huggingface.co/papers/2606.19236)."
+        },
+    )
+    stare_top_p_ratio: float = field(
+        default=0.1,
+        metadata={
+            "help": "Fraction of highest-surprisal tokens (within each advantage-sign partition) treated as "
+            "entropy-critical and reweighted by STARE. Paper Section 4.1 default is `0.1`."
+        },
+    )
+    stare_reweight_w: float = field(
+        default=1.1,
+        metadata={
+            "help": "Multiplicative weight `W > 1` applied to the per-token PG loss of positive-advantage "
+            "entropy-critical tokens (the set L+). Paper Section 4.2 default is `1.1`."
+        },
+    )
+    stare_reweight_m: float = field(
+        default=0.9,
+        metadata={
+            "help": "Multiplicative weight `M < 1` applied to the per-token PG loss of negative-advantage "
+            "entropy-critical tokens (the set L-). Only active when `stare_variant='C2'`. Paper Section 4.2 default "
+            "is `0.9`."
+        },
+    )
+    stare_target_entropy: float = field(
+        default=0.3,
+        metadata={
+            "help": "Target policy entropy floor for STARE's closed-loop gate (paper Section 4.3). The gate opens "
+            "(reweighting is active) when the batch-mean policy entropy falls below this value; otherwise weights "
+            "revert to 1 and STARE degrades to vanilla GRPO. Paper default is `0.3`."
+        },
+    )
     importance_sampling_level: str = field(
         default="token",
         metadata={
@@ -824,6 +883,10 @@ class GRPOConfig(_BaseConfig):
             "'vespo': Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth, "
             "asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in "
             "the [VESPO paper](https://huggingface.co/papers/2602.10693)."
+            "'stare': Surprisal-Guided Token-Level Advantage Reweighting for Policy Entropy Stability. Wraps the "
+            "GRPO dual-clip surrogate and reweights the per-token PG loss of entropy-critical tokens (the "
+            "highest-surprisal tokens within each advantage-sign partition), gated by a closed-loop target-entropy "
+            "signal. Introduced in the [STARE paper](https://huggingface.co/papers/2606.19236)."
         },
     )
     mask_truncated_completions: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3013,6 +3013,106 @@ class GRPOTrainer(_BaseTrainer):
 
         return phi_seq  # (B, 1)
 
+    @staticmethod
+    @torch.no_grad()
+    def compute_stare_token_weights(
+        per_token_logps: torch.Tensor,
+        advantages: torch.Tensor,
+        entropies: torch.Tensor,
+        mask: torch.Tensor,
+        variant: str = "O1",
+        top_p_ratio: float = 0.1,
+        reweight_w: float = 1.1,
+        reweight_m: float = 0.9,
+        target_entropy: float = 0.3,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        """
+        Compute STARE per-token PG-loss reweighting factors (paper Sections 4.1-4.3).
+
+        Splits valid response tokens by trajectory-level advantage sign into T+ = {A > 0} and T- = {A < 0}. Within
+        each set, ranks tokens in descending order of surprisal ``s = -log pi_theta(o)`` and selects the top
+        ``top_p_ratio`` to form the entropy-critical sets L+ (and L- for variant C2). The returned weights ``omega``
+        multiply the per-token PG loss:
+
+            - Variant ``"O1"`` (default, one-sided amplification): omega = W on L+, else 1.
+            - Variant ``"C2"`` (dual-sided regulation):           omega = W on L+, M on L-, else 1.
+
+        Gated by the closed-loop target-entropy signal: when the batch-mean policy entropy is at or above
+        ``target_entropy``, the gate stays closed and all weights revert to 1 (STARE degrades to vanilla GRPO).
+
+        Args:
+            per_token_logps: ``(B, T)`` current-policy token log-probs. Surprisal is ``-per_token_logps``.
+            advantages: ``(B, T)`` per-token advantages (the shared trajectory-level GRPO advantage broadcast over
+                tokens).
+            entropies: ``(B, T)`` per-token entropy from the actor forward pass. Used to compute the batch-mean
+                entropy ``H_bar`` that drives the closed-loop gate.
+            mask: ``(B, T)`` response-token mask (1 for response tokens).
+            variant: ``"O1"`` (default) or ``"C2"`` per paper Section 4.2.
+            top_p_ratio: Fraction of entropy-critical tokens to reweight within each partition.
+            reweight_w: Multiplicative weight ``W > 1`` for L+ (positive-advantage critical tokens).
+            reweight_m: Multiplicative weight ``M < 1`` for L- (negative-advantage critical tokens; ``"C2"`` only).
+            target_entropy: Entropy floor for the closed-loop gate (paper Section 4.3).
+
+        Returns:
+            weights: ``(B, T)`` reweighting factors (default 1.0). Scales the per-token PG loss in-place.
+            stats: Scalar metrics describing the selection and the applied weights.
+        """
+        if variant not in {"O1", "C2"}:
+            raise ValueError(f"Unsupported STARE variant: {variant!r}. Expected 'O1' or 'C2'.")
+        if not 0.0 <= top_p_ratio <= 1.0:
+            raise ValueError(f"Invalid stare_top_p_ratio: {top_p_ratio}. Expected a value in [0, 1].")
+
+        weights = torch.ones_like(advantages)
+        valid = mask > 0
+        valid_count = valid.float().sum().clamp_min(1.0)
+
+        # Closed-loop gate: batch-mean policy entropy vs target (paper Section 4.3).
+        batch_mean_entropy = (entropies.detach().float() * valid.float()).sum() / valid_count
+        gate_on = bool(batch_mean_entropy.item() < target_entropy)
+
+        positive_candidates = valid & (advantages > 0)
+        negative_candidates = valid & (advantages < 0)
+
+        # Surprisal s = -log pi_theta(o); detached because it only drives token selection.
+        surprisal = -per_token_logps.detach()
+
+        def top_surprisal_mask(candidate_mask: torch.Tensor) -> torch.Tensor:
+            """Select the top-``top_p_ratio`` highest-surprisal tokens within ``candidate_mask``."""
+            candidate_count = int(candidate_mask.sum().item())
+            selected = torch.zeros_like(candidate_mask, dtype=torch.bool)
+            if candidate_count == 0 or top_p_ratio <= 0.0:
+                return selected
+            # ceil(candidate_count * top_p_ratio), at least 1 token.
+            k = max(1, math.ceil(candidate_count * top_p_ratio))
+            k = min(k, candidate_count)
+            candidate_values = surprisal[candidate_mask]
+            _, topk_local_idx = torch.topk(candidate_values, k=k, largest=True)
+            flat_candidate_idx = candidate_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+            flat_selected_idx = flat_candidate_idx[topk_local_idx]
+            selected.reshape(-1)[flat_selected_idx] = True
+            return selected
+
+        l_plus = top_surprisal_mask(positive_candidates)
+        l_minus = (
+            top_surprisal_mask(negative_candidates) if variant == "C2" else torch.zeros_like(valid, dtype=torch.bool)
+        )
+
+        if gate_on:
+            weights = torch.where(l_plus, torch.full_like(weights, reweight_w), weights)
+            if variant == "C2":
+                weights = torch.where(l_minus, torch.full_like(weights, reweight_m), weights)
+
+        stats = {
+            "stare/gate_on": float(gate_on),
+            "stare/batch_entropy": float(batch_mean_entropy.item()),
+            "stare/positive_reweight_ratio": float((l_plus.float() * valid.float()).sum().item() / valid_count.item()),
+            "stare/negative_reweight_ratio": float(
+                (l_minus.float() * valid.float()).sum().item() / valid_count.item()
+            ),
+            "stare/mean_weight": float((weights * valid.float()).sum().item() / valid_count.item()),
+        }
+        return weights, stats
+
     def _compute_loss(self, model, inputs):
         # Compute the per-token log probabilities for the model
         prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
@@ -3130,6 +3230,28 @@ class GRPOTrainer(_BaseTrainer):
                 lambda_neg=self.args.vespo_lambda_neg,
             )
             per_token_loss = -phi_seq * advantages * per_token_logps
+        elif self.loss_type == "stare":
+            # Vanilla GRPO dual-clip surrogate (paper Section 4.2 / Algorithm 1 base).
+            coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
+            if self.args.delta is not None:
+                coef_1 = torch.clamp(coef_1, max=self.args.delta)
+            per_token_loss1 = coef_1 * advantages
+            per_token_loss2 = coef_2 * advantages
+            per_token_loss = -torch.min(per_token_loss1, per_token_loss2)
+
+            # STARE token-level PG-loss reweighting (paper Sections 4.1-4.3).
+            stare_weights, stare_stats = self.compute_stare_token_weights(
+                per_token_logps=per_token_logps,
+                advantages=advantages,
+                entropies=entropies,
+                mask=mask,
+                variant=self.args.stare_variant,
+                top_p_ratio=self.args.stare_top_p_ratio,
+                reweight_w=self.args.stare_reweight_w,
+                reweight_m=self.args.stare_reweight_m,
+                target_entropy=self.args.stare_target_entropy,
+            )
+            per_token_loss = per_token_loss * stare_weights
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}")
 
@@ -3151,7 +3273,7 @@ class GRPOTrainer(_BaseTrainer):
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             policy_loss = loss.detach()
             loss = loss / normalizer
-        elif self.loss_type == "bnpo":
+        elif self.loss_type in ["bnpo", "stare"]:
             loss = (per_token_loss * mask).sum() / mask.sum().clamp(min=1.0)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             policy_loss = loss.detach()
@@ -3269,7 +3391,7 @@ class GRPOTrainer(_BaseTrainer):
 
         self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
 
-        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo", "stare"]:
             # Compute the clipped probability ratios
             is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)
             is_high_clipped = (coef_1 > 1 + self.epsilon_high) & (advantages > 0)
@@ -3286,6 +3408,10 @@ class GRPOTrainer(_BaseTrainer):
             self._metrics[mode]["cispo_clip_ratio"].append(global_masked_mean(is_cispo_clipped.float()))
         elif self.loss_type == "vespo":
             self._metrics[mode]["vespo/phi_seq_mean"].append(global_masked_mean(phi_seq))
+
+        if self.loss_type == "stare":
+            for stat_name, stat_value in stare_stats.items():
+                self._metrics[mode][stat_name].append(stat_value)
 
         return loss
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -928,6 +928,14 @@ class GRPOTrainer(_BaseTrainer):
                     f"'token_mask'. Got: {self.vllm_importance_sampling_mode}."
                 )
 
+        if self.loss_type == "stare" and args.use_liger_kernel:
+            raise ValueError(
+                "STARE loss is not yet supported with `use_liger_kernel=True`. The fused Liger GRPO loss does not "
+                "currently apply STARE's per-token reweighting, so enabling both would silently bypass the STARE "
+                "objective. Set `use_liger_kernel=False` (the default) to use `loss_type='stare'`, or open a "
+                "follow-up issue if Liger-fused STARE is needed."
+            )
+
         # Multi-step
         self.num_iterations = args.num_iterations  # = 𝜇 in the GRPO paper
         self.epsilon_low = args.epsilon

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3085,19 +3085,26 @@ class GRPOTrainer(_BaseTrainer):
         surprisal = -per_token_logps.detach()
 
         def top_surprisal_mask(candidate_mask: torch.Tensor) -> torch.Tensor:
-            """Select the top-``top_p_ratio`` highest-surprisal tokens within ``candidate_mask``."""
-            candidate_count = int(candidate_mask.sum().item())
+            """Select the top-``top_p_ratio`` highest-surprisal tokens *per sequence* within ``candidate_mask``.
+
+            Paper Section 4.2 selects the entropy-critical set on a per-response basis: each row gets its own
+            ``ceil(row_candidate_count * top_p_ratio)`` budget. A batch-global topk would let longer or higher-
+            surprisal rows monopolise the budget and starve shorter completions.
+            """
             selected = torch.zeros_like(candidate_mask, dtype=torch.bool)
-            if candidate_count == 0 or top_p_ratio <= 0.0:
+            if top_p_ratio <= 0.0:
                 return selected
-            # ceil(candidate_count * top_p_ratio), at least 1 token.
-            k = max(1, math.ceil(candidate_count * top_p_ratio))
-            k = min(k, candidate_count)
-            candidate_values = surprisal[candidate_mask]
-            _, topk_local_idx = torch.topk(candidate_values, k=k, largest=True)
-            flat_candidate_idx = candidate_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
-            flat_selected_idx = flat_candidate_idx[topk_local_idx]
-            selected.reshape(-1)[flat_selected_idx] = True
+            for b in range(candidate_mask.size(0)):
+                row_mask = candidate_mask[b]
+                candidate_count = int(row_mask.sum().item())
+                if candidate_count == 0:
+                    continue
+                k = max(1, math.ceil(candidate_count * top_p_ratio))
+                k = min(k, candidate_count)
+                row_surprisal = surprisal[b][row_mask]
+                _, topk_local_idx = torch.topk(row_surprisal, k=k, largest=True)
+                flat_candidate_idx = row_mask.nonzero(as_tuple=False).squeeze(-1)
+                selected[b][flat_candidate_idx[topk_local_idx]] = True
             return selected
 
         l_plus = top_surprisal_mask(positive_candidates)


### PR DESCRIPTION
> **Status (2026-08-07)**: rebased onto current `main`; both Cursor Bugbot findings from the June review are resolved (see "Bugbot findings resolved" below). Ready for review.

# What does this PR do?

This PR implements the STARE policy loss as a new `loss_type` on `GRPOTrainer`, following the same dispatch convention as `dr_grpo`, `sapo`, `luspo`, `vespo`, etc.

Paper: https://huggingface.co/papers/2606.19236
Official implementation: https://github.com/hp-luo/STARE — specifically `verl/trainer/ppo/core_algos.py::compute_policy_loss_stare` and `STAREController` (Apache-2.0).


### Motivation

Standard GRPO exhibits policy entropy collapse during RL fine-tuning: the policy converges to near-deterministic outputs, losing the exploration needed to keep learning on hard problems. A first-order analysis of per-token entropy dynamics shows the change in entropy is proportional to the product of a token's advantage and an entropy-sensitivity term that grows with the token's surprisal — meaning updates on high-surprisal tokens dominate how fast the policy loses exploration. STARE identifies those *entropy-critical* tokens and applies a targeted per-token PG-loss reweight, gated by a closed-loop target-entropy signal so the intervention activates only when entropy is below the desired floor.

The STARE objective wraps the GRPO dual-clip surrogate with a per-token PG-loss reweighting factor `omega`:

- **Token partitioning** (paper §4.1): Split valid response tokens by `sign(A)` into `T+ = {A > 0}` and `T- = {A < 0}`. Within each set, rank tokens in descending order of surprisal `s = -log π_θ(o)` and select the top `stare_top_p_ratio` to form the entropy-critical sets `L+` (and `L-` for variant C2).
- **Advantage reweighting** (paper §4.2): `omega = W (> 1)` on `L+` (variant O1, default) or `omega = W` on `L+` and `omega = M (< 1)` on `L-` (variant C2 dual-sided regulation). Multiplies the per-token PG loss post-clip.
- **Closed-loop gate** (paper §4.3): The reweighting is active only when batch-mean policy entropy `H_bar < stare_target_entropy`. Otherwise weights revert to 1 and STARE degrades to vanilla GRPO.

**Paper defaults are wired in**: `stare_top_p_ratio=0.1`, `stare_reweight_w=1.1`, `stare_reweight_m=0.9`, `stare_target_entropy=0.3`, `stare_variant="O1"`.

**Aggregation note**: STARE joins the `bnpo` aggregation branch — matches verl's `loss_agg_mode="token-mean"` default for `compute_policy_loss_stare`, which is per-token mean over valid tokens.

**Out of scope for this PR (paper §4.4)**: Adaptive `W`/`M` decay across batches (the optional `STAREController` adaptive path in the reference). Can be added as a follow-up if there is interest — the controller would be stateful across steps and is gated behind `stare_adaptive=False` in the reference.

## Tests

- Added `"stare"` to the `loss_type` parametrize in `test_train_loss_types` so STARE runs through the full GRPO training-step path.
- Added `TestComputeStareTokenWeights` with 9 dedicated math-property tests covering: gate-closed behavior, O1 single-sided amplification, C2 dual-sided regulation, mask-exclusion of padded tokens, top-K selection cardinality, per-sequence (not batch-pooled) top-K selection, and input validation.

```
$ pytest tests/test_grpo_trainer.py::TestComputeStareTokenWeights -q
.........                                                                 [100%]
9 passed in 0.4s
```

A 1-step end-to-end smoke test on `trl-internal-testing/tiny-Qwen2ForCausalLM-2.5` (CPU, paper defaults) completes a full forward + backward + optimizer step, with all 27 parameters updating and STARE metrics surfaced in the training log line:

```
train_loss: 5.96e-08   grad_norm: 0.195   params_moved: 27/27
stare/gate_on: 0       stare/batch_entropy: 11.93
stare/positive_reweight_ratio: 0.036   stare/mean_weight: 1.0
```

The closed-loop gate behaves correctly here: random-init model has batch entropy ≈11.93 >> target 0.3, so the gate stays closed and STARE degrades to vanilla GRPO (paper §4.3 invariant). Gate-open behavior is exercised in the unit tests.


## Bugbot findings resolved

Both issues from Cursor Bugbot's June 24 review of commit `a0827b0a` are addressed on this branch:

- **Liger path bypass** (High severity): raises `ValueError` at config-validation when `loss_type="stare"` + `use_liger_kernel=True`, matching the existing VESPO precheck pattern. Prevents the fused Liger kernel from silently skipping STARE reweighting.
- **Batch-pooled top-k** (Medium severity): `top_surprisal_mask` now performs per-sequence topk against each row's own `ceil(candidate_count * top_p_ratio)` budget, aligned with paper §4.2's per-response selection. Added `test_top_p_ratio_is_per_sequence_not_batch_pooled` as a regression guard (fails against the batch-pooled version, passes against the fix).

## Code conventions

- `compute_stare_token_weights` is a `@staticmethod @torch.no_grad()` helper colocated with `get_gamma_weights` (VESPO precedent).
- `paper_index.md` entry added (matches VESPO/SAPO/GMPO format) including the STARE objective in LaTeX.
- Configuration parameters added to `GRPOConfig` with full docstrings and `field(..., metadata={"help": ...})` patterns.
- `ruff check` and `ruff format` clean on all changed files.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

Draft produced with AI assistance via the [Outrider](https://github.com/remyxai/outrider) harness, then human-reviewed by @smellslikeml. Commit trailers carry `Co-Authored-By: remyx-ai[bot]` and `Co-Authored-By: Claude Opus 4.7` attribution.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GRPO loss dispatch and training dynamics for users who opt in via `loss_type="stare"`; mitigated by validation, unit tests, and explicit rejection of unsupported Liger fusion.
> 
> **Overview**
> Adds **STARE** as a new `loss_type="stare"` on `GRPOTrainer`, alongside existing paper losses (VESPO, SAPO, etc.).
> 
> **`GRPOConfig`** gains `stare_variant`, `stare_top_p_ratio`, `stare_reweight_w`, `stare_reweight_m`, and `stare_target_entropy` (paper defaults). **`compute_stare_token_weights`** picks high-surprisal tokens within positive/negative advantage partitions, applies multiplicative PG-loss weights when batch mean entropy is below the target (closed-loop gate), and supports **O1** vs **C2** variants.
> 
> **`_compute_loss`** builds the standard GRPO dual-clip surrogate, then multiplies by STARE weights; aggregation follows **bnpo** (token-mean). STARE metrics are logged; **`use_liger_kernel=True`** is rejected so the objective is not silently skipped.
> 
> Docs add a **paper_index** entry; tests cover weight math, training smoke with `"stare"`, and the Liger incompatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22337c6153449fec1064e2eb23c1fc1c33842490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
