### PR TITLE
Fix PEFT ensure_weight_tying warning in liger + PEFT GRPO tests

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import gc
 import os
 import warnings
@@ -576,14 +575,12 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
-        # ensure_weight_tying suppresses the PEFT weight-tying warning; support for target_modules landed in PEFT 0.19.0
-        if Version(peft.__version__) >= Version("0.19.0"):
-            lora_config = LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"], ensure_weight_tying=True)
-            warn_ctx = contextlib.nullcontext()
-        else:
-            lora_config = LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"])
-            warn_ctx = pytest.warns(UserWarning, match="tie_word_embeddings")
-        with warn_ctx, pytest.raises(ValueError, match="lm_head"):
+        # ensure_weight_tying suppresses the PEFT weight-tying warning, which fires for target_modules since PEFT 0.19.0
+        lora_config = LoraConfig(
+            target_modules=["q_proj", "v_proj", "lm_head"],
+            **({"ensure_weight_tying": True} if Version(peft.__version__) >= Version("0.19.0") else {}),
+        )
+        with pytest.raises(ValueError, match="lm_head"):
             GRPOTrainer(
                 model=model,
                 reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
@@ -623,15 +620,12 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
-        # ensure_weight_tying suppresses the PEFT weight-tying warning; support for modules_to_save landed in PEFT 0.18.0
-        if Version(peft.__version__) >= Version("0.18.0"):
-            peft_config = LoraConfig(
-                target_modules=["q_proj", "v_proj"], modules_to_save=["lm_head"], ensure_weight_tying=True
-            )
-            warn_ctx = contextlib.nullcontext()
-        else:
-            peft_config = LoraConfig(target_modules=["q_proj", "v_proj"], modules_to_save=["lm_head"])
-            warn_ctx = pytest.warns(UserWarning, match="tie_word_embeddings")
+        # ensure_weight_tying suppresses the PEFT weight-tying warning, which fires for modules_to_save since PEFT 0.19.0
+        peft_config = LoraConfig(
+            target_modules=["q_proj", "v_proj"],
+            modules_to_save=["lm_head"],
+            **({"ensure_weight_tying": True} if Version(peft.__version__) >= Version("0.19.0") else {}),
+        )
         kwargs = {
             "model": model,
             "reward_funcs": "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
@@ -640,10 +634,9 @@ class TestGRPOTrainer(TrlTestCase):
             "peft_config": peft_config,
         }
         if is_liger_kernel_available():
-            with warn_ctx:
-                GRPOTrainer(**kwargs)  # must construct without raising
+            GRPOTrainer(**kwargs)  # must construct without raising
         else:
-            with warn_ctx, pytest.raises(ImportError):
+            with pytest.raises(ImportError):
                 GRPOTrainer(**kwargs)
 
     @require_peft

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import gc
 import os
 import warnings
@@ -56,6 +57,7 @@ from .testing_utils import (
 
 
 if is_peft_available():
+    import peft
     from peft import LoraConfig, PeftModel, get_peft_model
 
 
@@ -574,13 +576,20 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
-        with pytest.raises(ValueError, match="lm_head"):
+        # ensure_weight_tying suppresses the PEFT weight-tying warning; support for target_modules landed in PEFT 0.19.0
+        if Version(peft.__version__) >= Version("0.19.0"):
+            lora_config = LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"], ensure_weight_tying=True)
+            warn_ctx = contextlib.nullcontext()
+        else:
+            lora_config = LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"])
+            warn_ctx = pytest.warns(UserWarning, match="tie_word_embeddings")
+        with warn_ctx, pytest.raises(ValueError, match="lm_head"):
             GRPOTrainer(
                 model=model,
                 reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
                 args=training_args,
                 train_dataset=dataset,
-                peft_config=LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"]),
+                peft_config=lora_config,
             )
 
     @require_peft
@@ -614,17 +623,27 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
+        # ensure_weight_tying suppresses the PEFT weight-tying warning; support for modules_to_save landed in PEFT 0.18.0
+        if Version(peft.__version__) >= Version("0.18.0"):
+            peft_config = LoraConfig(
+                target_modules=["q_proj", "v_proj"], modules_to_save=["lm_head"], ensure_weight_tying=True
+            )
+            warn_ctx = contextlib.nullcontext()
+        else:
+            peft_config = LoraConfig(target_modules=["q_proj", "v_proj"], modules_to_save=["lm_head"])
+            warn_ctx = pytest.warns(UserWarning, match="tie_word_embeddings")
         kwargs = {
             "model": model,
             "reward_funcs": "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
             "args": training_args,
             "train_dataset": dataset,
-            "peft_config": LoraConfig(target_modules=["q_proj", "v_proj"], modules_to_save=["lm_head"]),
+            "peft_config": peft_config,
         }
         if is_liger_kernel_available():
-            GRPOTrainer(**kwargs)  # must construct without raising
+            with warn_ctx:
+                GRPOTrainer(**kwargs)  # must construct without raising
         else:
-            with pytest.raises(ImportError):
+            with warn_ctx, pytest.raises(ImportError):
                 GRPOTrainer(**kwargs)
 
     @require_peft


### PR DESCRIPTION
This PR fixes two UserWarnings emitted by PEFT in CI when running the liger + PEFT tests in test_grpo_trainer.py.

### Motivation

PEFT ≥ 0.18.0 warns when a model with tie_word_embeddings=True has a tied layer (e.g. lm_head) included in the adapter via modules_to_save or target_modules, but ensure_weight_tying is not set to True on the LoraConfig. Both affected tests deliberately include lm_head in the adapter config on a model with tied embeddings, so the warning fires as a side effect.

### Solution

For PEFT ≥ 0.18.0 (modules_to_save case) and ≥ 0.19.0 (target_modules case), pass ensure_weight_tying=True to LoraConfig to suppress the warning at the source. For older PEFT versions that predate the flag, fall back to pytest.warns to explicitly acknowledge the expected warning.

### Changes
Updated tests to handle PEFT version differences by conditionally setting `ensure_weight_tying` and using `contextlib.nullcontext()` or `pytest.warns` as appropriate, ensuring correct handling of warnings and errors across PEFT versions:
- In test_liger_kernel_with_peft_lm_head_raises: set ensure_weight_tying=True on LoraConfig for PEFT ≥ 0.19.0, with a pytest.warns fallback for older versions
- In test_liger_kernel_with_peft_modules_to_save_lm_head_allowed: set ensure_weight_tying=True on LoraConfig for PEFT ≥ 0.18.0, with a pytest.warns fallback for older versions
- Add import contextlib and import peft (under the is_peft_available() guard) to support the version-gated logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to LoRA config setup; no production trainer or library logic is modified.
> 
> **Overview**
> Silences **PEFT weight-tying `UserWarning`s** in CI for two existing Liger + PEFT GRPO tests that intentionally put `lm_head` in the adapter on tied-embedding models.
> 
> Adds `import peft` (behind `is_peft_available()`) and builds `LoraConfig` with **`ensure_weight_tying=True` when `peft >= 0.19.0`** in `test_liger_kernel_with_peft_lm_head_raises` and `test_liger_kernel_with_peft_modules_to_save_lm_head_allowed`. Test behavior (expected `ValueError` vs successful construction) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ac69416482b93450272f0df19cc8a6a345603e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->