### PR TITLE
Fix missing mm_token_type_ids when training new Qwen VLMs with liger kernel

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2831,6 +2831,13 @@ class TestGRPOTrainerVLM(TrlTestCase):
                     reason="Upstream issue tracked at https://github.com/linkedin/Liger-Kernel/issues/1117",
                 ),
             ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
         ],
     )
     @require_liger_kernel
@@ -2868,6 +2875,74 @@ class TestGRPOTrainerVLM(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+    )
+    @require_liger_kernel
+    def test_get_last_hidden_state_passes_mm_token_type_ids(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train").select(
+            range(1)
+        )
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            use_liger_kernel=True,
+            report_to="none",
+            logging_strategy="no",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # One unique prompt repeated num_generations times, matching the generation batch layout.
+        generation_batch = [dataset[0] for _ in range(trainer.num_generations)]
+        inputs = trainer._generate_and_score_completions(generation_batch)
+        assert "mm_token_type_ids" in inputs, "Expected mm_token_type_ids in scored VLM batch for Qwen3.5"
+
+        unwrapped_model = trainer.accelerator.unwrap_model(trainer.model)
+        prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
+        completion_ids, completion_mask = inputs["completion_ids"], inputs["completion_mask"]
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+        logits_to_keep = completion_ids.size(1)
+
+        backbone = unwrapped_model.base_model
+        with patch.object(backbone, "forward", wraps=backbone.forward) as mock_forward:
+            trainer._get_last_hidden_state(
+                unwrapped_model,
+                input_ids,
+                attention_mask,
+                logits_to_keep,
+                inputs.get("pixel_values"),
+                inputs.get("image_grid_thw"),
+                inputs.get("mm_token_type_ids"),
+                inputs.get("pixel_attention_mask"),
+                inputs.get("spatial_shapes"),
+                inputs.get("image_sizes"),
+                inputs.get("image_position_ids"),
+            )
+
+            assert mock_forward.call_count > 0, "backbone.forward was never called"
+            mm_token_type_ids = mock_forward.call_args.kwargs.get("mm_token_type_ids")
+            assert mm_token_type_ids is not None, "mm_token_type_ids should be passed to backbone.forward"
+            assert torch.equal(mm_token_type_ids, inputs["mm_token_type_ids"]), (
+                "mm_token_type_ids passed to backbone.forward should match the scored batch"
+            )
+
+        release_memory(trainer.model, trainer)
 
     @pytest.mark.parametrize(
         "model_id",

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1072,6 +1072,7 @@ class GRPOTrainer(_BaseTrainer):
         logits_to_keep,
         pixel_values=None,
         image_grid_thw=None,
+        mm_token_type_ids=None,
         pixel_attention_mask=None,
         spatial_shapes=None,
         image_sizes=None,
@@ -1086,6 +1087,8 @@ class GRPOTrainer(_BaseTrainer):
         # For Qwen models:
         if image_grid_thw is not None and pixel_values is not None:
             model_inputs["image_grid_thw"] = image_grid_thw
+        if mm_token_type_ids is not None and pixel_values is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         # For Gemma, SmolVLM2, LLaVa-Next etc.:
         if pixel_values is not None:
             model_inputs["pixel_values"] = pixel_values
@@ -2512,6 +2515,7 @@ class GRPOTrainer(_BaseTrainer):
             logits_to_keep,
             inputs.get("pixel_values"),
             inputs.get("image_grid_thw"),
+            inputs.get("mm_token_type_ids"),
             inputs.get("pixel_attention_mask"),
             inputs.get("spatial_shapes"),
             inputs.get("image_sizes"),


### PR DESCRIPTION
# What does this PR do?

Newer versions of the Qwen model (e.g., Qwen3.5) introduce a new input field, `mm_token_type_ids`, which is currently handled only in the standard loss computation path. This PR extends support for this field to the Liger Kernel path as well, enabling training of newer Qwen VLMs with the Liger Kernel loss. Simple tests included.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, conditional forward-arg change gated on `pixel_values`; standard loss path already handled the field. Risk is mainly incorrect VLM forward inputs for Qwen3.5+ with Liger.
> 
> **Overview**
> **Fixes Qwen3.5+ VLM GRPO training with Liger** by threading `mm_token_type_ids` through the fused-loss path, which previously omitted this input while the standard log-prob forward already included it.
> 
> `_get_last_hidden_state` now accepts `mm_token_type_ids` and adds it to backbone `model_inputs` when `pixel_values` is present (alongside existing Qwen fields like `image_grid_thw`). The Liger loss step passes `inputs.get("mm_token_type_ids")` into that helper.
> 
> Tests add Qwen3.5 to `test_train_vlm_and_liger` (transformers ≥ 5.2.0) and `test_get_last_hidden_state_passes_mm_token_type_ids`, which asserts scored batches include the field and that backbone `forward` receives matching tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0962a3ff774d213315c1e369a76aa14edff59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->