### PR TITLE
Pass device_ids to the GRPO PEFT+TP generation barrier

### DIFF
--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -668,7 +668,7 @@ class VLLMGeneration:
             # forces NCCL to fully drain before vLLM's TP communication starts.
             # See https://github.com/huggingface/trl/issues/3671
             if is_peft_model(self.model) and self.tensor_parallel_size > 1:
-                torch.distributed.barrier()
+                torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
 
             with profiler:
                 all_outputs = self.llm.generate(vllm_prompts, sampling_params=sampling_params, use_tqdm=False)


### PR DESCRIPTION
## What does this PR do?

Follow-up to #6139 (which fixes #3671).

#6139 added a `torch.distributed.barrier()` before `llm.generate()` in the PEFT + tensor-parallel colocate path of `VLLMGeneration.generate`. Because it is called without `device_ids`, PyTorch emits a warning on every PEFT + TP generation step:

> barrier(): using the device under current context. You can specify device_id in init_process_group to mute this warning.

Passing `device_ids=[torch.cuda.current_device()]` silences the warning and binds the barrier to the calling process's device. This is consistent with how this file already initializes the vLLM communicator (`init_communicator(device=torch.cuda.current_device())`). There is no change to the synchronization behavior.

**Verification:** ran the #3671 MWE (Qwen2-0.5B, GRPO + colocate vLLM + LoRA, `tensor_parallel_size=2`) on 2×A10G. Before: the warning prints on every PEFT+TP step. After: the warning is gone and training completes normally.

Follow-up to #6139 / #3671 (no separate issue to close).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Raised in my review of #6139 (follow-up to #3671).
- [ ] Did you make sure to update the documentation with your changes? (not applicable)
- [ ] Did you write any new necessary tests? (not applicable, silences a warning, no behavior change)

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@albertvillanova @qgallouedec, small follow-up to #6139, as discussed in that thread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument tweak to an existing barrier on the GRPO colocate path; no intended change to distributed semantics beyond silencing a warning.
> 
> **Overview**
> Follow-up to the PEFT + tensor-parallel NCCL drain barrier before colocated `llm.generate()`: **`torch.distributed.barrier()`** now passes **`device_ids=[torch.cuda.current_device()]`** so PyTorch stops warning about inferring the device from the current CUDA context.
> 
> Synchronization intent is unchanged; this matches how the vLLM server communicator is initialized elsewhere in the same module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28765fda110de99eb8c8f94f77d950eee0fd1303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->