### PR TITLE
Improve consistency of Liger Kernel initialization in DPO

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -776,8 +776,8 @@ class KTOTrainer(_BaseTrainer):
                 )
             self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
 
+        # Liger loss
         self.use_liger_kernel = args.use_liger_kernel
-        # Import Liger kernel if enabled
         if self.use_liger_kernel:
             if not is_liger_kernel_available():
                 raise ImportError(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -732,8 +732,10 @@ class DPOTrainer(_BaseTrainer):
                 "Label smoothing must be greater than 0.0 when using 'exo_pair' loss. The EXO paper recommends a "
                 "value of 1e-3."
             )
+
+        # Liger loss
         self.use_liger_kernel = args.use_liger_kernel
-        if args.use_liger_kernel:
+        if self.use_liger_kernel:
             if not is_liger_kernel_available():
                 raise ImportError(
                     "You set `use_liger_kernel=True` but the liger kernel is not available. "
@@ -744,7 +746,6 @@ class DPOTrainer(_BaseTrainer):
                     "Multiple loss types are not yet supported when using Liger kernel. If you need this feature, "
                     "please open a feature request at https://github.com/huggingface/trl/issues."
                 )
-            self.liger_loss_fn = LigerFusedLinearDPOLoss(beta=args.beta, loss_type=self.loss_types[0])
             if compute_metrics is not None:
                 raise ValueError(
                     "compute_metrics is not supported with the Liger kernel. compute_metrics requires to be able to "
@@ -760,6 +761,7 @@ class DPOTrainer(_BaseTrainer):
                     "`use_liger_kernel=True` is not supported with PEFT models. Set `use_liger_kernel=False` to train "
                     "a PEFT model."
                 )
+            self.liger_loss_fn = LigerFusedLinearDPOLoss(beta=args.beta, loss_type=self.loss_types[0])
 
         # Dataset
         # Skip dataset preparation if it's a VLM, where preprocessing (e.g., image-to-pixel conversion) is too costly


### PR DESCRIPTION
Improve consistency of Liger Kernel initialization in DPO.


This PR refactors how the Liger kernel is integrated into the `DPOTrainer`. The main changes improve consistency and clarity around enabling and initializing the Liger kernel and its associated loss function. It aligns the corresponding comments in the and `KTOTrainer` class.

### Changes

Integration and initialization improvements for Liger kernel:

* Standardized the assignment and checking of `use_liger_kernel` to use `self.use_liger_kernel` instead of directly referencing `args.use_liger_kernel` in both `DPOTrainer` and `KTOTrainer` constructors.
* Moved the initialization of `self.liger_loss_fn` for the Liger kernel in `DPOTrainer` to after PEFT model checks, ensuring it is only set when appropriate.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constructor reordering and comment/consistency changes in trainer init; no change to loss computation paths for valid configurations.
> 
> **Overview**
> Aligns **Liger kernel** setup in `DPOTrainer` and `KTOTrainer` with a shared `# Liger loss` section and consistent use of **`self.use_liger_kernel`** in conditionals (DPO previously gated on `args.use_liger_kernel`).
> 
> In **`DPOTrainer`**, **`self.liger_loss_fn`** (`LigerFusedLinearDPOLoss`) is now created **after** all Liger validation, including PEFT checks for `lm_head` adapters and prompt-learning methods, instead of immediately after the single-loss-type check. Invalid configs fail before the fused loss object is constructed; supported setups are unchanged.
> 
> **`KTOTrainer`** only gets the matching comment tweak; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090c74e922f6534bc9c72614821865de37979b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->