### PR TITLE
Align KTO with DPO: Align `F` import with the rest of the repo

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 import transformers
 from accelerate import PartialState
 from accelerate.logging import get_logger
@@ -29,7 +30,6 @@ from accelerate.utils import is_peft_model, tqdm
 from datasets import Dataset, IterableDataset, IterableDatasetDict, concatenate_datasets
 from datasets.fingerprint import Hasher
 from packaging.version import Version
-from torch.nn import functional as F
 from torch.utils.data import DataLoader, Sampler, SequentialSampler
 from transformers import (
     AutoProcessor,


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. (#4786)

`kto_trainer.py` was the only file using `from torch.nn import functional as F`. Switched it to `import torch.nn.functional as F`, which is the convention used everywhere else (22 files). Import block now matches `dpo_trainer.py`.

No behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file import reorder with no logic or API changes.
> 
> **Overview**
> As part of aligning experimental `KTOTrainer` with `DPOTrainer`, **`kto_trainer.py` now imports `F` the same way as the rest of TRL**: `import torch.nn.functional as F` next to `import torch`, instead of `from torch.nn import functional as F` lower in the import block.
> 
> This is **import-only**; `F.sigmoid` usage in KTO loss paths is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747eb82da9017040502ef86df7b2b8fb00a1ac59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->