### PR TITLE
Align KTO with DPO: Align error for Liger with PEFT

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -774,7 +774,7 @@ class TestKTOTrainer(TrlTestCase):
             report_to="none",
         )
 
-        with pytest.raises(ValueError, match="You cannot use `use_liger_kernel=True` with Peft models"):
+        with pytest.raises(ValueError, match="`use_liger_kernel=True` is not supported with PEFT models."):
             KTOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
                 args=training_args,

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -796,7 +796,8 @@ class KTOTrainer(_BaseTrainer):
                 )
             if is_peft_model(self.model):
                 raise ValueError(
-                    "You cannot use `use_liger_kernel=True` with Peft models. Please set `use_liger_kernel=False`."
+                    "`use_liger_kernel=True` is not supported with PEFT models. Set `use_liger_kernel=False` to train "
+                    "a PEFT model."
                 )
             self.liger_loss_fn = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
 


### PR DESCRIPTION
Align KTO with DPO: Align error for Liger with PEFT.

Follow-up to:
- #6225

Part of:
- #4786

This PR updates the error messaging for the incompatibility between `use_liger_kernel=True` and PEFT models to make it consistent with DPO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to an existing validation error and its test; no training or compatibility logic is modified.
> 
> **Overview**
> Updates the **`ValueError`** raised when **`KTOTrainer`** is configured with **`use_liger_kernel=True`** and a PEFT model so the wording matches **`DPOTrainer`**.
> 
> The message now states that **`use_liger_kernel=True` is not supported with PEFT models** and tells users to set **`use_liger_kernel=False`** to train a PEFT model. The KTO test **`test_init_fails_with_peft_and_liger`** was updated to assert the new string. Training behavior is unchanged—only the error text and test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee5f6631a3d621aded9fd669bb079850e523a21c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->