### PR TITLE
Align TPO with DPO: Add evaluate() override

### DIFF
--- a/tests/experimental/test_tpo_trainer.py
+++ b/tests/experimental/test_tpo_trainer.py
@@ -130,6 +130,20 @@ class TestTPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_evaluate_with_raw_dataset(self):
+        # `evaluate` should accept the same (unprocessed) dataset types as the trainer, e.g. a held-out test set
+        # passed directly to `evaluate`, mirroring DPO/KTO. See https://github.com/huggingface/trl/issues/6115.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        dataset = dataset.map(_add_reference_column)
+
+        training_args = TPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = TPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        metrics = trainer.evaluate(eval_dataset=dataset)
+        assert metrics["eval_loss"] is not None
+
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
         dataset = dataset.map(_add_reference_column)

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -777,6 +777,28 @@ class TPOTrainer(_BaseTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         return self._compute_loss(model, inputs, return_outputs)
 
+    def evaluate(
+        self,
+        eval_dataset: Dataset | dict[str, Dataset] | None = None,
+        ignore_keys: list[str] | None = None,
+        metric_key_prefix: str = "eval",
+    ) -> dict[str, float]:
+        # When a dataset is passed directly to `evaluate` (e.g. a held-out test set), preprocess it the same way
+        # `__init__` does, so that `evaluate` accepts the same dataset types as the trainer. `_prepare_dataset` is
+        # idempotent: it skips datasets that are already tokenized. A `str` selects a dataset that was already prepared
+        # at init time, so it's left untouched.
+        if eval_dataset is not None and not isinstance(eval_dataset, str):
+            if isinstance(eval_dataset, dict):
+                eval_dataset = {
+                    key: self._prepare_dataset(dataset, self.processing_class, self.args, key)
+                    for key, dataset in eval_dataset.items()
+                }
+            else:
+                eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
+        return super().evaluate(
+            eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
+        )
+
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"
         metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}  # average the metrics

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -774,9 +774,6 @@ class TPOTrainer(_BaseTrainer):
 
         return (loss, outputs) if return_outputs else loss
 
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        return self._compute_loss(model, inputs, return_outputs)
-
     def evaluate(
         self,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
@@ -798,6 +795,9 @@ class TPOTrainer(_BaseTrainer):
         return super().evaluate(
             eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
         )
+
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        return self._compute_loss(model, inputs, return_outputs)
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"


### PR DESCRIPTION
Follow-up to #6116 (core trainers) and #6148 (KTO): `TPOTrainer` preprocesses `eval_dataset` in `__init__`, but doesn't override `evaluate()`, so passing a raw (unprocessed) dataset directly to `evaluate(eval_dataset=...)` — e.g. a held-out test set — fails:

```
ValueError: No columns in the dataset match the model's forward method signature:
(prompt_ids, chosen_ids, rejected_ids, reference_ids). The following columns have been
ignored: [prompt, rejected, chosen, reference].
```

This adds the same `evaluate()` override as DPO/KTO: when a dataset is passed directly to `evaluate`, it is preprocessed with the trainer's idempotent `_prepare_dataset` (a `str` selects a dataset already prepared at init time and is left untouched; dicts are handled per key). TPO has no reference model / `precompute_ref_log_probs` and no VLM path, so the override is the simplest form (no precompute or vision branch).

This is the TPO case of the same issue as #6115 / #6116.

### Verification

- Added `test_evaluate_with_raw_dataset` (mirrors KTO's): it fails on `main` with the `ValueError` above and passes with this change.
- Full `tests/experimental/test_tpo_trainer.py` passes locally; `ruff check` / `ruff format --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API parity change on the eval path; behavior for init-time eval datasets and str keys is unchanged.
> 
> **Overview**
> **`TPOTrainer.evaluate`** now runs **`_prepare_dataset`** on eval data passed at call time (single dataset or dict of datasets), matching DPO/KTO. String dataset keys that were already prepared in **`__init__`** are unchanged.
> 
> Adds **`test_evaluate_with_raw_dataset`** so a held-out raw triple-preference set can be evaluated without the prior column-mismatch **`ValueError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e5dcce770e0e576c15b0202821b8fb0d68d5ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->