### PR TITLE
Align KTO with DPO: Align error for Liger with precompute_ref_logps

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -796,8 +796,8 @@ class KTOTrainer(_BaseTrainer):
                 )
             if self.precompute_ref_logps:
                 raise ValueError(
-                    "You cannot use `precompute_ref_log_probs=True` with liger kernel. Please set "
-                    "`precompute_ref_log_probs=False`."
+                    "Liger KTO loss does not support precomputing reference log probabilities. Either disable "
+                    "`precompute_ref_log_probs` or set `use_liger_kernel` to False."
                 )
             if is_peft_model(self.model):
                 raise ValueError(


### PR DESCRIPTION
Align KTO with DPO: Align error for Liger with precompute_ref_logps.

Part of:
- #4786


This PR makes a small update to the error message in the `__init__` method of `KTOTrainer` to clarify the usage restrictions when using the Liger KTO loss with `precompute_ref_logps`, aligned with `DPOTrainer`.

### Changes

- Improved the error message to more clearly explain that Liger KTO loss does not support precomputing reference log probabilities, and to suggest disabling `precompute_ref_log_probs` or setting `use_liger_kernel` to False.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to an initialization error message; no training or runtime logic is modified.
> 
> **Overview**
> Updates the `ValueError` raised in `KTOTrainer.__init__` when **`use_liger_kernel=True`** and **`precompute_ref_log_probs=True`** are used together.
> 
> The message now states that **Liger KTO loss does not support precomputing reference log probabilities**, and tells users to either turn off **`precompute_ref_log_probs`** or set **`use_liger_kernel`** to **`False`**—matching **`DPOTrainer`**’s wording for the same incompatible combination. Validation behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47da40206b50d388e32e6554fd85874d32d99bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->