### PR TITLE
Fix spurious liger token_accuracy CI warnings in SFT tests

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import copy
 import gc
 import json
@@ -950,7 +951,7 @@ class TestSFTTrainer(TrlTestCase):
             captured["skip_logits"] = inputs.get("skip_logits")
             dummy_loss = torch.tensor(1.0, requires_grad=True)
             dummy_outputs = MagicMock()
-            dummy_outputs.token_accuracy = None
+            dummy_outputs.token_accuracy = torch.tensor(0.5)
             dummy_outputs.logits = torch.randn(1, 5, trainer.model.config.vocab_size)
             return (dummy_loss, dummy_outputs)
 
@@ -994,7 +995,12 @@ class TestSFTTrainer(TrlTestCase):
         def mock_super_compute_loss(model, inputs, return_outputs=False, num_items_in_batch=None):
             captured["skip_logits"] = inputs.get("skip_logits")
             dummy_loss = torch.tensor(1.0, requires_grad=True)
-            dummy_outputs = (dummy_loss, torch.randn(1, 5, trainer.model.config.vocab_size))
+            DummyOutput = collections.namedtuple("DummyOutput", ["loss", "logits", "token_accuracy"])
+            dummy_outputs = DummyOutput(
+                loss=dummy_loss,
+                logits=torch.randn(1, 5, trainer.model.config.vocab_size),
+                token_accuracy=torch.tensor(0.5),
+            )
             return (dummy_loss, dummy_outputs)
 
         with patch("transformers.Trainer.compute_loss", side_effect=mock_super_compute_loss):


### PR DESCRIPTION
This PR fixes two test mocks in test_sft_trainer.py that were emitting spurious UserWarnings about liger-kernel not returning token_accuracy.

### Motivation

Both test_compute_loss_skip_logits_on_eval_without_metrics_with_liger and test_predict_does_not_skip_logits_with_liger are tests about skip_logits behaviour. Their mocks were accidentally simulating a broken liger call (returning None or no token_accuracy), which caused the SFT trainer's liger branch to emit a warning intended for genuine liger failures. The warning is correct by design; the mocks were not.

Real liger always returns token_accuracy when return_token_accuracy=True is set, even when skip_logits=True, because token accuracy is computed inside the fused kernel without materialising the full logits tensor.

### Changes

- In test_compute_loss_skip_logits_on_eval_without_metrics_with_liger: set dummy_outputs.token_accuracy = torch.tensor(0.5) instead of None
- In test_predict_does_not_skip_logits_with_liger: replace the bare tuple with a namedtuple that exposes a token_accuracy field while remaining tuple-indexable (required by transformers' prediction_step which slices outputs as outputs[1:])

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock fixes; no changes to SFT trainer or runtime behavior.
> 
> **Overview**
> Updates two **Liger + `skip_logits`** tests in `test_sft_trainer.py` so their patched `compute_loss` mocks behave like real liger-kernel (which always supplies `token_accuracy` when `return_token_accuracy=True`), instead of returning `None` or outputs without that field.
> 
> In **`test_compute_loss_skip_logits_on_eval_without_metrics_with_liger`**, the mock `MagicMock` now sets `token_accuracy` to a tensor instead of `None`. In **`test_predict_does_not_skip_logits_with_liger`**, the mock return value is a **`collections.namedtuple`** with `loss`, `logits`, and `token_accuracy` so it stays tuple-indexable for `prediction_step` while exposing the attribute the trainer reads. **`import collections`** is added for the namedtuple.
> 
> This removes spurious CI **`UserWarning`**s from the intentional liger failure path in `SFTTrainer.compute_loss`; production trainer logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aeb4664994969d719c650126946c1f429b32be9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->