### PR TITLE
Align KTO with DPO: Log `entropy` metric

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -58,6 +58,7 @@ from ...trainer.callbacks import SyncRefModelCallback
 from ...trainer.utils import (
     create_model_from_path,
     disable_dropout_in_model,
+    entropy_from_logits,
     flush_left,
     get_config_model_id,
     hash_module,
@@ -1454,6 +1455,18 @@ class KTOTrainer(_BaseTrainer):
         )
 
         self._metrics[mode]["kl"].append(kl.item())
+
+        # Entropy
+        per_token_entropy = entropy_from_logits(shift_logits.detach())
+        mask = batch["completion_mask"][:, 1:]
+        entropy_sum = (per_token_entropy * mask).sum()
+        total_tokens = mask.sum()
+
+        # Gather counts across ranks and weight-average
+        entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
+        total_tokens = self.accelerator.gather_for_metrics(total_tokens).sum()
+        entropy = (entropy_sum / total_tokens).item() if total_tokens > 0 else 0.0
+        self._metrics[mode]["entropy"].append(entropy)
 
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()


### PR DESCRIPTION
Part of the effort to align `KTOTrainer` (experimental) with `DPOTrainer`. #4786

`DPOTrainer` logs an `entropy` metric (mean per-token predictive entropy over completion tokens); `KTOTrainer` did not. Added it for parity, using the same token-weighted cross-rank averaging as DPO:

- Import `entropy_from_logits` from `trl.trainer.utils`.
- In `_compute_loss`, compute per-token entropy over the completion tokens (`completion_mask`), gather sums and token counts across ranks, and log the weighted mean as `entropy`.

Only added to `_compute_loss`, not `_compute_loss_liger`: the Liger path does not materialize logits, so entropy cannot be computed there (same as DPO).

No change to the loss or existing metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only metrics logging reusing the same helper and aggregation pattern as DPO; no loss or training logic changes.
> 
> **Overview**
> **Experimental `KTOTrainer` now logs mean per-token predictive entropy** over completion tokens, matching **`DPOTrainer`** behavior for alignment work (#4786).
> 
> The change imports **`entropy_from_logits`** and, in **`_compute_loss`**, computes entropy from detached **`shift_logits`**, masks with **`completion_mask[:, 1:]`**, and records a **token-weighted mean** after **`gather_for_metrics`** across ranks under the **`entropy`** metric key. **KTO loss and existing metrics are unchanged.**
> 
> Entropy is **not** added on the **Liger** path (**`_compute_loss_liger`**), because logits are not materialized there—same limitation as DPO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fdb24fca5e84bcb6168550cc7879c4a61a7a620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->