### PR TITLE
Align KTO with DPO: Align validation of liger and compute_metrics

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -789,6 +789,11 @@ class KTOTrainer(_BaseTrainer):
                     "You cannot set `loss_type='apo_zero_unpaired'` with liger-kernel."
                     "Only KTO loss is supported with liger-kernel."
                 )
+            if compute_metrics is not None:
+                raise ValueError(
+                    "compute_metrics is not supported with the Liger kernel. compute_metrics requires to be able to "
+                    "recover the logits from the forward pass, but Liger kernel does not materialize logits."
+                )
             if self.precompute_ref_logps:
                 raise ValueError(
                     "You cannot use `precompute_ref_log_probs=True` with liger kernel. Please set "


### PR DESCRIPTION
Align KTO with DPO: Align validation of liger and compute_metrics.

Part of:
- #4786

This PR adds a validation check in the `KTOTrainer` initialization to prevent the use of `compute_metrics` with the Liger kernel, as this configuration is not supported, as already done in `DPOTrainer`.

### Changes

Validation and error handling improvements:

* Added a check in the `__init__` method of `KTOTrainer` (`trl/experimental/kto/kto_trainer.py`) to raise a clear error if `compute_metrics` is provided when using the Liger kernel, since logits required for metrics computation are not materialized by this kernel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-only validation with no change to supported training paths; only blocks an already-incompatible configuration earlier with a clearer error.
> 
> **Overview**
> **KTOTrainer** now fails fast at init if **`use_liger_kernel=True`** and a **`compute_metrics`** callback is passed, matching **DPOTrainer** behavior.
> 
> The error explains that custom eval metrics need logits from the forward pass, which the Liger fused path does not materialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec4500cf4fec4904206dc1f6f7ba634b699ef3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->