### PR TITLE
Add dataset mixture fractions

### DIFF
--- a/docs/source/clis.md
+++ b/docs/source/clis.md
@@ -537,7 +537,9 @@ trl kto --config kto_config.yaml
 
 ### Using dataset mixtures
 
-You can use dataset mixtures to combine multiple datasets into a single training dataset. This is useful for training on diverse data sources or when you want to mix different types of data.
+You can use dataset mixtures to combine multiple datasets into a single training dataset. This is useful for training
+on diverse data sources or when you want to mix different types of data. Set `fraction` on a dataset entry to keep the
+first `fraction * len(dataset)` rows from that source before concatenation.
 
 <hfoptions id="trainer">
 <hfoption id="SFT">
@@ -547,7 +549,9 @@ You can use dataset mixtures to combine multiple datasets into a single training
 model_name_or_path: Qwen/Qwen2.5-0.5B
 datasets:
   - path: stanfordnlp/imdb
+    fraction: 0.5
   - path: roneneldan/TinyStories
+    fraction: 0.25
 ```
 
 Launch with:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -307,17 +307,27 @@ class TestGetDataset:
         train_dataset = result["train"]
         assert train_dataset.column_names == ["prompt"]
         prompts = train_dataset["prompt"]
-        expected_first_half = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
-        assert prompts[: len(prompts) // 2] == expected_first_half["prompt"]
-        expected_second_half = load_dataset("trl-internal-testing/zen", "standard_prompt_completion", split="train")
-        assert prompts[len(prompts) // 2 :] == expected_second_half["prompt"]
+        expected_first_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_prompt_completion", split="train"
+        )
+        expected_second_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        assert prompts[: len(expected_first_dataset)] == expected_first_dataset["prompt"]
+        assert prompts[len(expected_first_dataset) :] == expected_second_dataset["prompt"]
 
-    def test_dataset_mixture_with_weights(self):
+    def test_dataset_mixture_with_fractions(self):
         dataset_config1 = DatasetConfig(
-            path="trl-internal-testing/zen", name="standard_prompt_completion", split="train[:50%]", columns=["prompt"]
+            path="trl-internal-testing/zen",
+            name="standard_prompt_completion",
+            split="train",
+            fraction=0.5,
+            columns=["prompt"],
         )
         dataset_config2 = DatasetConfig(
-            path="trl-internal-testing/zen", name="standard_preference", split="train[:50%]", columns=["prompt"]
+            path="trl-internal-testing/zen",
+            name="standard_preference",
+            split="train",
+            fraction=0.25,
+            columns=["prompt"],
         )
         mixture_config = DatasetMixtureConfig(datasets=[dataset_config1, dataset_config2])
         result = get_dataset(mixture_config)
@@ -326,12 +336,29 @@ class TestGetDataset:
         train_dataset = result["train"]
         assert train_dataset.column_names == ["prompt"]
         prompts = train_dataset["prompt"]
-        expected_first_half = load_dataset("trl-internal-testing/zen", "standard_preference", split="train[:50%]")
-        assert prompts[: len(prompts) // 2] == expected_first_half["prompt"]
-        expected_second_half = load_dataset(
-            "trl-internal-testing/zen", "standard_prompt_completion", split="train[:50%]"
+        expected_first_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_prompt_completion", split="train"
         )
-        assert prompts[len(prompts) // 2 :] == expected_second_half["prompt"]
+        expected_second_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        num_first_examples = int(0.5 * len(expected_first_dataset))
+        num_second_examples = int(0.25 * len(expected_second_dataset))
+        assert prompts[:num_first_examples] == expected_first_dataset[:num_first_examples]["prompt"]
+        assert prompts[num_first_examples:] == expected_second_dataset[:num_second_examples]["prompt"]
+
+    def test_dataset_mixture_with_invalid_fraction(self):
+        with pytest.raises(ValueError, match="`fraction` must be between 0 and 1."):
+            DatasetConfig(path="trl-internal-testing/zen", name="standard_language_modeling", fraction=1.5)
+
+    def test_dataset_mixture_fraction_with_streaming_raises_error(self, tmp_path):
+        data_file = tmp_path / "data.jsonl"
+        data_file.write_text('{"prompt": "a"}\n{"prompt": "b"}\n')
+        mixture_config = DatasetMixtureConfig(
+            datasets=[DatasetConfig(path="json", data_files=str(data_file), fraction=0.5)],
+            streaming=True,
+        )
+
+        with pytest.raises(ValueError, match="Dataset fractions are only supported for non-streaming datasets."):
+            get_dataset(mixture_config)
 
     def test_dataset_mixture_with_test_split(self):
         mixture_config = DatasetMixtureConfig(
@@ -373,6 +400,7 @@ class TestGetDataset:
           name: standard_prompt_only
         - path: trl-internal-testing/zen
           name: standard_preference
+          fraction: 0.5
           columns:
           - prompt
         """
@@ -402,6 +430,7 @@ class TestGetDataset:
         assert isinstance(dataset_config2, DatasetConfig)
         assert dataset_config2.path == "trl-internal-testing/zen"
         assert dataset_config2.name == "standard_preference"
+        assert dataset_config2.fraction == 0.5
         assert dataset_config2.columns == ["prompt"]  # Columns specified
 
     def test_trlparser_parses_yaml_and_loads_dataset(self):

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -58,6 +58,8 @@ class DatasetConfig:
             Path(s) to source data file(s).
         split (`str`, *optional*, defaults to `"train"`):
             Which split of the data to load.
+        fraction (`float`, *optional*, defaults to `1.0`):
+            Fraction of the dataset split to keep, taken from the first rows.
         columns (`list[str]`, *optional*):
             List of column names to select from the dataset. If `None`, all columns are selected.
     """
@@ -67,7 +69,12 @@ class DatasetConfig:
     data_dir: str | None = None
     data_files: str | list[str] | dict[str, str] | None = None
     split: str = "train"
+    fraction: float = 1.0
     columns: list[str] | None = None
+
+    def __post_init__(self):
+        if self.fraction < 0 or self.fraction > 1:
+            raise ValueError("`fraction` must be between 0 and 1.")
 
 
 @dataclass
@@ -98,12 +105,14 @@ class DatasetMixtureConfig:
             data_dir: ...
             data_files: ...
             split: ...
+            fraction: ...
             columns: ...
           - path: ...
             name: ...
             data_dir: ...
             data_files: ...
             split: ...
+            fraction: ...
             columns: ...
         streaming: ...
         test_split_size: ...
@@ -435,6 +444,8 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
     datasets_list = []
     for dataset_config in mixture_config.datasets:
         logger.info(f"Loading dataset for mixture: {dataset_config.path} (config name: {dataset_config.name})")
+        if mixture_config.streaming and dataset_config.fraction < 1.0:
+            raise ValueError("Dataset fractions are only supported for non-streaming datasets.")
         dataset = datasets.load_dataset(
             path=dataset_config.path,
             name=dataset_config.name,
@@ -445,6 +456,8 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
         )
         if dataset_config.columns is not None:
             dataset = dataset.select_columns(dataset_config.columns)
+        if dataset_config.fraction < 1.0:
+            dataset = dataset.select(range(int(dataset_config.fraction * len(dataset))))
         datasets_list.append(dataset)
 
     if datasets_list:


### PR DESCRIPTION
# What does this PR do?

Adds per-dataset fractions to TRL's existing `DatasetMixtureConfig` flow.

Previously, dataset mixtures loaded through `get_dataset()` could concatenate multiple full dataset splits, but there was no explicit way to keep only a configured proportion of each source dataset. This PR adds a `fraction` field to `DatasetConfig`, defaulting to `1.0`, and applies it by selecting the first `int(fraction * len(dataset))` rows before concatenating the mixture.

This follows the behavior discussed in the issue:
- fractions are per original source dataset
- samples are selected deterministically from the first rows
- datasets are concatenated rather than interleaved
- no oversampling is introduced

Fractional mixing is rejected for streaming datasets because streaming datasets do not support `len()` / `select()`.

Example:

```yaml
datasets:
  - path: stanfordnlp/imdb
    fraction: 0.5
  - path: roneneldan/TinyStories
    fraction: 0.25
```

Fixes #2112.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

## Tests

```bash
.venv/bin/python -m ruff check trl/scripts/utils.py tests/test_cli_utils.py
.venv/bin/python -m pytest tests/test_cli_utils.py -q
.venv/bin/python -m pytest --collect-only -q tests
.venv/bin/python -m pip check
```

Results:

```text
All checks passed
25 passed, 1 warning
2075 tests collected
No broken requirements found
```
