### PR TITLE
Drop vLLM 0.14 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -220,8 +220,8 @@ options:
   --tensor_parallel_size TENSOR_PARALLEL_SIZE, --tensor-parallel-size TENSOR_PARALLEL_SIZE
                         Number of tensor parallel workers to use. (default: 1)
   --data_parallel_size DATA_PARALLEL_SIZE, --data-parallel-size DATA_PARALLEL_SIZE
-                        Number of data parallel workers to use. For dense models, keep this at 1. Starting from vLLM `0.14.0`, setting
-                        this above `1` for dense models is no longer supported/useful and will error out (see vLLM PR #30739).
+                        Number of data parallel workers to use. For dense models, keep this at 1. Setting this above `1` for
+                        dense models is not supported/useful and will error out (see vLLM PR #30739).
                         (default: 1)
   --host HOST           Host address to run the server on. (default: 0.0.0.0)
   --port PORT           Port to run the server on. (default: 8000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.14.0,<=0.23.0",
+    "vllm>=0.15.0,<=0.23.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.14.0") <= Version(_vllm_version) <= Version("0.23.0")):
+        if not (Version("0.15.0") <= Version(_vllm_version) <= Version("0.23.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.14.0 to 0.23.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.15.0 to 0.23.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -233,9 +233,8 @@ class ScriptArguments:
     data_parallel_size: int = field(
         default=1,
         metadata={
-            "help": "Number of data parallel workers to use. For dense models, keep this at 1. Starting from vLLM "
-            "`0.14.0`, setting this above `1` for dense models is no longer supported/useful and will error out (see "
-            "vLLM PR #30739)."
+            "help": "Number of data parallel workers to use. For dense models, keep this at 1. Setting this above "
+            "`1` for dense models is not supported/useful and will error out (see vLLM PR #30739)."
         },
     )
     host: str = field(

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -174,9 +174,8 @@ class ScriptArguments:
         tensor_parallel_size (`int`, *optional*, defaults to `1`):
             Number of tensor parallel workers to use.
         data_parallel_size (`int`, *optional*, defaults to `1`):
-            Number of data parallel workers to use. For dense models, keep this at 1. Starting from vLLM `0.14.0`,
-            setting this above `1` for dense models is no longer supported/useful and will error out (see vLLM PR
-            #30739).
+            Number of data parallel workers to use. For dense models, keep this at 1. Setting this above `1` for
+            dense models is not supported/useful and will error out (see vLLM PR #30739).
         host (`str`, *optional*, defaults to `"0.0.0.0"`):
             Host address to run the server on.
         port (`int`, *optional*, defaults to `8000`):

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -174,8 +174,8 @@ class ScriptArguments:
         tensor_parallel_size (`int`, *optional*, defaults to `1`):
             Number of tensor parallel workers to use.
         data_parallel_size (`int`, *optional*, defaults to `1`):
-            Number of data parallel workers to use. For dense models, keep this at 1. Setting this above `1` for
-            dense models is not supported/useful and will error out (see vLLM PR #30739).
+            Number of data parallel workers to use. For dense models, keep this at 1. Setting this above `1` for dense
+            models is not supported/useful and will error out (see vLLM PR #30739).
         host (`str`, *optional*, defaults to `"0.0.0.0"`):
             Host address to run the server on.
         port (`int`, *optional*, defaults to `8000`):


### PR DESCRIPTION
As per our internal discussion

<img width="1430" height="806" alt="trl_vllm_support_timeline" src="https://github.com/user-attachments/assets/ac88b72e-08e8-49aa-b43e-8137341b742e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor and messaging only; no runtime logic changes beyond version checks and documentation.
> 
> **Overview**
> **Raises the minimum supported vLLM version from 0.14.0 to 0.15.0** (upper bound stays at 0.23.0). `pip install "trl[vllm]"` now resolves `vllm>=0.15.0`, and `is_vllm_available()` warns when an installed version falls outside **0.15.0–0.23.0**.
> 
> Help text for `--data_parallel_size` in the vLLM serve CLI and docs no longer ties dense-model DP limits to “starting from vLLM 0.14.0”; it states the restriction directly (still referencing vLLM PR #30739).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6a67ef8c1e4ae801d6398112b1b90850d88223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->