### PR TITLE
Align Liger loss naming across core trainers

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1403,7 +1403,7 @@ class TestGRPOTrainer(TrlTestCase):
 
         with (
             patch.object(trainer, "_generate_and_score_completions", side_effect=gen_with_is_ratio),
-            patch.object(trainer.liger_grpo_loss, "forward", wraps=trainer.liger_grpo_loss.forward) as mock_forward,
+            patch.object(trainer.liger_loss, "forward", wraps=trainer.liger_loss.forward) as mock_forward,
         ):
             trainer.train()
 
@@ -3084,7 +3084,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
         )
         from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
 
-        assert isinstance(trainer.liger_grpo_loss, LigerFusedLinearGRPOLoss)
+        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
 
         previous_trainable_params = {n: param.clone() for n, param in model.named_parameters()}
 
@@ -3143,7 +3143,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
         )
         from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
 
-        assert isinstance(trainer.liger_grpo_loss, LigerFusedLinearGRPOLoss)
+        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
 
         # Verify PEFT adapter is properly initialized
         from peft import PeftModel
@@ -3194,7 +3194,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
         )
         from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
 
-        assert isinstance(trainer.liger_grpo_loss, LigerFusedLinearGRPOLoss)
+        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
 
         previous_trainable_params = {n: param.clone() for n, param in model.named_parameters()}
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -744,7 +744,7 @@ class DPOTrainer(_BaseTrainer):
                     "Multiple loss types are not yet supported when using Liger kernel. If you need this feature, "
                     "please open a feature request at https://github.com/huggingface/trl/issues."
                 )
-            self.liger_loss_fn = LigerFusedLinearDPOLoss(beta=args.beta, loss_type=self.loss_types[0])
+            self.liger_loss = LigerFusedLinearDPOLoss(beta=args.beta, loss_type=self.loss_types[0])
             if compute_metrics is not None:
                 raise ValueError(
                     "compute_metrics is not supported with the Liger kernel. compute_metrics requires to be able to "
@@ -1198,9 +1198,7 @@ class DPOTrainer(_BaseTrainer):
         labels = input_ids[:, 1:].clone()
         labels[shift_completion_mask == 0] = -100
 
-        loss, metrics = self.liger_loss_fn(
-            weight, hidden_states, labels, bias, ref_hidden_states, ref_weight, ref_bias
-        )
+        loss, metrics = self.liger_loss(weight, hidden_states, labels, bias, ref_hidden_states, ref_weight, ref_bias)
 
         (
             chosen_logps,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -826,7 +826,7 @@ class GRPOTrainer(_BaseTrainer):
             # redirect the model.module forward to the model forward to ensure pre-forward hooks are called
             self._forward_redirection = _ForwardRedirection()
 
-            self.liger_grpo_loss = LigerFusedLinearGRPOLoss(
+            self.liger_loss = LigerFusedLinearGRPOLoss(
                 beta=self.beta,
                 epsilon_low=self.epsilon_low,
                 epsilon_high=self.epsilon_high,
@@ -2572,7 +2572,7 @@ class GRPOTrainer(_BaseTrainer):
 
                 gather_ctx = deepspeed.zero.GatheredParameters(params, modifier_rank=None)
         with gather_ctx:
-            loss, metrics = self.liger_grpo_loss(
+            loss, metrics = self.liger_loss(
                 _input=last_hidden_state,
                 lin_weight=lm_head_weight,
                 selected_token_ids=completion_ids,


### PR DESCRIPTION
Align Liger loss naming across core trainers.


This PR standardizes the naming of the Liger loss attribute in both the DPO and GRPO trainers, changing it from `liger_loss_fn` or `liger_grpo_loss` to a consistent `liger_loss`. It also updates all references in the code and associated tests to use the new attribute name. This change improves code readability and maintainability by ensuring a single, clear attribute name is used throughout.

### Changes

### Attribute renaming and code consistency

* Renamed the Liger loss attribute from `liger_grpo_loss` and `liger_loss_fn` to `liger_loss` in both `trl/trainer/grpo_trainer.py` and `trl/trainer/dpo_trainer.py`, and updated all internal references accordingly. 
* Updated method calls to use `self.liger_loss` instead of the previous attribute names in both trainers. 

### Test updates

* Updated all test assertions and mocks in `tests/test_grpo_trainer.py` to use `liger_loss` instead of `liger_grpo_loss`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor across trainers and tests with no logic changes; any external code that referenced the old attribute names would break at import/runtime.
> 
> **Overview**
> Standardizes how DPO and GRPO trainers expose the fused Liger loss module by using a single **`liger_loss`** attribute instead of **`liger_loss_fn`** (DPO) and **`liger_grpo_loss`** (GRPO).
> 
> Initialization and forward paths in `dpo_trainer.py` and `grpo_trainer.py` now assign and call `self.liger_loss` with the same `LigerFusedLinear*` instances as before. GRPO tests that mock or assert on the Liger module were updated to use `trainer.liger_loss`.
> 
> This is a naming-only change; loss computation and trainer behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d0d519022c4e7b7c6ea8a996501ad23f4a3b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->