### PR TITLE
Docs: fix Jobs requirement — positive credit balance, not a Pro/Team/Enterprise plan

### DIFF
--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -13,7 +13,7 @@ For general details about Hugging Face Jobs (hardware selection, job monitoring,
 
 ## Requirements
 
-* A [Pro](https://hf.co/pro), [Team](https://hf.co/enterprise), or [Enterprise](https://hf.co/enterprise) plan
+* A Hugging Face account with a positive [credit balance](https://huggingface.co/settings/billing). Jobs is pay-as-you-go—you only pay for the seconds you use.
 * Logged in to the Hugging Face Hub (`hf auth login`)
 
 ## Using TRL Jobs

--- a/docs/source/lora_without_regret.md
+++ b/docs/source/lora_without_regret.md
@@ -89,7 +89,7 @@ hf jobs uv run \
 
 ```
 
-To use Hugging Face Jobs, you will need to be logged in to the Hugging Face Hub (`hf auth login`) and have a [Pro](https://hf.co/pro), [Team](https://hf.co/enterprise), or [Enterprise](https://hf.co/enterprise) plan. Check out the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for more details.
+To use Hugging Face Jobs, log in to the Hub (`hf auth login`) and have a positive [credit balance](https://huggingface.co/settings/billing). See the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for details.
 
 </hfoption>
 <hfoption id="local">
@@ -217,7 +217,7 @@ hf jobs uv run \
     --report_to trackio
 ```
 
-To use Hugging Face Jobs, you will need to be logged in to the Hugging Face Hub (`hf auth login`) and have a [Pro](https://hf.co/pro), [Team](https://hf.co/enterprise), or [Enterprise](https://hf.co/enterprise) plan. Check out the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for more details.
+To use Hugging Face Jobs, log in to the Hub (`hf auth login`) and have a positive [credit balance](https://huggingface.co/settings/billing). See the [Jobs documentation](https://huggingface.co/docs/huggingface_hub/en/guides/jobs) for details.
 
 </hfoption>
 <hfoption id="local">


### PR DESCRIPTION
The "Requirements" section of the Jobs training docs (and the two LoRA-guide Jobs callouts) stated that a Pro/Team/Enterprise plan is required to run Hugging Face Jobs. That's no longer accurate: Jobs is pay-as-you-go and available to any account with a positive credit balance. This matches the canonical [Jobs guide](https://huggingface.co/docs/huggingface_hub/en/guides/jobs), which says Jobs are "available to any user or organization with a positive credit balance."

Changes:
- `docs/source/jobs_training.md` — Requirements bullet
- `docs/source/lora_without_regret.md` — two Jobs callouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no code, config, or runtime impact.
> 
> **Overview**
> Updates TRL documentation so **Hugging Face Jobs** eligibility matches the current Hub model: any account with a positive [credit balance](https://huggingface.co/settings/billing), not a Pro/Team/Enterprise plan.
> 
> In `jobs_training.md`, the Requirements bullet now states pay-as-you-go billing and links to billing settings. In `lora_without_regret.md`, the two Jobs callouts (SFT and GRPO) use the same requirement and shorter wording, still pointing readers to the canonical Jobs guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444e35d13142cdc3795efa7fe5648c4ed55bd9c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->