### PR TITLE
Align KTO with DPO: clarify dtype default in `model` docstring

### DIFF
--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -394,7 +394,10 @@ class KTOTrainer(_BaseTrainer):
               path to a *directory* containing model weights saved using
               [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
               using `<ModelArchitecture>.from_pretrained` (where `<ModelArchitecture>` is derived from the model
-              config) with the keyword arguments in `args.model_init_kwargs`.
+              config) with the keyword arguments in `args.model_init_kwargs`. If `dtype` is not specified in
+              `args.model_init_kwargs`, it defaults to `float32`. This differs from
+              [`~transformers.PreTrainedModel.from_pretrained`], where (since Transformers v5) the dtype is inferred
+              from the model config.
             - A [`~transformers.PreTrainedModel`] object. Only causal language models are supported.
             - A [`~peft.PeftModel`] object. Only causal language models are supported.
         ref_model ([`~transformers.PreTrainedModel`], *optional*):


### PR DESCRIPTION
Ports the docstring clarification added to `DPOTrainer` in #5457 to `KTOTrainer`. The `model` argument's docstring now notes that when `dtype` is not specified in `args.model_init_kwargs`, it defaults to `float32` — unlike [`~transformers.PreTrainedModel.from_pretrained`], where (since Transformers v5) the dtype is inferred from the model config. This applies equally to KTO, which loads the model the same way (via `create_model_from_path`).

Docs only, no behavior change.
Part of #4786


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only update with no code or configuration behavior changes.
> 
> **Overview**
> **Documentation-only** change to `KTOTrainer`: the `model` argument docstring now states that when a model is loaded from a string via `args.model_init_kwargs`, missing `dtype` **defaults to `float32`**, unlike `PreTrainedModel.from_pretrained` (Transformers v5+), which infers dtype from the config.
> 
> This mirrors the same clarification already present on `DPOTrainer` and documents existing behavior through `create_model_from_path`; **no runtime or API changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ac62762e95552726886125b8a221114290a8f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->