### PR TITLE
Liger Teardown in Experimental Tests

### DIFF
--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 
 import pytest
@@ -241,6 +242,10 @@ class TestGKDTrainer(TrlTestCase):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
+    def teardown_method(self):
+        if hasattr(self, "_liger_module"):
+            importlib.reload(importlib.import_module(self._liger_module))
+
     def test_gkd_trainer(self):
         training_args = GKDConfig(
             output_dir=self.tmp_dir,
@@ -288,6 +293,7 @@ class TestGKDTrainer(TrlTestCase):
             train_dataset=dataset,
             processing_class=self.tokenizer,
         )
+        self._liger_module = trainer.model.__module__
 
         # Ensure liger fused JSD path is enabled; if not, skip (runtime may lack system libs)
         if not getattr(trainer, "use_liger_gkd_loss", False):
@@ -340,6 +346,7 @@ class TestGKDTrainer(TrlTestCase):
             eval_dataset=dummy_dataset["test"],
             processing_class=self.tokenizer,
         )
+        self._liger_module = trainer.model.__module__
 
         # evaluate() calls compute_loss with return_outputs=True; must not raise UnboundLocalError
         eval_results = trainer.evaluate()
@@ -370,6 +377,7 @@ class TestGKDTrainer(TrlTestCase):
             train_dataset=dataset,
             processing_class=self.tokenizer,
         )
+        self._liger_module = liger_trainer.model.__module__
 
         # Force student/teacher weights identical between trainers, then diverge teacher
         # so JSD is well above fp noise.
@@ -515,6 +523,7 @@ class TestGKDTrainer(TrlTestCase):
             train_dataset=dataset,
             processing_class=self.tokenizer,
         )
+        self._liger_module = trainer.model.__module__
         if not getattr(trainer, "use_liger_gkd_loss", False):
             pytest.skip("Liger fused JSD not enabled at runtime; skipping fused-loss assertion")
 

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
-
 import multiprocess
 import pytest
 import torch
@@ -290,10 +288,6 @@ class TestKTOTrainer(TrlTestCase):
         self.ref_model = AutoModelForCausalLM.from_pretrained(self.model_id)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
-
-    def teardown_method(self):
-        if hasattr(self, "_liger_module"):
-            importlib.reload(importlib.import_module(self._liger_module))
 
     @pytest.mark.parametrize(
         "config_name, loss_type, pre_compute, eval_dataset",
@@ -779,7 +773,6 @@ class TestKTOTrainer(TrlTestCase):
         trainer = KTOTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
         )
-        self._liger_module = trainer.model.__module__
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
@@ -803,7 +796,6 @@ class TestKTOTrainer(TrlTestCase):
             report_to="none",
         )
 
-        self._liger_module = "transformers.models.qwen2.modeling_qwen2"
         with pytest.raises(ValueError, match="You cannot use `use_liger_kernel=True` with Peft models"):
             KTOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
@@ -1050,10 +1042,6 @@ class TestKTOTrainer(TrlTestCase):
 
 @require_vision
 class TestKTOTrainerVLM(TrlTestCase):
-    def teardown_method(self):
-        if hasattr(self, "_liger_module"):
-            importlib.reload(importlib.import_module(self._liger_module))
-
     @pytest.mark.parametrize(
         "model_id",
         [
@@ -1270,7 +1258,6 @@ class TestKTOTrainerVLM(TrlTestCase):
             args=training_args,
             train_dataset=dataset,
         )
-        self._liger_module = trainer.model.__module__
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 

--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+
 import multiprocess
 import pytest
 import torch
@@ -288,6 +290,10 @@ class TestKTOTrainer(TrlTestCase):
         self.ref_model = AutoModelForCausalLM.from_pretrained(self.model_id)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    def teardown_method(self):
+        if hasattr(self, "_liger_module"):
+            importlib.reload(importlib.import_module(self._liger_module))
 
     @pytest.mark.parametrize(
         "config_name, loss_type, pre_compute, eval_dataset",
@@ -773,6 +779,7 @@ class TestKTOTrainer(TrlTestCase):
         trainer = KTOTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
         )
+        self._liger_module = trainer.model.__module__
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
@@ -796,6 +803,7 @@ class TestKTOTrainer(TrlTestCase):
             report_to="none",
         )
 
+        self._liger_module = "transformers.models.qwen2.modeling_qwen2"
         with pytest.raises(ValueError, match="You cannot use `use_liger_kernel=True` with Peft models"):
             KTOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
@@ -1042,6 +1050,10 @@ class TestKTOTrainer(TrlTestCase):
 
 @require_vision
 class TestKTOTrainerVLM(TrlTestCase):
+    def teardown_method(self):
+        if hasattr(self, "_liger_module"):
+            importlib.reload(importlib.import_module(self._liger_module))
+
     @pytest.mark.parametrize(
         "model_id",
         [
@@ -1258,6 +1270,7 @@ class TestKTOTrainerVLM(TrlTestCase):
             args=training_args,
             train_dataset=dataset,
         )
+        self._liger_module = trainer.model.__module__
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 

--- a/tests/experimental/test_sdft_trainer.py
+++ b/tests/experimental/test_sdft_trainer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+
 import pytest
 import torch
 from datasets import Dataset
@@ -61,6 +63,10 @@ class RecordingTeacherClient:
 
 
 class TestSDFTTrainer(TrlTestCase):
+    def teardown_method(self):
+        if hasattr(self, "_liger_module"):
+            importlib.reload(importlib.import_module(self._liger_module))
+
     @staticmethod
     def _trainable_param_snapshot(model):
         return {name: param.detach().clone() for name, param in model.named_parameters() if param.requires_grad}
@@ -153,6 +159,7 @@ class TestSDFTTrainer(TrlTestCase):
             args=SDFTConfig(use_liger_kernel=True, **common),
             train_dataset=dataset,
         )
+        self._liger_module = liger_trainer.model.__module__
 
         liger_trainer.model.load_state_dict(ref_trainer.model.state_dict())
         torch.manual_seed(0)

--- a/tests/experimental/test_sdpo_trainer.py
+++ b/tests/experimental/test_sdpo_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import logging
 
 import pytest
@@ -73,6 +74,10 @@ class RecordingTeacherClient:
 
 
 class TestSDPOTrainer(TrlTestCase):
+    def teardown_method(self):
+        if hasattr(self, "_liger_module"):
+            importlib.reload(importlib.import_module(self._liger_module))
+
     def test_trust_remote_code(self):
         dataset = Dataset.from_dict(
             {
@@ -197,6 +202,7 @@ class TestSDPOTrainer(TrlTestCase):
             args=SDPOConfig(use_liger_kernel=True, **common),
             train_dataset=dataset,
         )
+        self._liger_module = liger_trainer.model.__module__
 
         liger_trainer.model.load_state_dict(ref_trainer.model.state_dict())
         torch.manual_seed(0)


### PR DESCRIPTION
# What does this PR do?

Liger pollutes the testing environment, so we need a proper teardown to avoid failures when testing other trainers. These changes prevent unexpected failures in the experimental test suite when testing other trainers.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [X] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only isolation fixes with no production code or runtime behavior changes.
> 
> **Overview**
> **Liger kernel tests** in GKD, SDFT, and SDPO experimental suites now **reset global module state** after each test so later trainer tests do not inherit monkey-patched model classes.
> 
> Each affected test class adds a **`teardown_method`** that, when `_liger_module` was recorded, **`importlib.reload`s** that module. Liger-enabled cases set **`self._liger_module = trainer.model.__module__`** right after constructing the trainer with **`use_liger_kernel=True`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ddb4706621c65c43f9f0c4e2c5dded0c32ec7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->