### PR TITLE
Align KTO doc with DPO and fix Logged metrics wording

### DIFF
--- a/docs/source/cpo_trainer.md
+++ b/docs/source/cpo_trainer.md
@@ -62,7 +62,7 @@ accelerate launch examples/scripts/cpo.py \
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics:
+While training and evaluating, we record the following metrics:
 
 * `rewards/chosen`: the mean log probabilities of the policy model for the chosen responses scaled by beta
 * `rewards/rejected`: the mean log probabilities of the policy model for the rejected responses scaled by beta

--- a/docs/source/dpo_trainer.md
+++ b/docs/source/dpo_trainer.md
@@ -124,7 +124,7 @@ Several formulations of the objective have been proposed in the literature. Init
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/dpo_trainer.md
+++ b/docs/source/dpo_trainer.md
@@ -124,12 +124,12 @@ Several formulations of the objective have been proposed in the literature. Init
 
 ## Logged metrics
 
-While training and evaluating we record the following reward metrics:
+While training and evaluating we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.
 * `num_tokens`: The total number of tokens processed so far.
-* `loss`: The average cross-entropy loss computed over non-masked tokens in the current logging interval.
+* `loss`: The average DPO loss over the current logging interval.
 * `entropy`: The average entropy of the model's predicted token distribution over non-masked tokens.
 * `mean_token_accuracy`: The proportion of non-masked tokens for which the model’s top-1 prediction matches the token from the chosen completion.
 * `learning_rate`: The current learning rate, which may change dynamically if a scheduler is used.

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -169,7 +169,7 @@ To use this formulation, set `loss_type="sapo"` in the [`GRPOConfig`].
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics:
+While training and evaluating, we record the following metrics:
 
 - `num_tokens`: The total number of tokens processed so far, including both prompts and completions. When using tools, only non-tool tokens are counted.
 - `step_time`: The average time (in seconds) taken per training step (including generation).

--- a/docs/source/kto_trainer.md
+++ b/docs/source/kto_trainer.md
@@ -133,7 +133,7 @@ Here  \\( x \\) is the prompt,  \\( y \\) is the completion,  \\( \pi_{\theta} \
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/kto_trainer.md
+++ b/docs/source/kto_trainer.md
@@ -1,6 +1,6 @@
 # KTO Trainer
 
-[![model badge](https://img.shields.io/badge/All_models-KTO-blue)](https://huggingface.co/models?other=kto,trl)
+[![All_models-KTO-blue](https://img.shields.io/badge/All_models-KTO-blue)](https://huggingface.co/models?other=kto,trl)
 
 > [!WARNING]
 > As of TRL v1.0, `KTOTrainer` and `KTOConfig` have been moved to the `trl.experimental.kto` module.  
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Kahneman-Tversky Optimization (KTO) was introduced in [KTO: Model Alignment as Prospect Theoretic Optimization](https://huggingface.co/papers/2402.01306) by [Kawin Ethayarajh](https://huggingface.co/kawine), [Winnie Xu](https://huggingface.co/xwinxu), [Niklas Muennighoff](https://huggingface.co/Muennighoff), Dan Jurafsky, [Douwe Kiela](https://huggingface.co/douwekiela).
+TRL supports the Kahneman-Tversky Optimization (KTO) Trainer for training language models, as described in the paper [KTO: Model Alignment as Prospect Theoretic Optimization](https://huggingface.co/papers/2402.01306) by [Kawin Ethayarajh](https://huggingface.co/kawine), [Winnie Xu](https://huggingface.co/xwinxu), [Niklas Muennighoff](https://huggingface.co/Muennighoff), Dan Jurafsky, [Douwe Kiela](https://huggingface.co/douwekiela).
 
 The abstract from the paper is the following:
 
@@ -17,7 +17,7 @@ The abstract from the paper is the following:
 
 The official code can be found in [ContextualAI/HALOs](https://github.com/ContextualAI/HALOs).
 
-This post-training method was contributed by [Kashif Rasul](https://huggingface.co/kashif), [Younes Belkada](https://huggingface.co/ybelkada), [Lewis Tunstall](https://huggingface.co/lewtun) and Pablo Vicente.
+This post-training method was contributed by [Kashif Rasul](https://huggingface.co/kashif), [Younes Belkada](https://huggingface.co/ybelkada), [Lewis Tunstall](https://huggingface.co/lewtun), Pablo Vicente, and later refactored by [Albert Villanova del Moral](https://huggingface.co/albertvillanova).
 
 ## Quick start
 
@@ -74,13 +74,181 @@ Here are some other factors to consider when choosing a programming language for
  <strong><span style="color: green;">4</span> Python</strong>: Developed by Guido van Rossum in 1991, Python is a high-level, interpreted, and dynamically typed language known for its simplicity, readability, and versatility.
 </code></pre>
 
-## Expected dataset format
+## Expected dataset type and format
 
-KTO requires an [unpaired preference dataset](dataset_formats#unpaired-preference). Alternatively, you can provide a *paired* preference dataset (also known simply as a *preference dataset*). In this case, the trainer will automatically convert it to an unpaired format by separating the chosen and rejected responses, assigning `label = True` to the chosen completions and `label = False` to the rejected ones.
+KTO requires an [unpaired preference](dataset_formats#unpaired-preference) dataset. Alternatively, you can provide a *paired* preference dataset (also known simply as a *preference dataset*). In this case, the trainer will automatically convert it to an unpaired format by separating the chosen and rejected responses, assigning `label = True` to the chosen completions and `label = False` to the rejected ones.
 
-The [`experimental.kto.KTOTrainer`] supports both [conversational](dataset_formats#conversational) and [standard](dataset_formats#standard) dataset formats. When provided with a conversational dataset, the trainer will automatically apply the chat template to the dataset.
+The [`experimental.kto.KTOTrainer`] is compatible with both [standard](dataset_formats#standard) and [conversational](dataset_formats#conversational) dataset formats. When provided with a conversational dataset, the trainer will automatically apply the chat template to the dataset.
+
+```python
+# Standard format
+unpaired_preference_example = {"prompt": "The sky is", "completion": " blue.", "label": True}
+
+# Conversational format
+unpaired_preference_example = {"prompt": [{"role": "user", "content": "What color is the sky?"}],
+                               "completion": [{"role": "assistant", "content": "It is blue."}],
+                               "label": True}
+```
 
 In theory, the dataset should contain at least one chosen and one rejected completion. However, some users have successfully run KTO using *only* chosen or only rejected data. If using only rejected data, it is advisable to adopt a conservative learning rate.
+
+## Looking deeper into the KTO method
+
+Kahneman-Tversky Optimization (KTO) is a training method designed to align a language model using only a binary signal of whether an output is *desirable* or *undesirable* for a given input, rather than pairs of preferred/dispreferred completions. Drawing on the prospect theory of Kahneman and Tversky, it defines a *human-aware loss* (HALO) that directly maximizes the utility of generations, weighting desirable and undesirable examples asymmetrically to reflect human loss aversion.
+
+This section breaks down how KTO works in practice, covering the key steps: **preprocessing** and **loss computation**.
+
+### Preprocessing and tokenization
+
+During training, each example is expected to contain a prompt, a `completion`, and a boolean `label` indicating whether the completion is desirable (`True`) or undesirable (`False`). For more details on the expected formats, see [Dataset formats](dataset_formats).
+The [`experimental.kto.KTOTrainer`] tokenizes each input using the model's tokenizer.
+
+### Computing the loss
+
+The KL divergence term used by the KTO loss is estimated by pairing each prompt with a mismatched completion drawn from elsewhere in the batch. For this reason, loss types that estimate the KL term (all except `apo_zero_unpaired`) require a per-device train batch size greater than 1 and a sequential sampling strategy, so that the mismatched pairs are stable across a batch.
+
+The loss used in KTO (Eq. 7 of the [paper](https://huggingface.co/papers/2402.01306)) is defined as follows:
+
+$$
+\mathcal{L}_{\mathrm{KTO}}(\theta) = \mathbb{E}_{(x,y)}\!\left[ w(y)\Big(1 - v(x, y)\Big) \right]
+$$
+
+where the value  \\( v(x, y) \\) is
+
+$$
+v(x, y) = \begin{cases}
+\sigma\!\left(\beta\big(\log\frac{\pi_{\theta}(y\mid x)}{\pi_{\mathrm{ref}}(y\mid x)} - \mathrm{KL}\big)\right) & \text{if } y \text{ is desirable} \\
+\sigma\!\left(\beta\big(\mathrm{KL} - \log\frac{\pi_{\theta}(y\mid x)}{\pi_{\mathrm{ref}}(y\mid x)}\big)\right) & \text{if } y \text{ is undesirable}
+\end{cases}
+$$
+
+Here  \\( x \\) is the prompt,  \\( y \\) is the completion,  \\( \pi_{\theta} \\) is the policy model being trained,  \\( \pi_{\mathrm{ref}} \\) is the reference model,  \\( \sigma \\) is the sigmoid function,  \\( \beta > 0 \\) controls the deviation from the reference model, and  \\( \mathrm{KL} \\) is the estimated KL divergence term. The weight  \\( w(y) \\) is `desirable_weight` for desirable completions and `undesirable_weight` for undesirable ones, used to counter an imbalance between the number of desirable and undesirable examples.
+
+#### Loss Types
+
+| `loss_type=` | Description |
+| --- | --- |
+| `"kto"` (default) | The KTO loss from the [KTO](https://huggingface.co/papers/2402.01306) paper. A human-aware loss (HALO) based on Kahneman-Tversky prospect theory that maximizes the utility of desirable completions and minimizes it for undesirable ones, using an estimated KL divergence term as a reference point. |
+| `"apo_zero_unpaired"` | The unpaired variant of the APO-zero loss from the [APO](https://huggingface.co/papers/2408.06266) paper. It increases the likelihood of desirable completions and decreases the likelihood of undesirable ones without estimating the KL divergence term. Use this loss when you believe the desirable completions are better than the model's default output. |
+
+## Logged metrics
+
+While training and evaluating we record the following metrics:
+
+* `global_step`: The total number of optimizer steps taken so far.
+* `epoch`: The current epoch number, based on dataset iteration.
+* `num_tokens`: The total number of tokens processed so far.
+* `loss`: The average KTO loss over the current logging interval.
+* `entropy`: The average entropy of the model's predicted token distribution over non-masked tokens.
+* `kl`: The average estimated KL divergence between the policy and reference model, used as the reference point in the KTO loss.
+* `learning_rate`: The current learning rate, which may change dynamically if a scheduler is used.
+* `grad_norm`: The L2 norm of the gradients, computed before gradient clipping.
+* `logits/chosen`: The average logit values assigned by the model to the tokens in the chosen (desirable) completion.
+* `logits/rejected`: The average logit values assigned by the model to the tokens in the rejected (undesirable) completion.
+* `logps/chosen`: The average log-probability assigned by the model to the tokens in the chosen (desirable) completion.
+* `logps/rejected`: The average log-probability assigned by the model to the tokens in the rejected (undesirable) completion.
+* `rewards/chosen`: The average implicit reward computed for the chosen (desirable) completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y\mid x)}{\pi_{\mathrm{ref}}(y\mid x)} \\).
+* `rewards/rejected`: The average implicit reward computed for the rejected (undesirable) completion, computed as  \\( \beta \log \frac{\pi_{\theta}(y\mid x)}{\pi_{\mathrm{ref}}(y\mid x)} \\).
+* `rewards/margins`: The average implicit reward margin between the chosen and rejected completions.
+
+## Customization
+
+### Compatibility and constraints
+
+Some argument combinations are intentionally restricted in the current [`experimental.kto.KTOTrainer`] implementation:
+
+* With `use_liger_kernel=True`:
+  * only `loss_type="kto"` is supported (not `"apo_zero_unpaired"`),
+  * `compute_metrics` is not supported,
+  * `precompute_ref_log_probs=True` is not supported,
+  * PEFT models are not supported.
+* `sync_ref_model=True` is not supported when training with PEFT models that do not keep a standalone `ref_model`.
+* `sync_ref_model=True` cannot be combined with `precompute_ref_log_probs=True`.
+* `precompute_ref_log_probs=True` is not supported with `IterableDataset` (train or eval) or with vision datasets.
+* Loss types that estimate the KL divergence term (all except `"apo_zero_unpaired"`) require `train_sampling_strategy="sequential"` and a per-device train batch size greater than 1.
+
+### Model initialization
+
+You can directly pass the kwargs of the [`~transformers.AutoModelForCausalLM.from_pretrained()`] method to the [`experimental.kto.KTOConfig`]. For example, if you want to load a model in a different precision, analogous to
+
+```python
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2-0.5B-Instruct", dtype=torch.bfloat16)
+```
+
+you can do so by passing the `model_init_kwargs={"dtype": torch.bfloat16}` argument to the [`experimental.kto.KTOConfig`].
+
+```python
+from trl.experimental.kto import KTOConfig
+
+training_args = KTOConfig(
+    model_init_kwargs={"dtype": torch.bfloat16},
+)
+```
+
+Note that all keyword arguments of [`~transformers.AutoModelForCausalLM.from_pretrained()`] are supported.
+
+### Train adapters with PEFT
+
+We support tight integration with 🤗 PEFT library, allowing any user to conveniently train adapters and share them on the Hub, rather than training the entire model.
+
+```python
+from datasets import load_dataset
+from trl.experimental.kto import KTOTrainer
+from peft import LoraConfig
+
+dataset = load_dataset("trl-lib/kto-mix-14k", split="train")
+
+trainer = KTOTrainer(
+    "Qwen/Qwen2-0.5B-Instruct",
+    train_dataset=dataset,
+    peft_config=LoraConfig(),
+)
+
+trainer.train()
+```
+
+You can also continue training your [`~peft.PeftModel`]. For that, first load a `PeftModel` outside [`experimental.kto.KTOTrainer`] and pass it directly to the trainer without the `peft_config` argument being passed.
+
+> [!TIP]
+> When training adapters, you typically use a higher learning rate than full fine-tuning since only new parameters are being learned.
+
+### Train with Liger Kernel
+
+Liger Kernel is a collection of Triton kernels for LLM training that boosts multi-GPU throughput by 20%, cuts memory use by 60% (enabling up to 4× longer context), and works seamlessly with tools like FlashAttention, PyTorch FSDP, and DeepSpeed. For more information, see [Liger Kernel Integration](liger_kernel_integration).
+
+## Tool Calling with KTO
+
+The [`experimental.kto.KTOTrainer`] fully supports fine-tuning models with _tool calling_ capabilities. In this case, each dataset example should include:
+
+* The conversation messages (prompt and completion), including any tool calls (`tool_calls`) and tool responses (`tool` role messages)
+* The list of available tools in the `tools` column, typically provided as JSON schemas
+
+For details on the expected dataset structure, see the [Dataset Format — Tool Calling](dataset_formats#tool-calling) section.
+
+## Training Vision Language Models
+
+[`experimental.kto.KTOTrainer`] fully supports training Vision-Language Models (VLMs). To train a VLM, provide a dataset with either an `image` column (single image per sample) or an `images` column (list of images per sample). For more information on the expected dataset structure, see the [Dataset Format — Vision Dataset](dataset_formats#vision-dataset) section.
+
+```python
+from trl.experimental.kto import KTOConfig, KTOTrainer
+from datasets import load_dataset
+
+trainer = KTOTrainer(
+    model="Qwen/Qwen2.5-VL-3B-Instruct",
+    args=KTOConfig(max_length=None),
+    train_dataset=load_dataset("trl-internal-testing/zen-image", "conversational_unpaired_preference", split="train"),
+)
+trainer.train()
+```
+
+> [!TIP]
+> For VLMs, truncating may remove image tokens, leading to errors during training. To avoid this, set `max_length=None` in the [`experimental.kto.KTOConfig`]. This allows the model to process the full sequence length without truncating image tokens.
+>
+> ```python
+> KTOConfig(max_length=None, ...)
+> ```
+>
+> Only use `max_length` when you've verified that truncation won't remove image tokens for the entire dataset.
 
 ## Example script
 
@@ -118,19 +286,6 @@ Each choice of `beta` has a maximum learning rate it can tolerate before learnin
 
 The `desirable_weight` and `undesirable_weight` of the [`experimental.kto.KTOConfig`] refer to the weights placed on the losses for desirable/positive and undesirable/negative examples.
 By default, they are both 1. However, if you have more of one or the other, then you should upweight the less common type such that the ratio of (`desirable_weight`  \\(\times\\) number of positives) to (`undesirable_weight`  \\(\times\\) number of negatives) is in the range 1:1 to 4:3.
-
-## Logged metrics
-
-While training and evaluating, we record the following reward metrics:
-
-- `rewards/chosen_sum`: the sum of log probabilities of the policy model for the chosen responses scaled by beta
-- `rewards/rejected_sum`: the sum of log probabilities of the policy model for the rejected responses scaled by beta
-- `logps/chosen_sum`: the sum of log probabilities of the chosen completions
-- `logps/rejected_sum`: the sum of log probabilities of the rejected completions
-- `logits/chosen_sum`: the sum of logits of the chosen completions
-- `logits/rejected_sum`: the sum of logits of the rejected completions
-- `count/chosen`: the count of chosen samples in a batch
-- `count/rejected`: the count of rejected samples in a batch
 
 ## KTOTrainer
 

--- a/docs/source/nash_md_trainer.md
+++ b/docs/source/nash_md_trainer.md
@@ -111,7 +111,7 @@ python examples/scripts/nash_md.py \
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics:
+While training and evaluating, we record the following metrics:
 
 * `loss/kl`: The mean KL divergence between the model and reference data.
 * `objective/entropy`: The mean entropy of the model and reference data.

--- a/docs/source/online_dpo_trainer.md
+++ b/docs/source/online_dpo_trainer.md
@@ -110,7 +110,7 @@ python examples/scripts/dpo_online.py \
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics. Here is an example [tracked run at Weights and Biases](https://wandb.ai/huggingface/trl/runs/w4apmsi9)
+While training and evaluating, we record the following metrics. Here is an example [tracked run at Weights and Biases](https://wandb.ai/huggingface/trl/runs/w4apmsi9)
 
 * `objective/kl`: The mean Kullback-Leibler (KL) divergence between the current model and reference model.
 * `objective/entropy`: The mean entropy of the model, indicating the randomness of the actions chosen by the model.

--- a/docs/source/orpo_trainer.md
+++ b/docs/source/orpo_trainer.md
@@ -109,7 +109,7 @@ To scale how much the auxiliary loss contributes to the total loss, use the hype
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics:
+While training and evaluating, we record the following metrics:
 
 - `rewards/chosen`: the mean log probabilities of the policy model for the chosen responses scaled by beta
 - `rewards/rejected`: the mean log probabilities of the policy model for the rejected responses scaled by beta

--- a/docs/source/reward_trainer.md
+++ b/docs/source/reward_trainer.md
@@ -132,7 +132,7 @@ $$
 
 ## Logged metrics
 
-While training and evaluating we record the following reward metrics:
+While training and evaluating we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/reward_trainer.md
+++ b/docs/source/reward_trainer.md
@@ -132,7 +132,7 @@ $$
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -128,7 +128,7 @@ In a fully online, single-step setting (default),  \\( \frac{\pi_\theta(o_i \mid
 
 ## Logged metrics
 
-While training and evaluating, we record the following reward metrics:
+While training and evaluating, we record the following metrics:
 
 - `num_tokens`: The total number of tokens processed so far, including both prompts and completions.
 - `step_time`: The average time (in seconds) taken per training step (including generation).

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -118,7 +118,7 @@ Padding tokens (if present) are ignored in the loss computation by applying an i
 
 ## Logged metrics
 
-While training and evaluating we record the following reward metrics:
+While training and evaluating we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -118,7 +118,7 @@ Padding tokens (if present) are ignored in the loss computation by applying an i
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `global_step`: The total number of optimizer steps taken so far.
 * `epoch`: The current epoch number, based on dataset iteration.

--- a/docs/source/tpo_trainer.md
+++ b/docs/source/tpo_trainer.md
@@ -108,7 +108,7 @@ Setting `tpo_alpha=0.0` disables the NLL term entirely (the reference response i
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `loss`: The total TPO loss (contrastive + `tpo_alpha` × NLL) averaged over the current logging interval.
 * `entropy`: The average entropy of the model's predicted token distribution over completion tokens.

--- a/docs/source/xpo_trainer.md
+++ b/docs/source/xpo_trainer.md
@@ -113,7 +113,7 @@ python examples/scripts/xpo.py \
 
 ## Logged metrics
 
-While training and evaluating we record the following reward metrics:
+While training and evaluating we record the following metrics:
 
 * `loss/xpo`: The mean xpo part of the full loss.
 * `loss/dpo`: The mean dpo part of the full loss.

--- a/docs/source/xpo_trainer.md
+++ b/docs/source/xpo_trainer.md
@@ -113,7 +113,7 @@ python examples/scripts/xpo.py \
 
 ## Logged metrics
 
-While training and evaluating we record the following metrics:
+While training and evaluating, we record the following metrics:
 
 * `loss/xpo`: The mean xpo part of the full loss.
 * `loss/dpo`: The mean dpo part of the full loss.


### PR DESCRIPTION
Docs only.

**KTO doc (`kto_trainer.md`)** restructured to mirror `dpo_trainer.md`: added "Looking deeper into the KTO method" (loss + Loss Types table), "Customization" (constraints, model init, PEFT, Liger), "Tool Calling", and "Training Vision Language Models"; rewrote the "Logged metrics" section, which was wrong (listed non-existent `rewards/chosen_sum`, `count/chosen`, …); aligned shared wording with DPO. Kept KTO-only content (experimental warning, Example script, Usage tips).

**Logged metrics wording** across trainer docs:

- "reward metrics" → "metrics" in 11 docs (the lists include `loss`, `learning_rate`, `entropy`, `num_tokens`, … — not just rewards), matching `tpo_trainer.md`.
- DPO `loss` description fixed: was "cross-entropy loss" (copied from SFT), now "DPO loss" — DPO's loss is the preference loss, not token cross-entropy.

**Notes:** KTO's metrics list includes `entropy`/`num_tokens` (from two in-flight PRs) and the "Tool Calling" section assumes tool support from a separate PR: land those first. All referenced dataset/model IDs are real.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Markdown documentation with no runtime or training code modified.
> 
> **Overview**
> **Documentation-only** updates across TRL trainer guides.
> 
> **KTO (`kto_trainer.md`)** is expanded to follow the same structure as DPO: overview/badge tweaks, dataset format examples, a **Looking deeper into the KTO method** section (loss math + `loss_type` table), a corrected **Logged metrics** list (replacing obsolete `*_sum` / `count/*` names), **Customization** (Liger/PEFT/constraints), plus **Tool calling** and **VLM** sections. Contributor credit and section ordering are adjusted; usage tips stay at the end.
> 
> **Logged metrics** intros in **11 trainer docs** (CPO, DPO, GRPO, Nash-MD, Online DPO, ORPO, Reward, RLOO, SFT, TPO, XPO) now say **metrics** instead of **reward metrics**, since many logged fields are not rewards.
> 
> **DPO** clarifies that logged `loss` is the **average DPO preference loss**, not token cross-entropy (which had been copied from SFT).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf355127fbb92a448bf1e88813f23d224709d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->