### PR TITLE
Align format of versions in CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "Version is ${{ steps.get_version.outputs.version }}"
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  #v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/sync-huggingface-skills.yml
+++ b/.github/workflows/sync-huggingface-skills.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout trl repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create GitHub App token
         id: app_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
           private-key: ${{ secrets.APP_SECRET_PREM_HUB_SKILLS_REPO }}
@@ -40,7 +40,7 @@ jobs:
           repositories: huggingface/skills
 
       - name: Checkout huggingface/skills repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           repository: huggingface/skills
           token: ${{ steps.app_token.outputs.token }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ steps.app_token.outputs.token }}
           path: skills-repo


### PR DESCRIPTION
Align format of versions in CI workflows, for consistency with the rest of the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only formatting in workflow YAML; no changes to pins, secrets, or job logic.
> 
> **Overview**
> Normalizes **inline version comments** on pinned GitHub Actions in `publish.yml` and `sync-huggingface-skills.yml` so they match the rest of the repo (`  # vX.Y.Z` with a space before `#`).
> 
> Touches `actions/setup-python`, `actions/checkout`, `actions/create-github-app-token`, and `peter-evans/create-pull-request` lines only; **action SHAs and workflow behavior are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58fdc85860066d7e0c61800599f3c818bde2c0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->