### PR TITLE
Align KTO with DPO: Align Liger loss naming

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -803,7 +803,7 @@ class KTOTrainer(_BaseTrainer):
                 raise ValueError(
                     "You cannot use `use_liger_kernel=True` with Peft models. Please set `use_liger_kernel=False`."
                 )
-            self.liger_loss_fn = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
+            self.liger_loss = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
 
         if self.precompute_ref_logps:
             if isinstance(self.train_dataset, IterableDataset) or isinstance(
@@ -1272,7 +1272,7 @@ class KTOTrainer(_BaseTrainer):
                 chosen_rewards_sum,
                 rejected_rewards_sum,
             ),
-        ) = self.liger_loss_fn(
+        ) = self.liger_loss(
             _input=outputs.last_hidden_state[:, :-1],
             lin_weight=lm_head.weight,
             target=target,


### PR DESCRIPTION
Align KTO with DPO: Align Liger loss naming.

Follow-up to:
- #6243

Part of:
- #4786


This PR refactors the naming of the Liger loss function attribute in the `KTOTrainer` class to improve code clarity and consistency. The main change is renaming the attribute from `liger_loss_fn` to `liger_loss` and updating its usage accordingly.

### Changes

**Refactoring for clarity:**

* Renamed the Liger loss function attribute from `liger_loss_fn` to `liger_loss` in the `KTOTrainer` class constructor (`__init__`) for clearer and more consistent naming.
* Updated all internal references to use the new attribute name `liger_loss` instead of `liger_loss_fn` in the `_compute_loss_liger` method.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier rename only; no logic, API, or training behavior changes.
> 
> **Overview**
> Renames the Liger fused KTO loss attribute on `KTOTrainer` from `liger_loss_fn` to **`liger_loss`**, and updates the call site in **`_compute_loss_liger`** to match. This is a naming-only change so KTO follows the same convention as DPO after #6243; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba91ad21afa094e0e8cbe951174ce9e45719aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->