### PR TITLE
Pass GPU device_ids to barrier fix in GRPO + vLLM colocate + PEFT

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -665,10 +665,11 @@ class VLLMGeneration:
             # NCCL operations complete very quickly. On non-NVLink hardware (e.g. A40/A100), vLLM's
             # TP NCCL collective can race with NCCL's internal P2P/SHM channel cleanup from that
             # all-reduce, causing llm.generate() to hang. A barrier on the default process group
-            # forces NCCL to fully drain before vLLM's TP communication starts.
+            # forces NCCL to fully drain before vLLM's TP communication starts. We pass device_ids
+            # so NCCL uses this rank's device rather than guessing, which itself risks a hang.
             # See https://github.com/huggingface/trl/issues/3671
             if is_peft_model(self.model) and self.tensor_parallel_size > 1:
-                torch.distributed.barrier()
+                torch.distributed.barrier(device_ids=[accelerator.local_process_index])
 
             with profiler:
                 all_outputs = self.llm.generate(vllm_prompts, sampling_params=sampling_params, use_tqdm=False)


### PR DESCRIPTION
Pass GPU device_ids to barrier fix in GRPO + vLLM colocate + PEFT.

I forgot to push my last commit.

Follow-up to:
- #6139

This PR ensures that the correct device is specified during synchronization, reducing the risk of deadlocks.

### Changes

Distributed training stability:

* In the `generate` method, updated the call to `torch.distributed.barrier()` to pass `device_ids=[accelerator.local_process_index]`, ensuring NCCL uses the correct device for synchronization and reducing the likelihood of hangs on certain hardware.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to an existing distributed sync guard; no new code paths beyond specifying the GPU for the barrier.
> 
> **Overview**
> Follow-up to the PEFT + tensor-parallel colocate hang workaround in `VLLMGeneration.generate`: the pre-`llm.generate()` **`torch.distributed.barrier()`** now passes **`device_ids=[accelerator.local_process_index]`** so NCCL synchronizes on each rank’s GPU instead of inferring a device.
> 
> The inline comment is extended to note that wrong device selection during the barrier can itself cause hangs. Behavior is unchanged except for this narrower, hardware-specific stability fix on the existing PEFT + `tensor_parallel_size > 1` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde475dc13118f61ee3dc18c66cc72c68b96fb4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->