### PR TITLE
Fix teacher quantization kwargs and guard eval callback in GKD example

### DIFF
--- a/examples/scripts/gkd.py
+++ b/examples/scripts/gkd.py
@@ -93,8 +93,8 @@ if __name__ == "__main__":
     )
     if quantization_config is not None:
         # Passing None would not be treated the same as omitting the argument, so we include it only when valid.
-        model_kwargs["device_map"] = get_kbit_device_map()
-        model_kwargs["quantization_config"] = quantization_config
+        teacher_model_kwargs["device_map"] = get_kbit_device_map()
+        teacher_model_kwargs["quantization_config"] = quantization_config
 
     training_args.teacher_model_init_kwargs = teacher_model_kwargs
 
@@ -124,7 +124,8 @@ if __name__ == "__main__":
         peft_config=get_peft_config(model_args),
     )
 
-    if training_args.eval_strategy != "no":
+    # LogCompletionsCallback needs a "prompt" column, absent from conversational datasets.
+    if training_args.eval_strategy != "no" and "prompt" in dataset[script_args.dataset_test_split].column_names:
         generation_config = GenerationConfig(
             max_new_tokens=training_args.max_new_tokens, do_sample=True, temperature=training_args.temperature
         )


### PR DESCRIPTION
# What does this PR do?

Fixes two bugs in `examples/scripts/gkd.py`:
- Under `--load_in_4bit`, the teacher's quantization block set `model_kwargs` (the student) instead of `teacher_model_kwargs`, so the teacher loaded unquantized. Aligns with `distillation.py`.
- `LogCompletionsCallback` requires a `prompt` column and crashed eval on conversational (`messages`) datasets (`ValueError: Column 'prompt' doesn't exist.`); it is now attached only when that column exists.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-script-only fixes with no changes to core training libraries or security-sensitive paths.
> 
> **Overview**
> Fixes two bugs in the **GKD example script** (`examples/scripts/gkd.py`).
> 
> When `--load_in_4bit` is used, **quantization** is now applied to `teacher_model_kwargs` instead of mistakenly updating the student’s `model_kwargs`, so the teacher actually loads quantized (consistent with `distillation.py`).
> 
> **Eval logging** via `LogCompletionsCallback` is only registered when the eval split includes a `prompt` column, avoiding crashes on conversational datasets that only expose `messages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236f0e4955703f9e8b3c41a71366e34d6d2ecf67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->