### PR TITLE
Remove unused get_dataset_column_names from DPO

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -86,10 +86,6 @@ FLASH_ATTENTION_VARIANTS = {
 }
 
 
-def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
-    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
-
-
 @dataclass
 class DataCollatorForPreference(DataCollatorMixin):
     """


### PR DESCRIPTION
Remove unused `get_dataset_column_names` from DPO.

This PR removes the unused helper function `get_dataset_column_names` from the `trl/trainer/dpo_trainer.py` file, helping to clean up the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unused code with no call sites in the DPO trainer; no functional or API impact.
> 
> **Overview**
> Removes the dead helper `get_dataset_column_names` from `trl/trainer/dpo_trainer.py`. That function resolved column names from a `Dataset` or `IterableDataset` when `column_names` was unset, but nothing in the DPO trainer referenced it (dataset prep uses `next(iter(dataset))` directly instead).
> 
> No behavior change to DPO training or data collation—only a small cleanup of unused code in that module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04d31f410a5a8207c74420d2a32486568617c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->