### PR TITLE
Align KTO with DPO: Fix KTO `max_length` docstring (truncation direction)

### DIFF
--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -50,7 +50,7 @@ class KTOConfig(_BaseConfig):
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
         max_length (`int` or `None`, *optional*, defaults to `1024`):
-            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left.
+            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the end.
             If `None`, no truncation is applied.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
@@ -152,7 +152,7 @@ class KTOConfig(_BaseConfig):
         default=1024,
         metadata={
             "help": "Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from "
-            "the left. If `None`, no truncation is applied."
+            "the end. If `None`, no truncation is applied."
         },
     )
     pad_to_multiple_of: int | None = field(

--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -50,7 +50,7 @@ class KTOConfig(_BaseConfig):
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
         max_length (`int` or `None`, *optional*, defaults to `1024`):
-            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the end.
+            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the right.
             If `None`, no truncation is applied.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
@@ -152,7 +152,7 @@ class KTOConfig(_BaseConfig):
         default=1024,
         metadata={
             "help": "Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from "
-            "the end. If `None`, no truncation is applied."
+            "the right. If `None`, no truncation is applied."
         },
     )
     pad_to_multiple_of: int | None = field(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -103,7 +103,7 @@ class DataCollatorForUnpairedPreference(DataCollatorMixin):
         pad_token_id (`int`):
             Token ID to use for padding `input_ids` sequences.
         max_length (`int`, *optional*):
-            Maximum sequence length after assembly. Sequences longer than `max_length` are truncated from the end.
+            Maximum sequence length after assembly. Sequences longer than `max_length` are truncated from the right.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
         return_tensors (`str`, *optional*, defaults to `"pt"`):


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. #4786

`KTOConfig.max_length` was documented (class docstring + field `help`) as truncating "from the left". This is wrong: the collator truncates with `full_ids[:max_length]`, i.e. it keeps the start and drops the tail. That's truncating from the **right**.

Docs only, no behavior change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only documentation updates with no code path changes.
> 
> **Overview**
> Documentation-only fix so **KTO** `max_length` matches actual collator behavior and **DPO** alignment work (#4786).
> 
> `KTOConfig` and `DataCollatorForUnpairedPreference` previously said long sequences are truncated **from the left** (or “from the end” in the collator doc). The text collator uses `full_ids[:max_length]`, which keeps the prompt start and drops the tail—i.e. truncation **from the right**. Docstrings and the `max_length` field `help` now say “from the right” in `kto_config.py` and `kto_trainer.py`. **No runtime or training behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396a23d8057250773f903a3d02af00ad8c7ee805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->