### PR TITLE
🐛 Fix precompute_ref_log_probs with in-memory datasets

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import torch_device
@@ -237,6 +237,20 @@ class TestDPOTrainer(TrlTestCase):
 
         metrics = trainer.evaluate(eval_dataset=dataset)
         assert metrics["eval_loss"] is not None
+
+    def test_precompute_ref_log_probs_with_in_memory_dataset(self):
+        # Regression test for https://github.com/huggingface/trl/issues/6291: in-memory datasets (e.g. built with
+        # `Dataset.from_dict`) don't automatically write a cache file on `map`, so `_precompute_ref_logps` failed
+        # with FileNotFoundError when loading the expected cache file.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        dataset = Dataset.from_dict(dataset[:])  # force an in-memory dataset with no cache files
+
+        training_args = DPOConfig(output_dir=self.tmp_dir, precompute_ref_log_probs=True, report_to="none")
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+        assert "ref_chosen_logps" in trainer.train_dataset.column_names
+        assert "ref_rejected_logps" in trainer.train_dataset.column_names
 
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1162,6 +1162,10 @@ class DPOTrainer(_BaseTrainer):
                 batched=True,
                 remove_columns=dataset.column_names,
                 new_fingerprint=fingerprint,
+                # Pass the cache path explicitly: in-memory datasets (e.g. built
+                # with Dataset.from_dict) don't write any cache file otherwise,
+                # and Dataset.from_file(cache_file) below would fail.
+                cache_file_name=cache_file,
                 desc=f"Caching reference log probs for {name} dataset",
             )
         self.accelerator.wait_for_everyone()


### PR DESCRIPTION
# What does this PR do?

`_precompute_ref_logps` computes the expected cache file path but calls `dataset.map()` without `cache_file_name`. Disk-backed datasets auto-write the map cache to that path, but in-memory datasets (e.g. built with `Dataset.from_dict`) don't write any cache file, so the subsequent `Dataset.from_file(cache_file)` raises `FileNotFoundError`. Passing `cache_file_name` explicitly makes the cache always land where it's read.

Adds a regression test that forces an in-memory dataset with `precompute_ref_log_probs=True` — it reproduces the exact `FileNotFoundError` on main and passes with this change; the existing `test_evaluate_with_raw_dataset[True/False]` remain green.

Fixes #6291

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in reference log-prob caching for map-style datasets; behavior for disk-backed datasets should stay the same while in-memory paths stop failing.
> 
> **Overview**
> Fixes **DPO training with `precompute_ref_log_probs=True`** when the train set is an in-memory Hugging Face `Dataset` (e.g. from `Dataset.from_dict`), which previously crashed with `FileNotFoundError` ([#6291](https://github.com/huggingface/trl/issues/6291)).
> 
> `_precompute_ref_logps` already derives a cache path and reloads via `Dataset.from_file`, but the `map` that writes `ref_chosen_logps` / `ref_rejected_logps` did not set **`cache_file_name`**. Disk-backed datasets often persist that map to the expected path; in-memory ones do not, so the follow-up load failed. The `map` call now passes **`cache_file_name=cache_file`** so the cache is always written where it is read.
> 
> A regression test builds an in-memory dataset with `precompute_ref_log_probs=True` and asserts the reference log-prob columns exist on `train_dataset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713ac1abd552d7293422ce594b177b94fc6de392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->