### PR TITLE
Simplify tokenization [2/N]: Make _tokenize a module-level function

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -954,7 +954,6 @@ class DPOTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -968,15 +967,13 @@ class DPOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1031,7 +1028,7 @@ class DPOTrainer(_BaseTrainer):
             # function unhashable, forcing a random fingerprint that silently disables dataset caching.
             tokenize = self._tokenize
 
-            def tokenize_fn(example, processing_class, is_vlm):
+            def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 output = {}
@@ -1039,7 +1036,6 @@ class DPOTrainer(_BaseTrainer):
                     prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
-                        is_vlm,
                         tools=tools,
                         add_generation_prompt=True,
                         **example.get("chat_template_kwargs", {}),
@@ -1047,23 +1043,19 @@ class DPOTrainer(_BaseTrainer):
                     prompt_chosen_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
-                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                     prompt_rejected_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
-                        is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"], is_vlm)[
-                        "input_ids"
-                    ]
-                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"], is_vlm)[
+                    prompt_ids = tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"])["input_ids"]
+                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"])[
                         "input_ids"
                     ]
 
@@ -1088,7 +1080,7 @@ class DPOTrainer(_BaseTrainer):
 
             dataset = dataset.map(
                 tokenize_fn,
-                fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm},
+                fn_kwargs={"processing_class": processing_class},
                 **map_kwargs,
             )
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -406,6 +406,47 @@ class DataCollatorForVisionPreference(DataCollatorMixin):
         return output
 
 
+# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
+# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
+# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+def _tokenize(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
+    input: str | list,
+    is_vlm: bool,
+    **kwargs,
+) -> dict[str, list]:
+    """Tokenize a single example for dataset preprocessing.
+
+    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+    non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
+    examples.
+
+    Args:
+        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+            The tokenizer or processor to use.
+        input (`str` or `list`):
+            A string for non-conversational input, or a list of message dicts for conversational input.
+        is_vlm (`bool`):
+            Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+            dimension normalization.
+        **kwargs:
+            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
+
+    Returns:
+        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+    """
+    if isinstance(input, list):  # conversational: list of message dicts
+        if is_vlm:
+            input = prepare_multimodal_messages(input)
+        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
+    else:  # non-conversational: plain text string
+        result = processing_class(text=input)
+    # VLMs emit a batch dimension even for single examples; unwrap it
+    if is_vlm:
+        return {k: v[0] for k, v in result.items()}
+    return result
+
+
 class DPOTrainer(_BaseTrainer):
     """
     Trainer for Direct Preference Optimization (DPO) method. This algorithm was initially proposed in the paper [Direct
@@ -950,44 +991,6 @@ class DPOTrainer(_BaseTrainer):
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
-    @staticmethod
-    def _tokenize(
-        processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-        input: str | list,
-        is_vlm: bool,
-        **kwargs,
-    ) -> dict[str, list]:
-        """Tokenize a single example for dataset preprocessing.
-
-        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-        non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
-        examples.
-
-        Args:
-            processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-                The tokenizer or processor to use.
-            input (`str` or `list`):
-                A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
-            **kwargs:
-                Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-        Returns:
-            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-        """
-        if isinstance(input, list):  # conversational: list of message dicts
-            if is_vlm:
-                input = prepare_multimodal_messages(input)
-            result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-        else:  # non-conversational: plain text string
-            result = processing_class(text=input)
-        # VLMs emit a batch dimension even for single examples; unwrap it
-        if is_vlm:
-            return {k: v[0] for k, v in result.items()}
-        return result
-
     def _prepare_dataset(
         self,
         dataset: Dataset | IterableDataset,
@@ -1027,16 +1030,12 @@ class DPOTrainer(_BaseTrainer):
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-            # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the map
-            # function unhashable, forcing a random fingerprint that silently disables dataset caching.
-            tokenize = self._tokenize
-
             def tokenize_fn(example, processing_class, is_vlm):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 output = {}
                 if is_conversational(example):
-                    prompt_ids = tokenize(
+                    prompt_ids = _tokenize(
                         processing_class,
                         example["prompt"],
                         is_vlm,
@@ -1044,14 +1043,14 @@ class DPOTrainer(_BaseTrainer):
                         add_generation_prompt=True,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_chosen_ids = tokenize(
+                    prompt_chosen_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
                         is_vlm,
                         tools=tools,
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
-                    prompt_rejected_ids = tokenize(
+                    prompt_rejected_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
                         is_vlm,
@@ -1059,11 +1058,11 @@ class DPOTrainer(_BaseTrainer):
                         **example.get("chat_template_kwargs", {}),
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_chosen_ids = tokenize(processing_class, example["prompt"] + example["chosen"], is_vlm)[
+                    prompt_ids = _tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
+                    prompt_chosen_ids = _tokenize(processing_class, example["prompt"] + example["chosen"], is_vlm)[
                         "input_ids"
                     ]
-                    prompt_rejected_ids = tokenize(processing_class, example["prompt"] + example["rejected"], is_vlm)[
+                    prompt_rejected_ids = _tokenize(processing_class, example["prompt"] + example["rejected"], is_vlm)[
                         "input_ids"
                     ]
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -456,6 +456,46 @@ class DataCollatorForVisionUnpairedPreference(DataCollatorMixin):
         return output
 
 
+# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
+# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
+# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+def _tokenize(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
+    input: str | list,
+    is_vlm: bool,
+    **kwargs,
+) -> dict[str, list]:
+    """Tokenize a single example for dataset preprocessing.
+
+    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+    non-conversational input (str).
+
+    Args:
+        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+            The tokenizer or processor to use.
+        input (`str` or `list`):
+            A string for non-conversational input, or a list of message dicts for conversational input.
+        is_vlm (`bool`):
+            Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+            dimension normalization.
+        **kwargs:
+            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
+
+    Returns:
+        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+    """
+    if isinstance(input, list):  # conversational: list of message dicts
+        if is_vlm:
+            input = prepare_multimodal_messages(input)
+        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
+    else:  # non-conversational: plain text string
+        result = processing_class(text=input)
+    # VLMs emit a batch dimension even for single examples; unwrap it
+    if is_vlm:
+        return {k: v[0] for k, v in result.items()}
+    return result
+
+
 class KTOTrainer(_BaseTrainer):
     """
     Trainer for Kahneman-Tversky Optimization (KTO) method. This algorithm was initially proposed in the paper [KTO:
@@ -954,43 +994,6 @@ class KTOTrainer(_BaseTrainer):
                         self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size,
                     )
 
-    @staticmethod
-    def _tokenize(
-        processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-        input: str | list,
-        is_vlm: bool,
-        **kwargs,
-    ) -> dict[str, list]:
-        """Tokenize a single example for dataset preprocessing.
-
-        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-        non-conversational input (str).
-
-        Args:
-            processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-                The tokenizer or processor to use.
-            input (`str` or `list`):
-                A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
-            **kwargs:
-                Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-        Returns:
-            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-        """
-        if isinstance(input, list):  # conversational: list of message dicts
-            if is_vlm:
-                input = prepare_multimodal_messages(input)
-            result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-        else:  # non-conversational: plain text string
-            result = processing_class(text=input)
-        # VLMs emit a batch dimension even for single examples; unwrap it
-        if is_vlm:
-            return {k: v[0] for k, v in result.items()}
-        return result
-
     def _get_kl_dataset(
         self,
         dataset: Dataset | IterableDataset,
@@ -1087,16 +1090,12 @@ class KTOTrainer(_BaseTrainer):
             if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                 map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-            # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the map
-            # function unhashable, forcing a random fingerprint that silently disables dataset caching.
-            tokenize = self._tokenize
-
             def tokenize_fn(example, processing_class, is_vlm):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 if is_conversational(example):
                     chat_template_kwargs = example.get("chat_template_kwargs", {})
-                    prompt_ids = tokenize(
+                    prompt_ids = _tokenize(
                         processing_class,
                         example["prompt"],
                         is_vlm,
@@ -1104,7 +1103,7 @@ class KTOTrainer(_BaseTrainer):
                         add_generation_prompt=True,
                         **chat_template_kwargs,
                     )["input_ids"]
-                    prompt_completion_ids = tokenize(
+                    prompt_completion_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["completion"],
                         is_vlm,
@@ -1112,8 +1111,8 @@ class KTOTrainer(_BaseTrainer):
                         **chat_template_kwargs,
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_completion_ids = tokenize(
+                    prompt_ids = _tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
+                    prompt_completion_ids = _tokenize(
                         processing_class, example["prompt"] + example["completion"], is_vlm
                     )["input_ids"]
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -958,7 +958,6 @@ class KTOTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         **kwargs,
     ) -> dict[str, list]:
         """Tokenize a single example for dataset preprocessing.
@@ -971,15 +970,13 @@ class KTOTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             **kwargs:
                 Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
 
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1091,7 +1088,7 @@ class KTOTrainer(_BaseTrainer):
             # function unhashable, forcing a random fingerprint that silently disables dataset caching.
             tokenize = self._tokenize
 
-            def tokenize_fn(example, processing_class, is_vlm):
+            def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
                 if is_conversational(example):
@@ -1099,7 +1096,6 @@ class KTOTrainer(_BaseTrainer):
                     prompt_ids = tokenize(
                         processing_class,
                         example["prompt"],
-                        is_vlm,
                         tools=tools,
                         add_generation_prompt=True,
                         **chat_template_kwargs,
@@ -1107,15 +1103,14 @@ class KTOTrainer(_BaseTrainer):
                     prompt_completion_ids = tokenize(
                         processing_class,
                         example["prompt"] + example["completion"],
-                        is_vlm,
                         tools=tools,
                         **chat_template_kwargs,
                     )["input_ids"]
                 else:
-                    prompt_ids = tokenize(processing_class, example["prompt"], is_vlm)["input_ids"]
-                    prompt_completion_ids = tokenize(
-                        processing_class, example["prompt"] + example["completion"], is_vlm
-                    )["input_ids"]
+                    prompt_ids = tokenize(processing_class, example["prompt"])["input_ids"]
+                    prompt_completion_ids = tokenize(processing_class, example["prompt"] + example["completion"])[
+                        "input_ids"
+                    ]
 
                 if not prompt_completion_ids[: len(prompt_ids)] == prompt_ids:
                     logger.warning(
@@ -1129,9 +1124,7 @@ class KTOTrainer(_BaseTrainer):
                     "completion_ids": prompt_completion_ids[len(prompt_ids) :],
                 }
 
-            dataset = dataset.map(
-                tokenize_fn, fn_kwargs={"processing_class": processing_class, "is_vlm": self._is_vlm}, **map_kwargs
-            )
+            dataset = dataset.map(tokenize_fn, fn_kwargs={"processing_class": processing_class}, **map_kwargs)
 
             # Get KL datasets if needed
             if self.calculate_KL:

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -224,6 +224,37 @@ class DataCollatorForPreference(DataCollatorMixin):
         return output
 
 
+# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
+# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
+# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+def _tokenize(
+    processing_class: PreTrainedTokenizerBase,
+    input: str | list,
+    **kwargs,
+) -> dict[str, list]:
+    """Tokenize a single example for dataset preprocessing.
+
+    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+    non-conversational input (str).
+
+    Args:
+        processing_class ([`~transformers.PreTrainedTokenizerBase`]):
+            The tokenizer to use.
+        input (`str` or `list`):
+            A string for non-conversational input, or a list of message dicts for conversational input.
+        **kwargs:
+            Forwarded to `apply_chat_template` (e.g. `tools`).
+
+    Returns:
+        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+    """
+    if isinstance(input, list):  # conversational: list of message dicts
+        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
+    else:  # non-conversational: plain text string
+        result = processing_class(text=input)
+    return result
+
+
 class RewardTrainer(_BaseTrainer):
     """
     Trainer for Outcome-supervised Reward Models (ORM).
@@ -581,34 +612,6 @@ class RewardTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
-    @staticmethod
-    def _tokenize(
-        processing_class: PreTrainedTokenizerBase,
-        input: str | list,
-        **kwargs,
-    ) -> dict[str, list]:
-        """Tokenize a single example for dataset preprocessing.
-
-        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-        non-conversational input (str).
-
-        Args:
-            processing_class ([`~transformers.PreTrainedTokenizerBase`]):
-                The tokenizer to use.
-            input (`str` or `list`):
-                A string for non-conversational input, or a list of message dicts for conversational input.
-            **kwargs:
-                Forwarded to `apply_chat_template` (e.g. `tools`).
-
-        Returns:
-            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-        """
-        if isinstance(input, list):  # conversational: list of message dicts
-            result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-        else:  # non-conversational: plain text string
-            result = processing_class(text=input)
-        return result
-
     def _prepare_dataset(
         self,
         dataset: Dataset | IterableDataset,
@@ -661,11 +664,6 @@ class RewardTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-                # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the
-                # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-                # `_tokenize` is a static method, so `self._tokenize` is a plain function (no bound `self`).
-                tokenize = self._tokenize
-
                 def tokenize_fn(example, processing_class):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
@@ -674,13 +672,13 @@ class RewardTrainer(_BaseTrainer):
                         example["rejected"] = example["prompt"] + example["rejected"]
 
                     if is_conversational(example):
-                        chosen_ids = tokenize(
+                        chosen_ids = _tokenize(
                             processing_class,
                             example["chosen"],
                             tools=tools,
                             **example.get("chat_template_kwargs", {}),
                         )["input_ids"]
-                        rejected_ids = tokenize(
+                        rejected_ids = _tokenize(
                             processing_class,
                             example["rejected"],
                             tools=tools,
@@ -689,8 +687,8 @@ class RewardTrainer(_BaseTrainer):
                         output = {"chosen_ids": chosen_ids, "rejected_ids": rejected_ids}
                     else:
                         output = {
-                            "chosen_ids": tokenize(processing_class, example["chosen"])["input_ids"],
-                            "rejected_ids": tokenize(processing_class, example["rejected"])["input_ids"],
+                            "chosen_ids": _tokenize(processing_class, example["chosen"])["input_ids"],
+                            "rejected_ids": _tokenize(processing_class, example["rejected"])["input_ids"],
                         }
                     return output
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -788,6 +788,52 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
     return loss
 
 
+# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
+# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
+# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
+def _tokenize(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
+    input: str | list,
+    is_vlm: bool,
+    chat_template: str | None,
+    **kwargs,
+) -> dict[str, list]:
+    """Tokenize a single example for dataset preprocessing.
+
+    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+    non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
+    examples.
+
+    Args:
+        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+            The tokenizer or processor to use.
+        input (`str` or `list`):
+            A string for non-conversational input, or a list of message dicts for conversational input.
+        is_vlm (`bool`):
+            Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
+            dimension normalization.
+        chat_template (`str` or `None`):
+            Chat template forwarded to `apply_chat_template` for conversational input.
+        **kwargs:
+            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
+
+    Returns:
+        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+    """
+    if isinstance(input, list):  # conversational: list of message dicts
+        if is_vlm:
+            input = prepare_multimodal_messages(input)
+        result = processing_class.apply_chat_template(
+            input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
+        )
+    else:  # non-conversational: plain text string
+        result = processing_class(text=input)
+    # VLMs emit a batch dimension even for single examples; unwrap it
+    if is_vlm:
+        return {k: v[0] for k, v in result.items()}
+    return result
+
+
 class SFTTrainer(_BaseTrainer):
     """
     Trainer for Supervised Fine-Tuning (SFT) method.
@@ -1363,49 +1409,6 @@ class SFTTrainer(_BaseTrainer):
         # Add tags to the model
         self.model.add_model_tags(self._tag_names)
 
-    @staticmethod
-    def _tokenize(
-        processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-        input: str | list,
-        is_vlm: bool,
-        chat_template: str | None,
-        **kwargs,
-    ) -> dict[str, list]:
-        """Tokenize a single example for dataset preprocessing.
-
-        Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-        non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
-        examples.
-
-        Args:
-            processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-                The tokenizer or processor to use.
-            input (`str` or `list`):
-                A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
-            chat_template (`str` or `None`):
-                Chat template forwarded to `apply_chat_template` for conversational input.
-            **kwargs:
-                Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-        Returns:
-            `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-        """
-        if isinstance(input, list):  # conversational: list of message dicts
-            if is_vlm:
-                input = prepare_multimodal_messages(input)
-            result = processing_class.apply_chat_template(
-                input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
-            )
-        else:  # non-conversational: plain text string
-            result = processing_class(text=input)
-        # VLMs emit a batch dimension even for single examples; unwrap it
-        if is_vlm:
-            return {k: v[0] for k, v in result.items()}
-        return result
-
     def _prepare_dataset(
         self,
         dataset: Dataset | IterableDataset,
@@ -1488,10 +1491,6 @@ class SFTTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
-                # Bind `_tokenize` to a local so `tokenize_fn` doesn't capture `self`: a closure over `self` makes the
-                # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-                tokenize = self._tokenize
-
                 def tokenize_fn(
                     example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template
                 ):
@@ -1500,7 +1499,7 @@ class SFTTrainer(_BaseTrainer):
                     if "prompt" in example:  # prompt-completion case
                         output = {}
                         if is_conversational(example):
-                            prompt_ids = tokenize(
+                            prompt_ids = _tokenize(
                                 processing_class,
                                 example["prompt"],
                                 is_vlm,
@@ -1509,7 +1508,7 @@ class SFTTrainer(_BaseTrainer):
                                 add_generation_prompt=True,
                                 **example.get("chat_template_kwargs", {}),
                             )["input_ids"]
-                            prompt_completion_processed = tokenize(
+                            prompt_completion_processed = _tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
                                 is_vlm,
@@ -1522,10 +1521,10 @@ class SFTTrainer(_BaseTrainer):
                             if "assistant_masks" in prompt_completion_processed:
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
-                            prompt_ids = tokenize(processing_class, example["prompt"], is_vlm, chat_template)[
+                            prompt_ids = _tokenize(processing_class, example["prompt"], is_vlm, chat_template)[
                                 "input_ids"
                             ]
-                            prompt_completion_ids = tokenize(
+                            prompt_completion_ids = _tokenize(
                                 processing_class, example["prompt"] + example["completion"], is_vlm, chat_template
                             )["input_ids"]
 
@@ -1544,7 +1543,7 @@ class SFTTrainer(_BaseTrainer):
 
                     else:  # language modeling case
                         if is_conversational(example):
-                            processed = tokenize(
+                            processed = _tokenize(
                                 processing_class,
                                 example["messages"],
                                 is_vlm,
@@ -1556,7 +1555,7 @@ class SFTTrainer(_BaseTrainer):
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:
                             output = {
-                                "input_ids": tokenize(
+                                "input_ids": _tokenize(
                                     processing_class, example[dataset_text_field], is_vlm, chat_template
                                 )["input_ids"]
                             }

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1367,7 +1367,6 @@ class SFTTrainer(_BaseTrainer):
     def _tokenize(
         processing_class: PreTrainedTokenizerBase | ProcessorMixin,
         input: str | list,
-        is_vlm: bool,
         chat_template: str | None,
         **kwargs,
     ) -> dict[str, list]:
@@ -1382,9 +1381,6 @@ class SFTTrainer(_BaseTrainer):
                 The tokenizer or processor to use.
             input (`str` or `list`):
                 A string for non-conversational input, or a list of message dicts for conversational input.
-            is_vlm (`bool`):
-                Whether the processing class is a VLM processor, requiring multimodal message preparation and batch
-                dimension normalization.
             chat_template (`str` or `None`):
                 Chat template forwarded to `apply_chat_template` for conversational input.
             **kwargs:
@@ -1393,6 +1389,7 @@ class SFTTrainer(_BaseTrainer):
         Returns:
             `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
         """
+        is_vlm = isinstance(processing_class, ProcessorMixin)
         if isinstance(input, list):  # conversational: list of message dicts
             if is_vlm:
                 input = prepare_multimodal_messages(input)
@@ -1492,9 +1489,7 @@ class SFTTrainer(_BaseTrainer):
                 # map function unhashable, forcing a random fingerprint that silently disables dataset caching.
                 tokenize = self._tokenize
 
-                def tokenize_fn(
-                    example, processing_class, dataset_text_field, assistant_only_loss, is_vlm, chat_template
-                ):
+                def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, chat_template):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
                     if "prompt" in example:  # prompt-completion case
@@ -1503,7 +1498,6 @@ class SFTTrainer(_BaseTrainer):
                             prompt_ids = tokenize(
                                 processing_class,
                                 example["prompt"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 add_generation_prompt=True,
@@ -1512,7 +1506,6 @@ class SFTTrainer(_BaseTrainer):
                             prompt_completion_processed = tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
@@ -1522,11 +1515,9 @@ class SFTTrainer(_BaseTrainer):
                             if "assistant_masks" in prompt_completion_processed:
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
-                            prompt_ids = tokenize(processing_class, example["prompt"], is_vlm, chat_template)[
-                                "input_ids"
-                            ]
+                            prompt_ids = tokenize(processing_class, example["prompt"], chat_template)["input_ids"]
                             prompt_completion_ids = tokenize(
-                                processing_class, example["prompt"] + example["completion"], is_vlm, chat_template
+                                processing_class, example["prompt"] + example["completion"], chat_template
                             )["input_ids"]
 
                         # Check if the tokenized prompt starts with the tokenized prompt+completion
@@ -1547,7 +1538,6 @@ class SFTTrainer(_BaseTrainer):
                             processed = tokenize(
                                 processing_class,
                                 example["messages"],
-                                is_vlm,
                                 chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
@@ -1556,9 +1546,9 @@ class SFTTrainer(_BaseTrainer):
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:
                             output = {
-                                "input_ids": tokenize(
-                                    processing_class, example[dataset_text_field], is_vlm, chat_template
-                                )["input_ids"]
+                                "input_ids": tokenize(processing_class, example[dataset_text_field], chat_template)[
+                                    "input_ids"
+                                ]
                             }
 
                     if "assistant_masks" in output and 1 not in output["assistant_masks"]:
@@ -1576,7 +1566,6 @@ class SFTTrainer(_BaseTrainer):
                         "processing_class": processing_class,
                         "dataset_text_field": args.dataset_text_field,
                         "assistant_only_loss": args.assistant_only_loss,
-                        "is_vlm": self._is_vlm,
                         "chat_template": self.chat_template,
                     },
                     **map_kwargs,


### PR DESCRIPTION
Simplify tokenization [2/N]: Make _tokenize a module-level function.

This PR converts the private `_tokenize` static method into a module-level function in the DPO, KTO, reward, and SFT trainers.

Follow-up to (required):
- [x] #6298

### Motivation

`_tokenize` is a stateless static method: it uses neither self nor cls, so it does not need to live on the trainer class. Because it was a method, each _prepare_dataset had to bind it to a local (`tokenize = self._tokenize`) before defining the Dataset.map callback, so that the callback would not close over self. A closure over self makes the map function unhashable, which forces a random fingerprint and silently disables dataset caching. This workaround, plus an explanatory comment, was duplicated across all four trainers:
- #6206

### Solution

Moving `_tokenize` to module level lets the `tokenize_fn` map callback reference it directly, so the local-binding workaround and its comment can be removed. Behavior is unchanged: signatures and docstrings are preserved per file, and dataset caching still produces a stable content-based fingerprint. This also matches the existing precedent in the experimental BCO trainer, which already defines `_tokenize` at module level.

### Changes

- Move the `_tokenize` static method to a module-level function in the DPO, KTO, reward, and SFT trainers, keeping each trainer's own copy rather than sharing one, consistent with the self-contained trainer design.
- Add a short comment on each module-level function explaining why it is not a method, to prevent it from being moved back onto the class.
- Remove the `tokenize = self._tokenize` binding and its comment from each `_prepare_dataset`, and call `_tokenize` directly from the tokenization map callback.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocation of stateless tokenization helpers with no intended behavior change; risk is limited to preprocessing/caching edge cases if a trainer-specific `_tokenize` diverged.
> 
> **Overview**
> Moves **`_tokenize`** out of the DPO, KTO, Reward, and SFT trainer classes into a **module-level function** in each file (same logic and signatures as before; one copy per trainer, not shared).
> 
> **`_prepare_dataset`** no longer uses `tokenize = self._tokenize` or the related comment. The `Dataset.map` **`tokenize_fn`** calls **`_tokenize`** directly so the callback does not close over **`self`**, keeping the map function hashable and **Hugging Face `datasets` caching** fingerprints stable instead of silently disabling cache.
> 
> Each module-level **`_tokenize`** includes a short comment explaining why it is not a class method, aligned with the experimental BCO trainer pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 300586db2b70acedc7a601bcabfee6e3a75a2ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->