### PR TITLE
Simplify tokenization [4/N]: Bundle apply_chat_template kwargs

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -400,7 +400,7 @@ def _tokenize(
     processing_class: PreTrainedTokenizerBase | ProcessorMixin,
     input: str | list,
     chat_template: str | None = None,
-    **kwargs,
+    **apply_chat_template_kwargs,
 ) -> dict[str, list]:
     """
     Tokenize a single example for dataset preprocessing.
@@ -416,7 +416,7 @@ def _tokenize(
             A string for non-conversational input, or a list of message dicts for conversational input.
         chat_template (`str`, *optional*):
             Chat template forwarded to `apply_chat_template` for conversational input.
-        **kwargs:
+        **apply_chat_template_kwargs:
             Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`, `tools`).
 
     Returns:
@@ -427,7 +427,7 @@ def _tokenize(
         if is_vlm:
             input = prepare_multimodal_messages(input)
         result = processing_class.apply_chat_template(
-            input, tokenize=True, return_dict=True, chat_template=chat_template, **kwargs
+            input, tokenize=True, return_dict=True, chat_template=chat_template, **apply_chat_template_kwargs
         )
     else:  # non-conversational: plain text string
         result = processing_class(text=input)

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -992,26 +992,24 @@ class DPOTrainer(_BaseTrainer):
             def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
+                apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}
                 output = {}
                 if is_conversational(example):
                     prompt_ids = _tokenize(
                         processing_class,
                         example["prompt"],
-                        tools=tools,
                         add_generation_prompt=True,
-                        **example.get("chat_template_kwargs", {}),
+                        **apply_chat_template_kwargs,
                     )["input_ids"]
                     prompt_chosen_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["chosen"],
-                        tools=tools,
-                        **example.get("chat_template_kwargs", {}),
+                        **apply_chat_template_kwargs,
                     )["input_ids"]
                     prompt_rejected_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["rejected"],
-                        tools=tools,
-                        **example.get("chat_template_kwargs", {}),
+                        **apply_chat_template_kwargs,
                     )["input_ids"]
                 else:
                     prompt_ids = _tokenize(processing_class, example["prompt"])["input_ids"]

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1054,20 +1054,18 @@ class KTOTrainer(_BaseTrainer):
             def tokenize_fn(example, processing_class):
                 tools = example.get("tools")
                 tools = json.loads(tools) if isinstance(tools, str) else tools
+                apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}
                 if is_conversational(example):
-                    chat_template_kwargs = example.get("chat_template_kwargs", {})
                     prompt_ids = _tokenize(
                         processing_class,
                         example["prompt"],
-                        tools=tools,
                         add_generation_prompt=True,
-                        **chat_template_kwargs,
+                        **apply_chat_template_kwargs,
                     )["input_ids"]
                     prompt_completion_ids = _tokenize(
                         processing_class,
                         example["prompt"] + example["completion"],
-                        tools=tools,
-                        **chat_template_kwargs,
+                        **apply_chat_template_kwargs,
                     )["input_ids"]
                 else:
                     prompt_ids = _tokenize(processing_class, example["prompt"])["input_ids"]

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -636,6 +636,7 @@ class RewardTrainer(_BaseTrainer):
                 def tokenize_fn(example, processing_class):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
+                    apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}
                     if "prompt" in example:  # explicit prompt case
                         example["chosen"] = example["prompt"] + example["chosen"]
                         example["rejected"] = example["prompt"] + example["rejected"]
@@ -644,14 +645,12 @@ class RewardTrainer(_BaseTrainer):
                         chosen_ids = _tokenize(
                             processing_class,
                             example["chosen"],
-                            tools=tools,
-                            **example.get("chat_template_kwargs", {}),
+                            **apply_chat_template_kwargs,
                         )["input_ids"]
                         rejected_ids = _tokenize(
                             processing_class,
                             example["rejected"],
-                            tools=tools,
-                            **example.get("chat_template_kwargs", {}),
+                            **apply_chat_template_kwargs,
                         )["input_ids"]
                         output = {"chosen_ids": chosen_ids, "rejected_ids": rejected_ids}
                     else:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1449,6 +1449,7 @@ class SFTTrainer(_BaseTrainer):
                 def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, chat_template):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
+                    apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}
                     if "prompt" in example:  # prompt-completion case
                         output = {}
                         if is_conversational(example):
@@ -1456,17 +1457,15 @@ class SFTTrainer(_BaseTrainer):
                                 processing_class,
                                 example["prompt"],
                                 chat_template=chat_template,
-                                tools=tools,
                                 add_generation_prompt=True,
-                                **example.get("chat_template_kwargs", {}),
+                                **apply_chat_template_kwargs,
                             )["input_ids"]
                             prompt_completion_processed = _tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
                                 chat_template=chat_template,
-                                tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
-                                **example.get("chat_template_kwargs", {}),
+                                **apply_chat_template_kwargs,
                             )
                             prompt_completion_ids = prompt_completion_processed["input_ids"]
                             if "assistant_masks" in prompt_completion_processed:
@@ -1500,9 +1499,8 @@ class SFTTrainer(_BaseTrainer):
                                 processing_class,
                                 example["messages"],
                                 chat_template=chat_template,
-                                tools=tools,
                                 return_assistant_tokens_mask=assistant_only_loss,
-                                **example.get("chat_template_kwargs", {}),
+                                **apply_chat_template_kwargs,
                             )
                             output = {k: processed[k] for k in ("input_ids", "assistant_masks") if k in processed}
                         else:


### PR DESCRIPTION
This PR reduces the repeated keyword-argument plumbing in the trainers' tokenization functions and makes the forwarding contract of the shared `_tokenize` helper explicit.

Follow-up to (required):
- [x] #6302

### Motivation

In each trainer's tokenize_fn, every conversational _tokenize call repeated the same tools=tools, **example.get("chat_template_kwargs", {}) arguments. On top of that, the shared _tokenize helper collected these extra arguments in an opaque **kwargs, which did not convey that they are forwarded to apply_chat_template.

### Solution

Introduce a single apply_chat_template_kwargs local in each tokenize_fn that bundles tools and the example's chat_template_kwargs, and spread it into the _tokenize calls. Rename the _tokenize catch-all parameter to **apply_chat_template_kwargs so its purpose is self-documenting. These are readability changes only, with no behavioral difference.

### Changes

- Rename the catch-all parameter of _tokenize from **kwargs to **apply_chat_template_kwargs in data_utils, and update its docstring accordingly.
- In the DPO, KTO, reward, and SFT trainers, build one apply_chat_template_kwargs dictionary per tokenization function from tools and the example's chat_template_kwargs, and pass it to the _tokenize calls instead of repeating the arguments on each call.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Readability-only refactor with no intended behavior change; risk is limited to accidental kwargs merge order if `chat_template_kwargs` ever overlapped `tools`.
> 
> **Overview**
> Refactors how conversational dataset tokenization forwards options into `apply_chat_template`, without changing behavior.
> 
> In **`trl/data_utils.py`**, `_tokenize` renames its catch-all from `**kwargs` to **`**apply_chat_template_kwargs`** and documents that those arguments are passed through to `apply_chat_template`.
> 
> In **DPO, KTO, reward, and SFT** trainers, each `tokenize_fn` now builds one local dict—`apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}`—and spreads it into every conversational `_tokenize` call instead of repeating `tools=tools` and per-example `chat_template_kwargs` on each call. Call-specific flags such as `add_generation_prompt` or `return_assistant_tokens_mask` stay on individual `_tokenize` invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35e78a23cd908f344e4a690501f083b0c8fc82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->