### PR TITLE
 Fix GRPO vLLM sampling logprobs with None values

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -39,6 +39,7 @@ from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
 from trl.import_utils import is_liger_kernel_available
+from trl.trainer.grpo_trainer import _prepare_sampling_per_token_logps
 from trl.trainer.utils import get_kbit_device_map
 
 from .testing_utils import (
@@ -275,6 +276,20 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    def test_prepare_sampling_per_token_logps_accepts_none_values(self):
+        sampling_per_token_logps, sampling_per_token_logps_mask = _prepare_sampling_per_token_logps(
+            [[-0.1, None, -0.3], [None]], pad_to_multiple_of=4
+        )
+
+        torch.testing.assert_close(
+            sampling_per_token_logps,
+            torch.tensor([[-0.1, 0.0, -0.3, 0.0], [0.0, 0.0, 0.0, 0.0]]),
+        )
+        torch.testing.assert_close(
+            sampling_per_token_logps_mask,
+            torch.tensor([[True, False, True, False], [False, False, False, False]]),
+        )
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -127,6 +127,31 @@ RewardFunc = str | PreTrainedModel | Callable[..., list[float | None]]
 RolloutFunc = Callable[[list[str], "GRPOTrainer"], dict[str, Any]]
 
 
+def _prepare_sampling_per_token_logps(
+    sampling_per_token_logps_list: list[list[float | None]], pad_to_multiple_of: int | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    sampling_per_token_logps = [
+        torch.tensor([0.0 if logp is None else logp for logp in logps]) for logps in sampling_per_token_logps_list
+    ]
+    sampling_per_token_logps_mask = [
+        torch.tensor([logp is not None for logp in logps], dtype=torch.bool) for logps in sampling_per_token_logps_list
+    ]
+    return (
+        pad(
+            sampling_per_token_logps,
+            padding_value=0.0,
+            padding_side="right",
+            pad_to_multiple_of=pad_to_multiple_of,
+        ),
+        pad(
+            sampling_per_token_logps_mask,
+            padding_value=0,
+            padding_side="right",
+            pad_to_multiple_of=pad_to_multiple_of,
+        ),
+    )
+
+
 class _SupportsReset(Protocol):
     def reset(self, **kwargs) -> str | None: ...
 
@@ -2030,15 +2055,14 @@ class GRPOTrainer(_BaseTrainer):
             completion_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
         ).to(device=device)
         if sampling_per_token_logps_list is not None:
-            sampling_per_token_logps = [torch.tensor(logps) for logps in sampling_per_token_logps_list]
-            sampling_per_token_logps = pad(
-                sampling_per_token_logps,
-                padding_value=0.0,
-                padding_side="right",
-                pad_to_multiple_of=self.pad_to_multiple_of,
-            ).to(device=device)
+            sampling_per_token_logps, sampling_per_token_logps_mask = _prepare_sampling_per_token_logps(
+                sampling_per_token_logps_list, pad_to_multiple_of=self.pad_to_multiple_of
+            )
+            sampling_per_token_logps = sampling_per_token_logps.to(device=device)
+            sampling_per_token_logps_mask = sampling_per_token_logps_mask.to(device=device)
         else:
             sampling_per_token_logps = None
+            sampling_per_token_logps_mask = None
         if tool_mask_list is not None:
             tool_mask = [torch.tensor(mask) for mask in tool_mask_list]
             tool_mask = pad(
@@ -2205,6 +2229,9 @@ class GRPOTrainer(_BaseTrainer):
             # Compute the importance sampling ratio when using vLLM, to correct for potential distribution mismatch
             if self.use_vllm and self.vllm_importance_sampling_correction:
                 mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+                sampling_per_token_logps = torch.where(
+                    sampling_per_token_logps_mask, sampling_per_token_logps, old_per_token_logps.detach()
+                )
                 per_token_logps_diff = (old_per_token_logps - sampling_per_token_logps) * mask
 
                 sequence_level_is = self.vllm_importance_sampling_mode in ["sequence_mask", "sequence_truncate"]
@@ -2406,6 +2433,7 @@ class GRPOTrainer(_BaseTrainer):
         if self.use_vllm and self.vllm_importance_sampling_correction:
             delta = torch.abs(old_per_token_logps - sampling_per_token_logps)
             mask = completion_mask.bool() if tool_mask is None else (completion_mask * tool_mask).bool()
+            mask = mask & sampling_per_token_logps_mask
             delta = delta[mask]
             mean_delta = torch.mean(delta) if delta.numel() > 0 else torch.tensor(0.0, device=device)
             max_delta = torch.max(delta) if delta.numel() > 0 else torch.tensor(0.0, device=device)


### PR DESCRIPTION
## What does this PR do?

Fixes GRPO training with vLLM importance sampling correction when vLLM returns `NaN` sampling logprobs.

`extract_logprobs` intentionally converts vLLM `NaN` logprob values to `None`, but `GRPOTrainer` previously passed those nested values directly to `torch.tensor(...)`. This caused training to fail with:

```text
RuntimeError: Could not infer dtype of NoneType
```

This PR adds a small helper to safely prepare vLLM sampling logprobs by replacing missing values before tensorization while keeping a mask of which positions were valid. During vLLM importance sampling correction, missing sampling logprobs are filled with `old_per_token_logps`, making their importance sampling ratio neutral (`1`) instead of crashing or introducing arbitrary correction values.

The sampling logprob difference metric also excludes missing sampling logprob positions.

Fixes #6166.

## Changes

- Add `_prepare_sampling_per_token_logps` to safely tensorize sampling logprobs containing `None`
- Track a validity mask for vLLM sampling logprobs
- Treat missing sampling logprobs as neutral for vLLM importance sampling correction
- Exclude missing sampling logprobs from sampling logp difference metrics
- Add a regression test for `None` values in sampling logprobs

## Tests

```bash
python -m pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_prepare_sampling_per_token_logps_accepts_none_values
```

```
root@7d4aa4af5e5c:/workspace/trl_woo# python -m pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_prepare_sampling_per_token_logps_accepts_none_values
================================================================== test session starts ===================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace/trl_woo
configfile: pyproject.toml
plugins: xdist-3.8.0, rerunfailures-15.1, datadir-1.8.0, cov-7.1.0, anyio-4.12.0
collected 1 item                                                                                                                                         

tests/test_grpo_trainer.py .                                                                                                                       [100%]

==================================================================== warnings summary ====================================================================
../../usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:187
  /usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:187: UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version 12040). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org to install a PyTorch version that has been compiled with your version of the CUDA driver. (Triggered internally at /pytorch/c10/cuda/CUDAFunctions.cpp:119.)
    return torch._C._cuda_getDeviceCount() > 0

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 1 passed, 1 warning in 14.89s ==============================================================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vLLM importance sampling correction behavior for tokens with missing sampling logprobs, which affects GRPO training dynamics when that path is enabled.
> 
> **Overview**
> Fixes GRPO training crashes when vLLM importance sampling correction receives sampling logprobs that contain **`None`** (from vLLM `NaN` values converted upstream).
> 
> Adds **`_prepare_sampling_per_token_logps`** to tensorize logprobs safely: missing entries become `0.0` with a **validity mask** instead of calling `torch.tensor` on `None`. **`GRPOTrainer`** uses this helper when padding sampling logprobs, then during vLLM IS correction fills invalid positions with **`old_per_token_logps`** so the importance ratio is neutral rather than wrong or fatal. **Sampling logp difference metrics** also intersect their mask with the validity mask so missing positions are excluded.
> 
> Includes a focused regression test for mixed `None`/float logprobs and `pad_to_multiple_of`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e32c439a340eceae434c623a37eb8400143a0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->