### PR TITLE
Update CI huggingface/doc-builder

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2f7376e5d3e4a8857f511d932e9d8f652711e461  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
     with:
       commit_sha: ${{ github.sha }}
       package: trl

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2f7376e5d3e4a8857f511d932e9d8f652711e461  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2f7376e5d3e4a8857f511d932e9d8f652711e461  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
     with:
       package_name: trl
     secrets:


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to use a newer version of the shared `doc-builder` workflows. The reference for the reusable workflows in `.github/workflows/build_documentation.yml`, `.github/workflows/build_pr_documentation.yml`, and `.github/workflows/upload_pr_documentation.yml` has been updated to point to commit `e60a538eea9817ab312196d0d233604b01697265`.

Supersede and close #6303.

### Changes

Workflow updates:

* Updated the reusable workflow reference in `.github/workflows/build_documentation.yml` to use the latest commit of `doc-builder`.
* Updated the reusable workflow reference in `.github/workflows/build_pr_documentation.yml` to use the latest commit of `doc-builder`.
* Updated the reusable workflow reference in `.github/workflows/upload_pr_documentation.yml` to use the latest commit of `doc-builder`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only documentation workflow pin updates with no application or runtime code changes.
> 
> **Overview**
> Pins all three TRL documentation GitHub Actions workflows to a newer **`huggingface/doc-builder`** commit (`e60a538eea9817ab312196d0d233604b01697265`), replacing the previous pin (`2f7376e5d3e4a8857f511d932e9d8f652711e461`).
> 
> **`build_documentation.yml`**, **`build_pr_documentation.yml`**, and **`upload_pr_documentation.yml`** each update only the `uses:` reference for the shared reusable workflows; inputs and secrets are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab544732dede7d56f72b133b88de2f509ab48d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->