### PR TITLE
Factorize get_dataset_column_names from core trainers

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -979,3 +979,7 @@ def maybe_convert_to_chatml(example: dict[str, list]) -> dict[str, list]:
         example["messages"] = example.pop("conversations")
 
     return example
+
+
+def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
+    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -48,7 +48,7 @@ from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
 from ..chat_template_utils import clone_chat_template
-from ..data_utils import is_conversational
+from ..data_utils import get_dataset_column_names, is_conversational
 from ..models import get_act_offloading_ctx_manager
 from .base_trainer import _BaseTrainer
 from .reward_config import RewardConfig
@@ -130,10 +130,6 @@ def suppress_seqcls_warning():
         transformers_logger = logging.getLogger("transformers.modeling_utils")
         with _suppress_seqcls_cross_arch_keys(transformers_logger):
             yield
-
-
-def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
-    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
 
 
 @dataclass

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -54,6 +54,7 @@ from ..chat_template_utils import (
 )
 from ..data_utils import (
     apply_chat_template,
+    get_dataset_column_names,
     is_conversational,
     is_conversational_from_value,
     maybe_convert_to_chatml,
@@ -387,10 +388,6 @@ FLASH_ATTENTION_VARIANTS = {
     "kernels-community/flash-attn3",
     "kernels-community/vllm-flash-attn3",
 }
-
-
-def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
-    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
 
 
 @dataclass


### PR DESCRIPTION
Factorize get_dataset_column_names from core trainers.

This PR refactors the utility function `get_dataset_column_names` to improve code organization and reuse. The function is moved from individual trainer files to the shared `data_utils` module, and all references are updated accordingly.

### Changes

**Refactoring and code organization:**

* Moved the `get_dataset_column_names` function from both `trl/trainer/reward_trainer.py` and `trl/trainer/sft_trainer.py` into the shared `trl/data_utils.py` module for better code reuse and maintainability. 
* Updated import statements in `trl/trainer/reward_trainer.py` and `trl/trainer/sft_trainer.py` to import `get_dataset_column_names` from `data_utils` instead of defining it locally. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deduplication with no logic changes; only import paths and module placement differ.
> 
> **Overview**
> **Centralizes** the `get_dataset_column_names` helper (resolves column names for `Dataset` / `IterableDataset` when `column_names` may be `None`) in **`trl/data_utils.py`**.
> 
> **Removes** identical local definitions from **`reward_trainer.py`** and **`sft_trainer.py`**, which now import it alongside existing `data_utils` imports. Call sites in dataset preparation are unchanged in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4b7b83b69db64bfb89e16aca08fa472049f728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->