### PR TITLE
Test DPO init fails with compute_metrics and Liger

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -806,6 +806,24 @@ class TestDPOTrainer(TrlTestCase):
                 peft_config=LoraConfig(),
             )
 
+    @require_liger_kernel
+    def test_init_fails_with_compute_metrics_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="compute_metrics is not supported with the Liger kernel"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+                compute_metrics=lambda _: {},
+            )
+
     def test_train_with_iterable_dataset(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train", streaming=True)
 


### PR DESCRIPTION
Test DPO init fails with compute_metrics and Liger.

This PR adds a new test to ensure that using `compute_metrics` with the Liger kernel in the `DPOTrainer` raises a clear error. This helps prevent unsupported configurations and improves error messaging for users.

### Changes

Testing improvements:

* Added `test_init_fails_with_compute_metrics_and_liger` to verify that initializing `DPOTrainer` with both `compute_metrics` and `use_liger_kernel=True` raises a `ValueError` with an appropriate message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that documents existing initialization validation; no production code paths are modified.
> 
> **Overview**
> Adds **`test_init_fails_with_compute_metrics_and_liger`** next to the existing Liger + PEFT init guard in `tests/test_dpo_trainer.py`.
> 
> The test is gated with `@require_liger_kernel`, builds `DPOConfig(use_liger_kernel=True)`, and expects **`DPOTrainer`** construction to raise **`ValueError`** with message **`compute_metrics is not supported with the Liger kernel`** when a `compute_metrics` callback is passed. No trainer or runtime behavior changes—only regression coverage for the init-time check in **`DPOTrainer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e70680a57a138023c4796ff2e45914d2f4999b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->