### PR TITLE
Align KTO with DPO: Log `num_tokens` metric

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -740,6 +740,7 @@ class KTOTrainer(_BaseTrainer):
 
         # Initialize the metrics
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
+        self._total_train_tokens = 0
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the
         # model accepts loss-related kwargs. Since we compute our own loss, this check is irrelevant. We set
@@ -1301,6 +1302,12 @@ class KTOTrainer(_BaseTrainer):
 
         self._metrics[mode]["kl"].append(kl.item())
 
+        # Number of tokens
+        if mode == "train":
+            num_tokens_in_batch = self.accelerator.gather_for_metrics(batch["attention_mask"].sum()).sum().item()
+            self._total_train_tokens += num_tokens_in_batch
+        self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
+
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()
 
@@ -1454,6 +1461,12 @@ class KTOTrainer(_BaseTrainer):
         )
 
         self._metrics[mode]["kl"].append(kl.item())
+
+        # Number of tokens
+        if mode == "train":
+            num_tokens_in_batch = self.accelerator.gather_for_metrics(batch["attention_mask"].sum()).sum().item()
+            self._total_train_tokens += num_tokens_in_batch
+        self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`.

`DPOTrainer` logs a `num_tokens` metric (running count of training tokens seen); `KTOTrainer` did not. Added it for parity:

- Initialize `self._total_train_tokens = 0` in `__init__` (next to `self._metrics`).
- Accumulate and log `num_tokens` in both `_compute_loss` and `_compute_loss_liger`, matching DPO.

The counter is only incremented in `train` mode; the metric is logged in both modes.

No change to the loss or existing metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only metrics wiring with no changes to loss computation or training logic.
> 
> **Overview**
> **KTOTrainer** now reports a running **`num_tokens`** training metric so it matches **`DPOTrainer`** behavior.
> 
> A **`_total_train_tokens`** counter is initialized at startup. On each forward in **`_compute_loss`** and **`_compute_loss_liger`**, training batches add the distributed sum of **`attention_mask`** token counts; **`num_tokens`** is written into the trainer metrics (train increments the counter; eval logs the current cumulative total without updating it).
> 
> No changes to KTO loss or existing reward/KL metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cdac0c4cc0a57a5cd459bd6a102120c8272a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->