### PR TITLE
Make doc builds faster

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2f7376e5d3e4a8857f511d932e9d8f652711e461  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
     with:
       commit_sha: ${{ github.sha }}
       package: trl

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2f7376e5d3e4a8857f511d932e9d8f652711e461  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main (light installs, no custom container)
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Companion to the doc-builder tracker: huggingface/doc-builder#802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow references change; no application or library code is touched, though doc build behavior depends on the updated shared workflow.
> 
> **Overview**
> Updates the reusable **doc-builder** workflow pins in `build_documentation.yml` and `build_pr_documentation.yml` from `2f7376e5…` to `e60a538e…`, matching [huggingface/doc-builder#802](https://github.com/huggingface/doc-builder/pull/802).
> 
> That newer revision uses **lighter installs** and **drops the custom container**, which is intended to speed up main-branch and PR documentation builds without changing TRL-specific inputs (`package: trl`, secrets, or concurrency rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5782555747a72954da3828c1098793eb28cfc679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->