### PR TITLE
Fix multimodal tool call slicing in GRPO tool loop

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3053,6 +3053,126 @@ class TestGRPOTrainerVLM(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @require_jmespath
+    def test_train_with_tools_multimodal_multi_image_prompt(self):
+        # Test that tools correctly slice multimodal tensors when prompts have multiple images of different sizes.
+        from PIL import Image as PILImage
+
+        def empty_tool() -> str:
+            """Does nothing."""
+            return "done"
+
+        img1 = PILImage.new("RGB", (32, 32), color="red")
+        img2 = PILImage.new("RGB", (64, 64), color="blue")
+        dataset = Dataset.from_list(
+            [
+                {
+                    "prompt": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image", "image": img1},
+                                {"type": "image", "image": img2},
+                                {"type": "text", "text": "Describe"},
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "prompt": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "image", "image": img1}, {"type": "text", "text": "Describe"}],
+                        }
+                    ]
+                },
+            ]
+        )
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=512,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+            reward_funcs=lambda x, **kw: [1.0] * len(x),
+            args=training_args,
+            train_dataset=dataset,
+            tools=[empty_tool],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        def fake_generate(input_ids, **kwargs):
+            if input_ids.shape[0] == 4:
+                # 4 completions (batch size 2 * 2 generations)
+                completion_ids = torch.tensor(
+                    [
+                        # tool call
+                        [248058, 198, 27, 23783, 30091, 22076, 29, 198, 510, 23783, 29, 198, 248059, 248046],
+                        # no tool call
+                        [
+                            40,
+                            1459,
+                            914,
+                            1366,
+                            866,
+                            5224,
+                            248046,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                        ],
+                        # tool call
+                        [248058, 198, 27, 23783, 30091, 22076, 29, 198, 510, 23783, 29, 198, 248059, 248046],
+                        # no tool call
+                        [
+                            40,
+                            1459,
+                            914,
+                            1366,
+                            866,
+                            5224,
+                            248046,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                            248044,
+                        ],
+                    ],
+                    device=input_ids.device,
+                )
+            else:
+                completion_ids = torch.tensor(
+                    [
+                        [16936, 0, 248046],
+                    ]
+                    * input_ids.shape[0],
+                    device=input_ids.device,
+                )
+            return torch.cat([input_ids, completion_ids], dim=-1)
+
+        with patch.object(trainer.model, "generate", side_effect=fake_generate):
+            trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
 
 @pytest.mark.slow
 @require_torch_accelerator

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1800,14 +1800,51 @@ class GRPOTrainer(_BaseTrainer):
             loop_images = [merged_images[i] for i in idxs_with_tool] if merged_images else None
             if multimodal_fields:
                 loop_multimodal_fields = {}
+
+                # Pre-calculate counts for multimodal tensors that are flattened across the batch.
+                num_images = [len(imgs) if imgs else 0 for imgs in (images or [])] or [0] * len(prompts)
+                pixel_values = multimodal_fields.get("pixel_values")
+                image_grid_thw = multimodal_fields.get("image_grid_thw")
+
+                rows_per_sample = None
+                if image_grid_thw is not None and pixel_values is not None:
+                    rows_per_image = image_grid_thw.prod(dim=-1)
+                    rows_per_sample_split = torch.split(rows_per_image, num_images)
+                    rows_per_sample = [s.sum().item() for s in rows_per_sample_split]
+
                 for k, v in multimodal_fields.items():
-                    selected = [v[i] for i in idxs_with_tool]
-                    # Per-token fields (e.g. token_type_ids) need zero-padding to match extended prompt length
-                    if isinstance(selected[0], list):
-                        selected = [
-                            s + [0] * (len(pct) - len(s))
-                            for s, pct in zip(selected, prompt_completion_tool_ids, strict=True)
-                        ]
+                    if k == "pixel_values" and rows_per_sample is not None:
+                        selected_list = []
+                        offset = 0
+                        for i, rows in enumerate(rows_per_sample):
+                            if i in idxs_with_tool and rows > 0:
+                                selected_list.append(v[offset : offset + rows])
+                            offset += rows
+                        selected = (
+                            torch.cat(selected_list)
+                            if selected_list
+                            else torch.empty((0, *v.shape[1:]), dtype=v.dtype, device=v.device)
+                        )
+                    elif k == "image_grid_thw" and rows_per_sample is not None:
+                        selected_list = []
+                        offset = 0
+                        for i, n_imgs in enumerate(num_images):
+                            if i in idxs_with_tool and n_imgs > 0:
+                                selected_list.append(v[offset : offset + n_imgs])
+                            offset += n_imgs
+                        selected = (
+                            torch.cat(selected_list)
+                            if selected_list
+                            else torch.empty((0, *v.shape[1:]), dtype=v.dtype, device=v.device)
+                        )
+                    else:
+                        selected = [v[i] for i in idxs_with_tool]
+                        # Per-token fields (e.g. token_type_ids) need zero-padding to match extended prompt length
+                        if isinstance(selected[0], list):
+                            selected = [
+                                s + [0] * (len(pct) - len(s))
+                                for s, pct in zip(selected, prompt_completion_tool_ids, strict=True)
+                            ]
                     loop_multimodal_fields[k] = selected
             else:
                 loop_multimodal_fields = {}


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect multimodal tensor slicing inside `GRPOTrainer._tool_call_loop`.

For Qwen vision models, `pixel_values` is flattened across image patches instead of being batch-indexed. The previous tool loop selection used sample indexes directly, which selected only individual patch rows and caused a mismatch in the vision tower.

This updates the tool loop to:
- use `image_grid_thw` to calculate patch spans
- slice flattened `pixel_values` correctly
- preserve the existing behavior for normal batch-shaped fields

A regression test covering multimodal prompts with tool calls has also been added.

## Testing

- ruff check trl/trainer/grpo_trainer.py ✅
- ruff format ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets a narrow but correctness-critical path (VLM + tools); wrong slicing previously broke the vision tower, while other multimodal fields are unchanged.
> 
> **Overview**
> Fixes **incorrect multimodal tensor selection** when `GRPOTrainer` re-generates after tool calls for vision models (e.g. Qwen) where `pixel_values` is **flattened by image patches**, not one row per batch item.
> 
> In the tool loop, multimodal fields for samples that invoked tools are now built by deriving per-sample patch spans from `image_grid_thw` and image counts, then **offset-slicing** `pixel_values` and `image_grid_thw` for only those indices. List-style fields (e.g. per-token padding) keep the previous index-and-pad behavior.
> 
> Adds a regression test with **multi-image prompts of different sizes**, tool calls, and mocked `generate`, asserting training completes and weights update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96efac64b816ddcd4a292a17c93c3aa4683d1e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->