### PR TITLE
Align KTO with DPO: MoE load-balancing auxiliary loss

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -390,6 +390,10 @@ class TestKTOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+        # MoE models log the load-balancing auxiliary loss (on by default)
+        assert trainer.aux_loss_enabled
+        assert trainer.state.log_history[-1]["aux_loss"] is not None
+
     def test_train_with_ref_model_is_model_raises(self):
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
@@ -798,6 +802,24 @@ class TestKTOTrainer(TrlTestCase):
                 args=training_args,
                 train_dataset=dataset,
                 compute_metrics=lambda _: {},
+            )
+
+    @require_liger_kernel
+    def test_init_fails_with_moe_aux_loss_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        # The MoE auxiliary loss is on by default; it is incompatible with the Liger fused loss.
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="does not support the Mixture-of-Experts load-balancing auxiliary loss"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                args=training_args,
+                train_dataset=dataset,
             )
 
     def test_train_with_iterable_dataset(self):

--- a/trl/experimental/kto/kto_config.py
+++ b/trl/experimental/kto/kto_config.py
@@ -42,6 +42,10 @@ class KTOConfig(_BaseConfig):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
             [`~transformers.AutoModelForCausalLM.from_pretrained`] and
             [`~transformers.AutoProcessor.from_pretrained`].
+        router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
+            Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
+            (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
+            weight. Set to `0.0` to disable it.
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the model and reference model.
 
@@ -136,6 +140,14 @@ class KTOConfig(_BaseConfig):
         metadata={
             "help": "Whether to allow loading models and tokenizers that ship custom Python code from the Hub. "
             "Forwarded to `AutoModelForCausalLM.from_pretrained` and `AutoProcessor.from_pretrained`."
+        },
+    )
+    router_aux_loss_coef: float = field(
+        default=0.001,
+        metadata={
+            "help": "Coefficient of the load-balancing auxiliary loss. Only has an effect when training a "
+            "Mixture-of-Experts (MoE) model; for other models it does nothing. The auxiliary loss is added to the "
+            "training loss with this weight. Set to `0.0` to disable it."
         },
     )
     disable_dropout: bool = field(

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -652,8 +652,6 @@ class KTOTrainer(_BaseTrainer):
         self.loss_type = args.loss_type
         self.desirable_weight = args.desirable_weight
         self.undesirable_weight = args.undesirable_weight
-        self.aux_loss_enabled = getattr(model.config, "output_router_logits", False)
-        self.aux_loss_coef = getattr(model.config, "router_aux_loss_coef", 0.0)
         self.calculate_KL = calculate_kl
         if self.calculate_KL and args.train_sampling_strategy != "sequential":
             raise ValueError(
@@ -666,14 +664,6 @@ class KTOTrainer(_BaseTrainer):
             raise ValueError(
                 "Actual (not effective) batch size must be > 1. KTO will not work properly because the KL term will be equivalent to the implied reward."
             )
-        if self.aux_loss_enabled and self.aux_loss_coef == 0.0:
-            logger.warning(
-                "You set `output_router_logits` to `True` in the model config, but `router_aux_loss_coef` is set to "
-                "`0.0`, meaning the auxiliary loss will not be used. Either set `router_aux_loss_coef` to a value "
-                "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "
-                "loss.",
-            )
-
         # Liger loss
         self.use_liger_kernel = args.use_liger_kernel
         if self.use_liger_kernel:
@@ -741,6 +731,18 @@ class KTOTrainer(_BaseTrainer):
             self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
         else:
             self.maybe_activation_offload_context = contextlib.nullcontext()
+
+        # MoE load-balancing auxiliary loss, applied to Mixture-of-Experts models (no effect otherwise)
+        text_config = model.config.get_text_config()
+        is_moe = getattr(text_config, "output_router_logits", None) is not None
+        self.aux_loss_enabled = is_moe and args.router_aux_loss_coef != 0.0
+        self.router_aux_loss_coef = args.router_aux_loss_coef
+        if self.aux_loss_enabled and self.use_liger_kernel:
+            raise ValueError(
+                "Liger KTO loss does not support the Mixture-of-Experts load-balancing auxiliary loss, because it "
+                "fuses the loss without materializing the router logits. Either set `router_aux_loss_coef` to `0.0` "
+                "to disable the auxiliary loss, or set `use_liger_kernel` to False."
+            )
 
         # Reference model
         if ref_model is None:
@@ -1255,8 +1257,6 @@ class KTOTrainer(_BaseTrainer):
         }
         model_kwargs = {k: v for k, v in batch.items() if k not in _non_model_keys}
         model_kwargs["use_cache"] = False
-        if self.aux_loss_enabled:
-            model_kwargs["output_router_logits"] = True
 
         # `base_model` gives the inner module (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
         # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
@@ -1272,7 +1272,7 @@ class KTOTrainer(_BaseTrainer):
 
         # reference model
         with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
-            ref_outputs = ref_backbone(**{k: v for k, v in model_kwargs.items() if k != "output_router_logits"})
+            ref_outputs = ref_backbone(**model_kwargs)
         lm_head = model.get_output_embeddings()
         ref_lm_head = self.ref_model.get_output_embeddings()
 
@@ -1301,8 +1301,6 @@ class KTOTrainer(_BaseTrainer):
             ref_bias=ref_lm_head.bias if hasattr(lm_head, "bias") else None,
             kl=kl,
         )
-        if self.aux_loss_enabled:
-            loss += self.aux_loss_coef * outputs.aux_loss
 
         self._metrics[mode]["kl"].append(kl.item())
 
@@ -1365,8 +1363,6 @@ class KTOTrainer(_BaseTrainer):
             model_kwargs["output_router_logits"] = True
 
         outputs = model(**model_kwargs)
-        if self.aux_loss_enabled:
-            aux_loss = outputs.aux_loss
 
         shift_logits = outputs.logits[:, :-1, :]
         per_token_logps = selective_log_softmax(shift_logits, batch["input_ids"][:, 1:])
@@ -1504,7 +1500,9 @@ class KTOTrainer(_BaseTrainer):
 
         loss = losses.nanmean()
         if self.aux_loss_enabled:
-            loss += self.aux_loss_coef * aux_loss
+            aux_loss = outputs.aux_loss
+            loss = loss + self.router_aux_loss_coef * aux_loss
+            self._metrics[mode]["aux_loss"].append(self.accelerator.gather_for_metrics(aux_loss).mean().item())
 
         return (loss, outputs) if return_outputs else loss
 


### PR DESCRIPTION
Ports the MoE auxiliary-loss handling added to `DPOTrainer` in #6208 to `KTOTrainer`.

part of https://github.com/huggingface/trl/issues/4786

KTO previously read the coefficient from the model config via `getattr(model.config, "router_aux_loss_coef", 0.0)`. Replaced with DPO's approach:

- New `router_aux_loss_coef` config field (default `0.001`, on-by-default for MoE models, `0.0` to disable).
- `is_moe` detection via `model.config.get_text_config()`; `self.router_aux_loss_coef` used to weight `outputs.aux_loss`; `aux_loss` now logged as a metric.
- Raise if the aux loss is combined with `use_liger_kernel` (Liger fuses the loss without materializing router logits); the dead aux handling in the Liger path is removed.

No behavior change for non-MoE models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MoE KTO runs change default aux weighting (trainer config vs model config) and add a hard error for Liger+MoE; non-MoE paths are unaffected.
> 
> **Overview**
> Ports **DPO-style MoE load-balancing** into `KTOTrainer`, replacing config-driven `router_aux_loss_coef` on the model with an explicit training knob.
> 
> `KTOConfig` gains **`router_aux_loss_coef`** (default `0.001`; set `0.0` to turn off). MoE is detected via `get_text_config()` and `output_router_logits`; the aux term is weighted with this coefficient, **`aux_loss` is logged**, and **`use_liger_kernel` + MoE aux** now **raises** at init because Liger cannot materialize router logits.
> 
> Non-MoE models are unchanged. Tests cover MoE training metrics and the Liger/MoE incompatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08219a9a462e411500ac41141ebd9816d361fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->