### PR TITLE
Fix deprecation in CI Sync TRL skills

### DIFF
--- a/.github/workflows/sync-huggingface-skills.yml
+++ b/.github/workflows/sync-huggingface-skills.yml
@@ -34,7 +34,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
+          client-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
           private-key: ${{ secrets.APP_SECRET_PREM_HUB_SKILLS_REPO }}
           repositories: skills
 


### PR DESCRIPTION
Fix deprecation in CI Sync TRL skills.

Currently, a warning is emitted by GH Action "Sync TRL skill with huggingface/skills", step "Create GitHub App token" using "actions/create-github-app-token" GH Action: https://github.com/huggingface/trl/actions/runs/28205349188/job/83554678491
> Create GitHub App token
> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

This PR updates the input parameter for the `actions/create-github-app-token` action, replacing deprecated `app-id` with `client-id` in the `.github/workflows/sync-huggingface-skills.yml` file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line CI workflow input rename with the same secret value; no application or security logic changes.
> 
> **Overview**
> Updates the **Sync TRL skill with huggingface/skills** workflow so the `actions/create-github-app-token` step uses `client-id` instead of the deprecated `app-id` input.
> 
> The secret name (`APP_ID_HUB_SKILLS_REPO`) is unchanged; only the action input key matches the current API and removes the CI warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cc7c1cb495f21dcdf42ae8a2f013aacad88b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->