### PR TITLE
Fix `add_response_schema` tests for the new `parse_response` prefix requirement

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -181,7 +181,12 @@ class TestAddResponseSchema:
         response = text[len(prefix) :]
         # Here, we just test that the parsing doesn't raise an error.
         # The correctness of the parsing is tested in TestParseResponse
-        tokenizer.parse_response(response)
+        # The new-style `response_template` parser requires the prompt prefix; the legacy `response_schema` parser
+        # does not accept a `prefix=` argument.
+        if _SUPPORTS_RESPONSE_TEMPLATE:
+            tokenizer.parse_response(response, prefix=prefix)
+        else:
+            tokenizer.parse_response(response)
 
     @pytest.mark.parametrize(
         "processor_name",
@@ -217,7 +222,12 @@ class TestAddResponseSchema:
         response = text[len(prefix) :]
         # Here, we just test that the parsing doesn't raise an error.
         # The correctness of the parsing is tested in TestParseResponse
-        processor.tokenizer.parse_response(response)
+        # The new-style `response_template` parser requires the prompt prefix; the legacy `response_schema` parser
+        # does not accept a `prefix=` argument.
+        if _SUPPORTS_RESPONSE_TEMPLATE:
+            processor.tokenizer.parse_response(response, prefix=prefix)
+        else:
+            processor.tokenizer.parse_response(response)
 
 
 class TestSupportsToolCalling:


### PR DESCRIPTION
huggingface/transformers#46980 made `tokenizer.parse_response()` raise a loud error when `prefix=` is omitted while parsing with a new-style `response_template` (the streamable parser added in [huggingface/transformers#45847](https://github.com/huggingface/transformers/pull/45847)).

`TestAddResponseSchema.test_add_response_schema` and `test_add_response_schema_vlm` called `parse_response(response)` without a prefix, so they started failing on `transformers` `main`.

## Fix

Test-only. The library was already correct: `trl.chat_template_utils.parse_response` already passes `prefix=` when a new-style template is in use. This PR updates the two tests to do the same, gating on the existing `_SUPPORTS_RESPONSE_TEMPLATE` flag (the legacy `response_schema` parser does not accept `prefix=`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test assertions in `tests/test_chat_template_utils.py` change; library behavior is unchanged.
> 
> **Overview**
> Aligns **`TestAddResponseSchema`** smoke tests with upstream **`transformers`** behavior: new-style **`response_template`** parsing now requires **`prefix=`** on **`tokenizer.parse_response()`**, while the legacy **`response_schema`** path still must not receive that argument.
> 
> In **`test_add_response_schema`** and **`test_add_response_schema_vlm`**, calls are branched on the existing **`_SUPPORTS_RESPONSE_TEMPLATE`** flag so they pass the already-computed chat **`prefix`** when the new parser is active, and keep the old single-argument call otherwise. **No production code changes**—this mirrors what **`trl.chat_template_utils.parse_response`** already does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a08cfbb9b48d2d2fc6ed440582706a535f8e8790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->