### PR TITLE
🐛 Fix precompute_ref_log_probs with in-memory datasets

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import torch_device
@@ -237,6 +237,20 @@ class TestDPOTrainer(TrlTestCase):
 
         metrics = trainer.evaluate(eval_dataset=dataset)
         assert metrics["eval_loss"] is not None
+
+    def test_precompute_ref_log_probs_with_in_memory_dataset(self):
+        # Regression test for https://github.com/huggingface/trl/issues/6291: in-memory datasets (e.g. built with
+        # `Dataset.from_dict`) don't automatically write a cache file on `map`, so `_precompute_ref_logps` failed
+        # with FileNotFoundError when loading the expected cache file.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        dataset = Dataset.from_dict(dataset[:])  # force an in-memory dataset with no cache files
+
+        training_args = DPOConfig(output_dir=self.tmp_dir, precompute_ref_log_probs=True, report_to="none")
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+        assert "ref_chosen_logps" in trainer.train_dataset.column_names
+        assert "ref_rejected_logps" in trainer.train_dataset.column_names
 
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1162,6 +1162,10 @@ class DPOTrainer(_BaseTrainer):
                 batched=True,
                 remove_columns=dataset.column_names,
                 new_fingerprint=fingerprint,
+                # Pass the cache path explicitly: in-memory datasets (e.g. built
+                # with Dataset.from_dict) don't write any cache file otherwise,
+                # and Dataset.from_file(cache_file) below would fail.
+                cache_file_name=cache_file,
                 desc=f"Caching reference log probs for {name} dataset",
             )
         self.accelerator.wait_for_everyone()


### PR DESCRIPTION
`_precompute_ref_logps` computes the expected cache file path but calls `dataset.map()` without `cache_file_name`. Disk-backed datasets auto-write the map cache to that path, but in-memory datasets (e.g. built with `Dataset.from_dict`) don't write any cache file, so the subsequent `Dataset.from_file(cache_file)` raises `FileNotFoundError`. Passing `cache_file_name` explicitly makes the cache always land where it's read.

Adds a regression test that forces an in-memory dataset with `precompute_ref_log_probs=True` — it reproduces the exact `FileNotFoundError` on main and passes with this change; the existing `test_evaluate_with_raw_dataset[True/False]` remain green.

Fixes #6291

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fix to DPO reference log-prob caching with an explicit `datasets` map option; disk-backed datasets should behave the same, with a targeted regression test.
> 
> **Overview**
> Fixes **`FileNotFoundError`** when DPO training uses **`precompute_ref_log_probs=True`** with an **in-memory** Hugging Face `Dataset` (e.g. from `Dataset.from_dict`).
> 
> **`_precompute_ref_logps`** already derives a cache path and reloads via `Dataset.from_file(cache_file)`, but **`dataset.map()`** was called without **`cache_file_name`**. Disk-backed datasets still write the map cache to that path implicitly; in-memory datasets do not, so the follow-up load failed.
> 
> The change passes **`cache_file_name=cache_file`** into **`map`** so the reference log-prob columns are always written where the trainer expects them.
> 
> A regression test builds an in-memory dataset with **`precompute_ref_log_probs=True`** and checks that **`ref_chosen_logps`** and **`ref_rejected_logps`** are present after trainer init (fixes #6291).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713ac1abd552d7293422ce594b177b94fc6de392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->