### PR TITLE
fix(grpo): handle NaN vLLM sampling logprobs without crashing

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -274,6 +274,40 @@ class TestTransformersContinuousBatchingContract:
         )
 
 
+class TestGRPONanLogprobFix:
+    def test_none_logprob_backfilled_with_old_policy_logprob(self):
+        """
+        Reproduce the NaN logprob handling in `GRPOTrainer._generate_and_score_completions`.
+
+        vLLM can return NaN logprobs for near-deterministic tokens; `extract_logprobs` encodes them
+        as `None`. The trainer converts those `None` values to `-inf` so `torch.tensor` succeeds,
+        then backfills them with the old policy logprob so the importance-sampling ratio is neutral
+        for those tokens.
+        """
+        from trl.trainer.utils import pad
+
+        sampling_per_token_logps_list = [[-0.1, None, -0.2], [-0.3, None]]
+        sampling_per_token_logps = [
+            torch.tensor([float("-inf") if x is None else x for x in logps])
+            for logps in sampling_per_token_logps_list
+        ]
+        sampling_per_token_logps = pad(
+            sampling_per_token_logps,
+            padding_value=0.0,
+            padding_side="right",
+        )
+
+        old_per_token_logps = torch.tensor([[-0.5, -0.6, -0.7], [-0.8, -0.9, 0.0]])
+
+        nan_logprob_mask = torch.isneginf(sampling_per_token_logps)
+        sampling_per_token_logps = torch.where(
+            nan_logprob_mask, old_per_token_logps, sampling_per_token_logps
+        )
+
+        expected = torch.tensor([[-0.1, -0.6, -0.2], [-0.3, -0.9, 0.0]])
+        torch.testing.assert_close(sampling_per_token_logps, expected)
+
+
 class TestGRPOTrainer(TrlTestCase):
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2113,7 +2113,13 @@ class GRPOTrainer(_BaseTrainer):
             completion_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
         ).to(device=device)
         if sampling_per_token_logps_list is not None:
-            sampling_per_token_logps = [torch.tensor(logps) for logps in sampling_per_token_logps_list]
+            # vLLM may return NaN logprobs for near-deterministic tokens; `extract_logprobs` represents
+            # those as `None`. Convert them to `-inf` so that `torch.tensor` succeeds, then backfill
+            # with the old policy logprobs later so the importance-sampling ratio is neutral.
+            sampling_per_token_logps = [
+                torch.tensor([float("-inf") if x is None else x for x in logps])
+                for logps in sampling_per_token_logps_list
+            ]
             sampling_per_token_logps = pad(
                 sampling_per_token_logps,
                 padding_value=0.0,
@@ -2284,6 +2290,15 @@ class GRPOTrainer(_BaseTrainer):
                 )
             else:
                 old_per_token_logps = None
+
+            # Backfill tokens whose vLLM sampling logprob was NaN (represented as -inf) with the old
+            # policy logprob. This keeps the importance-sampling ratio neutral and avoids polluting
+            # reward/advantage estimation with an arbitrary sentinel value.
+            if sampling_per_token_logps is not None and old_per_token_logps is not None:
+                nan_logprob_mask = torch.isneginf(sampling_per_token_logps)
+                sampling_per_token_logps = torch.where(
+                    nan_logprob_mask, old_per_token_logps, sampling_per_token_logps
+                )
 
             # Compute the importance sampling ratio when using vLLM, to correct for potential distribution mismatch
             if self.use_vllm and self.vllm_importance_sampling_correction:


### PR DESCRIPTION
## Summary

Fixes a `RuntimeError: Could not infer dtype of NoneType` crash in `GRPOTrainer._generate_and_score_completions` triggered when vLLM emits NaN processed-logprobs for near-deterministic tokens.

`trl.generation.vllm_generation.extract_logprobs` already encodes NaN logprobs as `None`, but the consumer passed the nested list straight into `torch.tensor(...)`, which only checked the outer list. NaN is handled defensively everywhere else in this trainer (`torch.isnan(rewards_per_func)`, `torch.nan_to_num(advantages, ...)`); this path was the exception.

## Changes

1. `trl/trainer/grpo_trainer.py`: In `_generate_and_score_completions`, replace `None` sampling logprobs with `-inf` so `torch.tensor` succeeds, then backfill them with the old policy logprobs (computed a few lines later) so the importance-sampling ratio is neutral for the affected tokens. Using `old_per_token_logps` (rather than an arbitrary sentinel like `0.0`) keeps the IS ratio at 1 for those positions, which is the cleanest correction mentioned in the issue.

2. `tests/test_grpo_trainer.py`: Added `TestGRPONanLogprobFix.test_none_logprob_backfilled_with_old_policy_logprob` which reproduces the conversion path (NaN -> `-inf` -> backfill) and asserts the resulting tensor.

## Reproduction

From the issue (#6166):

    File ".../trl/trainer/grpo_trainer.py", line 2018, in _generate_and_score_completions
        sampling_per_token_logps = [torch.tensor(logps) for logps in sampling_per_token_logps_list]
    RuntimeError: Could not infer dtype of NoneType

Reachable in normal training once the policy becomes near-deterministic (entropy collapse): vLLM emits NaN processed-logprob for a near-probability-1 token -> `None` -> crash on the next generation step.

## Checklist

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? -> fixes #6166
- [ ] Did you make sure to update the documentation with your changes? -> N/A, internal trainer change.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: the bug analysis and patch were drafted with AI assistance, then reviewed and tested by a human.

Fixes #6166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-token logprobs used for vLLM importance sampling in GRPO, but only for previously invalid positions and with an intentional neutral-ratio correction.
> 
> **Overview**
> Fixes a **vLLM + GRPO** crash when sampling logprobs contain `None` (from NaN near-deterministic tokens) and `torch.tensor` fails in `_generate_and_score_completions`.
> 
> **`GRPOTrainer`**: `None` entries are mapped to `-inf` when building `sampling_per_token_logps`, then positions marked `-inf` are **replaced with `old_per_token_logps`** once the old-policy logprobs are computed. That keeps vLLM importance-sampling ratios at **1** for those tokens instead of using a bogus sentinel.
> 
> **Tests**: `TestGRPONanLogprobFix` asserts the None → `-inf` → backfill path matches expected tensors after padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923245b4266514da203edcd12f9f797cd51173f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->