### PR TITLE
Fix vLLM server-mode generation in `OnlineDPOTrainer`

### DIFF
--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -651,19 +651,15 @@ class OnlineDPOTrainer(_BaseTrainer):
             all_images = gather_object(images)
 
         if self.accelerator.is_main_process:
-            # Since 'prompts' contains 'num_generations' duplicates, we first take unique prompts, and generate
-            # num_generations outputs for each one. This is faster than generating outputs for each duplicate
-            # prompt individually.
-            ordered_set_of_prompts = all_prompts[:: self.num_generations]
+            # Online DPO generates `num_generations` (2) completions per prompt. Unlike GRPO, the prompts are
+            # not duplicated in the batch, so we generate directly for every prompt.
             if has_images:
-                ordered_set_of_images = [
-                    [img] if img is not None else None for img in all_images[:: self.num_generations]
-                ]
+                images_per_prompt = [[img] if img is not None else None for img in all_images]
             else:
-                ordered_set_of_images = None
+                images_per_prompt = None
             completion_ids = self.vllm_client.generate(
-                prompts=ordered_set_of_prompts,
-                images=ordered_set_of_images,
+                prompts=all_prompts,
+                images=images_per_prompt,
                 n=self.num_generations,
                 repetition_penalty=self.repetition_penalty,
                 temperature=self.temperature,
@@ -676,22 +672,24 @@ class OnlineDPOTrainer(_BaseTrainer):
                 else None,
                 generation_kwargs=self.args.generation_kwargs,
             )["completion_ids"]
-            # Flatten: each prompt generates 2 completions
-            completion_ids = [[comp_id] for prompt_completions in completion_ids for comp_id in prompt_completions]
         else:
             completion_ids = [None] * (len(all_prompts) * 2)
 
         # Broadcast completions to all processes
         completion_ids = broadcast_object_list(completion_ids, from_process=0)
 
-        # Each process takes its slice
+        # Each process takes the slice of completions for its local prompts. The server returns the 2 completions
+        # of each prompt consecutively ([p0c0, p0c1, p1c0, p1c1, ...]).
         process_slice = slice(
             self.accelerator.process_index * len(prompts) * 2,
             (self.accelerator.process_index + 1) * len(prompts) * 2,
         )
         completion_ids = completion_ids[process_slice]
+        # Reorder to block layout ([p0c0, p1c0, ..., p0c1, p1c1, ...]) to match the colocate and transformers
+        # generation paths, which is what the loss expects (`rewards.split(batch_size)`).
+        completion_ids = completion_ids[0::2] + completion_ids[1::2]
 
-        # Create prompt_ids by tokenizing locally
+        # Create prompt_ids by tokenizing locally, in the same block layout (2 copies per prompt)
         prompt_inputs = self.processing_class(
             text=prompts_text,
             return_tensors="pt",
@@ -699,9 +697,8 @@ class OnlineDPOTrainer(_BaseTrainer):
             padding_side="left",
             add_special_tokens=False,
         )
-        prompt_ids = []
-        for prompt_tokens in prompt_inputs["input_ids"]:
-            prompt_ids.extend([prompt_tokens.tolist(), prompt_tokens.tolist()])  # 2 copies for 2 completions
+        prompt_ids = [prompt_tokens.tolist() for prompt_tokens in prompt_inputs["input_ids"]]
+        prompt_ids = prompt_ids + prompt_ids  # 2 copies for 2 completions
         return completion_ids, prompt_ids
 
     def _generate_vllm_colocate(self, prompts, images=None):

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -651,8 +651,6 @@ class OnlineDPOTrainer(_BaseTrainer):
             all_images = gather_object(images)
 
         if self.accelerator.is_main_process:
-            # Online DPO generates `num_generations` (2) completions per prompt. Unlike GRPO, the prompts are
-            # not duplicated in the batch, so we generate directly for every prompt.
             if has_images:
                 images_per_prompt = [[img] if img is not None else None for img in all_images]
             else:
@@ -678,8 +676,7 @@ class OnlineDPOTrainer(_BaseTrainer):
         # Broadcast completions to all processes
         completion_ids = broadcast_object_list(completion_ids, from_process=0)
 
-        # Each process takes the slice of completions for its local prompts. The server returns the 2 completions
-        # of each prompt consecutively ([p0c0, p0c1, p1c0, p1c1, ...]).
+        # Slice to keep only the local part of the data
         process_slice = slice(
             self.accelerator.process_index * len(prompts) * 2,
             (self.accelerator.process_index + 1) * len(prompts) * 2,


### PR DESCRIPTION
Fixes #5514

## Background

`OnlineDPOTrainer` generates **2 completions per prompt** to form a preference pair, and everything downstream (reward computation, `rewards.split(batch_size)`, the chosen/rejected split) assumes a **block layout**: the first half of the batch is one completion per prompt, the second half the other (prompt `i` at rows `i` and `i+N`). The colocate and transformers generation paths both produce exactly this layout.

Unlike GRPO, Online DPO does **not** duplicate prompts in the batch (no `RepeatSampler`).

The vLLM server path (`_generate_vllm_server`) was copy-pasted from GRPO and never adapted to these semantics. As a result it has been broken since the feature was introduced in #3783: it ran without crashing but trained on meaningless data.

## The bugs

Three compounding issues in `_generate_vllm_server`:

1. **Double-flatten (#5514).** `VLLMClient.generate(...)["completion_ids"]` already returns `list[list[int]]` (one token-id list per completion), but the trainer re-flattened it, turning every *token* into its own single-token completion.

   ```text
   server returns:  [[11, 12, 13], [21, 22]]          2 completions (3 and 2 tokens)
   old code made:   [[11],[12],[13],[21],[22]]         5 "completions" of 1 token each   ✗
   ```

2. **Wrong prompt subsampling.** `all_prompts[::self.num_generations]` de-duplicates prompts (correct for GRPO, its `RepeatSampler` duplicates them), but it silently drops half the batch in Online DPO, where prompts are unique.

3. **Interleaved vs block ordering.** The server returns completions interleaved (grouped by prompt), and the trainer built `prompt_ids` interleaved to match. But the loss splits the batch in half (`rewards.split(batch_size)`), which assumes **block** order. Preference pairs were therefore formed across **different prompts**.

   ```text
   2 prompts A, B → 2 completions each.   "A0" = prompt A, completion 0.

   server returns (grouped by prompt):    [ A0  A1  B0  B1 ]
   loss/reward code expects (block):      [ A0  B0 | A1  B1 ]
                                            └── rewards.split(batch_size) pairs row i with row i+N ──┘

   old path kept interleaved order  →  split pairs:   A0 vs B0  ✗   A1 vs B1  ✗   (different prompts!)
   fixed to block order             →  split pairs:   A0 vs A1  ✓   B0 vs B1  ✓   (same prompt)
   ```

Bug 1 masked bug 2: flattening produced enough single-token entries to fill the per-process slice, so the count happened to line up and nothing crashed. Removing only the flatten (the minimal fix proposed in the issue) instead surfaces a crash at `torch.cat((prompt_ids, completion_ids))`.

## Verification

Real `OnlineDPOTrainer` run in vLLM server mode on 2 GPUs, `Qwen/Qwen2-0.5B-Instruct`, a length reward, batch size 2:

```python
from datasets import Dataset
from transformers import AutoTokenizer

from trl.experimental.online_dpo.online_dpo_config import OnlineDPOConfig
from trl.experimental.online_dpo.online_dpo_trainer import OnlineDPOTrainer

MODEL = "Qwen/Qwen2-0.5B-Instruct"


def reward_len(completions, **kwargs):
    # Trivial reward: prefer shorter completions. Return one float per completion.
    return [-abs(len(c) - 20) for c in completions]


prompts = [
    "What is the capital of France?",
    "Write a short greeting.",
    "Name a primary color.",
    "Say hello.",
]
dataset = Dataset.from_dict({"prompt": prompts})

config = OnlineDPOConfig(
    output_dir="/tmp/claude-150110/online_dpo_5514",
    per_device_train_batch_size=2,
    max_steps=2,
    max_new_tokens=32,
    use_vllm=True,
    vllm_mode="server",
    logging_steps=1,
    report_to=[],
)

tokenizer = AutoTokenizer.from_pretrained(MODEL)

trainer = OnlineDPOTrainer(
    model=MODEL,
    reward_funcs=reward_len,
    args=config,
    train_dataset=dataset,
    processing_class=tokenizer,
)

trainer.train()
print("DONE")
```

## Note

The existing `test_train_with_vllm_server` never caught this: it is `@pytest.mark.slow`, requires an external running server, and only asserts `"train_loss" in log_history` (which passes even on garbage data). A stronger server-mode test that checks completion shape and pairing would be a good follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the experimental Online DPO training loop and reward pairing semantics; incorrect layout would silently train on wrong preferences, but the change aligns server mode with existing colocate/Transformers behavior.
> 
> **Overview**
> **Fixes vLLM server-mode generation in `OnlineDPOTrainer`** so preference pairs match the same **block batch layout** used by colocate and Transformers paths (`rewards.split(batch_size)` pairs row `i` with row `i+N`).
> 
> `_generate_vllm_server` no longer de-duplicates gathered prompts with `all_prompts[::num_generations]` (GRPO-style; Online DPO keeps unique prompts). It calls `VLLMClient.generate` with the full `all_prompts` list and drops the extra flatten that turned each completion token into a fake one-token completion.
> 
> After the per-process slice, completions are **reordered** from server interleaved order to block order via `completion_ids[0::2] + completion_ids[1::2]`, and `prompt_ids` are built in the same layout (duplicate the tokenized prompt list once instead of interleaving per row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d543da3a4259c6a1d6f87c91fc89e5f71937eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->