### PR TITLE
Fix tiny DeepSeek-V3 configs for MLA: num_key_value_heads =num_attention_heads

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm.py
@@ -34,7 +34,12 @@ generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = DeepseekV3Config(
     vocab_size=len(tokenizer.vocab),
     hidden_size=8,
-    num_attention_heads=4,
+    # DeepSeek-V3 uses MLA, not GQA: kv_b_proj always reconstructs K/V with the full
+    # num_attention_heads, so num_key_value_heads must equal num_attention_heads (i.e.
+    # num_key_value_groups == 1). A mismatch (e.g. 4/2) is silently ignored by the KV
+    # projection but makes SDPA repeat_kv the already-full K/V heads, crashing with a
+    # head-count mismatch (see transformers#46960).
+    num_attention_heads=2,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,

--- a/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
+++ b/scripts/generate_tiny_models/for_causal_lm/deepseek_v3_for_causal_lm_0528.py
@@ -36,7 +36,12 @@ generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = DeepseekV3Config(
     vocab_size=len(tokenizer.vocab),
     hidden_size=8,
-    num_attention_heads=4,
+    # DeepSeek-V3 uses MLA, not GQA: kv_b_proj always reconstructs K/V with the full
+    # num_attention_heads, so num_key_value_heads must equal num_attention_heads (i.e.
+    # num_key_value_groups == 1). A mismatch (e.g. 4/2) is silently ignored by the KV
+    # projection but makes SDPA repeat_kv the already-full K/V heads, crashing with a
+    # head-count mismatch (see transformers#46960).
+    num_attention_heads=2,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,


### PR DESCRIPTION
Fix tiny DeepSeek-V3 configs for MLA: num_key_value_heads =num_attention_heads.

Fix #6265.

This PR updates the configuration of the DeepSeek-V3 tiny model generation scripts to ensure compatibility between the number of attention heads and key/value heads, preventing runtime errors related to head-count mismatches.

### Motivation

The two tiny DeepSeek-V3 generators build the config with `num_attention_heads=4, num_key_value_heads=2`. But DeepSeek-V3 uses **MLA**, not GQA: `DeepseekV3Attention.kv_b_proj` always reconstructs K/V with the full `num_attention_heads`, so `num_key_value_heads` never affects any layer shape: it only feeds `num_key_value_groups = num_attention_heads // num_key_value_heads` (= 2). Real DeepSeek-V3/R1 keep `num_key_value_heads == num_attention_heads` (`128 == 128`, groups = 1); the tiny models invented a GQA ratio that MLA cannot honor.

The mismatch was masked until now. In `sdpa_attention_forward`, when `attention_mask is None`, SDPA took the `enable_gqa=True` path, where query and key already having equal head counts (4 each, since MLA materializes all heads) made the broadcast a no-op.

[transformers#46960](https://github.com/huggingface/transformers/pull/46960) ("Fix silent SDPA math-kernel fallback for GQA when key/value head_dim > 256 or differ") legitimately disables `enable_gqa` when key/value `head_dim` differ — exactly the MLA case (`qk_head_dim=192` vs `v_head_dim=128`). SDPA now takes the `repeat_kv(groups=2)` path and inflates the already-full K/V heads from 4 to 8, colliding with query's 4 heads. This is a config bug in the fixtures, not a transformers regression, so #46960 is not reverted.

DeepSeek-V3 (both variants) is the only impacted family: every other tiny model is standard MHA/GQA with `key.head_dim == value.head_dim`, so `enable_gqa` still applies and `num_attention_heads=4, num_key_value_heads=2` remains a valid GQA ratio for them.

### Solution

Set `num_attention_heads=2, num_key_value_heads=2` (groups = 1) in both generators, restoring the MLA invariant, plus an explanatory comment to prevent future regressions. The regenerated tiny models are pushed to the Hub:
- https://huggingface.co/trl-internal-testing/tiny-DeepseekV3ForCausalLM/discussions/3
- https://huggingface.co/trl-internal-testing/tiny-DeepseekV3ForCausalLM-0528/discussions/4

**These Hub PRs must be merged for CI to pick up the fix.**

### Changes

Configuration fixes for attention heads:

* In both `deepseek_v3_for_causal_lm.py` and `deepseek_v3_for_causal_lm_0528.py`, the `num_attention_heads` parameter is changed from 4 to 2, with an explanatory comment added. This ensures that `num_attention_heads` matches `num_key_value_heads`, as required by DeepSeek-V3's MLA architecture, and avoids runtime errors caused by mismatches (see transformers#46960).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tiny-model generation scripts and comments change; no runtime library or auth/data paths are touched.
> 
> **Overview**
> Fixes **tiny DeepSeek-V3 generator configs** so `num_attention_heads` matches `num_key_value_heads` (2/2 instead of 4/2). DeepSeek-V3 uses MLA, not GQA; a fake GQA ratio made SDPA’s `repeat_kv` double already-full K/V heads after transformers#46960, causing head-count crashes in smoke tests/CI.
> 
> The same change and an inline comment documenting the MLA invariant are applied in `deepseek_v3_for_causal_lm.py` and `deepseek_v3_for_causal_lm_0528.py`. Regenerated Hub tiny models are expected to be merged separately for CI to pick up the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffa9fe6ef660acd902405d0b76f70966fb43d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->