### PR TITLE
Set explicit owner in CI Sync TRL skills

### DIFF
--- a/.github/workflows/sync-huggingface-skills.yml
+++ b/.github/workflows/sync-huggingface-skills.yml
@@ -36,7 +36,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
           private-key: ${{ secrets.APP_SECRET_PREM_HUB_SKILLS_REPO }}
-          repositories: skills
+          owner: huggingface
+          repositories: huggingface/skills
 
       - name: Checkout huggingface/skills repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Set explicit owner in CI Sync TRL skills:
- Set explicit owner in `actions/create-github-app-token`.

This PR makes a small update to the `.github/workflows/sync-huggingface-skills.yml` workflow to clarify the repository being accessed. The change specifies both the `owner` and the full repository name for improved clarity and correctness.

### Changes

- Updated the `github-app-token` action step to explicitly set the `owner` to `huggingface` and use the full repository name `huggingface/skills` instead of just `skills`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to GitHub App token inputs; no application or data-path impact.
> 
> **Overview**
> Updates the **Sync TRL skill** workflow so `actions/create-github-app-token` scopes the installation token correctly for the target repo.
> 
> The step now passes **`owner: huggingface`** and **`repositories: huggingface/skills`** instead of only `skills`, matching the checkout/PR target and the action’s expected repo identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f434efc814f9817c0ee3678f9571914ce7bed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->