### PR TITLE
Raise a clear error when GKD student and teacher vocab sizes differ

### DIFF
--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -189,6 +189,14 @@ class GKDTrainer(SFTTrainer):
             teacher_model_init_kwargs.setdefault("trust_remote_code", args.trust_remote_code)
             teacher_model = AutoModelForCausalLM.from_pretrained(teacher_model, **teacher_model_init_kwargs)
 
+        if self.model.config.vocab_size != teacher_model.config.vocab_size:
+            raise ValueError(
+                f"The student model has vocab_size {self.model.config.vocab_size} but the teacher model has "
+                f"vocab_size {teacher_model.config.vocab_size}. GKD compares the teacher's full next-token "
+                f"distribution, which requires a shared vocabulary. Use a teacher with the same vocab_size, or "
+                f"GOLD for cross-tokenizer distillation."
+            )
+
         # Disable dropout in the model
         if args.disable_dropout:
             disable_dropout_in_model(self.model)


### PR DESCRIPTION
# What does this PR do?

White-box logit KD in `GKDTrainer` requires the student and teacher to share `vocab_size`. When they differ, training failed with a cryptic broadcast error in `kl_div` (e.g. `Qwen2.5-0.5B` is 151936 but `Qwen2.5-7B` is 152064). `GKDTrainer` now validates this at init and raises a clear error pointing to GOLD for cross-tokenizer distillation. `DistillationTrainer` already handles this by resizing the teacher embeddings.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time validation only; no change to training logic when vocab sizes already match.
> 
> **Overview**
> **GKDTrainer** now checks that the student and teacher share the same `vocab_size` right after the teacher is loaded, instead of failing later with an obscure `kl_div` broadcast error when logits shapes disagree.
> 
> On mismatch it raises a **`ValueError`** that states both sizes, notes that GKD needs a shared vocabulary for full next-token distributions, and suggests matching teachers or **GOLD** for cross-tokenizer distillation (unlike **DistillationTrainer**, which can resize teacher embeddings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408920f4e91df8fb3a2fdb2d4696e70810c7e2e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->