### PR TITLE
Align KTO with DPO: Test init fails with compute_metrics and Liger

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -782,6 +782,24 @@ class TestKTOTrainer(TrlTestCase):
                 peft_config=LoraConfig(),
             )
 
+    @require_liger_kernel
+    def test_init_fails_with_compute_metrics_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="compute_metrics is not supported with the Liger kernel"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+                compute_metrics=lambda _: {},
+            )
+
     def test_train_with_iterable_dataset(self):
         # KTO's default `kto` loss estimates the KL term from neighboring examples in a fixed-order batch, which is not
         # possible with a streaming dataset; use `apo_zero_unpaired` which does not require the KL term.


### PR DESCRIPTION
Align KTO with DPO: Test init fails with compute_metrics and Liger.

Part of:
- #4786 

Follow-up to:
- #6231

This PR adds a new test to ensure that using the `compute_metrics` argument with the Liger kernel in `KTOTrainer` raises an appropriate error. This helps prevent unsupported configurations and improves the robustness of the trainer initialization logic.

### Changes

Testing improvements:

* Added `test_init_fails_with_compute_metrics_and_liger` to verify that initializing `KTOTrainer` with both `compute_metrics` and `use_liger_kernel=True` raises a `ValueError`, enforcing correct usage and error messaging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime or trainer logic is modified.
> 
> **Overview**
> Adds **`test_init_fails_with_compute_metrics_and_liger`** in `test_kto_trainer.py`, gated with `@require_liger_kernel`, to mirror the DPO trainer coverage.
> 
> The test builds `KTOTrainer` with `use_liger_kernel=True` and a `compute_metrics` callback and expects initialization to raise **`ValueError`** with message **`compute_metrics is not supported with the Liger kernel`**, locking in the existing init guard in `KTOTrainer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936dfd3b8c01062bd2a7fe0c5425ec6f8de09bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->