### PR TITLE
Add experimental VIMPO trainer

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -145,6 +145,8 @@
     title: SSD
   - local: tpo_trainer
     title: TPO
+  - local: vimpo_trainer
+    title: VIMPO
   - local: xpo_trainer
     title: XPO
   title: Experimental

--- a/docs/source/dataset_formats.md
+++ b/docs/source/dataset_formats.md
@@ -420,6 +420,7 @@ Choosing the right dataset type depends on the task you are working on and the s
 | [`experimental.orpo.ORPOTrainer`] | [Preference (explicit prompt recommended)](#preference) |
 | [`experimental.ppo.PPOTrainer`] | Tokenized language modeling |
 | [`experimental.prm.PRMTrainer`] | [Stepwise supervision](#stepwise-supervision) |
+| [`experimental.vimpo.VIMPOTrainer`] | [Prompt-only](#prompt-only) |
 | [`experimental.xpo.XPOTrainer`] | [Prompt-only](#prompt-only) |
 
 ## Using any dataset with TRL: preprocessing and conversion

--- a/docs/source/example_overview.md
+++ b/docs/source/example_overview.md
@@ -95,6 +95,7 @@ Scripts are maintained in the [`trl/scripts`](https://github.com/huggingface/trl
 | [`examples/scripts/ssd.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/ssd.py) | This script shows how to use the [`experimental.ssd.SSDTrainer`] for Simple Self-Distillation (SSD) on code generation. |
 | [`examples/scripts/ssd_eval.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/ssd_eval.py) | This script evaluates SSD-trained checkpoints on LiveCodeBench with vLLM and the official `codegen_metrics` (pass@k). |
 | [`examples/scripts/tpo.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/tpo.py) | This script shows how to use the [`experimental.tpo.TPOTrainer`] for Triple Preference Optimization (TPO) using the [tpo-alignment/triple-preference-ultrafeedback-40K](https://huggingface.co/datasets/tpo-alignment/triple-preference-ultrafeedback-40K) dataset. |
+| [`examples/scripts/vimpo.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/vimpo.py) | This script shows how to use the [`experimental.vimpo.VIMPOTrainer`] to fine-tune a model with verifiable math rewards using the [AI-MO/NuminaMath-TIR](https://huggingface.co/datasets/AI-MO/NuminaMath-TIR) dataset. |
 | [`examples/scripts/xpo.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/xpo.py) | This script shows how to use the [`experimental.xpo.XPOTrainer`] to fine-tune a model. |
 
 ### OpenEnv Scripts

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -691,6 +691,30 @@ training_args = GRPOConfig(
 )
 ```
 
+### VIMPO: Value-Implicit Policy Optimization for LLMs
+
+**📜 Paper**: https://huggingface.co/papers/2606.20008
+
+VIMPO is a critic-free RLVR method that keeps GRPO-style grouped rollouts while recovering token-level credit assignment from a policy-implied value recurrence. It trains a terminal value loss against the centered final reward and optionally adds a PPO-style actor branch using detached policy-implied advantages. In TRL, the experimental implementation reuses GRPO's rollout and reward pipeline and replaces the loss with the raw VIMPO objective from the paper. See [VIMPO](vimpo_trainer).
+
+```python
+from trl.experimental.vimpo import VIMPOConfig, VIMPOTrainer
+
+training_args = VIMPOConfig(
+    vimpo_beta=5e-4,
+    vimpo_actor_coeff=5e-3,
+    num_generations=8,
+)
+
+trainer = VIMPOTrainer(
+    model="your-model",
+    reward_funcs=[...],
+    args=training_args,
+    train_dataset=dataset,
+)
+trainer.train()
+```
+
 
 ### Rethinking the Trust Region in LLM Reinforcement Learning
 

--- a/docs/source/vimpo_trainer.md
+++ b/docs/source/vimpo_trainer.md
@@ -1,0 +1,62 @@
+# VIMPO Trainer
+
+[VIMPO: Value-Implicit Policy Optimization for LLMs](https://huggingface.co/papers/2606.20008) is a critic-free RLVR method that keeps GRPO-style grouped rollouts while recovering token-level credit assignment from a policy-implied value recurrence. VIMPO trains a terminal value loss against the centered final reward and can add a PPO-style actor branch using detached policy-implied advantages.
+
+To use VIMPO, you can use the [`VIMPOTrainer`] class in `trl.experimental.vimpo`.
+
+## Usage
+
+```python
+from trl.experimental.vimpo import VIMPOConfig, VIMPOTrainer
+
+training_args = VIMPOConfig(
+    vimpo_beta=5e-4,
+    vimpo_actor_coeff=5e-3,
+    num_generations=8,
+)
+trainer = VIMPOTrainer(
+    model="Qwen/Qwen3-0.6B",
+    reward_funcs=...,
+    train_dataset=...,
+    args=training_args,
+)
+trainer.train()
+```
+
+VIMPO reuses GRPO's generation and reward-function interface. The implementation follows the paper's raw VIMPO setting: exact `KL(pi_theta || pi_ref)`, detached KL in the terminal value loss, a frozen reference policy, centered rewards without reward scaling, and a PPO actor branch controlled by `vimpo_actor_coeff` with normalized detached actor advantages.
+
+## Expected dataset type
+
+VIMPO requires a [prompt-only dataset](dataset_formats#prompt-only). The [`experimental.vimpo.VIMPOTrainer`] supports both [conversational](dataset_formats#conversational) and [standard](dataset_formats#standard) dataset formats. When provided with a conversational dataset, the trainer will automatically apply the chat template to the dataset.
+
+## Example script
+
+Use [`examples/scripts/vimpo.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/vimpo.py) to launch VIMPO training on [AI-MO/NuminaMath-TIR](https://huggingface.co/datasets/AI-MO/NuminaMath-TIR) with verifiable math rewards.
+
+```bash
+accelerate launch \
+    --config_file examples/accelerate_configs/deepspeed_zero3.yaml \
+    examples/scripts/vimpo.py \
+    --model_name_or_path Qwen/Qwen3-0.6B \
+    --output_dir vimpo-Qwen3-0.6B \
+    --learning_rate 1e-5 \
+    --dtype bfloat16 \
+    --max_completion_length 1024 \
+    --use_peft \
+    --lora_target_modules "q_proj", "v_proj" \
+    --per_device_train_batch_size 8 \
+    --num_generations 8 \
+    --vimpo_beta 5e-4 \
+    --vimpo_actor_coeff 5e-3
+```
+
+## VIMPOTrainer
+
+[[autodoc]] experimental.vimpo.VIMPOTrainer
+    - train
+    - save_model
+    - push_to_hub
+
+## VIMPOConfig
+
+[[autodoc]] experimental.vimpo.VIMPOConfig

--- a/examples/scripts/vimpo.py
+++ b/examples/scripts/vimpo.py
@@ -1,0 +1,129 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# /// script
+# dependencies = [
+#     "trl[peft]",
+#     "math-verify",
+#     "latex2sympy2_extended",
+#     "trackio",
+#     "kernels",
+# ]
+# ///
+
+"""
+NuminaMath example: VIMPO on math reasoning with verifiable rewards.
+
+pip install math_verify latex2sympy2_extended peft trackio
+
+# For Qwen/Qwen3-0.6B
+pip install num2words==0.5.14
+
+accelerate launch \
+    --config_file examples/accelerate_configs/deepspeed_zero3.yaml \
+    examples/scripts/vimpo.py \
+    --model_name_or_path Qwen/Qwen3-0.6B \
+    --output_dir vimpo-Qwen3-0.6B \
+    --learning_rate 1e-5 \
+    --dtype bfloat16 \
+    --max_completion_length 1024 \
+    --use_peft \
+    --lora_target_modules "q_proj", "v_proj" \
+    --log_completions \
+    --per_device_train_batch_size 8 \
+    --num_generations 8 \
+    --gradient_accumulation_steps 2 \
+    --steps_per_generation 8 \
+    --vimpo_beta 5e-4 \
+    --vimpo_actor_coeff 5e-3
+"""
+
+import torch
+from datasets import load_dataset
+
+from trl import (
+    ModelConfig,
+    ScriptArguments,
+    TrlParser,
+    get_kbit_device_map,
+    get_peft_config,
+    get_quantization_config,
+)
+from trl.experimental.vimpo import VIMPOConfig, VIMPOTrainer
+from trl.rewards import accuracy_reward, think_format_reward
+
+
+if __name__ == "__main__":
+    parser = TrlParser((ScriptArguments, VIMPOConfig, ModelConfig))
+    script_args, training_args, model_args = parser.parse_args_and_config()
+
+    ################
+    # Model & Processor
+    ################
+    dtype = model_args.dtype if model_args.dtype in ["auto", None] else getattr(torch, model_args.dtype)
+    training_args.model_init_kwargs = dict(
+        revision=model_args.model_revision,
+        attn_implementation=model_args.attn_implementation,
+        dtype=dtype,
+    )
+    quantization_config = get_quantization_config(model_args)
+    if quantization_config is not None:
+        # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
+        training_args.model_init_kwargs["device_map"] = get_kbit_device_map()
+        training_args.model_init_kwargs["quantization_config"] = quantization_config
+
+    ################
+    # Dataset
+    ################
+    train_dataset, eval_dataset = load_dataset("AI-MO/NuminaMath-TIR", split=["train[:5%]", "test[:5%]"])
+
+    SYSTEM_PROMPT = (
+        "A conversation between user and assistant. The user asks a question, and the assistant solves it. The "
+        "assistant first thinks about the reasoning process in the mind and then provides the answer. The reasoning "
+        "process must be enclosed within <think></think> tags, and the final answer must be enclosed in \\boxed{}, "
+        "i.e., <think>\nThis is my reasoning.\n</think>\n\\boxed{answer}"
+    )
+
+    def make_conversation(example):
+        return {
+            "prompt": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": example["problem"]},
+            ],
+        }
+
+    train_dataset = train_dataset.map(make_conversation)
+    eval_dataset = eval_dataset.map(make_conversation)
+
+    train_dataset = train_dataset.remove_columns(["messages", "problem"])
+    eval_dataset = eval_dataset.remove_columns(["messages", "problem"])
+
+    ################
+    # Training
+    ################
+    trainer = VIMPOTrainer(
+        model=model_args.model_name_or_path,
+        args=training_args,
+        reward_funcs=[think_format_reward, accuracy_reward],
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        peft_config=get_peft_config(model_args),
+    )
+
+    trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
+
+    # Save and push to hub
+    trainer.save_model(training_args.output_dir)
+    if training_args.push_to_hub:
+        trainer.push_to_hub(dataset_name=script_args.dataset_name or "AI-MO/NuminaMath-TIR")

--- a/tests/experimental/test_vimpo_trainer.py
+++ b/tests/experimental/test_vimpo_trainer.py
@@ -1,0 +1,106 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from datasets import Dataset, load_dataset
+
+from trl.experimental.vimpo import VIMPOConfig, VIMPOTrainer
+from trl.experimental.vimpo.vimpo_trainer import _compute_vimpo_gae
+
+from ..testing_utils import TrlTestCase
+
+
+class TestVIMPOConfig:
+    def test_defaults(self):
+        args = VIMPOConfig("dummy", use_cpu=True)
+        assert args.scale_rewards == "none"
+        assert args.vimpo_beta == 5e-4
+        assert args.vimpo_actor_coeff == 5e-3
+        assert args.vimpo_gae_lambda == 1.0
+
+    def test_invalid_vimpo_beta(self):
+        with pytest.raises(ValueError, match="vimpo_beta"):
+            VIMPOConfig("dummy", vimpo_beta=0.0, use_cpu=True)
+
+
+class TestVIMPOTrainer(TrlTestCase):
+    def test_vimpo_gae_masks_padding(self):
+        token_advantages = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 0.0]])
+        mask = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]])
+
+        advantages = _compute_vimpo_gae(token_advantages, mask, lam=0.5)
+
+        expected = torch.tensor([[2.75, 3.5, 3.0], [6.5, 5.0, 0.0]])
+        torch.testing.assert_close(advantages, expected)
+
+    def test_train(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train").select(range(3))
+
+        training_args = VIMPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            max_steps=1,
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=2,  # keep the exact full-distribution KL path cheap
+            vimpo_beta=0.1,
+            vimpo_actor_coeff=5e-3,
+            report_to="none",
+            use_cpu=True,
+        )
+        trainer = VIMPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        assert "vimpo/value_loss" in trainer.state.log_history[-1]
+        assert "vimpo/actor_advantage" in trainer.state.log_history[-1]
+        assert "kl" in trainer.state.log_history[-1]
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_rejects_inherited_beta(self):
+        dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
+        training_args = VIMPOConfig(output_dir=self.tmp_dir, beta=0.1, report_to="none", use_cpu=True)
+
+        with pytest.raises(ValueError, match="vimpo_beta"):
+            VIMPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    def test_rejects_reward_scaling(self):
+        dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
+        training_args = VIMPOConfig(output_dir=self.tmp_dir, scale_rewards="group", report_to="none", use_cpu=True)
+
+        with pytest.raises(ValueError, match="scale_rewards"):
+            VIMPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )

--- a/trl/experimental/vimpo/__init__.py
+++ b/trl/experimental/vimpo/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .vimpo_config import VIMPOConfig
+from .vimpo_trainer import VIMPOTrainer
+
+
+__all__ = ["VIMPOConfig", "VIMPOTrainer"]

--- a/trl/experimental/vimpo/vimpo_config.py
+++ b/trl/experimental/vimpo/vimpo_config.py
@@ -1,0 +1,68 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from ...trainer.grpo_config import GRPOConfig
+
+
+@dataclass
+class VIMPOConfig(GRPOConfig):
+    # docstyle-ignore
+    r"""
+    Configuration class for the [`experimental.vimpo.VIMPOTrainer`].
+
+    [`VIMPOConfig`] inherits the rollout, reward, and batching parameters from [`GRPOConfig`]. VIMPO uses the same
+    online RLVR data path as GRPO, but replaces the GRPO policy loss with the Value-Implicit Policy Optimization
+    objective from [VIMPO: Value-Implicit Policy Optimization for LLMs](https://huggingface.co/papers/2606.20008).
+
+    Parameters:
+        vimpo_beta (`float`, *optional*, defaults to `5e-4`):
+            Coefficient beta applied to the policy-reference log-ratio and exact KL terms in the VIMPO value and actor
+            objectives.
+        vimpo_actor_coeff (`float`, *optional*, defaults to `5e-3`):
+            Coefficient c_A applied to the PPO-style actor branch. Set to `0.0` to train with only the terminal value
+            loss.
+        vimpo_gae_lambda (`float`, *optional*, defaults to `1.0`):
+            Lambda parameter used to accumulate the policy-implied one-step advantages before the actor loss.
+        scale_rewards (`str`, *optional*, defaults to `"none"`):
+            VIMPO's terminal value target uses unscaled centered rewards, `R - mean_group(R)`.
+    """
+
+    scale_rewards: str = field(
+        default="none",
+        metadata={"help": "VIMPO's terminal value target uses unscaled centered rewards, `R - mean_group(R)`."},
+    )
+    vimpo_beta: float = field(
+        default=5e-4,
+        metadata={"help": "Coefficient beta applied to the policy-reference log-ratio and exact KL terms."},
+    )
+    vimpo_actor_coeff: float = field(
+        default=5e-3,
+        metadata={"help": "Coefficient applied to the PPO-style actor branch. Set to 0.0 for value-only VIMPO."},
+    )
+    vimpo_gae_lambda: float = field(
+        default=1.0,
+        metadata={"help": "Lambda parameter used for VIMPO's GAE-style actor advantage accumulation."},
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.vimpo_beta <= 0.0:
+            raise ValueError(f"vimpo_beta must be > 0.0, got {self.vimpo_beta}.")
+        if self.vimpo_actor_coeff < 0.0:
+            raise ValueError(f"vimpo_actor_coeff must be >= 0.0, got {self.vimpo_actor_coeff}.")
+        if not 0.0 <= self.vimpo_gae_lambda <= 1.0:
+            raise ValueError(f"vimpo_gae_lambda must be in [0.0, 1.0], got {self.vimpo_gae_lambda}.")

--- a/trl/experimental/vimpo/vimpo_trainer.py
+++ b/trl/experimental/vimpo/vimpo_trainer.py
@@ -1,0 +1,383 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+import torch
+from accelerate.utils import is_peft_model
+
+from ...extras.profiling import profiling_decorator
+from ...models.utils import disable_gradient_checkpointing
+from ...trainer.grpo_trainer import GRPOTrainer
+from ...trainer.utils import (
+    entropy_from_logits,
+    get_config_model_id,
+    nanmax,
+    nanmin,
+    selective_log_softmax,
+    use_adapter,
+)
+from .vimpo_config import VIMPOConfig
+
+
+def _compute_vimpo_gae(token_advantages: torch.Tensor, mask: torch.Tensor, lam: float) -> torch.Tensor:
+    """Compute VIMPO's GAE-style reverse accumulation over valid response tokens."""
+    advantages = torch.zeros_like(token_advantages)
+    lastgaelam = torch.zeros(token_advantages.size(0), dtype=token_advantages.dtype, device=token_advantages.device)
+    for t in reversed(range(token_advantages.size(1))):
+        lastgaelam = token_advantages[:, t] + lam * lastgaelam
+        lastgaelam = lastgaelam * mask[:, t]
+        advantages[:, t] = lastgaelam
+    return advantages
+
+
+class VIMPOTrainer(GRPOTrainer):
+    """
+    Trainer for Value-Implicit Policy Optimization (VIMPO).
+
+    VIMPO (https://huggingface.co/papers/2606.20008) is a critic-free RLVR method that uses a policy-implied value
+    recurrence derived from a KL-regularized optimality condition. It reuses GRPO's rollout and reward computation, then
+    trains with a terminal value loss and an optional PPO-style actor loss using token-level policy-implied advantages.
+    """
+
+    _tag_names = ["trl", "vimpo"]
+    _name = "VIMPO"
+    _paper = {
+        "title": "VIMPO: Value-Implicit Policy Optimization for LLMs",
+        "id": "2606.20008",
+        # docstyle-ignore
+        "citation": textwrap.dedent("""\
+            @article{kang2026vimpo,
+                title        = {{VIMPO: Value-Implicit Policy Optimization for LLMs}},
+                author       = {Zhewei Kang and Aosong Feng and Sergey Levine and Dawn Song and Xuandong Zhao},
+                year         = 2026,
+                eprint       = {arXiv:2606.20008},
+            }"""),
+    }
+
+    def __init__(self, model, reward_funcs, args=None, **kwargs):
+        if args is None:
+            model_name = model if isinstance(model, str) else get_config_model_id(model.config)
+            args = VIMPOConfig(f"{model_name.split('/')[-1]}-VIMPO")
+        elif args.beta != 0.0:
+            raise ValueError("VIMPO uses `vimpo_beta`; leave the inherited GRPO `beta` set to 0.0.")
+        if args.sync_ref_model:
+            raise ValueError("VIMPO uses the frozen-reference setting from the paper; set `sync_ref_model=False`.")
+        if args.use_liger_kernel:
+            raise ValueError("VIMPO does not support `use_liger_kernel=True`.")
+        if args.multi_objective_aggregation != "sum_then_normalize":
+            raise ValueError("VIMPO currently supports `multi_objective_aggregation='sum_then_normalize'` only.")
+        if args.scale_rewards != "none":
+            raise ValueError("VIMPO uses the paper target `R - mean_group(R)`; set `scale_rewards='none'`.")
+
+        self.vimpo_beta = args.vimpo_beta
+        self.vimpo_actor_coeff = args.vimpo_actor_coeff
+        self.vimpo_gae_lambda = args.vimpo_gae_lambda
+
+        # GRPO only creates/copies a reference model when `beta != 0.0`. Temporarily enable that path, then disable
+        # GRPO's own KL-penalty semantics after initialization. VIMPO uses `vimpo_beta` inside its objective instead.
+        args.beta = args.vimpo_beta
+        super().__init__(model, reward_funcs, args=args, **kwargs)
+        self.beta = 0.0
+        self.args.beta = 0.0
+
+    def _masked_whiten(self, values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        local = values[mask.bool()].float()
+        if local.numel() == 0:
+            return torch.zeros_like(values)
+
+        pad_value = torch.finfo(local.dtype).max
+        padded = self.accelerator.pad_across_processes(local, dim=0, pad_index=pad_value)
+        gathered = self.accelerator.gather(padded)
+        gathered = gathered[gathered != pad_value]
+        if gathered.numel() <= 1:
+            return torch.zeros_like(values)
+
+        mean = gathered.mean()
+        std = gathered.std(unbiased=False)
+        return ((values.float() - mean) / (std + 1e-8)).to(values.dtype) * mask
+
+    def _build_model_inputs(
+        self,
+        logits_to_keep,
+        input_ids_batch,
+        attention_mask_batch,
+        start,
+        batch_size,
+        pixel_values=None,
+        image_grid_thw=None,
+        num_images=None,
+        pixel_attention_mask=None,
+        spatial_shapes=None,
+        num_tiles=None,
+        image_sizes=None,
+        token_type_ids=None,
+        mm_token_type_ids=None,
+        image_position_ids=None,
+        compute_aux_loss=False,
+    ):
+        model_inputs = {"input_ids": input_ids_batch, "attention_mask": attention_mask_batch}
+        if image_grid_thw is not None and pixel_values is not None:
+            rows_per_image = image_grid_thw.prod(dim=-1)
+            rows_per_sample = torch.split(rows_per_image, num_images)
+            rows_per_sample = torch.stack([s.sum() for s in rows_per_sample])
+            cum_rows = torch.cat([torch.tensor([0], device=rows_per_sample.device), rows_per_sample.cumsum(0)])
+            row_start, row_end = cum_rows[start].item(), cum_rows[start + batch_size].item()
+            model_inputs["pixel_values"] = pixel_values[row_start:row_end]
+            cum_imgs = torch.tensor([0] + num_images).cumsum(0)
+            img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
+            model_inputs["image_grid_thw"] = image_grid_thw[img_start:img_end]
+        elif image_position_ids is not None and pixel_values is not None:
+            cum_imgs = torch.tensor([0] + num_images).cumsum(0)
+            img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
+            model_inputs["pixel_values"] = pixel_values[img_start:img_end]
+            model_inputs["image_position_ids"] = image_position_ids[img_start:img_end]
+        elif spatial_shapes is not None and pixel_values is not None:
+            # LFM2-VL tensors are tile-indexed.
+            cum_tiles = torch.tensor([0] + num_tiles).cumsum(0)
+            tile_start, tile_end = cum_tiles[start], cum_tiles[start + batch_size]
+            model_inputs["pixel_values"] = pixel_values[tile_start:tile_end]
+            model_inputs["pixel_attention_mask"] = pixel_attention_mask[tile_start:tile_end]
+            model_inputs["spatial_shapes"] = spatial_shapes[tile_start:tile_end]
+        elif pixel_values is not None:
+            model_inputs["pixel_values"] = pixel_values[start : start + batch_size]
+        if pixel_attention_mask is not None and spatial_shapes is None:
+            model_inputs["pixel_attention_mask"] = pixel_attention_mask[start : start + batch_size]
+        if image_sizes is not None:
+            model_inputs["image_sizes"] = image_sizes[start : start + batch_size]
+        if token_type_ids is not None:
+            model_inputs["token_type_ids"] = token_type_ids[start : start + batch_size]
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids[start : start + batch_size]
+
+        # Only add logits_to_keep if the model supports it
+        if "logits_to_keep" in self.model_kwarg_keys:
+            # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
+            model_inputs["logits_to_keep"] = logits_to_keep + 1
+
+        model_inputs["use_cache"] = False  # only used in generation; set False to suppress warnings
+
+        # MoE models: request router logits so the model returns `outputs.aux_loss`. VLM wrappers honor this only
+        # as a forward kwarg (not from the model config), so it must be passed here.
+        if compute_aux_loss:
+            model_inputs["output_router_logits"] = True
+
+        return model_inputs
+
+    def _get_ref_outputs(self, model_inputs):
+        if self.ref_model is not None:
+            return self.ref_model(**model_inputs)
+        if not is_peft_model(self.model):
+            raise RuntimeError("VIMPO requires a reference model or a PEFT model whose adapter can be disabled.")
+
+        model = self.accelerator.unwrap_model(self.model)
+        with use_adapter(model, adapter_name="ref" if "ref" in model.peft_config else None):
+            return self.model(**model_inputs)
+
+    @profiling_decorator
+    def _get_per_token_logps_entropies_and_kls(
+        self,
+        model,
+        input_ids,
+        attention_mask,
+        logits_to_keep,
+        batch_size=None,
+        compute_aux_loss=False,
+        pixel_values=None,
+        image_grid_thw=None,
+        num_images=None,
+        pixel_attention_mask=None,
+        spatial_shapes=None,
+        num_tiles=None,
+        image_sizes=None,
+        token_type_ids=None,
+        mm_token_type_ids=None,
+        image_position_ids=None,
+    ):
+        batch_size = batch_size or input_ids.size(0)  # Chunk inputs into smaller batches to reduce memory peak
+        all_logps = []
+        all_ref_logps = []
+        all_token_kls = []
+        all_entropies = []
+        all_aux_losses = []
+        for start in range(0, input_ids.size(0), batch_size):
+            input_ids_batch = input_ids[start : start + batch_size]
+            attention_mask_batch = attention_mask[start : start + batch_size]
+            model_inputs = self._build_model_inputs(
+                logits_to_keep,
+                input_ids_batch,
+                attention_mask_batch,
+                start,
+                batch_size,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                num_images=num_images,
+                pixel_attention_mask=pixel_attention_mask,
+                spatial_shapes=spatial_shapes,
+                num_tiles=num_tiles,
+                image_sizes=image_sizes,
+                token_type_ids=token_type_ids,
+                mm_token_type_ids=mm_token_type_ids,
+                image_position_ids=image_position_ids,
+                compute_aux_loss=compute_aux_loss,
+            )
+
+            outputs = model(**model_inputs)
+            logits = outputs.logits
+            logits = logits[:, :-1, :]
+            logits = logits[:, -logits_to_keep:, :]
+            logits.div_(self.temperature)
+            completion_ids = input_ids_batch[:, -logits_to_keep:]
+            logps = selective_log_softmax(logits, completion_ids)
+
+            with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
+                log_probs = torch.log_softmax(logits.float(), dim=-1)
+                ref_outputs = self._get_ref_outputs(model_inputs)
+                ref_logits = ref_outputs.logits
+                ref_logits = ref_logits[:, :-1, :]
+                ref_logits = ref_logits[:, -logits_to_keep:, :]
+                ref_logits.div_(self.temperature)
+                ref_logps = selective_log_softmax(ref_logits, completion_ids)
+                ref_log_probs = torch.log_softmax(ref_logits.float(), dim=-1)
+                token_kls = (log_probs.exp() * (log_probs - ref_log_probs)).sum(dim=-1).to(logps.dtype)
+
+            all_logps.append(logps)
+            all_ref_logps.append(ref_logps)
+            all_token_kls.append(token_kls)
+
+            with torch.no_grad():
+                all_entropies.append(entropy_from_logits(logits))
+
+            if compute_aux_loss:
+                all_aux_losses.append(outputs.aux_loss)
+
+        logps = torch.cat(all_logps, dim=0)
+        ref_logps = torch.cat(all_ref_logps, dim=0)
+        token_kls = torch.cat(all_token_kls, dim=0)
+        entropies = torch.cat(all_entropies, dim=0)
+        aux_loss = torch.stack(all_aux_losses).mean() if compute_aux_loss else None
+        return logps, ref_logps, token_kls, entropies, aux_loss
+
+    def _compute_loss(self, model, inputs):
+        # Compute the per-token log probabilities for the model
+        prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
+        completion_ids, completion_mask = inputs["completion_ids"], inputs["completion_mask"]
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+        logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
+        mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
+
+        per_token_logps, ref_per_token_logps, token_kls, entropies, aux_loss = (
+            self._get_per_token_logps_entropies_and_kls(
+                model,
+                input_ids,
+                attention_mask,
+                logits_to_keep,
+                compute_aux_loss=self.aux_loss_enabled,
+                pixel_values=inputs.get("pixel_values"),
+                image_grid_thw=inputs.get("image_grid_thw"),
+                num_images=inputs.get("num_images"),
+                pixel_attention_mask=inputs.get("pixel_attention_mask"),
+                spatial_shapes=inputs.get("spatial_shapes"),
+                num_tiles=inputs.get("num_tiles"),
+                image_sizes=inputs.get("image_sizes"),
+                token_type_ids=inputs.get("token_type_ids"),
+                mm_token_type_ids=inputs.get("mm_token_type_ids"),
+                image_position_ids=inputs.get("image_position_ids"),
+            )
+        )
+
+        rho = self.vimpo_beta * (per_token_logps - ref_per_token_logps)
+        kappa = self.vimpo_beta * token_kls
+        value_terms = (rho - kappa.detach()) * mask
+        terminal_value = value_terms.sum(dim=-1)
+        # VIMPO rejects reward scaling, so inherited GRPO advantages are the unscaled centered rewards.
+        centered_rewards = inputs["advantages"].to(dtype=terminal_value.dtype, device=terminal_value.device)
+        value_residual = terminal_value - centered_rewards
+        value_loss = 0.5 * value_residual.square().mean()
+
+        old_per_token_logps = inputs.get("old_per_token_logps")
+        old_per_token_logps = per_token_logps.detach() if old_per_token_logps is None else old_per_token_logps
+
+        actor_loss = torch.zeros_like(value_loss)
+        if self.vimpo_actor_coeff != 0.0:
+            actor_advantages = rho.detach() - kappa.detach()
+            actor_advantages = _compute_vimpo_gae(actor_advantages, mask, self.vimpo_gae_lambda)
+            raw_actor_advantages = actor_advantages
+            actor_advantages = self._masked_whiten(actor_advantages, mask)
+            actor_advantages = actor_advantages.detach()
+
+            log_ratio = per_token_logps - old_per_token_logps
+            ratio = torch.exp(log_ratio)
+            clipped_ratio = torch.clamp(ratio, 1 - self.epsilon_low, 1 + self.epsilon_high)
+            per_token_actor_loss1 = ratio * actor_advantages
+            per_token_actor_loss2 = clipped_ratio * actor_advantages
+            per_token_actor_loss = -torch.min(per_token_actor_loss1, per_token_actor_loss2)
+            if self.use_vllm and self.vllm_importance_sampling_correction:
+                per_token_actor_loss = per_token_actor_loss * inputs["importance_sampling_ratio"]
+
+            normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
+            actor_loss = (per_token_actor_loss * mask).sum() / normalizer
+
+        mode = "train" if self.model.training else "eval"
+        normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+        loss = value_loss / normalizer + self.vimpo_actor_coeff * actor_loss
+
+        # The policy loss above is scaled for gradient accumulation (HF auto-scaling is off here), so scale aux too
+        if self.aux_loss_enabled:
+            loss = loss + self.router_aux_loss_coef * aux_loss / normalizer
+            self._metrics[mode]["aux_loss"].append(self.accelerator.gather_for_metrics(aux_loss).mean().item())
+
+        completion_token_count = mask.sum().clamp(min=1.0)
+        mean_exact_kl = (token_kls * mask).sum() / completion_token_count
+        mean_entropy = (entropies * mask).sum() / completion_token_count
+        mean_rho = (rho * mask).sum() / completion_token_count
+        mean_kappa = (kappa * mask).sum() / completion_token_count
+
+        self._metrics[mode]["vimpo/value_loss"].append(self.accelerator.gather(value_loss.detach()).nanmean().item())
+        self._metrics[mode]["vimpo/actor_loss"].append(self.accelerator.gather(actor_loss.detach()).nanmean().item())
+        self._metrics[mode]["vimpo/terminal_value"].append(
+            self.accelerator.gather(terminal_value.detach()).nanmean().item()
+        )
+        self._metrics[mode]["vimpo/value_residual"].append(
+            self.accelerator.gather(value_residual.detach()).nanmean().item()
+        )
+        self._metrics[mode]["vimpo/rho"].append(self.accelerator.gather(mean_rho.detach()).nanmean().item())
+        self._metrics[mode]["vimpo/kappa"].append(self.accelerator.gather(mean_kappa.detach()).nanmean().item())
+        self._metrics[mode]["kl"].append(self.accelerator.gather(mean_exact_kl.detach()).nanmean().item())
+        self._metrics[mode]["entropy"].append(self.accelerator.gather(mean_entropy.detach()).nanmean().item())
+
+        if self.vimpo_actor_coeff != 0.0:
+            mean_raw_actor_advantage = (raw_actor_advantages * mask).sum() / completion_token_count
+            self._metrics[mode]["vimpo/actor_advantage"].append(
+                self.accelerator.gather(mean_raw_actor_advantage.detach()).nanmean().item()
+            )
+
+            is_low_clipped = (ratio < 1 - self.epsilon_low) & (actor_advantages < 0)
+            is_high_clipped = (ratio > 1 + self.epsilon_high) & (actor_advantages > 0)
+            is_region_clipped = is_low_clipped | is_high_clipped
+            low_clip = (is_low_clipped.float() * mask).sum() / completion_token_count
+            high_clip = (is_high_clipped.float() * mask).sum() / completion_token_count
+            clip_ratio = (is_region_clipped.float() * mask).sum() / completion_token_count
+
+            gathered_low_clip = self.accelerator.gather(low_clip)
+            self._metrics[mode]["clip_ratio/low_mean"].append(gathered_low_clip.nanmean().item())
+            self._metrics[mode]["clip_ratio/low_min"].append(nanmin(gathered_low_clip).item())
+            gathered_high_clip = self.accelerator.gather(high_clip)
+            self._metrics[mode]["clip_ratio/high_mean"].append(gathered_high_clip.nanmean().item())
+            self._metrics[mode]["clip_ratio/high_max"].append(nanmax(gathered_high_clip).item())
+            gathered_clip_ratio = self.accelerator.gather(clip_ratio)
+            self._metrics[mode]["clip_ratio/region_mean"].append(gathered_clip_ratio.nanmean().item())
+
+        return loss

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -60,6 +60,7 @@ _TELEMETRY_TRAINERS = {
     "SDPOTrainer",
     "SSDTrainer",
     "TPOTrainer",
+    "VIMPOTrainer",
     "XPOTrainer",
 }
 


### PR DESCRIPTION
# What does this PR do?

Adds an experimental implementation of VIMPO for RLVR-style training.

This includes:
- `VIMPOConfig` and `VIMPOTrainer` under `trl.experimental.vimpo`
- a NuminaMath example script with verifiable math rewards and boxed-answer prompting
- focused trainer tests for the VIMPO-specific loss path and configuration behavior
- documentation for VIMPO, dataset/example references, and a `paper_index.md` entry

VIMPO is added under `trl.experimental`, so it is opt-in and isolated from the stable trainer APIs.

Validation run locally:
- `ruff check trl/experimental/vimpo tests/experimental/test_vimpo_trainer.py examples/scripts/vimpo.py`
- `ruff format --check trl/experimental/vimpo tests/experimental/test_vimpo_trainer.py examples/scripts/vimpo.py`
- `python -m compileall -q trl/experimental/vimpo tests/experimental/test_vimpo_trainer.py examples/scripts/vimpo.py`
- `pytest -q tests/experimental/test_vimpo_trainer.py`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that is the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Maintainers familiar with GRPO/PPO-style trainers and experimental RL methods would be helpful reviewers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental trainer only; it subclasses GRPO and duplicates forward/KL paths, so bugs would affect RL training runs but not stable trainer APIs.
> 
> **Overview**
> Adds **Value-Implicit Policy Optimization (VIMPO)** under `trl.experimental.vimpo` as an opt-in RLVR trainer that keeps GRPO-style grouped rollouts and reward APIs but swaps in the paper’s value-implicit objective.
> 
> `VIMPOTrainer` subclasses `GRPOTrainer`, overrides `_compute_loss` with a terminal value loss against centered rewards (`R - mean_group(R)`), exact per-token `KL(π_θ || π_ref)`, and an optional PPO-style actor branch (`vimpo_actor_coeff`) using GAE over detached policy-implied advantages. It wires a frozen reference via a temporary `beta` hack, rejects GRPO `beta`, reward scaling, ref sync, and Liger. `VIMPOConfig` extends `GRPOConfig` with `vimpo_beta`, `vimpo_actor_coeff`, and `vimpo_gae_lambda`, defaulting `scale_rewards` to `"none"`.
> 
> Also ships `examples/scripts/vimpo.py` (NuminaMath-TIR + verifiable math rewards), tests for config, GAE masking, a short training smoke run, and docs (trainer page, toctree, dataset formats, example overview, paper index). `VIMPOTrainer` is registered in `base_trainer.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677bbeee10dddd239c104b3d6d130d063c94df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->