### PR TITLE
Pass device_ids to the GRPO PEFT+TP generation barrier

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -668,7 +668,7 @@ class VLLMGeneration:
             # forces NCCL to fully drain before vLLM's TP communication starts.
             # See https://github.com/huggingface/trl/issues/3671
             if is_peft_model(self.model) and self.tensor_parallel_size > 1:
-                torch.distributed.barrier()
+                torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
 
             with profiler:
                 all_outputs = self.llm.generate(vllm_prompts, sampling_params=sampling_params, use_tqdm=False)


### PR DESCRIPTION
Follow-up to #6139 (fixes #3671).

#6139 added a `torch.distributed.barrier()` before `llm.generate()` for the PEFT + tensor-parallel colocate path. Called without `device_ids`, it emits a warning on every PEFT+TP generation step:

> barrier(): using the device under current context. You can specify device_id in init_process_group to mute this warning.

Passing `device_ids=[torch.cuda.current_device()]` silences the warning and binds the barrier to the calling process's device. This is consistent with how this file already initializes the vLLM communicator with `torch.cuda.current_device()`. No change to the synchronization behavior.

### Verification

Ran the #3671 MWE (Qwen2-0.5B, GRPO + colocate vLLM + LoRA, `tensor_parallel_size=2`) on 2×A10G:

- **before:** the warning prints on every PEFT+TP step;
- **after:** the warning is gone and training completes normally (no behavioral change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to an existing barrier call; verified as warning-only with no training behavior change.
> 
> **Overview**
> Updates the **PEFT + tensor-parallel** pre-generation `torch.distributed.barrier()` in `VLLMGeneration.generate` to pass **`device_ids=[torch.cuda.current_device()]`**, matching how the vLLM server communicator is initialized in the same module.
> 
> This removes the per-step PyTorch warning about inferring the barrier device from the current context. **Synchronization intent is unchanged**—the barrier still drains NCCL before `llm.generate()` to avoid the hang described in trl#3671.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28765fda110de99eb8c8f94f77d950eee0fd1303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->