### PR TITLE
Drop vLLM 0.15 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.13.0` to `0.23.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.16.0` to `0.23.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.15.0,<=0.23.0",
+    "vllm>=0.16.0,<=0.23.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.15.0") <= Version(_vllm_version) <= Version("0.23.0")):
+        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.23.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.15.0 to 0.23.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
As per the plan 

<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/cef9c809-2c93-41a5-9f53-a3fac661b284" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dependency bounds only; no runtime integration logic changed beyond aligning the existing version warning.
> 
> **Overview**
> **Raises the minimum supported vLLM version from 0.15.0 to 0.16.0** (upper bound stays `0.23.0`).
> 
> The supported range is updated in three places: the vLLM integration doc warning, the `trl[vllm]` optional dependency in `pyproject.toml`, and the version check plus warning text in `is_vllm_available()` in `trl/import_utils.py`. Users on vLLM 0.15.x will see the compatibility warning and `pip install "trl[vllm]"` will no longer resolve to 0.15.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5f3ebf3e11b641d8214879ccd1654b7b17ec51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->