### PR TITLE
Fix dataset fingerprinting in DPO/SFT tokenization

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -888,10 +888,11 @@ class DPOTrainer(_BaseTrainer):
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
+    @staticmethod
     def _tokenize(
-        self,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
+        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -905,6 +906,9 @@ class DPOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
+            is_vlm (`bool`):
+                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
@@ -912,13 +916,13 @@ class DPOTrainer(_BaseTrainer):
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
         if isinstance(input, list):  # conversational: list of message dicts
-            if self._is_vlm:
+            if is_vlm:
                 input = prepare_multimodal_messages(input)
             result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
         else:  # non-conversational: plain text string
             result = processing_class(text=input)
         # VLMs emit a batch dimension even for single examples; unwrap it
-        if self._is_vlm:
+        if is_vlm:
             return {k: v[0] for k, v in result.items()}
         return result
 
@@ -961,36 +965,43 @@ class DPOTrainer(_BaseTrainer):
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-            def tokenize_fn(example, processing_class):
+            # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the map
+            # function unhashable, forcing a random fingerprint that silently disables dataset caching.
+            tokenize = self._tokenize
+
+            def tokenize_fn(example, processing_class, is_vlm):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 output = {}
                 if is_conversational(example):
-                    prompt_ids = self._tokenize(
+                    prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
+                        is_vlm,
                         tools=tools,
                         add_generation_prompt=True,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_chosen_ids = self._tokenize(
+                    prompt_chosen_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
+                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_rejected_ids = self._tokenize(
+                    prompt_rejected_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
+                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                 else:
-                    prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
-                    prompt_chosen_ids = self._tokenize(processing_class, example["prompt"] + example["chosen"])[
+                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
+                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"], is_vlm)[
                         "input_ids"
                     ]
-                    prompt_rejected_ids = self._tokenize(processing_class, example["prompt"] + example["rejected"])[
+                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"], is_vlm)[
                         "input_ids"
                     ]
 
@@ -1013,7 +1024,11 @@ class DPOTrainer(_BaseTrainer):
                 output["rejected_ids"] = prompt_rejected_ids[len(prompt_ids) :]
                 return output
 
-            dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)
+            dataset = dataset.map(
+                tokenize_fn,
+                fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm},
+                **map_kwargs,
+            )
 
         return dataset
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -565,6 +565,34 @@ class RewardTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
+    @staticmethod
+    def _tokenize(
+        processing_class: PreTrainedTokenizerBase,
+        input: str | list,
+        **kwargs,
+    ) -> dict[str, list]:
+        """Tokenize a single example for dataset preprocessing.
+
+        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+        non-conversational input (str).
+
+        Args:
+            processing_class ([`~transformers.PreTrainedTokenizerBase`]):
+                The tokenizer to use.
+            input (`str` or `list`):
+                A string for non-conversational input, or a list of message dicts for conversational input.
+            **kwargs:
+                Forwarded to `apply_chat_template` (e.g. `tools`).
+
+        Returns:
+            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+        """
+        if isinstance(input, list):  # conversational: list of message dicts
+            result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
+        else:  # non-conversational: plain text string
+            result = processing_class(text=input)
+        return result
+
     def _prepare_dataset(
         self,
         dataset: Dataset | IterableDataset,
@@ -617,6 +645,11 @@ class RewardTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
+                # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the
+                # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+                # `_tokenize` is a static method, so `self._tokenize` is a plain function (no bound `self`).
+                tokenize = self._tokenize
+
                 def tokenize_fn(example, processing_class):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
@@ -625,23 +658,23 @@ class RewardTrainer(_BaseTrainer):
                         example["rejected"] = example["prompt"] + example["rejected"]
 
                     if is_conversational(example):
-                        chosen_ids = processing_class.apply_chat_template(
+                        chosen_ids = tokenize(
+                            processing_class,
                             example["chosen"],
                             tools=tools,
-                            return_dict=True,
                             **example.get("chat_template_kwargs", {}),
                         )["input_ids"]
-                        rejected_ids = processing_class.apply_chat_template(
+                        rejected_ids = tokenize(
+                            processing_class,
                             example["rejected"],
                             tools=tools,
-                            return_dict=True,
                             **example.get("chat_template_kwargs", {}),
                         )["input_ids"]
                         output = {"chosen_ids": chosen_ids, "rejected_ids": rejected_ids}
                     else:
                         output = {
-                            "chosen_ids": processing_class(text=example["chosen"])["input_ids"],
-                            "rejected_ids": processing_class(text=example["rejected"])["input_ids"],
+                            "chosen_ids": tokenize(processing_class, example["chosen"])["input_ids"],
+                            "rejected_ids": tokenize(processing_class, example["rejected"])["input_ids"],
                         }
                     return output
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1497,7 +1497,9 @@ class SFTTrainer(_BaseTrainer):
                 # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
                 tokenize = self._tokenize
 
-                def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template):
+                def tokenize_fn(
+                    example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template
+                ):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
                     if "prompt" in example:  # prompt-completion case

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1368,10 +1368,12 @@ class SFTTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
+    @staticmethod
     def _tokenize(
-        self,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
+        is_vlm: bool,
+        chat_template: str | None,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -1385,6 +1387,11 @@ class SFTTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
+            is_vlm (`bool`):
+                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+                dimension normalization.
+            chat_template (`str` or `None`):
+                Chat template forwarded to `apply_chat_template` for conversational input.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
@@ -1392,15 +1399,15 @@ class SFTTrainer(_BaseTrainer):
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
         if isinstance(input, list):  # conversational: list of message dicts
-            if self._is_vlm:
+            if is_vlm:
                 input = prepare_multimodal_messages(input)
             result = processing_class.apply_chat_template(
-                input, tokenize=True, return_dict=True, chat_template=self.chat_template, **kwargs
+                input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
             )
         else:  # non-conversational: plain text string
             result = processing_class(text=input)
         # VLMs emit a batch dimension even for single examples; unwrap it
-        if self._is_vlm:
+        if is_vlm:
             return {k: v[0] for k, v in result.items()}
         return result
 
@@ -1486,22 +1493,30 @@ class SFTTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-                def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss):
+                # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the
+                # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+                tokenize = self._tokenize
+
+                def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
                     if "prompt" in example:  # prompt-completion case
                         output = {}
                         if is_conversational(example):
-                            prompt_ids = self._tokenize(
+                            prompt_ids = tokenize(
                                 processing_class,
                                 example["prompt"],
+                                is_vlm,
+                                chat_template,
                                 tools=tools,
                                 add_generation_prompt=True,
                                 **example.get("chat_template_kwargs", {}),
                             )["input_ids"]
-                            prompt_completion_processed = self._tokenize(
+                            prompt_completion_processed = tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
+                                is_vlm,
+                                chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **example.get("chat_template_kwargs", {}),
@@ -1510,9 +1525,11 @@ class SFTTrainer(_BaseTrainer):
                             if "assistant_masks" in prompt_completion_processed:
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
-                            prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
-                            prompt_completion_ids = self._tokenize(
-                                processing_class, example["prompt"] + example["completion"]
+                            prompt_ids = tokenize(processing_class, example["prompt"], is_vlm, chat_template)[
+                                "input_ids"
+                            ]
+                            prompt_completion_ids = tokenize(
+                                processing_class, example["prompt"] + example["completion"], is_vlm, chat_template
                             )["input_ids"]
 
                         # Check if the tokenized prompt starts with the tokenized prompt+completion
@@ -1530,9 +1547,11 @@ class SFTTrainer(_BaseTrainer):
 
                     else:  # language modeling case
                         if is_conversational(example):
-                            processed = self._tokenize(
+                            processed = tokenize(
                                 processing_class,
                                 example["messages"],
+                                is_vlm,
+                                chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **example.get("chat_template_kwargs", {}),
@@ -1540,7 +1559,9 @@ class SFTTrainer(_BaseTrainer):
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:
                             output = {
-                                "input_ids": self._tokenize(processing_class, example[dataset_text_field])["input_ids"]
+                                "input_ids": tokenize(
+                                    processing_class, example[dataset_text_field], is_vlm, chat_template
+                                )["input_ids"]
                             }
 
                     if "assistant_masks" in output and 1 not in output["assistant_masks"]:
@@ -1558,6 +1579,8 @@ class SFTTrainer(_BaseTrainer):
                         "processing_class": processing_class,
                         "dataset_text_field": args.dataset_text_field,
                         "assistant_only_loss": args.assistant_only_loss,
+                        "is_vlm": self._is_vlm,
+                        "chat_template": self.chat_template,
                     },
                     **map_kwargs,
                 )


### PR DESCRIPTION
`DPOTrainer` and `SFTTrainer` tokenize via a nested `tokenize_fn` passed to `Dataset.map` that called `self._tokenize(...)`, capturing the whole trainer. When `datasets` fingerprints the map function it tries to pickle `self`; if that fails it falls back to a **random fingerprint**, silently disabling tokenization caching and logging:

```
Parameter 'function'=<function DPOTrainer._prepare_dataset.<locals>.tokenize_fn ...> couldn't be hashed properly, a random hash was used instead. ...
```

## Background

Not a recent regression: the self-capture dates back to **#3906**; **#5369** only moved it into the `_tokenize` helper. **#6116** made it *visible* — its `evaluate()` override re-tokenizes a raw eval set after the model is accelerate-wrapped, so `self` is no longer picklable and hashing now raises instead of quietly returning a (still-wrong) hash. #6116 also added the `test_evaluate_with_raw_dataset` test that surfaced it.

## Fix

Make `_tokenize` a `@staticmethod` taking the `self`-derived values (`is_vlm`, plus `chat_template` for SFT) explicitly. `tokenize_fn` references it through a local (`tokenize = self._tokenize`, no bound `self`) and gets those values via `fn_kwargs`, like the existing `processing_class`. No `self` in the closure → hashable again.

Scope: **DPO** and **SFT** had the bug — fixed. **Reward** never captured `self` (no bug), but is realigned to the same `_tokenize` static-helper structure for consistency. **GRPO/RLOO** unaffected (tokenize during generation, not via `Dataset.map`).

## Reproducer

Warns on `main`, silent after this PR:

```python
from datasets import load_dataset
from trl import DPOTrainer

dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
trainer = DPOTrainer(model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", train_dataset=dataset)
trainer.evaluate(eval_dataset=dataset)
```

Before the fix:

```console
$ python repro.py
Loading weights: 100%|██████████████████████████████████| 27/27 [00:00<00:00, 1060.31it/s]
Loading weights: 100%|██████████████████████████████████| 27/27 [00:00<00:00, 4642.95it/s]
Parameter 'function'=<function DPOTrainer._prepare_dataset.<locals>.tokenize_fn at 0x7fec260267a0> of the transform datasets.arrow_dataset.Dataset._map_single couldn't be hashed properly, a random hash was used instead. Make sure your transforms and parameters are serializable with pickle or dill for the dataset fingerprinting and caching to work. If you reuse this transform, the caching mechanism will consider it to be different from the previous calls and recompute everything. This warning is only shown once. Subsequent hashing failures won't be shown.
Tokenizing eval dataset: 100%|████████████████████| 17/17 [00:00<00:00, 1208.47 examples/s]
100%|██████████████████████████████████████████████████████| 3/3 [00:00<00:00, 67.07it/s]
```

After the fix:

```
$ python repro.py
Loading weights: 100%|██████████████████████████████████| 27/27 [00:00<00:00, 1369.13it/s]
Loading weights: 100%|██████████████████████████████████| 27/27 [00:00<00:00, 2944.83it/s]
100%|██████████████████████████████████████████████████████| 3/3 [00:00<00:00, 87.99it/s]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of dataset preprocessing only; tokenization behavior is intended to be unchanged aside from enabling correct caching.
> 
> **Overview**
> Fixes **Hugging Face `datasets` fingerprinting** for preference/SFT preprocessing: nested `tokenize_fn` closures no longer capture the trainer instance, so `Dataset.map` can hash the transform and **reuse tokenization caches** instead of falling back to a random fingerprint (and the associated warning).
> 
> **DPO** and **SFT** turn `_tokenize` into a `@staticmethod` and pass trainer-derived flags (`is_vlm`, and `chat_template` for SFT) through `fn_kwargs`. **`tokenize_fn`** calls a local `tokenize = self._tokenize` so the mapped function stays picklable even after Accelerate wraps the model (e.g. raw eval sets re-tokenized in `evaluate()`).
> 
> **RewardTrainer** gets the same static `_tokenize` helper and local binding for consistency; it did not previously close over `self` in the map path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9ce2da24f01a0d9b28d8177b540e5f048640d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->