### PR TITLE
Fix data types for PPO models

### DIFF
--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -38,6 +38,7 @@ from transformers import (
     DataCollatorWithPadding,
     FeatureExtractionMixin,
     GenerationConfig,
+    PreTrainedModel,
     PreTrainedTokenizerBase,
     ProcessorMixin,
     TrainerCallback,
@@ -314,15 +315,15 @@ class PPOTrainer(_BaseTrainer):
             Training arguments.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`]):
             Class to process the data.
-        model (`torch.nn.Module`):
+        model ([`~transformers.PreTrainedModel`]):
             Model to be trained. This is the policy model.
-        ref_model (`torch.nn.Module`, *optional*):
+        ref_model ([`~transformers.PreTrainedModel`], *optional*):
             Reference model used to compute the KL divergence. If `None`, a copy of the policy model is created.
-        reward_model (`torch.nn.Module`):
+        reward_model ([`~transformers.PreTrainedModel`]):
             Reward model used to compute the rewards.
         train_dataset ([`~datasets.Dataset`]):
             Dataset for training.
-        value_model (`torch.nn.Module`):
+        value_model ([`~transformers.PreTrainedModel`]):
             Value model used to predict the value of a state.
         data_collator ([`~transformers.DataCollatorWithPadding`], *optional*):
             Data collator to batch and pad samples from the dataset. If `None`, a default data collator is created
@@ -359,11 +360,11 @@ class PPOTrainer(_BaseTrainer):
         self,
         args: PPOConfig,
         processing_class: PreTrainedTokenizerBase | BaseImageProcessor | FeatureExtractionMixin | ProcessorMixin,
-        model: nn.Module,
-        ref_model: nn.Module | None,
-        reward_model: nn.Module,
+        model: PreTrainedModel,
+        ref_model: PreTrainedModel | None,
+        reward_model: PreTrainedModel,
         train_dataset: Dataset,
-        value_model: nn.Module,
+        value_model: PreTrainedModel,
         data_collator: DataCollatorWithPadding | None = None,
         eval_dataset: Dataset | dict[str, Dataset] | None = None,
         # less commonly used


### PR DESCRIPTION
Fix data types for PPO models.

Fix #1977.

This PR updates the type annotations and documentation for the `PPOTrainer` class in `trl/experimental/ppo/ppo_trainer.py` to use `transformers.PreTrainedModel` instead of the generic `torch.nn.Module` for all model-related parameters. This change ensures better type safety and clarity when using the `PPOTrainer` with Hugging Face Transformers models.

**Type annotation and documentation improvements:**

* Updated the import statements to include `PreTrainedModel` from `transformers`.
* Changed the type annotations and docstrings for the `model`, `ref_model`, `reward_model`, and `value_model` parameters in the `PPOTrainer` class to use `PreTrainedModel` instead of `nn.Module`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and documentation only; no runtime logic changes.
> 
> **Overview**
> Tightens **`PPOTrainer`** typing so policy, reference, reward, and value models are documented and annotated as **`transformers.PreTrainedModel`** instead of generic **`torch.nn.Module`**.
> 
> Adds the **`PreTrainedModel`** import and updates **`__init__`** parameter types plus the class docstring to match. **No training or rollout behavior changes**—this is for static typing and API clarity (addresses #1977).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9773e3755bf8d360a1038cc1441e9c865d3072c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->