### PR TITLE
fix(grpo): handle NaN/None sampling logprobs from vLLM in importance-sampling correction

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -238,6 +238,64 @@ class TestGRPORolloutDispatch:
             trainer._generate(["prompt"])
 
 
+class TestVllmNanLogprobHandling:
+    """Regression tests for NaN/None logprob handling in GRPO with vLLM importance sampling.
+
+    vLLM returns NaN logprobs for near-deterministic tokens (sampled-token probability ≈ 1).
+    extract_logprobs() converts those NaN values to None. Prior to the fix these None values
+    caused a crash in _generate_and_score_completions: torch.tensor() raised
+    "RuntimeError: Could not infer dtype of NoneType" (issue #6166).
+    """
+
+    def test_none_logprobs_do_not_crash_tensor_construction(self):
+        """None entries from extract_logprobs() must not raise RuntimeError."""
+        # Simulate sampling_per_token_logps_list with a None at position 1
+        # (token 1 was near-deterministic; vLLM gave it NaN, extract_logprobs set it to None).
+        sampling_per_token_logps_list = [
+            [-0.5, None, -0.3],  # sequence 0: token 1 is near-deterministic
+            [-0.2, -0.7],  # sequence 1: all tokens have valid logprobs
+        ]
+
+        # Replicate the fixed construction from grpo_trainer.py
+        result = [
+            torch.tensor([float("nan") if lp is None else lp for lp in logps])
+            for logps in sampling_per_token_logps_list
+        ]
+
+        assert torch.isnan(result[0][1]), "None must become NaN after conversion"
+        assert not torch.isnan(result[0][0]), "Non-None values must remain finite"
+        assert not torch.isnan(result[1][0]), "Non-None values in other sequences must remain finite"
+
+    def test_nan_sampling_logprobs_yield_neutral_is_ratio(self):
+        """NaN sampling logprobs must produce an IS ratio of 1 after the fix."""
+        # Simulate old_per_token_logps (recomputed by the current training-model weights)
+        old_per_token_logps = torch.tensor([[-0.5, -1.2, -0.3]])
+        # sampling has NaN at position 1 (near-deterministic token from vLLM)
+        sampling_per_token_logps = torch.tensor([[-0.5, float("nan"), -0.3]])
+
+        # Apply the fix: replace NaN with old_per_token_logps so IS ratio = exp(0) = 1
+        nan_mask = torch.isnan(sampling_per_token_logps)
+        fixed = torch.where(nan_mask, old_per_token_logps, sampling_per_token_logps)
+
+        is_ratio = torch.exp(old_per_token_logps - fixed)
+        assert torch.isclose(is_ratio[0, 1], torch.tensor(1.0)), (
+            f"IS ratio at NaN position must be 1.0, got {is_ratio[0, 1].item()}"
+        )
+
+    def test_nan_removal_is_complete(self):
+        """After applying the fix, no NaN must remain in sampling_per_token_logps."""
+        old_logps = torch.tensor([[-0.5, -1.2, -0.3], [-0.8, -0.4, -0.9]])
+        sampling = torch.tensor([
+            [-0.5, float("nan"), -0.3],
+            [float("nan"), -0.4, float("nan")],
+        ])
+
+        nan_mask = torch.isnan(sampling)
+        fixed = torch.where(nan_mask, old_logps, sampling)
+
+        assert not torch.isnan(fixed).any(), "No NaN values must remain after applying the fix"
+
+
 @pytest.mark.skipif(
     Version(transformers.__version__) < Version("5.8.0"),
     reason="transformers continuous batching requires transformers>=5.8.0",

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2135,7 +2135,14 @@ class GRPOTrainer(_BaseTrainer):
             completion_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
         ).to(device=device)
         if sampling_per_token_logps_list is not None:
-            sampling_per_token_logps = [torch.tensor(logps) for logps in sampling_per_token_logps_list]
+            # vLLM sets logprob to NaN for near-deterministic tokens (those where the sampled token
+            # had probability ≈ 1). The original list may therefore contain None entries (as produced
+            # by extract_logprobs()). torch.tensor() cannot handle None, so convert them to float NaN
+            # here; the NaN positions are handled in the importance-sampling correction block below.
+            sampling_per_token_logps = [
+                torch.tensor([float("nan") if lp is None else lp for lp in logps])
+                for logps in sampling_per_token_logps_list
+            ]
             sampling_per_token_logps = pad(
                 sampling_per_token_logps,
                 padding_value=0.0,
@@ -2310,6 +2317,13 @@ class GRPOTrainer(_BaseTrainer):
             # Compute the importance sampling ratio when using vLLM, to correct for potential distribution mismatch
             if self.use_vllm and self.vllm_importance_sampling_correction:
                 mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+                # Replace any remaining NaN sampling logprobs (from near-deterministic tokens) with
+                # the recomputed logprobs so that those positions contribute an IS ratio of exactly
+                # 1 (i.e. exp(old - sampling) = exp(0) = 1), leaving the loss unchanged for tokens
+                # whose sampling distribution cannot be meaningfully estimated.
+                nan_mask = torch.isnan(sampling_per_token_logps)
+                if nan_mask.any():
+                    sampling_per_token_logps = torch.where(nan_mask, old_per_token_logps, sampling_per_token_logps)
                 per_token_logps_diff = (old_per_token_logps - sampling_per_token_logps) * mask
 
                 sequence_level_is = self.vllm_importance_sampling_mode in ["sequence_mask", "sequence_truncate"]


### PR DESCRIPTION
## Summary

Fixes #6166.

When `vllm_importance_sampling_correction` is enabled, vLLM sometimes returns `NaN` logprobs for near-deterministic tokens (tokens whose sampled probability is ≈ 1). `extract_logprobs()` converts those `NaN` values to `None`. The downstream call:

```python
sampling_per_token_logps = [torch.tensor(logps) for logps in sampling_per_token_logps_list]
```

crashes with:

```
RuntimeError: Could not infer dtype of NoneType
```

because `torch.tensor()` cannot infer a dtype from a list that contains a Python `None`.

### Fix — two steps

**Step 1 — convert `None` → `float("nan")` during tensor construction**

```python
sampling_per_token_logps = [
    torch.tensor([float("nan") if lp is None else lp for lp in logps])
    for logps in sampling_per_token_logps_list
]
```

This keeps the information that a particular position had an unknown sampling logprob, without crashing.

**Step 2 — replace `NaN` positions before computing the IS ratio**

Inside the IS correction block, before `per_token_logps_diff = (old − sampling) * mask`:

```python
nan_mask = torch.isnan(sampling_per_token_logps)
if nan_mask.any():
    sampling_per_token_logps = torch.where(nan_mask, old_per_token_logps, sampling_per_token_logps)
```

Setting `sampling = old` at NaN positions makes `exp(old − sampling) = exp(0) = 1`, i.e. those tokens contribute a **neutral IS weight**. This is the correct semantics: if we cannot estimate the vLLM sampling probability for a token we should not apply any IS correction for it. (Note: `0 * nan = nan` in IEEE 754, so simply masking would not clear NaN at real completion tokens — the `torch.where` substitution is required.)

This is consistent with how TRL already handles NaN elsewhere in the same file (other `isnan`/`nan_to_num` guards).

## Test plan

- [x] `TestVllmNanLogprobHandling::test_none_logprobs_do_not_crash_tensor_construction` — verifies `None` → `NaN` without `RuntimeError`
- [x] `TestVllmNanLogprobHandling::test_nan_sampling_logprobs_yield_neutral_is_ratio` — verifies IS ratio = 1.0 at NaN positions
- [x] `TestVllmNanLogprobHandling::test_nan_removal_is_complete` — verifies no NaN remains after the substitution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GRPO loss math for vLLM importance sampling; behavior change is limited to previously crashing or NaN-poisoned token positions, but incorrect substitution would skew training weights.
> 
> **Overview**
> Fixes **#6166** when **vLLM importance-sampling correction** is on: vLLM can emit **NaN** logprobs for near-deterministic tokens, and **`extract_logprobs()`** turns those into **`None`**, which made **`torch.tensor(logps)`** crash in **`_generate_and_score_completions`**.
> 
> **`grpo_trainer.py`** now maps **`None` → `float("nan")`** when building **`sampling_per_token_logps`**, then before the IS ratio replaces any **NaN** sampling logprobs with **`old_per_token_logps`** so **`exp(old − sampling) = 1`** at those positions (neutral correction instead of NaN in the loss).
> 
> Adds **`TestVllmNanLogprobHandling`** regression tests for tensor construction, neutral IS ratio, and post-fix NaN cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3159cc93cbe3e1a7468c0345c672a5900223a49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->