### PR TITLE
Factorize get_dataset_column_names from experimental trainers

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -979,3 +979,7 @@ def maybe_convert_to_chatml(example: dict[str, list]) -> dict[str, list]:
         example["messages"] = example.pop("conversations")
 
     return example
+
+
+def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
+    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -46,6 +46,7 @@ from transformers.utils import is_peft_available
 from ...data_utils import (
     apply_chat_template,
     extract_prompt,
+    get_dataset_column_names,
     is_conversational,
     prepare_multimodal_messages,
     unpair_preference_dataset,
@@ -78,10 +79,6 @@ if is_peft_available():
 
 
 logger = get_logger(__name__)
-
-
-def get_dataset_column_names(dataset: Dataset | IterableDataset) -> list[str]:
-    return list(next(iter(dataset)).keys()) if dataset.column_names is None else dataset.column_names
 
 
 @dataclass


### PR DESCRIPTION
Factorize get_dataset_column_names from experimental trainers.

Follow-up to:
- #6272 

This PR refactors how dataset column names are retrieved by moving the `get_dataset_column_names` utility function from `KTOTrainer` to `data_utils` for better code reuse and maintainability. The import statements are updated accordingly to use the centralized utility.

### Changes

**Refactoring and code organization:**

* Moved the `get_dataset_column_names` function from `trl/experimental/kto/kto_trainer.py` to `trl/data_utils.py` to centralize dataset utility functions.
* Updated the import in `trl/experimental/kto/kto_trainer.py` to use `get_dataset_column_names` from `data_utils.py` instead of a local definition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no behavior change; KTO KL dataset column handling is unchanged aside from import path.
> 
> **Overview**
> Moves **`get_dataset_column_names`** out of `KTOTrainer` into **`trl/data_utils.py`**, alongside other dataset helpers, so column resolution for `Dataset` / `IterableDataset` (including when `column_names` is `None`) lives in one shared place.
> 
> `kto_trainer.py` drops the local definition and imports the helper from `data_utils`; **`_get_kl_dataset`** still uses it the same way when building the KL dataset and choosing `remove_columns` on map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b13db78a67fa322098311b20d11634fec86dcea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->