### PR TITLE
Fix GRPOTrainer vLLM prompt token expansion bug with VLMs (#6294)

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1527,13 +1527,26 @@ class GRPOTrainer(_BaseTrainer):
                 prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
+            
+            if self.use_vllm and images is not None:
+                texts = self.processing_class.apply_chat_template(
+                    conversation=prompts,
+                    chat_template=self.chat_template,
+                    add_generation_prompt=True,
+                    tokenize=False,
+                    **self.chat_template_kwargs,
+                )
+                vllm_prompt_ids = self.processing_class.tokenizer(texts, add_special_tokens=False)["input_ids"]
+            else:
+                vllm_prompt_ids = prompt_ids
         else:
             prompt_ids = self.processing_class(text=prompts)["input_ids"]
             images = None
             multimodal_fields = {}
-        return prompt_ids, images, multimodal_fields
+            vllm_prompt_ids = prompt_ids
+        return prompt_ids, images, multimodal_fields, vllm_prompt_ids
 
-    def _generate_single_turn(self, prompt_ids, images, multimodal_fields):
+    def _generate_single_turn(self, prompt_ids, images, multimodal_fields, vllm_prompt_ids=None):
         device = self.accelerator.device
         mode = "train" if self.model.training else "eval"
 
@@ -1548,7 +1561,7 @@ class GRPOTrainer(_BaseTrainer):
             # Generate using vLLM with raw token IDs
             num_generations = self.num_generations if mode == "train" else self.num_generations_eval
             _, completion_ids, logprobs, _ = self.vllm_generation.generate(
-                prompts=prompt_ids,
+                prompts=vllm_prompt_ids if vllm_prompt_ids is not None else prompt_ids,
                 images=images,
                 num_generations=num_generations,
                 profiler=profiling_context(self, "vLLM.generate"),
@@ -1920,8 +1933,8 @@ class GRPOTrainer(_BaseTrainer):
             images = None
             multimodal_fields = {}
         else:
-            prompt_ids, images, multimodal_fields = self._tokenize_prompts(prompts)
-            completion_ids, logprobs = self._generate_single_turn(prompt_ids, images, multimodal_fields)
+            prompt_ids, images, multimodal_fields, vllm_prompt_ids = self._tokenize_prompts(prompts)
+            completion_ids, logprobs = self._generate_single_turn(prompt_ids, images, multimodal_fields, vllm_prompt_ids=vllm_prompt_ids)
             extra_fields = {}
 
         # Decode completions. It's important to use `parse_response` when possible, because it handles tool calls.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1531,6 +1531,7 @@ class GRPOTrainer(_BaseTrainer):
             if self.use_vllm and images is not None:
                 texts = self.processing_class.apply_chat_template(
                     conversation=prompts,
+                    tools=self.tools or None,  # `or None`: Llama bug: it renders tool boilerplate for tools=[]
                     chat_template=self.chat_template,
                     add_generation_prompt=True,
                     tokenize=False,


### PR DESCRIPTION
# What does this PR do?

Fixes #6294

Currently, when using `GRPOTrainer` with `use_vllm=True` for multimodal models (like SmolVLM), the image processor expands the `<image>` token into multiple image features (e.g. 729 tokens) *before* passing them to vLLM. vLLM then receives these already-expanded token IDs but applies its own prompt updates, causing the first image feature token to be re-expanded into another huge block of tokens. This corrupts the prompt and leads to garbage generation rollouts.

This PR implements the fix by allowing `_tokenize_prompts` to generate a pure, text-only set of `vllm_prompt_ids` (with `add_special_tokens=False`) before the image processor artificially expands them. These unexpanded tokens are now safely passed directly to `vllm_generation.generate()`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the vLLM generation input for conversational multimodal prompts; text-only and non-vLLM paths are unchanged, but GRPO rollouts depend on correct prompt/image alignment with vLLM.
> 
> **Overview**
> Fixes corrupted vLLM rollouts when **GRPOTrainer** runs multimodal models (e.g. SmolVLM) with `use_vllm=True`: the VLM processor was expanding `<image>` into hundreds of feature tokens before vLLM, and vLLM expanded again on top of that.
> 
> **`_tokenize_prompts`** now also returns **`vllm_prompt_ids`**. When vLLM is on and the batch has images, those IDs come from the chat template as plain text (`tokenize=False`) plus tokenizer encoding with `add_special_tokens=False`—before the full processor run that inflates image tokens. Expanded **`prompt_ids`** and **`multimodal_fields`** are unchanged for the training-model forward path.
> 
> **`_generate_single_turn`** passes **`vllm_prompt_ids`** into **`vllm_generation.generate`** instead of the processor-expanded lists; **`_generate`** threads the new return value through the default rollout path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c2772486b89294882f63cc14d238b43aafdccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->