### PR TITLE
Fix dataset fingerprinting in experimental KTO and TPO trainers

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -828,10 +828,11 @@ class KTOTrainer(_BaseTrainer):
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
+    @staticmethod
     def _tokenize(
-        self,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
+        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -844,6 +845,9 @@ class KTOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
+            is_vlm (`bool`):
+                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
@@ -851,13 +855,13 @@ class KTOTrainer(_BaseTrainer):
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
         if isinstance(input, list):  # conversational: list of message dicts
-            if self._is_vlm:
+            if is_vlm:
                 input = prepare_multimodal_messages(input)
             result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
         else:  # non-conversational: plain text string
             result = processing_class(text=input)
         # VLMs emit a batch dimension even for single examples; unwrap it
-        if self._is_vlm:
+        if is_vlm:
             return {k: v[0] for k, v in result.items()}
         return result
 
@@ -957,24 +961,30 @@ class KTOTrainer(_BaseTrainer):
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-            def tokenize_fn(example, processing_class):
+            # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the map
+            # function unhashable, forcing a random fingerprint that silently disables dataset caching.
+            tokenize = self._tokenize
+
+            def tokenize_fn(example, processing_class, is_vlm):
                 if is_conversational(example):
                     chat_template_kwargs = example.get("chat_template_kwargs", {})
-                    prompt_ids = self._tokenize(
+                    prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
+                        is_vlm,
                         add_generation_prompt=True,
                         **chat_template_kwargs,
                     )["input_ids"]
-                    prompt_completion_ids = self._tokenize(
+                    prompt_completion_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["completion"],
+                        is_vlm,
                         **chat_template_kwargs,
                     )["input_ids"]
                 else:
-                    prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
-                    prompt_completion_ids = self._tokenize(
-                        processing_class, example["prompt"] + example["completion"]
+                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
+                    prompt_completion_ids = tokenize(
+                        processing_class, example["prompt"] + example["completion"], is_vlm
                     )["input_ids"]
 
                 if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
@@ -989,7 +999,11 @@ class KTOTrainer(_BaseTrainer):
                     "completion_ids": prompt_completion_ids[len(prompt_ids) :],
                 }
 
-            dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)
+            dataset = dataset.map(
+                tokenize_fn,
+                fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm},
+                **map_kwargs,
+            )
 
             # Get KL datasets if needed
             if self.calculate_KL:

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -463,8 +463,8 @@ class TPOTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
+    @staticmethod
     def _tokenize(
-        self,
         processing_class: PreTrainedTokenizerBase,
         input: str | list,
         **kwargs,
@@ -545,45 +545,47 @@ class TPOTrainer(_BaseTrainer):
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
+            # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the map
+            # function unhashable, forcing a random fingerprint that silently disables dataset caching.
+            tokenize = self._tokenize
+
             def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 output = {}
                 if is_conversational(example):
-                    prompt_ids = self._tokenize(
+                    prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
                         tools=tools,
                         add_generation_prompt=True,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_chosen_ids = self._tokenize(
+                    prompt_chosen_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_rejected_ids = self._tokenize(
+                    prompt_rejected_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_reference_ids = self._tokenize(
+                    prompt_reference_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["reference"],
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                 else:
-                    prompt_ids = self._tokenize(processing_class, example["prompt"])["input_ids"]
-                    prompt_chosen_ids = self._tokenize(processing_class, example["prompt"] + example["chosen"])[
+                    prompt_ids = tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"])["input_ids"]
+                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"])[
                         "input_ids"
                     ]
-                    prompt_rejected_ids = self._tokenize(processing_class, example["prompt"] + example["rejected"])[
-                        "input_ids"
-                    ]
-                    prompt_reference_ids = self._tokenize(processing_class, example["prompt"] + example["reference"])[
+                    prompt_reference_ids = tokenize(processing_class, example["prompt"] + example["reference"])[
                         "input_ids"
                     ]
 


### PR DESCRIPTION
Follow-up to #6206, which fixed dataset fingerprinting in the core `DPOTrainer` / `SFTTrainer` / `RewardTrainer`. The two experimental trainers `KTOTrainer` and `TPOTrainer` still have the pattern #6206 removed: their tokenization map is a closure that calls `self._tokenize(...)`, so it captures `self`. A map function that closes over `self` (which holds the model and other unpicklable state) can't be hashed stably, so `datasets` falls back to a random fingerprint and silently disables caching of the tokenized dataset — re-tokenizing on every run.

This applies the same fix as #6206: make `_tokenize` a `@staticmethod` and bind it to a local (`tokenize = self._tokenize`) before defining the map function, so the closure no longer captures `self`.

- **KTO**: `_tokenize` uses the VLM flag, so `is_vlm` becomes an explicit parameter passed through `fn_kwargs` (exactly as in #6206's DPO).
- **TPO**: `_tokenize` doesn't reference `self` at all, so it simply becomes a `@staticmethod`.

No behavior change: the tokenized output is identical; only the map function's hashability (and therefore cache reuse across runs) changes.

`CPOTrainer` and `ORPOTrainer` share the same pattern (a `self`-bound `tokenize_row`) but are intentionally left out here to avoid conflicts: CPO's data pipeline is being refactored in #5837, and ORPO's `_prepare_dataset` is touched by #6230. They can be aligned once those land.

### Verification

- `tests/experimental/test_kto_trainer.py` and `tests/experimental/test_tpo_trainer.py` pass in full (tokenized output unchanged); `ruff check` / `ruff format --check` clean. Validated on a single GPU (RTX 4080).
- Like #6206, this doesn't add a fingerprint-specific test: the fallback to a random fingerprint only triggers for processing classes / models that `datasets` can't hash, which the tiny CI fixtures don't exercise. The existing suites cover tokenization correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to dataset preprocessing closures with no training-loss or tokenization logic changes; behavior is intended to be identical aside from caching.
> 
> **Overview**
> Aligns **experimental `KTOTrainer` and `TPOTrainer`** with the dataset-fingerprint fix from #6206 so `dataset.map` during preprocessing can be cached across runs instead of re-tokenizing every time.
> 
> In both trainers, **`_tokenize` is now a `@staticmethod`**, and **`tokenize_fn` calls a local `tokenize = self._tokenize`** so the map callback no longer closes over `self` (which held the model and broke stable hashing). **KTO** also threads **`is_vlm` as an explicit argument** via `fn_kwargs`, matching DPO’s VLM handling.
> 
> Tokenized outputs are unchanged; only **cache fingerprint stability** improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7b8e486b9118f0c5ea8fdaff82601bdaedc2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->