### PR TITLE
Simplify tokenization [1/N]: Remove redundant is_vlm parameter

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -954,7 +954,6 @@ class DPOTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -968,15 +967,13 @@ class DPOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1031,7 +1028,7 @@ class DPOTrainer(_BaseTrainer):
             # function unhashable, forcing a random fingerprint that silently disables dataset caching.
             tokenize = self._tokenize
 
-            def tokenize_fn(example, processing_class, is_vlm):
+            def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 output = {}
@@ -1039,7 +1036,6 @@ class DPOTrainer(_BaseTrainer):
                     prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
-                        is_vlm,
                         tools=tools,
                         add_generation_prompt=True,
                         **example.get("chat_template_kwargs", {}),
@@ -1047,23 +1043,19 @@ class DPOTrainer(_BaseTrainer):
                     prompt_chosen_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
-                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                     prompt_rejected_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
-                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"], is_vlm)[
-                        "input_ids"
-                    ]
-                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"], is_vlm)[
+                    prompt_ids = tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"])["input_ids"]
+                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"])[
                         "input_ids"
                     ]
 
@@ -1088,7 +1080,7 @@ class DPOTrainer(_BaseTrainer):
 
             dataset = dataset.map(
                 tokenize_fn,
-                fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm},
+                fn_kwargs={"processing_class": processing_class},
                 **map_kwargs,
             )
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -958,7 +958,6 @@ class KTOTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -971,15 +970,13 @@ class KTOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1091,7 +1088,7 @@ class KTOTrainer(_BaseTrainer):
             # function unhashable, forcing a random fingerprint that silently disables dataset caching.
             tokenize = self._tokenize
 
-            def tokenize_fn(example, processing_class, is_vlm):
+            def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 if is_conversational(example):
@@ -1099,7 +1096,6 @@ class KTOTrainer(_BaseTrainer):
                     prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
-                        is_vlm,
                         tools=tools,
                         add_generation_prompt=True,
                         **chat_template_kwargs,
@@ -1107,15 +1103,14 @@ class KTOTrainer(_BaseTrainer):
                     prompt_completion_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["completion"],
-                        is_vlm,
                         tools=tools,
                         **chat_template_kwargs,
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_completion_ids = tokenize(
-                        processing_class, example["prompt"] + example["completion"], is_vlm
-                    )["input_ids"]
+                    prompt_ids = tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_completion_ids = tokenize(processing_class, example["prompt"] + example["completion"])[
+                        "input_ids"
+                    ]
 
                 if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
                     logger.warning(
@@ -1129,9 +1124,7 @@ class KTOTrainer(_BaseTrainer):
                     "completion_ids": prompt_completion_ids[len(prompt_ids) :],
                 }
 
-            dataset = dataset.map(
-                tokenize_fn, fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm}, **map_kwargs
-            )
+            dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)
 
             # Get KL datasets if needed
             if self.calculate_KL:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1367,7 +1367,6 @@ class SFTTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         chat_template: str | None,
         **kwargs,
     ) -> dict[str, list]:
@@ -1382,9 +1381,6 @@ class SFTTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             chat_template (`str` or `None`):
                 Chat template forwarded to `apply_chat_template` for conversational input.
             **kwargs:
@@ -1393,6 +1389,7 @@ class SFTTrainer(_BaseTrainer):
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1492,9 +1489,7 @@ class SFTTrainer(_BaseTrainer):
                 # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
                 tokenize = self._tokenize
 
-                def tokenize_fn(
-                    example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template
-                ):
+                def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, chat_template):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
                     if "prompt" in example:  # prompt-completion case
@@ -1503,7 +1498,6 @@ class SFTTrainer(_BaseTrainer):
                             prompt_ids = tokenize(
                                 processing_class,
                                 example["prompt"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 add_generation_prompt=True,
@@ -1512,7 +1506,6 @@ class SFTTrainer(_BaseTrainer):
                             prompt_completion_processed = tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
@@ -1522,11 +1515,9 @@ class SFTTrainer(_BaseTrainer):
                             if "assistant_masks" in prompt_completion_processed:
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
-                            prompt_ids = tokenize(processing_class, example["prompt"], is_vlm, chat_template)[
-                                "input_ids"
-                            ]
+                            prompt_ids = tokenize(processing_class, example["prompt"], chat_template)["input_ids"]
                             prompt_completion_ids = tokenize(
-                                processing_class, example["prompt"] + example["completion"], is_vlm, chat_template
+                                processing_class, example["prompt"] + example["completion"], chat_template
                             )["input_ids"]
 
                         # Check if the tokenized prompt starts with the tokenized prompt+completion
@@ -1547,7 +1538,6 @@ class SFTTrainer(_BaseTrainer):
                             processed = tokenize(
                                 processing_class,
                                 example["messages"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
@@ -1556,9 +1546,9 @@ class SFTTrainer(_BaseTrainer):
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:
                             output = {
-                                "input_ids": tokenize(
-                                    processing_class, example[dataset_text_field], is_vlm, chat_template
-                                )["input_ids"]
+                                "input_ids": tokenize(processing_class, example[dataset_text_field], chat_template)[
+                                    "input_ids"
+                                ]
                             }
 
                     if "assistant_masks" in output and 1 not in output["assistant_masks"]:
@@ -1576,7 +1566,6 @@ class SFTTrainer(_BaseTrainer):
                         "processing_class": processing_class,
                         "dataset_text_field": args.dataset_text_field,
                         "assistant_only_loss": args.assistant_only_loss,
-                        "is_vlm": self._is_vlm,
                         "chat_template": self.chat_template,
                     },
                     **map_kwargs,


### PR DESCRIPTION
Simplify tokenization [1/N]: Remove redundant `is_vlm` parameter.

This PR refactors the tokenization logic in the DPO, KTO, and SFT trainers to simplify the handling of VLM (Vision-Language Model) processors. The main change is to remove the explicit `is_vlm` parameter from the tokenization functions and instead infer whether the processor is a VLM by checking its type. This reduces redundancy and streamlines the code.

### Changes

**Tokenization logic simplification:**

* Removed the `is_vlm` parameter from the `_tokenize` and related `tokenize_fn` functions in `dpo_trainer.py`, `kto_trainer.py`, and `sft_trainer.py`. The code now determines if the processor is a VLM by checking if it is an instance of `ProcessorMixin`.
* Updated all calls to `_tokenize` and `tokenize_fn` to remove the `is_vlm` argument, passing only the necessary parameters.

**Documentation updates:**

* Removed references to the `is_vlm` parameter from function docstrings to reflect the new logic and avoid confusion. 

**Behavioral consistency:**

* The logic for preparing multimodal messages is now consistently applied based on processor type, ensuring that the correct processing is performed for both VLM and non-VLM cases. 

These changes make the codebase easier to maintain and less error-prone by reducing unnecessary parameters and centralizing the logic for determining processor type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with the same VLM branch logic; risk is only if a non-processor were misclassified, which matches existing trainer `processing_class` typing.
> 
> **Overview**
> **DPO, KTO, and SFT** dataset preprocessing no longer threads an explicit `is_vlm` flag through `_tokenize` and the `dataset.map` `tokenize_fn` helpers.
> 
> Inside `_tokenize`, vision-language handling (multimodal message prep and unwrapping the processor batch dimension) is keyed off `isinstance(processing_class, ProcessorMixin)` instead of a caller-supplied boolean. `fn_kwargs` for mapping drop `is_vlm` / `self._is_vlm`, and docstrings no longer document that parameter.
> 
> Intended behavior for tokenizer vs processor paths is unchanged; this is API cleanup ahead of further tokenization refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604866f84dc06c0e2e87f9b7003e69848307c335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->