### PR TITLE
Use trl's guarded `is_liger_kernel_available` in DPOTrainer

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -42,9 +42,10 @@ from transformers import (
 from transformers.data.data_collator import DataCollatorMixin
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import EvalPrediction
-from transformers.utils import is_liger_kernel_available, is_peft_available
+from transformers.utils import is_peft_available
 
 from ..data_utils import apply_chat_template, extract_prompt, is_conversational, prepare_multimodal_messages
+from ..import_utils import is_liger_kernel_available
 from ..models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp
 from ..models.utils import disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer


### PR DESCRIPTION
Part of the effort to align `DPOTrainer` and `KTOTrainer` (experimental). #4786

`DPOTrainer` imported `is_liger_kernel_available` from `transformers.utils`, which only checks that liger is installed. Switched it to `trl.import_utils.is_liger_kernel_available`, which additionally enforces the minimum supported version (liger ≥ 0.8.0, `LIGER_KERNEL_MIN_VERSION`).

This matches `KTOTrainer` and `GRPOTrainer`, which already use the guarded version.

No behavior change beyond rejecting liger installs older than the supported minimum.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only alignment with existing TRL trainers; behavior changes only for liger versions below 0.8.0, which were previously allowed but may be unsupported.
> 
> **Overview**
> **`DPOTrainer`** now imports **`is_liger_kernel_available`** from **`trl.import_utils`** instead of **`transformers.utils`**, matching **`KTOTrainer`** and **`GRPOTrainer`**.
> 
> TRL’s helper still requires **`liger_kernel`** to be installed, and additionally treats versions below **`0.8.0`** (`LIGER_KERNEL_MIN_VERSION`) as unavailable. That affects the conditional import of **`LigerFusedLinearDPOLoss`** and the **`use_liger_kernel=True`** guard in **`__init__`**: environments with an older liger install will no longer enable the fused Liger DPO path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f952b95028fe0c7a63c52f7513dced089f97d390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->