### PR TITLE
Align KTO with DPO: Guard for Liger and aux_loss

### DIFF
--- a/tests/experimental/test_kto_trainer.py
+++ b/tests/experimental/test_kto_trainer.py
@@ -783,6 +783,25 @@ class TestKTOTrainer(TrlTestCase):
             )
 
     @require_liger_kernel
+    def test_init_fails_with_moe_aux_loss_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        # KTO gates the MoE auxiliary loss on the model config's `output_router_logits` (unlike DPO, which enables it
+        # whenever the architecture is MoE and `router_aux_loss_coef != 0`), so enable it explicitly on the config.
+        # The auxiliary loss is incompatible with the Liger fused loss.
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3MoeForCausalLM", output_router_logits=True
+        )
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="does not support the Mixture-of-Experts load-balancing auxiliary loss"):
+            KTOTrainer(model=model, args=training_args, train_dataset=dataset)
+
+    @require_liger_kernel
     def test_init_fails_with_compute_metrics_and_liger(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
 

--- a/trl/experimental/kto/kto_trainer.py
+++ b/trl/experimental/kto/kto_trainer.py
@@ -673,6 +673,12 @@ class KTOTrainer(_BaseTrainer):
                 "greater than `0.0`, or set `output_router_logits` to `False` if you don't want to use the auxiliary "
                 "loss.",
             )
+        if self.aux_loss_enabled and args.use_liger_kernel:
+            raise ValueError(
+                "Liger KTO loss does not support the Mixture-of-Experts load-balancing auxiliary loss, because it "
+                "fuses the loss without materializing the router logits. Either set `output_router_logits` to `False` "
+                "in the model config to disable the auxiliary loss, or set `use_liger_kernel` to False."
+            )
 
         # Liger loss
         self.use_liger_kernel = args.use_liger_kernel


### PR DESCRIPTION
Align KTO with DPO: Guard for Liger and aux_loss.

Part of:
- #4786

This PR adds validation to prevent the use of the Liger KTO loss when the Mixture-of-Experts (MoE) load-balancing auxiliary loss is enabled, as these features are incompatible. It also adds a corresponding test to ensure this error is raised appropriately.

### Changes

Validation logic:

* Added a check in the `KTOTrainer` initializer (`trl/experimental/kto/kto_trainer.py`) to raise a `ValueError` if both the auxiliary loss and Liger kernel are enabled, with a clear error message describing the incompatibility.

Testing:

* Added a new test `test_init_fails_with_moe_aux_loss_and_liger` in `tests/experimental/test_kto_trainer.py` to verify that initializing `KTOTrainer` with both the auxiliary loss and Liger kernel enabled raises the expected error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small init-time validation and test only; no change to training paths when the incompatible combo is not used.
> 
> **Overview**
> **KTO** now fails fast at init when **Liger** (`use_liger_kernel=True`) is combined with MoE load-balancing auxiliary loss (`output_router_logits=True` on the model config), matching the existing **DPO** guard. The error explains that fused Liger KTO loss cannot use router logits and tells callers to disable aux loss or turn off Liger.
> 
> A **`@require_liger_kernel`** test loads a tiny MoE model with `output_router_logits=True` and asserts `KTOTrainer` raises the expected `ValueError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd88878d14a7a76c000b6189634776f1fb7734f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->