### PR TITLE
Simplify tokenization [3/N]: Factor _tokenize into a single shared function

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -396,6 +396,47 @@ def maybe_apply_chat_template(
         return example
 
 
+def _tokenize(
+    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
+    input: str | list,
+    chat_template: str | None = None,
+    **kwargs,
+) -> dict[str, list]:
+    """
+    Tokenize a single example for dataset preprocessing.
+
+    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
+    non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
+    examples.
+
+    Args:
+        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
+            The tokenizer or processor to use.
+        input (`str` or `list`):
+            A string for non-conversational input, or a list of message dicts for conversational input.
+        chat_template (`str`, *optional*):
+            Chat template forwarded to `apply_chat_template` for conversational input.
+        **kwargs:
+            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`, `tools`).
+
+    Returns:
+        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
+    """
+    is_vlm = isinstance(processing_class, ProcessorMixin)
+    if isinstance(input, list):  # conversational: list of message dicts
+        if is_vlm:
+            input = prepare_multimodal_messages(input)
+        result = processing_class.apply_chat_template(
+            input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
+        )
+    else:  # non-conversational: plain text string
+        result = processing_class(text=input)
+    # VLMs emit a batch dimension even for single examples; unwrap it
+    if is_vlm:
+        return {k: v[0] for k, v in result.items()}
+    return result
+
+
 def _unpair_row(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
     batch_size = len(batch["chosen"])
     new_batch = {

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -45,7 +45,7 @@ from transformers.data.data_collator import DataCollatorMixin
 from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
-from ..data_utils import apply_chat_template, extract_prompt, is_conversational, prepare_multimodal_messages
+from ..data_utils import _tokenize, apply_chat_template, extract_prompt, is_conversational, prepare_multimodal_messages
 from ..import_utils import is_liger_kernel_available
 from ..models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp
 from ..models.utils import disable_gradient_checkpointing
@@ -404,44 +404,6 @@ class DataCollatorForVisionPreference(DataCollatorMixin):
         if "mm_token_type_ids" in processed_prompts:
             output["mm_token_type_ids"] = mm_token_type_ids
         return output
-
-
-# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
-# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
-# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-def _tokenize(
-    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-    input: str | list,
-    **kwargs,
-) -> dict[str, list]:
-    """Tokenize a single example for dataset preprocessing.
-
-    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-    non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
-    examples.
-
-    Args:
-        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-            The tokenizer or processor to use.
-        input (`str` or `list`):
-            A string for non-conversational input, or a list of message dicts for conversational input.
-        **kwargs:
-            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-    Returns:
-        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-    """
-    is_vlm = isinstance(processing_class, ProcessorMixin)
-    if isinstance(input, list):  # conversational: list of message dicts
-        if is_vlm:
-            input = prepare_multimodal_messages(input)
-        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-    else:  # non-conversational: plain text string
-        result = processing_class(text=input)
-    # VLMs emit a batch dimension even for single examples; unwrap it
-    if is_vlm:
-        return {k: v[0] for k, v in result.items()}
-    return result
 
 
 class DPOTrainer(_BaseTrainer):

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -45,6 +45,7 @@ from transformers.trainer_utils import EvalPrediction, has_length
 from transformers.utils import is_peft_available
 
 from ..data_utils import (
+    _tokenize,
     apply_chat_template,
     extract_prompt,
     get_dataset_column_names,
@@ -454,43 +455,6 @@ class DataCollatorForVisionUnpairedPreference(DataCollatorMixin):
 
         output["label"] = [example["label"] for example in examples]
         return output
-
-
-# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
-# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
-# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-def _tokenize(
-    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-    input: str | list,
-    **kwargs,
-) -> dict[str, list]:
-    """Tokenize a single example for dataset preprocessing.
-
-    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-    non-conversational input (str).
-
-    Args:
-        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-            The tokenizer or processor to use.
-        input (`str` or `list`):
-            A string for non-conversational input, or a list of message dicts for conversational input.
-        **kwargs:
-            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-    Returns:
-        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-    """
-    is_vlm = isinstance(processing_class, ProcessorMixin)
-    if isinstance(input, list):  # conversational: list of message dicts
-        if is_vlm:
-            input = prepare_multimodal_messages(input)
-        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-    else:  # non-conversational: plain text string
-        result = processing_class(text=input)
-    # VLMs emit a batch dimension even for single examples; unwrap it
-    if is_vlm:
-        return {k: v[0] for k, v in result.items()}
-    return result
 
 
 class KTOTrainer(_BaseTrainer):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -49,7 +49,7 @@ from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
 from ..chat_template_utils import clone_chat_template
-from ..data_utils import get_dataset_column_names, is_conversational
+from ..data_utils import _tokenize, get_dataset_column_names, is_conversational
 from ..models import get_act_offloading_ctx_manager
 from .base_trainer import _BaseTrainer
 from .reward_config import RewardConfig
@@ -222,37 +222,6 @@ class DataCollatorForPreference(DataCollatorMixin):
         if "margin" in examples[0]:
             output["margin"] = margins
         return output
-
-
-# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
-# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
-# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-def _tokenize(
-    processing_class: PreTrainedTokenizerBase,
-    input: str | list,
-    **kwargs,
-) -> dict[str, list]:
-    """Tokenize a single example for dataset preprocessing.
-
-    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-    non-conversational input (str).
-
-    Args:
-        processing_class ([`~transformers.PreTrainedTokenizerBase`]):
-            The tokenizer to use.
-        input (`str` or `list`):
-            A string for non-conversational input, or a list of message dicts for conversational input.
-        **kwargs:
-            Forwarded to `apply_chat_template` (e.g. `tools`).
-
-    Returns:
-        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-    """
-    if isinstance(input, list):  # conversational: list of message dicts
-        result = processing_class.apply_chat_template(input, tokenize=True, return_dict=True, **kwargs)
-    else:  # non-conversational: plain text string
-        result = processing_class(text=input)
-    return result
 
 
 class RewardTrainer(_BaseTrainer):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -54,6 +54,7 @@ from ..chat_template_utils import (
     is_chat_template_stop_token_trained,
 )
 from ..data_utils import (
+    _tokenize,
     apply_chat_template,
     get_dataset_column_names,
     is_conversational,
@@ -786,49 +787,6 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
         num_items_in_batch = loss_mask.sum()
     loss = (per_token_loss * loss_mask).sum() / num_items_in_batch
     return loss
-
-
-# `_tokenize` is a module-level function rather than a trainer method so that `tokenize_fn` (the `Dataset.map`
-# callback in `_prepare_dataset`) can reference it without closing over `self`: a closure over `self` would make the
-# map function unhashable, forcing a random fingerprint that silently disables dataset caching.
-def _tokenize(
-    processing_class: PreTrainedTokenizerBase | ProcessorMixin,
-    input: str | list,
-    chat_template: str | None,
-    **kwargs,
-) -> dict[str, list]:
-    """Tokenize a single example for dataset preprocessing.
-
-    Dispatches to `apply_chat_template` for conversational input (list of message dicts) and to `__call__` for
-    non-conversational input (str). For VLMs, normalizes the batch dimension that processors emit even for single
-    examples.
-
-    Args:
-        processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`]):
-            The tokenizer or processor to use.
-        input (`str` or `list`):
-            A string for non-conversational input, or a list of message dicts for conversational input.
-        chat_template (`str` or `None`):
-            Chat template forwarded to `apply_chat_template` for conversational input.
-        **kwargs:
-            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`).
-
-    Returns:
-        `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
-    """
-    is_vlm = isinstance(processing_class, ProcessorMixin)
-    if isinstance(input, list):  # conversational: list of message dicts
-        if is_vlm:
-            input = prepare_multimodal_messages(input)
-        result = processing_class.apply_chat_template(
-            input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
-        )
-    else:  # non-conversational: plain text string
-        result = processing_class(text=input)
-    # VLMs emit a batch dimension even for single examples; unwrap it
-    if is_vlm:
-        return {k: v[0] for k, v in result.items()}
-    return result
 
 
 class SFTTrainer(_BaseTrainer):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1455,7 +1455,7 @@ class SFTTrainer(_BaseTrainer):
                             prompt_ids = _tokenize(
                                 processing_class,
                                 example["prompt"],
-                                chat_template,
+                                chat_template=chat_template,
                                 tools=tools,
                                 add_generation_prompt=True,
                                 **example.get("chat_template_kwargs", {}),
@@ -1463,7 +1463,7 @@ class SFTTrainer(_BaseTrainer):
                             prompt_completion_processed = _tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
-                                chat_template,
+                                chat_template=chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **example.get("chat_template_kwargs", {}),
@@ -1472,9 +1472,13 @@ class SFTTrainer(_BaseTrainer):
                             if "assistant_masks" in prompt_completion_processed:
                                 output["assistant_masks"] = prompt_completion_processed["assistant_masks"]
                         else:
-                            prompt_ids = _tokenize(processing_class, example["prompt"], chat_template)["input_ids"]
+                            prompt_ids = _tokenize(processing_class, example["prompt"], chat_template=chat_template)[
+                                "input_ids"
+                            ]
                             prompt_completion_ids = _tokenize(
-                                processing_class, example["prompt"] + example["completion"], chat_template
+                                processing_class,
+                                example["prompt"] + example["completion"],
+                                chat_template=chat_template,
                             )["input_ids"]
 
                         # Check if the tokenized prompt starts with the tokenized prompt+completion
@@ -1495,7 +1499,7 @@ class SFTTrainer(_BaseTrainer):
                             processed = _tokenize(
                                 processing_class,
                                 example["messages"],
-                                chat_template,
+                                chat_template=chat_template,
                                 tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **example.get("chat_template_kwargs", {}),
@@ -1503,9 +1507,9 @@ class SFTTrainer(_BaseTrainer):
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:
                             output = {
-                                "input_ids": _tokenize(processing_class, example[dataset_text_field], chat_template)[
-                                    "input_ids"
-                                ]
+                                "input_ids": _tokenize(
+                                    processing_class, example[dataset_text_field], chat_template=chat_template
+                                )["input_ids"]
                             }
 
                     if "assistant_masks" in output and 1 not in output["assistant_masks"]:


### PR DESCRIPTION
This PR replaces the four separate `_tokenize` functions in the DPO, KTO, reward, and SFT trainers with a single shared `_tokenize` in `data_utils`.

Follow-up to (required):
- [x] #6301

### Motivation

Each of the DPO, KTO, reward, and SFT trainers defines its own near-identical module-level `_tokenize` function for turning a single example into token ids. This is dataset-preprocessing logic, the same family as the helpers already centralized in `data_utils` (is_conversational, apply_chat_template, prepare_multimodal_messages), and it already depends on prepare_multimodal_messages from that module. Keeping four copies in sync is avoidable duplication.

### Solution

Add one `_tokenize` function to `data_utils` and import it in the four trainers. The shared version unifies the previously divergent signatures with is_vlm=False and chat_template=None defaults, so every trainer's existing call convention keeps working unchanged. `chat_template=None` matches apply_chat_template's own default, so it is a no-op for the trainers that never passed it, and dataset caching still produces a stable fingerprint.

### Changes

- Add a shared `_tokenize` function to data_utils, alongside the dataset-preprocessing helpers it already depends on, with is_vlm and chat_template as optional arguments so it covers all four trainers.
- Remove the module-level `_tokenize` function from the DPO, KTO, reward, and SFT trainers and import the shared helper instead.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deduplication of dataset preprocessing; behavior is intended to stay equivalent across trainers, with low blast radius outside tokenization paths.
> 
> **Overview**
> **Consolidates four near-duplicate module-level `_tokenize` helpers** (DPO, KTO, reward, SFT) into a single implementation in `data_utils`, next to related preprocessing utilities.
> 
> The shared function keeps the module-level design so `Dataset.map` callbacks stay hashable for caching. It unifies prior variants with optional `chat_template` and VLM handling (`prepare_multimodal_messages`, batch-dimension unwrap). **SFT** call sites now pass `chat_template` as a keyword argument for consistency with the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b65ef060023c9bc2203c458e6b3cedafe1e5ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->