### PR TITLE
Align KTO with DPO: Support PEFT with Liger

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -28,7 +28,8 @@ from ..testing_utils import TrlTestCase, require_bitsandbytes, require_liger_ker
 
 
 if is_peft_available():
-    from peft import LoraConfig, get_peft_model
+    from peft import LoraConfig, PromptTuningConfig, get_peft_model
+    from peft.utils import TaskType
 
 
 @require_vision
@@ -765,21 +766,63 @@ class TestKTOTrainer(TrlTestCase):
 
     @require_liger_kernel
     @require_peft
-    def test_init_fails_with_peft_and_liger(self):
+    def test_train_with_liger_kernel_and_peft(self):
+        # A LoRA adapter that does not target lm_head leaves the head as a plain Linear, so Liger reads the real
+        # weight. Verify the full PEFT+Liger path actually trains (peft params change, base params stay frozen).
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+        base_param_names = [f"base_model.model.{n}" for n, _ in model.named_parameters()]
         dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
-
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             use_liger_kernel=True,
             report_to="none",
         )
+        trainer = KTOTrainer(
+            model=model_id,
+            args=training_args,
+            train_dataset=dataset,
+            peft_config=LoraConfig(target_modules=["q_proj", "v_proj"]),
+        )
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n in base_param_names:
+                torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
+            elif "base_layer" not in n:
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-        with pytest.raises(ValueError, match="`use_liger_kernel=True` is not supported with PEFT models."):
+    @require_liger_kernel
+    @require_peft
+    def test_liger_kernel_with_peft_lm_head_raises(self):
+        # The Liger fused KTO loss reads `lm_head.weight` directly, so a LoRA adapter on `lm_head` is silently
+        # ignored and never trained. The trainer must fail fast instead of training a silently-frozen head.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        training_args = KTOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
+        with pytest.raises(ValueError, match="lm_head"):
             KTOTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
                 args=training_args,
                 train_dataset=dataset,
-                peft_config=LoraConfig(),
+                peft_config=LoraConfig(target_modules=["q_proj", "v_proj", "lm_head"]),
+            )
+
+    @require_liger_kernel
+    @require_peft
+    def test_liger_kernel_with_peft_prompt_learning_raises(self):
+        # Prompt-learning methods inject virtual tokens via PeftModel.forward(), which the Liger KTO loss bypasses.
+        # The trainer must fail fast to avoid computing the loss on the wrong (truncated) sequence.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        training_args = KTOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
+        with pytest.raises(ValueError, match="prompt-learning"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+                peft_config=PromptTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=8),
             )
 
     @require_liger_kernel

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -77,7 +77,8 @@ if is_liger_kernel_available():
 
 if is_peft_available():
     import peft
-    from peft import LoraConfig, PeftConfig, PeftModel, get_peft_model
+    from peft import LoraConfig, PeftConfig, PeftModel, PromptLearningConfig, get_peft_model
+    from peft.tuners.tuners_utils import BaseTunerLayer
 
 
 logger = get_logger(__name__)
@@ -698,10 +699,31 @@ class KTOTrainer(_BaseTrainer):
                     "`precompute_ref_log_probs` or set `use_liger_kernel` to False."
                 )
             if is_peft_model(model):
-                raise ValueError(
-                    "`use_liger_kernel=True` is not supported with PEFT models. Set `use_liger_kernel=False` to train "
-                    "a PEFT model."
-                )
+                # The Liger fused KTO loss multiplies the hidden states by `lm_head.weight` directly. When the LM head
+                # is targeted by a PEFT adapter (`"lm_head"` in `target_modules`), `lm_head.weight` is the frozen base
+                # weight and the trainable adapter parameters live in separate submodules that Liger never sees. The
+                # head adapter would silently receive no gradient, so the model trains as if `lm_head` were frozen.
+                # Fail loudly rather than train a silently-frozen head.
+                output_embeddings = model.get_output_embeddings()
+                if isinstance(output_embeddings, BaseTunerLayer):
+                    raise ValueError(
+                        "`use_liger_kernel=True` is incompatible with applying a PEFT adapter to `lm_head`. The Liger "
+                        "fused KTO loss reads `lm_head.weight` directly, so the adapter on the head is ignored and "
+                        "never trained. Either remove `'lm_head'` from your `target_modules`, or set "
+                        "`use_liger_kernel=False`."
+                    )
+                # Prompt-learning methods (PromptTuning, PrefixTuning, P-Tuning) inject virtual tokens via
+                # `PeftModel.forward()`. The Liger KTO loss bypasses `PeftModel.forward()` by calling the backbone
+                # directly, so virtual tokens are never prepended and the loss is computed on the wrong sequence.
+                # Fail loudly rather than train on a silently corrupted input.
+                if any(isinstance(cfg, PromptLearningConfig) for cfg in model.peft_config.values()):
+                    raise ValueError(
+                        "`use_liger_kernel=True` is incompatible with prompt-learning PEFT methods (PromptTuning, "
+                        "PrefixTuning, P-Tuning). The Liger KTO loss bypasses `PeftModel.forward()` by calling the "
+                        "backbone directly, so virtual tokens are never prepended and the loss is computed on the "
+                        "wrong sequence. Use a weight-based adapter such as LoRA instead, or set "
+                        "`use_liger_kernel=False`."
+                    )
 
         # Dataset
         # Skip dataset preparation for VLMs: tokenization and image processing happen on-the-fly in the collator.
@@ -1235,12 +1257,6 @@ class KTOTrainer(_BaseTrainer):
         num_rejected = (len(labels) - num_chosen).to(self.accelerator.device)
 
         KL_logps = self._compute_kl_logps(model, batch)
-        ref_KL_logps = self._compute_kl_logps(self.ref_model, batch)
-        if self.calculate_KL:
-            kl = (KL_logps - ref_KL_logps).mean().detach()
-            kl = self.accelerator.gather_for_metrics(kl).mean().clamp(min=0)
-        else:
-            kl = torch.zeros(1).to(self.accelerator.device)
 
         _non_model_keys = {
             "completion_mask",
@@ -1257,6 +1273,10 @@ class KTOTrainer(_BaseTrainer):
         model_kwargs["use_cache"] = False
         if self.aux_loss_enabled:
             model_kwargs["output_router_logits"] = True
+        ref_model_kwargs = {k: v for k, v in model_kwargs.items() if k != "output_router_logits"}
+
+        if is_peft_model(model):
+            model = model.base_model.model
 
         # `base_model` gives the inner module (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
         # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
@@ -1264,17 +1284,45 @@ class KTOTrainer(_BaseTrainer):
         # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `base_model is self` (re-runs `lm_head`).
         # Fall back to `.model` there.
         if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
-            backbone, ref_backbone = model.model, self.ref_model.model
+            backbone = model.model
         else:
-            backbone, ref_backbone = model.base_model, self.ref_model.base_model
+            backbone = model.base_model
 
         outputs = backbone(**model_kwargs)
+        lm_head = model.get_output_embeddings()
 
         # reference model
         with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
-            ref_outputs = ref_backbone(**{k: v for k, v in model_kwargs.items() if k != "output_router_logits"})
-        lm_head = model.get_output_embeddings()
-        ref_lm_head = self.ref_model.get_output_embeddings()
+            if self.ref_model is None:
+                # PEFT model with no explicit reference model: recover reference behaviour by disabling / switching to
+                # the frozen "ref" adapter, exactly as _compute_loss does for logit-based reference computation.
+                model_unwrapped = self.accelerator.unwrap_model(self.model)
+                with use_adapter(
+                    model_unwrapped, adapter_name="ref" if "ref" in model_unwrapped.peft_config else None
+                ):
+                    ref_KL_logps = self._compute_kl_logps(self.model, batch)
+                    ref_model_inner = model_unwrapped.base_model.model
+                    if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
+                        ref_backbone = ref_model_inner.model
+                    else:
+                        ref_backbone = ref_model_inner.base_model
+                    ref_outputs = ref_backbone(**ref_model_kwargs)
+                    ref_lm_head = model_unwrapped.get_output_embeddings()
+            else:
+                ref_KL_logps = self._compute_kl_logps(self.ref_model, batch)
+                ref_model_inner = self.ref_model.base_model.model if is_peft_model(self.ref_model) else self.ref_model
+                if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
+                    ref_backbone = ref_model_inner.model
+                else:
+                    ref_backbone = ref_model_inner.base_model
+                ref_outputs = ref_backbone(**ref_model_kwargs)
+                ref_lm_head = self.ref_model.get_output_embeddings()
+
+        if self.calculate_KL:
+            kl = (KL_logps - ref_KL_logps).mean().detach()
+            kl = self.accelerator.gather_for_metrics(kl).mean().clamp(min=0)
+        else:
+            kl = torch.zeros(1).to(self.accelerator.device)
 
         shift_completion_mask = batch["completion_mask"][:, 1:]
         target = batch["input_ids"][:, 1:].clone()

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -1271,9 +1271,6 @@ class KTOTrainer(_BaseTrainer):
         }
         model_kwargs = {k: v for k, v in batch.items() if k not in _non_model_keys}
         model_kwargs["use_cache"] = False
-        if self.aux_loss_enabled:
-            model_kwargs["output_router_logits"] = True
-        ref_model_kwargs = {k: v for k, v in model_kwargs.items() if k != "output_router_logits"}
 
         if is_peft_model(model):
             model = model.base_model.model
@@ -1306,7 +1303,7 @@ class KTOTrainer(_BaseTrainer):
                         ref_backbone = ref_model_inner.model
                     else:
                         ref_backbone = ref_model_inner.base_model
-                    ref_outputs = ref_backbone(**ref_model_kwargs)
+                    ref_outputs = ref_backbone(**model_kwargs)
                     ref_lm_head = model_unwrapped.get_output_embeddings()
             else:
                 ref_KL_logps = self._compute_kl_logps(self.ref_model, batch)
@@ -1315,7 +1312,7 @@ class KTOTrainer(_BaseTrainer):
                     ref_backbone = ref_model_inner.model
                 else:
                     ref_backbone = ref_model_inner.base_model
-                ref_outputs = ref_backbone(**ref_model_kwargs)
+                ref_outputs = ref_backbone(**model_kwargs)
                 ref_lm_head = self.ref_model.get_output_embeddings()
 
         if self.calculate_KL:
@@ -1349,8 +1346,6 @@ class KTOTrainer(_BaseTrainer):
             ref_bias=ref_lm_head.bias if hasattr(lm_head, "bias") else None,
             kl=kl,
         )
-        if self.aux_loss_enabled:
-            loss += self.aux_loss_coef * outputs.aux_loss
 
         self._metrics[mode]["kl"].append(kl.item())
 


### PR DESCRIPTION
Align KTO with DPO: Support PEFT with Liger.

Follow-up to:
- #6159 

Part of:
- #4786

This PR enables training PEFT models with the Liger fused KTO loss in the experimental KTOTrainer, aligning it with the DPO trainer (#6159).

### Motivation

Previously the experimental KTOTrainer rejected any combination of PEFT and use_liger_kernel=True with a blanket error, even though the common case (a weight-based adapter such as LoRA that does not target lm_head) works correctly. DPO already supports this combination, so KTO was needlessly more restrictive.

### Solution

The blanket restriction is replaced with real support in the Liger loss path. When the model is a PEFT model, the trainer unwraps it to the underlying backbone before invoking the fused loss, and recovers reference-model behaviour from the frozen adapter when no explicit reference model is provided (matching the logit-based reference computation).

Two configurations remain genuinely incompatible with the fused loss and now fail loudly instead of being blanket-rejected or, worse, silently mistraining:

- An adapter targeting lm_head: the Liger loss reads lm_head.weight directly, so the head adapter would receive no gradient and train as if frozen.
- Prompt-learning methods (PromptTuning, PrefixTuning, P-Tuning): they inject virtual tokens via PeftModel.forward(), which the fused loss bypasses, so the loss would be computed on the wrong sequence.

### Changes

- Remove the blanket error forbidding PEFT models when use_liger_kernel=True.
- Add PEFT support to the Liger KTO loss path, including reference-model recovery via the frozen adapter when no reference model is supplied.
- Raise a clear error when a PEFT adapter targets lm_head under the Liger loss.
- Raise a clear error when a prompt-learning PEFT method is combined with the Liger loss.
- Replace the old init-fails test with a test that verifies the full PEFT + Liger training path (adapter params update, base params stay frozen).
- Add tests covering the lm_head-adapter and prompt-learning error cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core training loss wiring for PEFT+Liger (reference adapter switching and backbone unwrapping); wrong behavior could silently affect alignment runs, though incompatible configs now fail fast.
> 
> **Overview**
> **Experimental `KTOTrainer` now allows `use_liger_kernel=True` with weight-based PEFT (e.g. LoRA that does not target `lm_head`)**, matching DPO behavior instead of rejecting all PEFT+Liger combinations.
> 
> Init-time checks are narrowed: **`lm_head` adapters** and **prompt-learning PEFT** (PromptTuning, etc.) still raise clear `ValueError`s because the fused loss reads `lm_head.weight` directly and bypasses `PeftModel.forward()`.
> 
> The **Liger loss path** unwraps PEFT models to the inner backbone for the forward pass, and when no separate `ref_model` is set it **derives reference hidden states via the frozen `ref` adapter** (same idea as the logit-based path). Tests add an end-to-end LoRA+Liger train case and separate tests for the two incompatible PEFT setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa6eb16c8a97ac71a5ce89abf2bc39cf41b87ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->