### PR TITLE
Align KTO with DPO: Remove stray misplaced comment in KTO `_get_train_sampler`

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1075,9 +1075,7 @@ class KTOTrainer(_BaseTrainer):
             if train_dataset is None or not has_length(train_dataset):
                 return None
             return SequentialSampler(train_dataset)
-        return super()._get_train_sampler(
-            train_dataset
-        )  # Override training step to add activation offloading context.
+        return super()._get_train_sampler(train_dataset)
 
     def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
         model_hash = hash_module(self.ref_model or self.model)


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. #4786

`KTOTrainer._get_train_sampler` ended with a dangling `# Override training step to add activation offloading context.` comment on its `return super()._get_train_sampler(...)` line. That comment belongs to `training_step` (where it also correctly appears)

No behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only cleanup with no logic changes.
> 
> **Overview**
> Removes a **misplaced** inline comment on `KTOTrainer._get_train_sampler` that described activation offloading during `training_step`. That note already sits on `training_step` (aligned with `DPOTrainer`).
> 
> The `return super()._get_train_sampler(...)` call is unchanged aside from minor formatting. **No runtime or training behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6aac84a80c377befd7e6ac476230cafc032ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->