### PR TITLE
Fix GRPO tool loop handling for image-returning tools

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -14,6 +14,7 @@
 
 import gc
 import os
+import textwrap
 import warnings
 from collections.abc import Callable
 from types import SimpleNamespace
@@ -2778,6 +2779,82 @@ class TestGRPOTrainer(TrlTestCase):
 
 @require_vision
 class TestGRPOTrainerVLM(TrlTestCase):
+    @pytest.mark.xfail(
+        condition=Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+        strict=True,
+    )
+    def test_tool_suffix_ids_include_user_image_from_tool_response(self):
+        from PIL import Image as PILImage
+
+        processor = AutoProcessor.from_pretrained("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink")
+        # This mirrors VLM templates that render image placeholders for user messages while keeping tool messages
+        # text-only.
+        processor.chat_template = textwrap.dedent(r"""
+        {%- for message in messages %}
+            {%- if message.role == 'user' %}
+                {{- '<|im_start|>user\n' }}
+                {%- if message.content is string %}
+                    {{- message.content }}
+                {%- else %}
+                    {%- for content in message.content %}
+                        {%- if content.type == 'image' or 'image' in content %}
+                            {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+                        {%- elif 'text' in content %}
+                            {{- content.text }}
+                        {%- endif %}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '<|im_end|>\n' }}
+            {%- elif message.role == 'assistant' %}
+                {{- '<|im_start|>assistant\n' }}
+                {%- if message.tool_calls %}
+                    {%- for tool_call in message.tool_calls %}
+                        {%- if tool_call.function %}
+                            {%- set tool_call = tool_call.function %}
+                        {%- endif %}
+                        {{- '<tool_call>' + tool_call.name + '</tool_call>' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '<|im_end|>\n' }}
+            {%- elif message.role == 'tool' %}
+                {{- '<|im_start|>tool\n' }}
+                {%- if message.content is string %}
+                    {{- message.content }}
+                {%- else %}
+                    {%- for content in message.content %}
+                        {%- if 'text' in content %}
+                            {{- content.text }}
+                        {%- endif %}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endfor %}
+        {%- if add_generation_prompt %}
+            {{- '<|im_start|>assistant\n' }}
+        {%- endif %}""")
+
+        trainer = object.__new__(GRPOTrainer)
+        trainer._is_vlm = True
+        trainer.processing_class = processor
+        trainer._tokenizer = processor.tokenizer
+        trainer.chat_template = None
+        trainer.chat_template_kwargs = {}
+
+        suffix_ids = trainer._get_tool_suffix_ids(
+            [
+                {"role": "tool", "name": "screenshot_tool", "content": [{"type": "text", "text": "Rendered"}]},
+                {
+                    "role": "user",
+                    "content": [{"type": "image", "image": PILImage.new("RGB", (8, 8), color="red")}],
+                },
+            ]
+        )
+
+        image_pad_token_id = processor.tokenizer.convert_tokens_to_ids("<|image_pad|>")
+        assert image_pad_token_id in suffix_ids
+
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1634,7 +1634,8 @@ class GRPOTrainer(_BaseTrainer):
         """Get token IDs for tool result formatting by using a minimal dummy conversation."""
         # Use the real tool name instead of a dummy: some templates (e.g. GPT-OSS) derive the tool response
         # header from the assistant's tool call name.
-        dummy_tool_calls = [{"type": "function", "function": {"name": tool_messages[0]["name"], "arguments": {}}}]
+        tool_name = next(message["name"] for message in tool_messages if message["role"] == "tool")
+        dummy_tool_calls = [{"type": "function", "function": {"name": tool_name, "arguments": {}}}]
         dummy_messages = [
             {"role": "user", "content": "dummy"},
             {
@@ -1678,9 +1679,20 @@ class GRPOTrainer(_BaseTrainer):
         if eos_positions:
             prefix_ids = prefix_ids[: eos_positions[-1] + 1]
 
-        if full_ids[: len(prefix_ids)] != prefix_ids:
-            raise ValueError("Unexpected tokenization: the EOS-trimmed prefix IDs are not a prefix of the full IDs.")
-        return full_ids[len(prefix_ids) :]
+        if full_ids[: len(prefix_ids)] == prefix_ids:
+            return full_ids[len(prefix_ids) :]
+
+        # Some templates render assistant-final scaffolding (for example a thinking prelude) only when the assistant
+        # message is the last message. Once tool/user result messages are appended, that scaffolding disappears, so the
+        # full prefix is no longer an exact prefix. In that case, align on the longest rendered suffix of the assistant
+        # tool-call block and return the tool-result tokens after it.
+        for suffix_len in range(len(prefix_ids) - 1, 0, -1):
+            prefix_suffix = prefix_ids[-suffix_len:]
+            for start in range(0, len(full_ids) - suffix_len + 1):
+                if full_ids[start : start + suffix_len] == prefix_suffix:
+                    return full_ids[start + suffix_len :]
+
+        raise ValueError("Unexpected tokenization: could not align the tool-call prefix with the full IDs.")
 
     def _tool_call_loop(self, prompts, prompt_ids, completion_ids, completions, logprobs, images, multimodal_fields):
         # Tool execution loop: execute tools, then regenerate completions with tool results appended to the prompt
@@ -1752,27 +1764,38 @@ class GRPOTrainer(_BaseTrainer):
                             tool_call_results.append((name, result))
 
                 for name, result in tool_call_results:
-                    # Support multimodal tool responses: if the tool returns a list of content blocks
-                    # (e.g., [{"type": "image", "image": ...}, {"type": "text", "text": "..."}]),
-                    # pass them through directly so _tokenize_prompts can extract images for VLMs.
+                    # Many VLM chat templates render image placeholders for user messages only. Keep the textual
+                    # tool result in the tool message, and surface tool-rendered images as a synthetic user message
+                    # so the tokenized suffix contains image tokens matching the collected image features.
                     content = result if isinstance(result, list) else str(result)
-                    tool_message = {"role": "tool", "name": name, "content": content}
-                    # Collect images from multimodal tool responses
+                    image_parts = []
                     if isinstance(content, list):
+                        text_parts = []
                         for part in content:
                             if isinstance(part, dict) and part.get("type") == "image":
+                                image_parts.append(part)
                                 tool_images[idx_with_tool].append(part["image"])
+                            else:
+                                text_parts.append(part)
+                        tool_content = text_parts if text_parts else ""
+                    else:
+                        tool_content = content
+                    tool_message = {"role": "tool", "name": name, "content": tool_content}
                     prompt_completion_tool.append(tool_message)
                     completions[idx_with_tool].append(tool_message)
+                    if image_parts:
+                        image_message = {"role": "user", "content": image_parts}
+                        prompt_completion_tool.append(image_message)
 
             # Build token IDs by concatenation: prompt + completion + tool_suffix.
             prompt_completion_tool_ids = []
             for idx in range(len(idxs_with_tool)):
                 idx_with_tool = idxs_with_tool[idx]
-                # Extract trailing tool messages from completions
+                # Extract trailing tool results and any synthetic user image messages from the prompt transcript.
                 tool_messages = []
-                for message in reversed(completions[idx_with_tool]):
-                    if message["role"] == "tool":
+                prompt_completion_tool = prompt_completion_tools[idx]
+                for message in reversed(prompt_completion_tool):
+                    if message["role"] in {"tool", "user"}:
                         tool_messages.insert(0, message)
                     else:
                         break


### PR DESCRIPTION
# What does this PR do?

This PR fixes multimodal tool responses in `GRPOTrainer` when a tool returns images for a VLM.

Previously, image blocks returned by tools were kept inside `role="tool"` messages. Some VLM chat templates render image placeholders only for `role="user"` messages, so the image tensors could be collected while the tokenized prompt contained no matching image tokens. That can lead to image feature/token mismatches.

This PR splits multimodal tool results so text remains in the tool message, while returned image blocks are surfaced as synthetic user messages for prompt rendering. The synthetic user image messages are kept out of `completions` so reward tokenizers do not receive structured image blocks. It also makes tool suffix token extraction robust to suffixes that include non-tool messages and templates with assistant-final scaffolding.

Fixes #5663.

## Tests

- `python3 -m py_compile trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py`
- `env -u PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/vieveks/miniconda3/envs/trl-dev/bin/pytest tests/test_grpo_trainer.py::TestGRPOTrainerVLM::test_tool_suffix_ids_include_user_image_from_tool_response tests/test_grpo_trainer.py::TestGRPOTrainerVLM::test_train_with_tools_multimodal_response -q`
- `env -u PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/vieveks/miniconda3/envs/trl-dev/bin/pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_with_tools -q`
- `env -u PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/vieveks/miniconda3/envs/trl-dev/bin/pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_with_environment_factory -q`
- `env -u PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/vieveks/miniconda3/envs/trl-dev/bin/pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_with_malformed_tool_calls -q`

Also ran `tests/test_grpo_trainer.py -q -k "tool or vlm"`; interrupted during a slow HF Hub download after 18 passed, 3 skipped, no failures observed.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GRPO tool-loop tokenization and message shaping on a critical VLM path; misalignment could still break training or image feature/token matching, though scoped to tool follow-ups with new tests.
> 
> **Overview**
> Fixes **GRPOTrainer** multimodal tool handling when tools return images: many VLM chat templates only emit image placeholder tokens on **`user`** messages, so keeping image blocks inside **`tool`** messages could collect image tensors without matching tokens in the prompt.
> 
> The tool loop now **splits** list-shaped tool results—text stays in the tool message; image blocks are appended as a **synthetic user** message on the prompt transcript only (not in `completions`, so reward tokenizers avoid structured image blocks). **`_get_tool_suffix_ids`** picks the first tool role’s name (not `tool_messages[0]`), falls back to suffix alignment when prefix slicing fails (templates that drop assistant scaffolding after tool/user follow-ups), and suffix extraction walks the prompt transcript for trailing **`tool`** and **`user`** messages instead of only tool rows from `completions`.
> 
> Adds **`test_tool_suffix_ids_include_user_image_from_tool_response`** to assert image pad tokens appear in suffix IDs when a synthetic user image follows a tool message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985de76622f57fc17d4d5f808a0251068cfc39d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->