### PR TITLE
Align KTO with DPO: Support tool calling

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import json
 import os
 import textwrap
 from collections import defaultdict
@@ -972,12 +973,15 @@ class KTOTrainer(_BaseTrainer):
             tokenize = self._tokenize
 
             def tokenize_fn(example, processing_class, is_vlm):
+                tools = example.get("tools")
+                tools = json.loads(tools) if isinstance(tools, str) else tools
                 if is_conversational(example):
                     chat_template_kwargs = example.get("chat_template_kwargs", {})
                     prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
                         is_vlm,
+                        tools=tools,
                         add_generation_prompt=True,
                         **chat_template_kwargs,
                     )["input_ids"]
@@ -985,6 +989,7 @@ class KTOTrainer(_BaseTrainer):
                         processing_class,
                         example["prompt"] + example["completion"],
                         is_vlm,
+                        tools=tools,
                         **chat_template_kwargs,
                     )["input_ids"]
                 else:
@@ -1056,6 +1061,7 @@ class KTOTrainer(_BaseTrainer):
                     "image",
                     "images",
                     "label",
+                    "tools",
                     "chat_template_kwargs",
                 ]
             else:


### PR DESCRIPTION
`KTOTrainer` ignored the `tools` column during tokenization, so tool schemas were never rendered into the prompt. Tool-calling datasets trained as if no tools were defined.

The existing `test_train_toolcall_data` (mirrors DPO's, uses `trl-internal-testing/toolcall`) now genuinely exercises tool rendering; it passes.

Matches DPO's behavior: tool calling is supported on the text path; the vision collator does not wire tools through in either trainer.

#4786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow preprocessing change aligned with existing DPO behavior; no auth, security, or core training-loop logic changes.
> 
> **Overview**
> **KTO** now honors a dataset **`tools`** column when tokenizing conversational examples, matching **DPO** on the text path.
> 
> During `_prepare_dataset`, each example’s `tools` value is read (JSON-parsed when stored as a string) and forwarded into `_tokenize` / `apply_chat_template` for both prompt-only and prompt+completion tokenization, so tool schemas are rendered into the prompt instead of being dropped. For vision datasets, **`tools`** is added to signature columns so it survives `remove_unused_columns` (the vision collator still does not wire tools through, same as DPO).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d059b9f5b5df984ed709a910394dd0d033ecab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->