### PR TITLE
Align KTO with DPO: Fix KTO `compute_metrics` type hint (`EvalLoopOutput` → `EvalPrediction`)

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -40,7 +40,7 @@ from transformers import (
     TrainerCallback,
 )
 from transformers.data.data_collator import DataCollatorMixin
-from transformers.trainer_utils import EvalLoopOutput, has_length
+from transformers.trainer_utils import EvalPrediction, has_length
 from transformers.utils import is_peft_available
 
 from ...data_utils import (
@@ -470,7 +470,7 @@ class KTOTrainer(_BaseTrainer):
         train_dataset: Dataset | IterableDataset | None = None,
         eval_dataset: Dataset | IterableDataset | dict[str, Dataset | IterableDataset] | None = None,
         processing_class: PreTrainedTokenizerBase | ProcessorMixin | None = None,
-        compute_metrics: Callable[[EvalLoopOutput], dict] | None = None,
+        compute_metrics: Callable[[EvalPrediction], dict] | None = None,
         callbacks: list[TrainerCallback] | None = None,
         optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
         peft_config: "PeftConfig | None" = None,


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. #4786

`KTOTrainer.__init__` typed `compute_metrics` as `Callable[[EvalLoopOutput], dict]`, which was both wrong (the Trainer passes an `EvalPrediction` to `compute_metrics`, not an `EvalLoopOutput`) and inconsistent with the trainer's own docstring, which already documents it as `EvalPrediction`. Switched the annotation and the import to `EvalPrediction`, matching `DPOTrainer`.

No behavior change (type-annotation only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only change in experimental KTO trainer; no logic, data, or API behavior is modified.
> 
> **Overview**
> Aligns experimental `KTOTrainer` with `DPOTrainer` by correcting the `compute_metrics` typing only.
> 
> The import and `__init__` annotation now use **`EvalPrediction`** instead of **`EvalLoopOutput`**, matching what Hugging Face `Trainer` actually passes into `compute_metrics` and what the class docstring already described. **No runtime or training behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a770365257831a621ce3970a087dbe38bbc4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->