### PR TITLE
Align KTO with DPO: Align models import

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -51,8 +51,8 @@ from ...data_utils import (
     unpair_preference_dataset,
 )
 from ...import_utils import is_liger_kernel_available
-from ...models import get_act_offloading_ctx_manager
-from ...models.utils import disable_gradient_checkpointing, prepare_deepspeed, prepare_fsdp
+from ...models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp
+from ...models.utils import disable_gradient_checkpointing
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.callbacks import SyncRefModelCallback
 from ...trainer.utils import (


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. #4786 

`KTOTrainer` imported `prepare_deepspeed`/`prepare_fsdp` from `...models.utils` and `get_act_offloading_ctx_manager` on a separate line. Rerouted them to match `DPOTrainer` (and `GRPOTrainer`/`RLOOTrainer`):

- `from ...models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp`
- `from ...models.utils import disable_gradient_checkpointing`

`prepare_deepspeed`/`prepare_fsdp` are re-exported by `models/__init__`, so this resolves to the same functions. No behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with identical symbols; no training or logic changes.
> 
> **Overview**
> **KTOTrainer** import layout is updated to match **DPOTrainer** (and GRPO/RLOO): `get_act_offloading_ctx_manager`, `prepare_deepspeed`, and `prepare_fsdp` now come from `...models`, while `disable_gradient_checkpointing` stays on `...models.utils`.
> 
> This is part of aligning experimental KTO with DPO (#4786). `prepare_deepspeed` / `prepare_fsdp` are re-exported from `trl.models` (same implementations as `models.utils`), so runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef0eb81e7138958a7a2f6dea7b97ff35c5df193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->