### PR TITLE
Fix GRPOTrainer vLLM prompt token expansion bug with VLMs (Fixes #6294)

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1527,13 +1527,26 @@ class GRPOTrainer(_BaseTrainer):
                 prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
+            
+            if self.use_vllm and images is not None:
+                texts = self.processing_class.apply_chat_template(
+                    conversation=prompts,
+                    chat_template=self.chat_template,
+                    add_generation_prompt=True,
+                    tokenize=False,
+                    **self.chat_template_kwargs,
+                )
+                vllm_prompt_ids = self.processing_class.tokenizer(texts, add_special_tokens=False)["input_ids"]
+            else:
+                vllm_prompt_ids = prompt_ids
         else:
             prompt_ids = self.processing_class(text=prompts)["input_ids"]
             images = None
             multimodal_fields = {}
-        return prompt_ids, images, multimodal_fields
+            vllm_prompt_ids = prompt_ids
+        return prompt_ids, images, multimodal_fields, vllm_prompt_ids
 
-    def _generate_single_turn(self, prompt_ids, images, multimodal_fields):
+    def _generate_single_turn(self, prompt_ids, images, multimodal_fields, vllm_prompt_ids=None):
         device = self.accelerator.device
         mode = "train" if self.model.training else "eval"
 
@@ -1548,7 +1561,7 @@ class GRPOTrainer(_BaseTrainer):
             # Generate using vLLM with raw token IDs
             num_generations = self.num_generations if mode == "train" else self.num_generations_eval
             _, completion_ids, logprobs, _ = self.vllm_generation.generate(
-                prompts=prompt_ids,
+                prompts=vllm_prompt_ids if vllm_prompt_ids is not None else prompt_ids,
                 images=images,
                 num_generations=num_generations,
                 profiler=profiling_context(self, "vLLM.generate"),
@@ -1920,8 +1933,8 @@ class GRPOTrainer(_BaseTrainer):
             images = None
             multimodal_fields = {}
         else:
-            prompt_ids, images, multimodal_fields = self._tokenize_prompts(prompts)
-            completion_ids, logprobs = self._generate_single_turn(prompt_ids, images, multimodal_fields)
+            prompt_ids, images, multimodal_fields, vllm_prompt_ids = self._tokenize_prompts(prompts)
+            completion_ids, logprobs = self._generate_single_turn(prompt_ids, images, multimodal_fields, vllm_prompt_ids=vllm_prompt_ids)
             extra_fields = {}
 
         # Decode completions. It's important to use `parse_response` when possible, because it handles tool calls.


### PR DESCRIPTION
## What does this PR do?

Fixes #6294 

Currently, when using `GRPOTrainer` with `use_vllm=True` for multimodal models (like SmolVLM), the image processor expands the `<image>` token into multiple image features (e.g. 729 tokens) *before* passing them to vLLM. vLLM then receives these already-expanded token IDs but applies its own prompt updates, causing the first image feature token to be re-expanded into another huge block of tokens. This corrupts the prompt and leads to garbage generation rollouts.

This PR implements the fix by allowing `_tokenize_prompts` to generate a pure, text-only set of `vllm_prompt_ids` (with `add_special_tokens=False`) before the image processor artificially expands them. These unexpanded tokens are now safely passed directly to `vllm_generation.generate()`.

**Changes:**
- Added a 4th return value (`vllm_prompt_ids`) to `_tokenize_prompts` to hold the raw text token IDs when `use_vllm=True`.
- Updated `_generate_single_turn` to accept and prioritize `vllm_prompt_ids` if provided.
- Updated `compute_loss` to route the tokens correctly.

No workflows or CI files were touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the vLLM rollout tokenization path for multimodal GRPO; wrong IDs would break training quality, but the change is narrow and aligns vLLM with its own prompt handling.
> 
> **Overview**
> Fixes corrupted GRPO rollouts when **`use_vllm=True`** with multimodal models: the VLM processor was expanding image placeholders into hundreds of feature tokens before vLLM ran, and vLLM expanded them again.
> 
> **`_tokenize_prompts`** now also returns **`vllm_prompt_ids`**. For vLLM + images, those IDs come from chat-template text tokenized with **`add_special_tokens=False`**, before processor-side image expansion. Expanded **`prompt_ids`** and **`multimodal_fields`** are unchanged for the Hugging Face training forward path.
> 
> **`_generate_single_turn`** prefers **`vllm_prompt_ids`** for **`vllm_generation.generate()`**; **`_generate`** passes them through from tokenization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee50fe37b916aa651dccf4a12c18ad24565fd3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->