### PR TITLE
[Opened by mistake, please ignore] Support encoder-decoder models in SFTTrainer

### DIFF
--- a/docs/source/dataset_formats.md
+++ b/docs/source/dataset_formats.md
@@ -343,6 +343,8 @@ prompt_completion_example = {"prompt": [{"role": "user", "content": "What color 
 
 For examples of prompt-completion datasets, refer to the [Prompt-completion datasets collection](https://huggingface.co/collections/trl-lib/prompt-completion-datasets-677ea2bb20bbb6bdccada216).
 
+For encoder-decoder models trained with [`SFTTrainer`], use the prompt-completion format. The `"prompt"` is used as the encoder input and the `"completion"` is used as the decoder target.
+
 #### Preference
 
 A preference dataset is used for tasks where the model is trained to choose between two or more possible completions to the same prompt. This dataset includes a `"prompt"`, a `"chosen"` completion, and a `"rejected"` completion. The model is trained to select the `"chosen"` response over the `"rejected"` response.
@@ -410,7 +412,7 @@ Choosing the right dataset type depends on the task you are working on and the s
 | [`GRPOTrainer`] | [Prompt-only](#prompt-only) |
 | [`RewardTrainer`] | [Preference (implicit prompt recommended)](#preference) |
 | [`RLOOTrainer`] | [Prompt-only](#prompt-only) |
-| [`SFTTrainer`] | [Language modeling](#language-modeling) or [Prompt-completion](#prompt-completion) |
+| [`SFTTrainer`] | [Language modeling](#language-modeling) or [Prompt-completion](#prompt-completion). Encoder-decoder models require [Prompt-completion](#prompt-completion). |
 | [`experimental.bco.BCOTrainer`] | [Unpaired preference](#unpaired-preference) or [Preference (explicit prompt recommended)](#preference) |
 | [`experimental.cpo.CPOTrainer`] | [Preference (explicit prompt recommended)](#preference) |
 | [`experimental.gkd.GKDTrainer`] | [Prompt-completion](#prompt-completion) |

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -27,7 +27,7 @@ trainer.train()
 
 ## Expected dataset type and format
 
-SFT supports both [language modeling](dataset_formats#language-modeling) and [prompt-completion](dataset_formats#prompt-completion) datasets. The [`SFTTrainer`] is compatible with both [standard](dataset_formats#standard) and [conversational](dataset_formats#conversational) dataset formats. When provided with a conversational dataset, the trainer will automatically apply the chat template to the dataset.
+SFT supports both [language modeling](dataset_formats#language-modeling) and [prompt-completion](dataset_formats#prompt-completion) datasets for causal language models. For encoder-decoder models, such as T5, BART, or Aya, use a prompt-completion dataset: the prompt is used as the encoder input and the completion is used as the decoder target. The [`SFTTrainer`] is compatible with both [standard](dataset_formats#standard) and [conversational](dataset_formats#conversational) dataset formats. When provided with a conversational dataset, the trainer will automatically apply the chat template to the dataset.
 
 ```python
 # Standard language modeling
@@ -91,7 +91,7 @@ This section breaks down how SFT works in practice, covering the key steps: **pr
 ### Preprocessing and tokenization
 
 During training, each example is expected to contain a **text field** or a **(prompt, completion)** pair, depending on the dataset format. For more details on the expected formats, see [Dataset formats](dataset_formats).
-The [`SFTTrainer`] tokenizes each input using the model's tokenizer. If both prompt and completion are provided separately, they are concatenated before tokenization.
+The [`SFTTrainer`] tokenizes each input using the model's tokenizer. For causal language models, if both prompt and completion are provided separately, they are concatenated before tokenization. For encoder-decoder models, prompt-completion examples are tokenized as separate source and target sequences.
 
 ### Computing the loss
 
@@ -104,17 +104,20 @@ $$
 $$
   
 where  \\( y_t \\) is the target token at timestep  \\( t \\), and the model is trained to predict the next token given the previous ones. In practice, padding tokens are masked out during loss computation.
+For encoder-decoder models, the same negative log-likelihood objective is computed over the decoder labels, conditioned on the encoder input.
 
 > [!TIP]
-> The paper [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification](https://huggingface.co/papers/2508.05629) proposes an alternative loss function, called **Dynamic Fine-Tuning (DFT)**, which aims to improve generalization by rectifying the reward signal. This method can be enabled by setting `loss_type="dft"` in the [`SFTConfig`]. For more details, see [Paper Index - Dynamic Fine-Tuning](paper_index#on-the-generalization-of-sft-a-reinforcement-learning-perspective-with-reward-rectification).
+> The paper [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification](https://huggingface.co/papers/2508.05629) proposes an alternative loss function, called **Dynamic Fine-Tuning (DFT)**, which aims to improve generalization by rectifying the reward signal. For causal language models, this method can be enabled by setting `loss_type="dft"` in the [`SFTConfig`]. For more details, see [Paper Index - Dynamic Fine-Tuning](paper_index#on-the-generalization-of-sft-a-reinforcement-learning-perspective-with-reward-rectification).
 
 > [!TIP]
-> By default, [`SFTTrainer`] uses `loss_type="chunked_nll"`: same math as `"nll"`, but the `lm_head` projection skips ignored-label tokens and the cross-entropy is processed in chunks, so peak activation memory does not scale with the full vocab × seq_len logits tensor. To fall back to the standard path, set `loss_type="nll"`. When `use_liger_kernel=True`, the default automatically resolves to `"nll"` (the two paths are not compatible). See [Chunked cross-entropy for reducing peak memory usage](reducing_memory_usage#chunked-cross-entropy-for-reducing-peak-memory-usage).
+> By default, [`SFTTrainer`] uses `loss_type="chunked_nll"` for causal language models: same math as `"nll"`, but the `lm_head` projection skips ignored-label tokens and the cross-entropy is processed in chunks, so peak activation memory does not scale with the full vocab × seq_len logits tensor. To fall back to the standard path, set `loss_type="nll"`. When `use_liger_kernel=True`, the default automatically resolves to `"nll"` (the two paths are not compatible). Encoder-decoder models use `"nll"`. See [Chunked cross-entropy for reducing peak memory usage](reducing_memory_usage#chunked-cross-entropy-for-reducing-peak-memory-usage).
 
 ### Label shifting and masking
 
-During training, the loss is computed using a **one-token shift**: the model is trained to predict each token in the sequence based on all previous tokens. Specifically, the input sequence is shifted right by one position to form the target labels.
+During causal language model training, the loss is computed using a **one-token shift**: the model is trained to predict each token in the sequence based on all previous tokens. Specifically, the input sequence is shifted right by one position to form the target labels.
 Padding tokens (if present) are ignored in the loss computation by applying an ignore index (default: `-100`) to the corresponding positions. This ensures that the loss focuses only on meaningful, non-padding tokens.
+
+For encoder-decoder models, the trainer passes the completion tokens as `labels`; the model prepares decoder inputs from those labels internally. The trainer does not concatenate the prompt and completion into one causal sequence for encoder-decoder training.
 
 ## Logged metrics
 
@@ -133,7 +136,7 @@ While training and evaluating we record the following reward metrics:
 
 ### Model initialization
 
-You can directly pass the kwargs of the [`~transformers.AutoModelForCausalLM.from_pretrained()`] method to the [`SFTConfig`]. For example, if you want to load a model in a different precision, analogous to
+You can directly pass the kwargs of the model's `from_pretrained()` method to the [`SFTConfig`]. For example, if you want to load a causal language model in a different precision, analogous to
 
 ```python
 model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", dtype=torch.bfloat16)
@@ -149,7 +152,7 @@ training_args = SFTConfig(
 )
 ```
 
-Note that all keyword arguments of [`~transformers.AutoModelForCausalLM.from_pretrained()`] are supported.
+Note that all keyword arguments of the resolved model architecture are supported. Causal language models are loaded with [`~transformers.AutoModelForCausalLM`]; encoder-decoder models are loaded with [`~transformers.AutoModelForSeq2SeqLM`].
 
 ### Packing
 
@@ -160,6 +163,9 @@ training_args = SFTConfig(packing=True)
 ```
 
 For more details on packing, see [Packing](reducing_memory_usage#packing).
+
+> [!WARNING]
+> Packing is supported only for causal language models. Encoder-decoder models do not support `packing=True`, `eval_packing=True`, or `padding_free=True`.
 
 ### Train on assistant messages only
 
@@ -197,6 +203,38 @@ trainer.train()
 
 > [!TIP]
 > Training on completion only is compatible with training on assistant messages only. In this case, use a [conversational](dataset_formats#conversational) [prompt-completion](dataset_formats#prompt-completion) dataset and set `assistant_only_loss=True` in the [`SFTConfig`].
+
+For encoder-decoder models, prompt-completion training always uses the prompt as the encoder input and the completion as the decoder labels. This means the loss is computed on the completion side; `completion_only_loss=False` does not make prompt tokens decoder targets.
+
+### Train encoder-decoder models
+
+[`SFTTrainer`] supports encoder-decoder models for sequence-to-sequence supervised fine-tuning. Use a [prompt-completion](dataset_formats#prompt-completion) dataset, where `"prompt"` contains the source text and `"completion"` contains the target text.
+
+```python
+from datasets import Dataset
+from trl import SFTConfig, SFTTrainer
+
+dataset = Dataset.from_dict(
+    {
+        "prompt": ["Translate to German: The sky is blue."],
+        "completion": ["Der Himmel ist blau."],
+    }
+)
+
+trainer = SFTTrainer(
+    model="google/flan-t5-small",
+    args=SFTConfig(
+        loss_type="nll",
+        packing=False,
+    ),
+    train_dataset=dataset,
+)
+trainer.train()
+```
+
+For processed datasets, encoder-decoder examples must contain both `input_ids` and `labels`. Language modeling datasets with only a `"text"` or `"messages"` column are not supported for encoder-decoder models because they do not define a separate decoder target.
+
+The following SFT features are currently not supported for encoder-decoder models: packing, padding-free training, Dynamic Fine-Tuning (`loss_type="dft"`), and Liger kernels.
 
 ### Train adapters with PEFT
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -29,6 +29,7 @@ from packaging.version import parse as parse_version
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
+    AutoModelForSeq2SeqLM,
     AutoTokenizer,
     BitsAndBytesConfig,
     TrainingArguments,
@@ -409,6 +410,55 @@ class TestSFTTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_seq2seq_prompt_completion(self):
+        model_id = "trl-internal-testing/tiny-T5ForConditionalGeneration"
+        dataset = Dataset.from_list(
+            [
+                {"prompt": "Translate to German: Hello.", "completion": "Hallo."},
+                {"prompt": "Translate to German: Goodbye.", "completion": "Auf Wiedersehen."},
+            ]
+        )
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            max_steps=1,
+            per_device_train_batch_size=1,
+            gradient_checkpointing=False,
+            report_to="none",
+        )
+        trainer = SFTTrainer(model=model_id, args=training_args, train_dataset=dataset)
+
+        assert trainer.args.loss_type == "nll"
+        assert trainer.train_dataset[0]["input_ids"] != trainer.train_dataset[0]["labels"]
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    def test_seq2seq_prompt_completion_builds_decoder_labels(self):
+        model_id = "trl-internal-testing/tiny-T5ForConditionalGeneration"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = AutoModelForSeq2SeqLM.from_pretrained(model_id, dtype="float32")
+        dataset = Dataset.from_list([{"prompt": "Translate to German: Hello.", "completion": "Hallo."}])
+
+        training_args = SFTConfig(output_dir=self.tmp_dir, gradient_checkpointing=False, report_to="none")
+        trainer = SFTTrainer(model=model, args=training_args, train_dataset=dataset, processing_class=tokenizer)
+
+        decoded_input = tokenizer.decode(trainer.train_dataset[0]["input_ids"], skip_special_tokens=True)
+        decoded_labels = tokenizer.decode(trainer.train_dataset[0]["labels"], skip_special_tokens=True)
+
+        assert "Translate to German" in decoded_input
+        assert "Translate to German" not in decoded_labels
+        assert "Hallo" in decoded_labels
+
+    def test_seq2seq_rejects_packing(self):
+        model_id = "trl-internal-testing/tiny-T5ForConditionalGeneration"
+        dataset = Dataset.from_list([{"prompt": "Translate to German: Hello.", "completion": "Hallo."}])
+        training_args = SFTConfig(output_dir=self.tmp_dir, packing=True, report_to="none")
+
+        with pytest.raises(ValueError, match="Packing is not supported"):
+            SFTTrainer(model=model_id, args=training_args, train_dataset=dataset)
 
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -37,12 +37,13 @@ class SFTConfig(_BaseConfig):
         > Parameters that control the model
 
         model_init_kwargs (`dict[str, Any]`, *optional*):
-            Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
-            argument of the [`SFTTrainer`] is provided as a string.
+            Keyword arguments for the model's `from_pretrained` method, used when the `model` argument of the
+            [`SFTTrainer`] is provided as a string. Causal language models are loaded with
+            [`~transformers.AutoModelForCausalLM`]; encoder-decoder models are loaded with
+            [`~transformers.AutoModelForSeq2SeqLM`].
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`].
+            the model's `from_pretrained` method and [`~transformers.AutoProcessor.from_pretrained`].
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
@@ -77,7 +78,7 @@ class SFTConfig(_BaseConfig):
             Whether to shuffle the dataset.
         packing (`bool`, *optional*, defaults to `False`):
             Whether to group multiple sequences into fixed-length blocks to improve computational efficiency and reduce
-            padding. Uses `max_length` to define sequence length.
+            padding. Uses `max_length` to define sequence length. Only supported for causal language models.
         packing_strategy (`str`, *optional*, defaults to `"bfd"`):
             Strategy for packing sequences. Can be `"bfd"` (best-fit decreasing, truncates overflow), `"bfd_split"`
             (best-fit decreasing, splits overflow sequences), or `"wrapped"` (aggressive, cuts mid-sequence).
@@ -86,7 +87,7 @@ class SFTConfig(_BaseConfig):
             continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
             supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch structure. When
             packing is enabled with strategy `"bfd"`, padding-free is enabled, regardless of the value of this
-            parameter.
+            parameter. Only supported for causal language models.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
         eval_packing (`bool`, *optional*):
@@ -99,21 +100,24 @@ class SFTConfig(_BaseConfig):
             only on the completion, which is supported only for [prompt-completion](#prompt-completion) datasets. If
             `False`, loss is computed on the entire sequence. If `None` (default), the behavior depends on the dataset:
             loss is computed on the completion for [prompt-completion](#prompt-completion) datasets, and on the full
-            sequence for [language modeling](#language-modeling) datasets.
+            sequence for [language modeling](#language-modeling) datasets. For encoder-decoder models, prompt tokens
+            are used as encoder inputs and completion tokens are used as decoder labels, so the loss is computed on the
+            completion side.
         assistant_only_loss (`bool`, *optional*, defaults to `False`):
             Whether to compute loss only on the assistant part of the sequence. If set to `True`, loss is computed only
             on the assistant responses, which is supported only for [conversational](#conversational) datasets. If
             `False`, loss is computed on the entire sequence.
         loss_type (`str`, *optional*, defaults to `"chunked_nll"`):
             Type of loss to use. When left unset, it defaults to `"chunked_nll"`, except when `use_liger_kernel=True`,
-            in which case it defaults to `"nll"`. Possible values are:
+            in which case it defaults to `"nll"`. Encoder-decoder models use `"nll"`. Possible values are:
 
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
-              in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.
+              in chunks of tokens to reduce peak activation memory. Only supported for causal language models and not
+              compatible with `use_liger_kernel`.
 
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
@@ -149,7 +153,7 @@ class SFTConfig(_BaseConfig):
     model_init_kwargs: dict[str, Any] | str | None = field(
         default=None,
         metadata={
-            "help": "Keyword arguments for `AutoModelForCausalLM.from_pretrained`, used when the `model` argument of "
+            "help": "Keyword arguments for the model's `from_pretrained` method, used when the `model` argument of "
             "the `SFTTrainer` is provided as a string."
         },
     )
@@ -165,7 +169,7 @@ class SFTConfig(_BaseConfig):
         default=False,
         metadata={
             "help": "Whether to allow loading models and tokenizers that ship custom Python code from the Hub. "
-            "Forwarded to `AutoModelForCausalLM.from_pretrained` and `AutoProcessor.from_pretrained`."
+            "Forwarded to the model's `from_pretrained` method and `AutoProcessor.from_pretrained`."
         },
     )
     chat_template_path: str | None = field(
@@ -226,7 +230,8 @@ class SFTConfig(_BaseConfig):
         default=False,
         metadata={
             "help": "Whether to group multiple sequences into fixed-length blocks to improve computational efficiency "
-            "and reduce padding. Uses `max_length` to define sequence length."
+            "and reduce padding. Uses `max_length` to define sequence length. Only supported for causal language "
+            "models."
         },
     )
     packing_strategy: str = field(
@@ -245,7 +250,7 @@ class SFTConfig(_BaseConfig):
             "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this "
             "is only supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch "
             "structure. When packing is enabled with strategy `'bfd'`, padding-free is enabled, regardless of the "
-            "value of this parameter."
+            "value of this parameter. Only supported for causal language models."
         },
     )
     pad_to_multiple_of: int | None = field(
@@ -266,7 +271,8 @@ class SFTConfig(_BaseConfig):
                 "computed only on the completion, which is supported only for prompt-completion datasets. If `False`, "
                 "loss is computed on the entire sequence. If `None` (default), the behavior depends on the dataset: "
                 "loss is computed on the completion for prompt-completion datasets, and on the full sequence for "
-                "language modeling datasets."
+                "language modeling datasets. For encoder-decoder models, prompt tokens are used as encoder inputs "
+                "and completion tokens are used as decoder labels."
             )
         },
     )
@@ -284,13 +290,14 @@ class SFTConfig(_BaseConfig):
         default=None,
         metadata={
             "help": "Type of loss to use. When left unset, it defaults to `'chunked_nll'`, except when "
-            "`use_liger_kernel=True`, in which case it defaults to `'nll'`. Possible values are `'nll'` (standard "
-            "negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), and "
-            "`'chunked_nll'` (same math as `'nll'`, but the `lm_head` projection is computed on non-ignored tokens "
-            "only — positions with `labels == -100` are dropped before the matmul — and the cross-entropy is "
-            "processed in chunks of tokens to reduce peak activation memory; not compatible with `use_liger_kernel`; "
-            "the patched `lm_head` path covers standard causal LMs and VLMs whose language model exposes a top-level "
-            "`lm_head`, architectures with a non-standard head are not supported)."
+            "`use_liger_kernel=True`, in which case it defaults to `'nll'`. Encoder-decoder models use `'nll'`. "
+            "Possible values are `'nll'` (standard negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, "
+            "https://huggingface.co/papers/2508.05629), and `'chunked_nll'` (same math as `'nll'`, but the "
+            "`lm_head` projection is computed on non-ignored tokens only — positions with `labels == -100` are "
+            "dropped before the matmul — and the cross-entropy is processed in chunks of tokens to reduce peak "
+            "activation memory; not compatible with `use_liger_kernel`; the patched `lm_head` path covers standard "
+            "causal LMs and VLMs whose language model exposes a top-level `lm_head`, architectures with a "
+            "non-standard head are not supported)."
         },
     )
     activation_offloading: bool = field(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -843,8 +843,9 @@ class SFTTrainer(_BaseTrainer):
               [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
               using `<ModelArchitecture>.from_pretrained` (where `<ModelArchitecture>` is derived from the model
               config) with the keyword arguments in `args.model_init_kwargs`.
-            - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported.
-            - A [`~peft.PeftModel`] object. Only causal language models are supported.
+            - A [`~transformers.PreTrainedModel`] object. Causal language models and encoder-decoder language models
+              are supported.
+            - A [`~peft.PeftModel`] object. Causal language models and encoder-decoder language models are supported.
         args ([`SFTConfig`], *optional*):
             Configuration for this trainer. If `None`, a default configuration is used.
         data_collator ([`~transformers.DataCollator`], *optional*):
@@ -862,6 +863,8 @@ class SFTTrainer(_BaseTrainer):
               and content).
 
             The trainer also supports processed datasets (tokenized) as long as they contain an `input_ids` field.
+            For encoder-decoder models, datasets must be prompt-completion datasets, or processed datasets with both
+            `input_ids` and `labels`.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):
@@ -985,6 +988,7 @@ class SFTTrainer(_BaseTrainer):
             self._is_vlm = False
         else:
             raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
+        self._is_encoder_decoder = getattr(model.config, "is_encoder_decoder", False)
 
         if args.eos_token is not None:
             if args.eos_token not in self._tokenizer.get_vocab():
@@ -1029,6 +1033,24 @@ class SFTTrainer(_BaseTrainer):
                 "drop them, causing pixel_values to be forwarded to the model with no corresponding visual "
                 "tokens in input_ids. Use truncation_mode='keep_start' (the default) or set max_length=None."
             )
+        if self._is_encoder_decoder:
+            if args.packing:
+                raise ValueError("Packing is not supported for encoder-decoder models. Please set `packing=False`.")
+            if args.padding_free:
+                raise ValueError(
+                    "Padding-free training is not supported for encoder-decoder models. Please set "
+                    "`padding_free=False`."
+                )
+            if args.loss_type == "chunked_nll":
+                logger.warning(
+                    "`loss_type='chunked_nll'` is only supported for causal language models. Using "
+                    "`loss_type='nll'` for encoder-decoder training."
+                )
+                args.loss_type = "nll"
+            elif args.loss_type == "dft":
+                raise ValueError("`loss_type='dft'` is not supported for encoder-decoder models.")
+            if args.use_liger_kernel:
+                raise ValueError("`use_liger_kernel=True` is not supported for encoder-decoder models.")
 
         # PEFT
         if peft_config is not None:
@@ -1425,6 +1447,8 @@ class SFTTrainer(_BaseTrainer):
         # If the dataset is already preprocessed (tokenized), skip the processing steps.
         column_names = get_dataset_column_names(dataset)
         is_processed = "input_ids" in column_names
+        if self._is_encoder_decoder and is_processed and "labels" not in column_names:
+            raise ValueError("Processed datasets for encoder-decoder models must include a `labels` column.")
 
         # Build the kwargs for the `map` function
         map_kwargs = {}
@@ -1511,24 +1535,47 @@ class SFTTrainer(_BaseTrainer):
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
                             prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
-                            prompt_completion_ids = self._tokenize(
-                                processing_class, example["prompt"] + example["completion"]
-                            )["input_ids"]
+                            if self._is_encoder_decoder:
+                                completion_ids = self._tokenize(processing_class, example["completion"])["input_ids"]
+                            else:
+                                prompt_completion_ids = self._tokenize(
+                                    processing_class, example["prompt"] + example["completion"]
+                                )["input_ids"]
 
-                        # Check if the tokenized prompt starts with the tokenized prompt+completion
-                        if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
-                            logger.warning(
-                                "Mismatch between tokenized prompt and the start of tokenized prompt+completion. "
-                                "This may be due to unexpected tokenizer behavior, whitespace issues, or special "
-                                "token handling. Verify that the tokenizer is processing text consistently."
-                            )
-
-                        # Create completion mask
-                        completion_mask = [0] * len(prompt_ids) + [1] * (len(prompt_completion_ids) - len(prompt_ids))
-                        output["input_ids"] = prompt_completion_ids
-                        output["completion_mask"] = completion_mask
+                        if self._is_encoder_decoder:
+                            output["input_ids"] = prompt_ids
+                            if is_conversational(example):
+                                # Check if the tokenized prompt starts with the tokenized prompt+completion
+                                if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
+                                    logger.warning(
+                                        "Mismatch between tokenized prompt and the start of tokenized "
+                                        "prompt+completion. This may be due to unexpected tokenizer behavior, "
+                                        "whitespace issues, or special token handling. Verify that the tokenizer is "
+                                        "processing text consistently."
+                                    )
+                                completion_ids = prompt_completion_ids[len(prompt_ids) :]
+                            output["labels"] = completion_ids
+                        else:
+                            # Check if the tokenized prompt starts with the tokenized prompt+completion
+                            if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
+                                logger.warning(
+                                    "Mismatch between tokenized prompt and the start of tokenized prompt+completion. "
+                                    "This may be due to unexpected tokenizer behavior, whitespace issues, or special "
+                                    "token handling. Verify that the tokenizer is processing text consistently."
+                                )
+                            # Create completion mask
+                            completion_mask = [0] * len(prompt_ids) + [
+                                1
+                            ] * (len(prompt_completion_ids) - len(prompt_ids))
+                            output["input_ids"] = prompt_completion_ids
+                            output["completion_mask"] = completion_mask
 
                     else:  # language modeling case
+                        if self._is_encoder_decoder:
+                            raise ValueError(
+                                "Encoder-decoder models require a prompt-completion dataset with `prompt` and "
+                                "`completion` columns."
+                            )
                         if is_conversational(example):
                             processed = self._tokenize(
                                 processing_class,
@@ -1745,7 +1792,10 @@ class SFTTrainer(_BaseTrainer):
             self._metrics[mode]["entropy"].append(entropy)
         elif not self.args.use_liger_kernel:  # liger doesn't return logits
             with torch.no_grad():
-                if "shift_labels" in inputs:
+                if self._is_encoder_decoder:
+                    shift_logits = outputs.logits
+                    shift_labels = labels
+                elif "shift_labels" in inputs:
                     # When using CP or SP, labels are pre-shifted.
                     shift_logits = outputs.logits
                     shift_labels = inputs["shift_labels"]
@@ -1755,7 +1805,8 @@ class SFTTrainer(_BaseTrainer):
 
                 # Prompt Tuning and P-Tuning output logits for virtual tokens but Prefix-Tuning does not.
                 if (
-                    self.num_virtual_tokens > 0
+                    not self._is_encoder_decoder
+                    and self.num_virtual_tokens > 0
                     and model.peft_config[model.active_adapter].peft_type != PeftType.PREFIX_TUNING
                 ):
                     shift_logits = shift_logits[:, self.num_virtual_tokens :, :]

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -40,6 +40,7 @@ from transformers import (
     AutoConfig,
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
+    AutoModelForSeq2SeqLM,
     BitsAndBytesConfig,
     PretrainedConfig,
     PreTrainedModel,
@@ -1031,12 +1032,12 @@ def create_model_from_path(
             # Remote-code checkpoint: the architecture name lives in the dynamic module, not in
             # `transformers`. Pick the most specific auto class declared in `config.auto_map`.
             auto_map = config.auto_map or {}
-            for candidate in (AutoModelForImageTextToText, AutoModelForCausalLM):
+            for candidate in (AutoModelForImageTextToText, AutoModelForSeq2SeqLM, AutoModelForCausalLM):
                 if candidate.__name__ in auto_map:
                     architecture = candidate
                     break
             else:
-                architecture = AutoModelForCausalLM
+                architecture = AutoModelForSeq2SeqLM if config.is_encoder_decoder else AutoModelForCausalLM
     model = architecture.from_pretrained(model_id, **kwargs)
     return model
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SFT preprocessing, model loading, and loss/metrics paths; incorrect label handling could silently break seq2seq training, though new tests mitigate this.
> 
> **Overview**
> **`SFTTrainer`** now supports encoder-decoder models (e.g. T5, FLAN-T5) for seq2seq SFT, not only causal LMs.
> 
> Prompt-completion data is tokenized as **encoder `input_ids` + decoder `labels`** instead of concatenating prompt and completion. Language-modeling-only datasets are rejected for encoder-decoder models; pre-tokenized datasets must include **`labels`**. String model IDs load via **`AutoModelForSeq2SeqLM`** when `config.is_encoder_decoder` is true.
> 
> Encoder-decoder training **forces `loss_type="nll"`** (with a warning if `chunked_nll` was set) and **raises** on packing, padding-free, DFT, and Liger kernels. Training metrics (entropy/accuracy) use decoder logits without the causal one-token shift.
> 
> Docs and **`SFTConfig`** help text are updated; new tests cover T5 prompt-completion training, decoder label construction, and packing rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340a2a7277fdf781ee4657aa34af88bebdf84194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->