### PR TITLE
Raise ValueError instead of NotImplementedError for Liger DPO with PEFT

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -798,7 +798,7 @@ class TestDPOTrainer(TrlTestCase):
             report_to="none",
         )
 
-        with pytest.raises(NotImplementedError, match="Liger DPO loss is not implemented for PEFT models."):
+        with pytest.raises(ValueError, match="`use_liger_kernel=True` is not supported with PEFT models."):
             DPOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
                 args=training_args,

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -753,7 +753,10 @@ class DPOTrainer(_BaseTrainer):
                     "`precompute_ref_log_probs` or set `use_liger_kernel` to False."
                 )
             if is_peft_model(model):
-                raise NotImplementedError("Liger DPO loss is not implemented for PEFT models.")
+                raise ValueError(
+                    "`use_liger_kernel=True` is not supported with PEFT models. Set `use_liger_kernel=False` to train "
+                    "a PEFT model."
+                )
 
         # Dataset
         # Skip dataset preparation if it's a VLM, where preprocessing (e.g., image-to-pixel conversion) is too costly


### PR DESCRIPTION
This PR changes the exception raised by `DPOTrainer` when `use_liger_kernel=True` is combined with a PEFT model, from `NotImplementedError` to `ValueError`.

### Motivation

`NotImplementedError` (a subclass of `RuntimeError`) is meant for abstract methods that subclasses must override, or as a development placeholder. Rejecting an invalid combination of constructor arguments is not that case: the user passed arguments of the right type whose combination is unsupported, which is idiomatically a `ValueError`.

This also restores consistency. The two sibling Liger guards in the same block (`compute_metrics` and `precompute_ref_log_probs`) already raise `ValueError`, as does the analogous Liger + PEFT guard in `GRPOTrainer`.

### Changes

- Raise `ValueError` instead of `NotImplementedError` when `use_liger_kernel=True` is used with a PEFT model in DPOTrainer.
- Reword the error message to state the unsupported combination and the actionable remedy (`use_liger_kernel=False`).
- Update the corresponding test to expect `ValueError` and the new message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the exception type and message change at init for an already-unsupported configuration; training behavior is unchanged for valid setups.
> 
> **Overview**
> When `DPOTrainer` is constructed with **`use_liger_kernel=True`** and a **PEFT** model, it now raises **`ValueError`** instead of **`NotImplementedError`**, matching the other Liger configuration guards in the same block and the style used in **`GRPOTrainer`**.
> 
> The error text now states that the flag combination is unsupported and tells callers to set **`use_liger_kernel=False`** to train with PEFT. **`test_init_fails_with_peft_and_liger`** expects **`ValueError`** and the updated message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1049f92bbf2002b2b9ab704f6a25fa38fe169da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->