### PR TITLE
Fix activation offload storage dedupe reuse

### DIFF
--- a/tests/test_activation_offloading.py
+++ b/tests/test_activation_offloading.py
@@ -18,6 +18,7 @@ from transformers import AutoModelForCausalLM
 from transformers.testing_utils import torch_device
 from transformers.utils import is_peft_available
 
+from trl.models import activation_offloading as activation_offloading_module
 from trl.models.activation_offloading import NoOpManager, OffloadActivations
 
 from .testing_utils import TrlTestCase, require_peft, require_torch_accelerator
@@ -193,6 +194,53 @@ class TestActivationOffloading(TrlTestCase):
             f"Deduplication should result in fewer storages ({unique_storages_offloaded}) "
             f"than total tensors ({total_tensor_ids})"
         )
+
+        loss.backward()
+
+    @require_torch_accelerator
+    def test_reused_storage_key_after_stash_reap_is_not_deduplicated(self):
+        """A reused allocator address should not be treated as a live view."""
+
+        class SaveTensor(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tensor):
+                ctx.save_for_backward(tensor)
+                return tensor.sum()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (tensor,) = ctx.saved_tensors
+                return torch.ones_like(tensor) * grad_output
+
+        first = torch.randn(4, 4, device=torch_device, requires_grad=True)
+        filler = torch.randn(4, 4, device=torch_device, requires_grad=True)
+        reused = torch.randn(4, 4, device=torch_device, requires_grad=True)
+
+        def fake_storage_key(tensor):
+            if id(tensor) in {id(first), id(reused)}:
+                return ("reused-storage-key", tensor.dtype)
+            return (id(tensor), tensor.dtype)
+
+        offload_ctx = OffloadActivations(
+            use_pin_memory=False,
+            use_streams=True,
+            min_offload_size=1,
+            max_fwd_stash_size=1,
+        )
+
+        original_get_unique_tensor_key = activation_offloading_module._get_unique_tensor_key
+        activation_offloading_module._get_unique_tensor_key = fake_storage_key
+        try:
+            with offload_ctx:
+                loss = SaveTensor.apply(first) + SaveTensor.apply(filler) + SaveTensor.apply(reused)
+        finally:
+            activation_offloading_module._get_unique_tensor_key = original_get_unique_tensor_key
+
+        offloaded_count = sum(1 for _, modified, _, _, _ in offload_ctx.tracker.values() if modified)
+        deduplicated_count = sum(1 for _, modified, _, _, _ in offload_ctx.tracker.values() if not modified)
+
+        assert offloaded_count == 3
+        assert deduplicated_count == 0
 
         loss.backward()
 

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -348,7 +348,7 @@ class OffloadActivations(saved_tensors_hooks):
                 # Stash to keep activation alive til s1 is done
                 self.fwd_stash[tensor_id] = (activation, event)
 
-                # Track this storage for deduplication while the GPU tensor is live.
+                # Track storage only while fwd_stash keeps the GPU tensor live; single-stream has no release point.
                 track_storage_key(storage_key, tensor_id)
 
             return tensor_id

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -139,6 +139,7 @@ class OffloadActivations(saved_tensors_hooks):
 
         # Storage deduplication: maps storage key to tensor_id to avoid offloading same storage multiple times
         self.storage_to_tensor_id = {}
+        self._storage_key_by_tensor_id = {}
 
         # Parameter filtering: track parameter storage pointers to skip them during offloading
         self.param_storages = set()
@@ -194,6 +195,15 @@ class OffloadActivations(saved_tensors_hooks):
             # get the number of bytes in a tensor, for memory management purposes
             return x.element_size() * x.nelement()  # x.element_size() * x._base_storage().nbytes()
 
+        def track_storage_key(storage_key: tuple, tensor_id: int):
+            self.storage_to_tensor_id[storage_key] = tensor_id
+            self._storage_key_by_tensor_id[tensor_id] = storage_key
+
+        def release_storage_key(tensor_id: int):
+            storage_key = self._storage_key_by_tensor_id.pop(tensor_id, None)
+            if storage_key is not None and self.storage_to_tensor_id.get(storage_key) == tensor_id:
+                del self.storage_to_tensor_id[storage_key]
+
         # -------- core pack / unpack work -------- #
         def pack_tensor(activation: torch.Tensor) -> int:
             # activations are passed in during forward pass - from here we take over and return a unique id
@@ -206,6 +216,7 @@ class OffloadActivations(saved_tensors_hooks):
                 self.is_first_backward_call = True
                 # Reset deduplication map for new forward pass
                 self.storage_to_tensor_id = {}
+                self._storage_key_by_tensor_id = {}
 
             # query for basic tensor info
             num_bytes = get_num_bytes_tensor(activation)
@@ -218,6 +229,7 @@ class OffloadActivations(saved_tensors_hooks):
             if storage_key in self.storage_to_tensor_id:
                 # Storage already offloaded - don't offload again, just track the reference
                 self.tracker[tensor_id] = (activation, False, None, None, None)  # Keep on GPU, don't offload
+                track_storage_key(storage_key, tensor_id)
                 return tensor_id
 
             # Check if tensor is on CPU (skip offloading)
@@ -266,6 +278,7 @@ class OffloadActivations(saved_tensors_hooks):
                         _, ev = self.fwd_stash[id]
                         self.s0.wait_event(ev)
                         del self.fwd_stash[id]
+                        release_storage_key(id)
                     else:
                         break
 
@@ -335,8 +348,8 @@ class OffloadActivations(saved_tensors_hooks):
                 # Stash to keep activation alive til s1 is done
                 self.fwd_stash[tensor_id] = (activation, event)
 
-            # Track this storage for deduplication
-            self.storage_to_tensor_id[storage_key] = tensor_id
+                # Track this storage for deduplication while the GPU tensor is live.
+                track_storage_key(storage_key, tensor_id)
 
             return tensor_id
 
@@ -377,6 +390,7 @@ class OffloadActivations(saved_tensors_hooks):
 
             # clear tensor from tracking
             del self.tracker[unpack_tensor_id]
+            release_storage_key(unpack_tensor_id)
             # Only set is_first_forward_call to True when all tensors have been unpacked
             if len(self.tracker) == 0:
                 self.is_first_forward_call = True
@@ -515,6 +529,7 @@ class OffloadActivations(saved_tensors_hooks):
                         _, ev = self.fwd_stash[id]
                         self.s0.wait_event(ev)
                         del self.fwd_stash[id]
+                        release_storage_key(id)
 
                     # wait on prev node's events and del those
                     for id in prev_node_ids:
@@ -532,6 +547,7 @@ class OffloadActivations(saved_tensors_hooks):
 
             # clear tensor from tracking
             del self.tracker[unpack_tensor_id]
+            release_storage_key(unpack_tensor_id)
             # Only set is_first_forward_call to True when all tensors have been unpacked
             if len(self.tracker) == 0:
                 self.is_first_forward_call = True
@@ -589,6 +605,7 @@ class OffloadActivations(saved_tensors_hooks):
         """
         self.tracker.clear()
         self.storage_to_tensor_id.clear()
+        self._storage_key_by_tensor_id.clear()
         self.tensor_id = 0
         self.is_first_forward_call = True
         self.is_first_backward_call = True


### PR DESCRIPTION
# What does this PR do?

in #4247, the intent was to track duplicate storage when the tensors are views. however, tensors are offloaded and released, the allocator will reuse storage pointers for new tensors, which end up not getting offloaded. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core autograd pack/unpack and stream stash timing for activation offloading; wrong release timing could break dedup for real views or reintroduce skipped offloads.
> 
> **Overview**
> Fixes incorrect **storage deduplication** in `OffloadActivations` where a GPU allocator could **reuse a storage address** after an activation was offloaded and its stash entry dropped; the old key stayed in `storage_to_tensor_id`, so unrelated later tensors were treated as views and **skipped offloading**.
> 
> The change adds **`track_storage_key` / `release_storage_key`** and a **`_storage_key_by_tensor_id`** map so dedupe entries are removed when tensors are actually done: when **`fwd_stash` is reaped** during forward, on **unpack** in backward, when **leftover `fwd_stash` is cleared** at backward start, and on context **`__enter__`**. With streams, storage is only registered while the forward stash keeps the GPU tensor alive.
> 
> Adds **`test_reused_storage_key_after_stash_reap_is_not_deduplicated`**, which simulates a reused storage key and expects **three offloads and zero false dedupes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae050849daa681a6ac97dac70dc31ee4203a71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->