### PR TITLE
Guard compute_mfu against a zero denominator (world_size == 0)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1347,6 +1347,10 @@ class TestComputeMfu(TrlTestCase):
         tps = peak * world_size / flops
         assert compute_mfu(flops, tps, world_size, peak_flops_per_device=peak) == pytest.approx(100.0)
 
+    def test_zero_world_size_returns_zero(self):
+        # A zero denominator (e.g. world_size == 0) must return 0.0, not raise ZeroDivisionError.
+        assert compute_mfu(100e9, 1000.0, 0) == 0.0
+
 
 class TestAdjustedMfu(TrlTestCase):
     MOE_MODEL_ID = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1472,7 +1472,11 @@ def compute_mfu(
     Returns:
         `float`: MFU as a percentage (0-100).
     """
-    return 100 * (flops_per_token * tokens_per_second) / (peak_flops_per_device * world_size)
+    denominator = peak_flops_per_device * world_size
+    if denominator == 0:
+        # No compute capacity to utilize (e.g. world_size == 0); MFU is 0 rather than a ZeroDivisionError.
+        return 0.0
+    return 100 * (flops_per_token * tokens_per_second) / denominator
 
 
 def adjusted_mfu(mfu: float, config: PretrainedConfig, seq_len: int) -> float:


### PR DESCRIPTION
# What does this PR do?

`compute_mfu` (in `trl/trainer/utils.py`) divides by `peak_flops_per_device * world_size` with no guard, so a zero denominator (`world_size == 0`, or a zero `peak_flops_per_device`) raises `ZeroDivisionError: float division by zero`:

```python
from trl.trainer.utils import compute_mfu

compute_mfu(flops_per_token=1000, tokens_per_second=5000.0, world_size=0)
# ZeroDivisionError: float division by zero
```

`compute_mfu` is a metric helper for the trainer's logging path, so a degenerate input should not be able to abort training. This returns `0.0` when the denominator is zero (no compute capacity to utilize, so MFU is 0) instead of raising; normal inputs are unchanged.

A regression test is added to `TestComputeMfu` in `tests/test_utils.py`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny change to a metric helper with no effect on normal training inputs; only avoids crashes on edge-case logging values.
> 
> **Overview**
> **`compute_mfu`** no longer divides when `peak_flops_per_device * world_size` is zero (e.g. `world_size == 0` or zero peak FLOPs). It returns **`0.0`** instead of raising **`ZeroDivisionError`**, so degenerate inputs on the trainer MFU logging path cannot crash training. Valid inputs behave the same as before.
> 
> A regression test **`test_zero_world_size_returns_zero`** was added in **`TestComputeMfu`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3839e9ac207506d1945182efa0cfa52879c5e63a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->