### PR TITLE
Align Liger loss naming across experimental trainers

### DIFF
--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -478,7 +478,7 @@ class DistillationTrainer(_BaseTrainer):
         # ── Liger fused JSD loss ──
         self.use_liger_loss = False
         if args.use_liger_kernel:
-            self.liger_jsd_loss = LigerFusedLinearJSDLoss(
+            self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.beta,
                 ignore_index=-100,
                 temperature=args.temperature,
@@ -1594,7 +1594,7 @@ class DistillationTrainer(_BaseTrainer):
         student_head = unwrapped_student.get_output_embeddings()
         teacher_head = unwrapped_teacher.get_output_embeddings()
 
-        loss = self.liger_jsd_loss(
+        loss = self.liger_loss(
             student_input=student_hidden,
             student_weight=student_head.weight,
             teacher_input=teacher_hidden,

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -146,7 +146,7 @@ class GKDTrainer(SFTTrainer):
         if args.use_liger_kernel:
             # Match the non-Liger path: pure JSD (no hard CE component) and no temperature
             # scaling, since `generalized_jsd_loss` is called without a `temperature` argument.
-            self.liger_jsd_loss = LigerFusedLinearJSDLoss(
+            self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.beta,
                 ignore_index=-100,
                 compiled=False,
@@ -358,7 +358,7 @@ class GKDTrainer(SFTTrainer):
             teacher_head = unwrapped_teacher.get_output_embeddings()
 
             # liger fused jsd loss
-            loss = self.liger_jsd_loss(
+            loss = self.liger_loss(
                 student_input=student_hidden,
                 student_weight=student_head.weight,
                 teacher_input=teacher_hidden,

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -770,7 +770,7 @@ class GOLDTrainer(SFTTrainer):
         # Liger fused GKD loss (JSD)
         self.use_liger_gkd_loss = False
         if args.use_liger_kernel:
-            self.liger_jsd_loss = LigerFusedLinearJSDLoss(
+            self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.beta,
                 ignore_index=-100,
                 temperature=args.temperature,
@@ -1745,7 +1745,7 @@ class GOLDTrainer(SFTTrainer):
                 student_head = unwrapped_student.get_output_embeddings()
                 teacher_head = unwrapped_teacher.get_output_embeddings()
 
-                loss = self.liger_jsd_loss(
+                loss = self.liger_loss(
                     student_input=student_hidden,
                     student_weight=student_head.weight,
                     teacher_input=teacher_hidden,

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -393,7 +393,7 @@ class SDFTTrainer(_BaseTrainer):
                     "`use_liger_kernel` is incompatible with `distillation_is_clip`: the fused kernel does not expose "
                     "per-token losses for importance-sampling clipping."
                 )
-            self.liger_jsd_loss = LigerFusedLinearJSDLoss(
+            self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.distillation_alpha,
                 ignore_index=-100,
                 temperature=args.temperature,
@@ -1216,7 +1216,7 @@ class SDFTTrainer(_BaseTrainer):
         # Per-sequence then batch mean (grpo), matching the non-Liger path: the fused kernel reduces by total tokens
         # (bnpo), so we call it per sequence and average.
         seq_losses = [
-            self.liger_jsd_loss(
+            self.liger_loss(
                 student_input=student_hidden[i],
                 student_weight=student_head.weight,
                 teacher_input=teacher_hidden[i],

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -524,7 +524,7 @@ class SDPOTrainer(_BaseTrainer):
                     "The Liger fused loss reduces with a token-level mean (equivalent to `loss_type='bnpo'`); the "
                     f"configured `loss_type={args.loss_type!r}` is ignored on the Liger path."
                 )
-            self.liger_jsd_loss = LigerFusedLinearJSDLoss(
+            self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.distillation_alpha,
                 ignore_index=-100,
                 temperature=args.temperature,
@@ -1578,7 +1578,7 @@ class SDPOTrainer(_BaseTrainer):
         # Per-sequence then batch mean (grpo), matching the non-Liger path: the fused kernel reduces by total tokens
         # (bnpo), so we call it per sequence and average.
         seq_losses = [
-            self.liger_jsd_loss(
+            self.liger_loss(
                 student_input=student_hidden[i],
                 student_weight=student_head.weight,
                 teacher_input=teacher_hidden[i],


### PR DESCRIPTION
Align Liger loss naming across experimental trainers.

Follow-up to:
- #6243

This PR standardizes the naming of the Liger loss instance variable across multiple experimental trainer classes. The variable previously named `liger_jsd_loss` is now consistently renamed to `liger_loss` wherever it is initialized and used. This improves code clarity and consistency across the codebase.

### Changes

**Variable renaming for consistency:**

* Renamed the `liger_jsd_loss` instance variable to `liger_loss` in the constructors of the following trainer classes: `DistillationTrainer`, `GKDTrainer`, `GOLDTrainer`, `SDFTTrainer`, and `SDPOTrainer` (`trl/experimental/distillation/distillation_trainer.py`, `trl/experimental/gkd/gkd_trainer.py`, `trl/experimental/gold/gold_trainer.py`, `trl/experimental/sdft/sdft_trainer.py`, `trl/experimental/sdpo/sdpo_trainer.py`). 

* Updated all usages of the renamed variable from `self.liger_jsd_loss` to `self.liger_loss` in the corresponding loss computation methods in each trainer. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only refactor with no training or loss behavior changes.
> 
> **Overview**
> Renames the fused Liger JSD loss instance from **`liger_jsd_loss`** to **`liger_loss`** in five experimental trainers: `DistillationTrainer`, `GKDTrainer`, `GOLDTrainer`, `SDFTTrainer`, and `SDPOTrainer`.
> 
> Initialization and loss forward calls are updated in each file; **`LigerFusedLinearJSDLoss`** construction and arguments are unchanged. This aligns naming with follow-up to #6243 so the attribute name is consistent across distillation-style trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416fbd22eaa2adf5f9e43303d9d638da21c8038e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->