### PR TITLE
Default AsyncGRPO token_budget to vLLM max_model_len

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -120,6 +120,7 @@ class TestAsyncGRPOTrainer(TrlTestCase):
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
+            token_budget=256,  # set explicitly; the stub worker has no real vLLM server to query for max_model_len
             vllm_server_timeout=5.0,  # short timeout so test fails fast if queue runs dry
             report_to="none",
         )
@@ -225,20 +226,6 @@ class TestPackingAwareBatching(TrlTestCase):
             assert all(len(group) > 0 for group in groups)  # every row stays non-empty
             lengths = [len(sample["input_ids"]) for group in groups for sample in group]
             assert all(length <= 8 for length in lengths)  # the oversized sample (12) was dropped
-
-    def test_token_budget_defaults_to_per_device_bs_times_completion_length(self):
-        # Unset token_budget resolves to per_device_train_batch_size * max_completion_length = 3 * 8.
-        args = AsyncGRPOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=3,
-            max_completion_length=8,
-            bf16=False,
-            report_to="none",
-        )
-        assert args.token_budget == 24
-        # An explicit <= 0 value is left untouched and disables budgeting (-> FixedCountBatcher).
-        args = AsyncGRPOConfig(output_dir=self.tmp_dir, token_budget=-1, bf16=False, report_to="none")
-        assert args.token_budget == -1
 
     def test_fixed_count_batcher_yields_balanced_fixed_count_micro_batches(self):
         source = (_rollout_sample(length) for length in itertools.cycle((4, 3, 2, 1)))

--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -77,11 +77,11 @@ class AsyncGRPOConfig(_BaseConfig):
             Maximum number of real tokens packed into a single row (one DP rank's forward) for dynamic
             token-budgeted micro-batching. When `> 0`, a `TokenBudgetBatcher` forms Σ Lᵢ²-balanced micro-batches
             whose rows each stay within this budget, bounding peak memory independently of the sample count (the
-            number of samples per row becomes dynamic). If `None` (default), it is set to
-            `per_device_train_batch_size * max_completion_length`. A sample longer than `token_budget` fits in no
-            row and is dropped with a warning, so raise it to avoid dropping samples. Set `<= 0` to disable token
-            budgeting and instead pack a fixed `per_device_train_batch_size × num_processes` samples per
-            micro-batch, Σ Lᵢ²-balanced across the rows.
+            number of samples per row becomes dynamic). If `None` (default), it is set to the vLLM server's
+            `max_model_len` (queried at train start) — the cap on prompt + completion length — so no rollout sample
+            can ever exceed the budget. A sample longer than `token_budget` fits in no row and is dropped with a
+            warning. Set `<= 0` to disable token budgeting and instead pack a fixed `per_device_train_batch_size ×
+            num_processes` samples per micro-batch, Σ Lᵢ²-balanced across the rows.
 
         > Parameters that control the async rollout pipeline
 
@@ -219,10 +219,10 @@ class AsyncGRPOConfig(_BaseConfig):
             "help": "Maximum number of real tokens packed into a single row (one DP rank's forward) for dynamic "
             "token-budgeted micro-batching. When > 0, a `TokenBudgetBatcher` forms Σ Lᵢ²-balanced micro-batches "
             "whose rows each stay within this budget, bounding peak memory independently of the sample count. If "
-            "None (default), it is set to `per_device_train_batch_size * max_completion_length`. A sample longer "
-            "than `token_budget` fits in no row and is dropped with a warning, so raise it to avoid dropping "
-            "samples. Set <= 0 to disable token budgeting and instead pack a fixed `per_device_train_batch_size × "
-            "num_processes` samples per micro-batch, Σ Lᵢ²-balanced across the rows."
+            "None (default), it is set to the vLLM server's `max_model_len` (queried at train start), so no "
+            "rollout sample can ever exceed the budget. A sample longer than `token_budget` fits in no row and is "
+            "dropped with a warning. Set <= 0 to disable token budgeting and instead pack a fixed "
+            "`per_device_train_batch_size × num_processes` samples per micro-batch, Σ Lᵢ²-balanced across the rows."
         },
     )
 
@@ -275,11 +275,6 @@ class AsyncGRPOConfig(_BaseConfig):
 
     def __post_init__(self):
         super().__post_init__()
-
-        # Default the per-row budget to ~`per_device_train_batch_size` worst-case samples (set <= 0 to disable
-        # budgeting and use FixedCountBatcher).
-        if self.token_budget is None:
-            self.token_budget = self.per_device_train_batch_size * self.max_completion_length
 
         # Accelerator config: required for the async IterableDataset-backed dataloader to work correctly.
         # split_batches=True and dispatch_batches=True ensure that the main process drives the dataloader

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+import requests
 import torch
 from accelerate.logging import get_logger
 from datasets import Dataset, IterableDataset
@@ -174,6 +175,13 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
             }
 
 
+def _get_vllm_max_model_len(server_url: str, timeout: float) -> int:
+    """Query the vLLM server for the served model's `max_model_len` (the cap on prompt + completion tokens)."""
+    response = requests.get(f"{server_url.rstrip('/')}/v1/models", timeout=timeout)
+    response.raise_for_status()
+    return response.json()["data"][0]["max_model_len"]
+
+
 def _balance_by_squared_length(examples: list[dict[str, Any]], num_groups: int) -> list[list[dict[str, Any]]]:
     """Greedily partition `examples` into `num_groups` rows (one per DP rank), balancing each row's Σ Lᵢ².
 
@@ -235,8 +243,8 @@ class TokenBudgetBatcher(torch.utils.data.IterableDataset):
 
     Every emitted micro-batch has all `num_processes` rows non-empty (a rank forwarding zero tokens would desync
     FSDP/EP collectives): a micro-batch is only closed once every row holds at least one sample. A sample longer than
-    `token_budget` fits in no row, so it is dropped with a warning; set `token_budget` ≥ the longest sample
-    (`max_completion_length` + the longest prompt) to avoid dropping samples.
+    `token_budget` fits in no row, so it is dropped with a warning; set `token_budget` ≥ the vLLM server's
+    `max_model_len` (the cap on prompt + completion) to avoid dropping samples.
 
     Args:
         dataset ([`RolloutQueueDataset`]):
@@ -660,6 +668,11 @@ class AsyncGRPOTrainer(_BaseTrainer):
                 stale_after_s=self.args.heartbeat_stale_after_s,
                 max_staleness=self.args.max_staleness,
             )
+            if self.args.token_budget is None:
+                self.args.token_budget = _get_vllm_max_model_len(
+                    self.args.vllm_server_base_url, self.args.vllm_server_timeout
+                )
+                logger.info(f"token_budget unset; defaulting to vLLM max_model_len={self.args.token_budget}")
             # The planner partitions the rollout stream into Σ Lᵢ²-balanced micro-batches of `num_processes` rows.
             # TokenBudgetBatcher caps each row at `token_budget` tokens (dynamic count, bounds peak memory);
             # FixedCountBatcher uses a fixed `per_device_train_batch_size × num_processes` samples per micro-batch.

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -668,7 +668,15 @@ class AsyncGRPOTrainer(_BaseTrainer):
                 stale_after_s=self.args.heartbeat_stale_after_s,
                 max_staleness=self.args.max_staleness,
             )
+            # Default the token budget to the vLLM server's max_model_len (the cap on prompt + completion), so no
+            # rollout sample can exceed it. Only the built-in worker manages a vLLM server (weight_transfer is set);
+            # with a custom rollout_worker there may be none to query, so require an explicit budget instead.
             if self.args.token_budget is None:
+                if self.weight_transfer is None:
+                    raise ValueError(
+                        "Set `token_budget` explicitly when passing a custom `rollout_worker`: the default is the "
+                        "vLLM server's max_model_len, which is only queried for the built-in rollout worker."
+                    )
                 self.args.token_budget = _get_vllm_max_model_len(
                     self.args.vllm_server_base_url, self.args.vllm_server_timeout
                 )


### PR DESCRIPTION
Follow-up to #6092. Fixes the default value of `AsyncGRPOConfig.token_budget`

At `per_device_train_batch_size=1` the budget collapses to exactly `max_completion_length`, so **every sample with a non-trivial prompt gets dropped**  and if all queued samples are oversize, the batcher never yields and the dataloader blocks. (Both flagged by Cursor Bugbot on #6092)

## Fix

Default `token_budget` to the **vLLM server's `max_model_len`** :  the cap on `prompt + completion`, so no rollout sample can ever exceed the budget.

## Verification

Against a live `vllm serve Qwen/Qwen3-0.6B --max-model-len 2048`:
- `GET /v1/models` → `"max_model_len": 2048`, and `_get_vllm_max_model_len` returns `2048`.
- `POST /v1/completions` with `max_tokens=2048` + a prompt is rejected with *"maximum context length is 2048 tokens … 2048 output tokens … 0 input tokens"* — confirming `max_model_len`
caps prompt **and** completion together.

Existing `TestPackingAwareBatching` tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Train-start HTTP to vLLM and a larger default budget change memory/throughput characteristics, but the change fixes sample dropping and blocking; custom rollout users must set token_budget explicitly.
> 
> **Overview**
> Fixes a follow-up to #6092 where the old default `token_budget = per_device_train_batch_size × max_completion_length` could equal only `max_completion_length` at batch size 1, so **prompt + completion** rollouts were dropped and the dataloader could stall.
> 
> When `token_budget` is unset, it is now resolved in **`get_train_dataloader`** by calling **`_get_vllm_max_model_len`** (`GET {vllm_server}/v1/models`) so the budget matches the server’s **`max_model_len`** (prompt + completion cap). Config **`__post_init__`** no longer sets this default. Custom **`rollout_worker`** (no built-in vLLM / `weight_transfer is None`) must pass **`token_budget` explicitly** or training raises **`ValueError`**.
> 
> Tests set **`token_budget=256`** for the stub worker and drop the test that asserted the old config default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ac43a1e52f91dbf7e0c604f8011d2ce79a7e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->