### PR TITLE
Fix precompute_ref_log_probs guard for iterable datasets nested in a dict

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import torch_device
@@ -1377,6 +1377,35 @@ class TestDPOTrainerVLM(TrlTestCase):
                 model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
                 args=training_args,
                 train_dataset=dataset,
+            )
+
+    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
+    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
+        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
+        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
+        # `IterableDatasetDict` as the eval dataset.
+        map_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        iterable_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_preference", split="train", streaming=True
+        )
+
+        train_dataset, eval_dataset = map_dataset, None
+        if iterable_as == "train":
+            train_dataset = iterable_dataset
+        elif iterable_as == "eval":
+            eval_dataset = iterable_dataset
+        elif iterable_as == "eval_dict":
+            eval_dataset = {"eval": iterable_dataset}
+        elif iterable_as == "eval_iterable_dataset_dict":
+            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
+
+        training_args = DPOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
             )
 
     @require_liger_kernel

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -889,6 +889,39 @@ class TestDPOTrainer(TrlTestCase):
                 compute_metrics=lambda _: {},
             )
 
+    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
+    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
+        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
+        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
+        # `IterableDatasetDict` as the eval dataset.
+        map_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        iterable_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_preference", split="train", streaming=True
+        )
+
+        train_dataset, eval_dataset = map_dataset, None
+        if iterable_as == "train":
+            train_dataset = iterable_dataset
+        elif iterable_as == "eval":
+            eval_dataset = iterable_dataset
+        elif iterable_as == "eval_dict":
+            eval_dataset = {"eval": iterable_dataset}
+        elif iterable_as == "eval_iterable_dataset_dict":
+            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
+
+        # `max_steps` lets the iterable-train case reach the precompute check instead of failing earlier on the
+        # missing dataset length required by the learning-rate scheduler.
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir, max_steps=1, report_to="none", precompute_ref_log_probs=True
+        )
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+            )
+
     def test_train_with_iterable_dataset(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train", streaming=True)
 
@@ -1377,35 +1410,6 @@ class TestDPOTrainerVLM(TrlTestCase):
                 model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
                 args=training_args,
                 train_dataset=dataset,
-            )
-
-    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
-    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
-        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
-        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
-        # `IterableDatasetDict` as the eval dataset.
-        map_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
-        iterable_dataset = load_dataset(
-            "trl-internal-testing/zen", "standard_preference", split="train", streaming=True
-        )
-
-        train_dataset, eval_dataset = map_dataset, None
-        if iterable_as == "train":
-            train_dataset = iterable_dataset
-        elif iterable_as == "eval":
-            eval_dataset = iterable_dataset
-        elif iterable_as == "eval_dict":
-            eval_dataset = {"eval": iterable_dataset}
-        elif iterable_as == "eval_iterable_dataset_dict":
-            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
-
-        training_args = DPOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)
-        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
-            DPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                args=training_args,
-                train_dataset=train_dataset,
-                eval_dataset=eval_dataset,
             )
 
     @require_liger_kernel

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -865,6 +865,44 @@ class TestKTOTrainer(TrlTestCase):
                 train_dataset=dataset,
             )
 
+    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
+    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
+        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
+        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
+        # `IterableDatasetDict` as the eval dataset.
+        map_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        iterable_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_unpaired_preference", split="train", streaming=True
+        )
+
+        train_dataset, eval_dataset = map_dataset, None
+        if iterable_as == "train":
+            train_dataset = iterable_dataset
+        elif iterable_as == "eval":
+            eval_dataset = iterable_dataset
+        elif iterable_as == "eval_dict":
+            eval_dataset = {"eval": iterable_dataset}
+        elif iterable_as == "eval_iterable_dataset_dict":
+            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
+
+        # `apo_zero_unpaired` avoids KTO's KL term, which (like precompute) is incompatible with streaming datasets,
+        # so the precompute error is what surfaces. `max_steps` lets the iterable-train case reach the precompute
+        # check instead of failing earlier on the missing dataset length required by the learning-rate scheduler.
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="apo_zero_unpaired",
+            max_steps=1,
+            report_to="none",
+            precompute_ref_log_probs=True,
+        )
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+            )
+
     def test_train_with_iterable_dataset(self):
         # KTO's default `kto` loss estimates the KL term from neighboring examples in a fixed-order batch, which is not
         # possible with a streaming dataset; use `apo_zero_unpaired` which does not require the KL term.
@@ -1302,35 +1340,6 @@ class TestKTOTrainerVLM(TrlTestCase):
                 model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
                 args=training_args,
                 train_dataset=dataset,
-            )
-
-    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
-    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
-        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
-        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
-        # `IterableDatasetDict` as the eval dataset.
-        map_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
-        iterable_dataset = load_dataset(
-            "trl-internal-testing/zen", "standard_unpaired_preference", split="train", streaming=True
-        )
-
-        train_dataset, eval_dataset = map_dataset, None
-        if iterable_as == "train":
-            train_dataset = iterable_dataset
-        elif iterable_as == "eval":
-            eval_dataset = iterable_dataset
-        elif iterable_as == "eval_dict":
-            eval_dataset = {"eval": iterable_dataset}
-        elif iterable_as == "eval_iterable_dataset_dict":
-            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
-
-        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)
-        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
-            KTOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                args=training_args,
-                train_dataset=train_dataset,
-                eval_dataset=eval_dataset,
             )
 
     @require_liger_kernel

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -16,7 +16,7 @@ import multiprocess
 import pytest
 import torch
 import transformers
-from datasets import load_dataset
+from datasets import IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.utils import is_peft_available
@@ -1302,6 +1302,35 @@ class TestKTOTrainerVLM(TrlTestCase):
                 model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
                 args=training_args,
                 train_dataset=dataset,
+            )
+
+    @pytest.mark.parametrize("iterable_as", ["train", "eval", "eval_dict", "eval_iterable_dataset_dict"])
+    def test_precompute_ref_log_probs_raises_for_iterable_dataset(self, iterable_as):
+        # `precompute_ref_log_probs=True` caches reference log-probs by index, which requires random access and is
+        # therefore incompatible with a streaming `IterableDataset` — whether passed directly or nested in a dict or
+        # `IterableDatasetDict` as the eval dataset.
+        map_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        iterable_dataset = load_dataset(
+            "trl-internal-testing/zen", "standard_unpaired_preference", split="train", streaming=True
+        )
+
+        train_dataset, eval_dataset = map_dataset, None
+        if iterable_as == "train":
+            train_dataset = iterable_dataset
+        elif iterable_as == "eval":
+            eval_dataset = iterable_dataset
+        elif iterable_as == "eval_dict":
+            eval_dataset = {"eval": iterable_dataset}
+        elif iterable_as == "eval_iterable_dataset_dict":
+            eval_dataset = IterableDatasetDict({"eval": iterable_dataset})
+
+        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none", precompute_ref_log_probs=True)
+        with pytest.raises(ValueError, match="precompute_ref_log_probs.*not supported with IterableDataset"):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
             )
 
     @require_liger_kernel

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -28,7 +28,7 @@ import transformers
 from accelerate import PartialState
 from accelerate.logging import get_logger
 from accelerate.utils import is_peft_model, tqdm
-from datasets import Dataset, IterableDataset, IterableDatasetDict, concatenate_datasets
+from datasets import Dataset, IterableDataset, concatenate_datasets
 from datasets.fingerprint import Hasher
 from packaging.version import Version
 from torch.utils.data import DataLoader
@@ -922,14 +922,6 @@ class DPOTrainer(_BaseTrainer):
             self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
 
         if args.precompute_ref_log_probs:
-            if isinstance(self.train_dataset, IterableDataset) or isinstance(
-                self.eval_dataset, (IterableDataset, IterableDatasetDict)
-            ):
-                raise ValueError(
-                    "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
-                    "Dataset or set `precompute_ref_log_probs=False`."
-                )
-
             self.train_dataset = self._precompute_ref_logps(
                 self.train_dataset,
                 "train",
@@ -1119,6 +1111,11 @@ class DPOTrainer(_BaseTrainer):
                 ]
 
     def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
+        if isinstance(dataset, IterableDataset):
+            raise ValueError(
+                "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
+                "Dataset or set `precompute_ref_log_probs=False`."
+            )
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -28,7 +28,7 @@ import transformers
 from accelerate import PartialState
 from accelerate.logging import get_logger
 from accelerate.utils import is_peft_model, tqdm
-from datasets import Dataset, IterableDataset, IterableDatasetDict, concatenate_datasets
+from datasets import Dataset, IterableDataset, concatenate_datasets
 from datasets.fingerprint import Hasher
 from packaging.version import Version
 from torch.utils.data import DataLoader, Sampler, SequentialSampler
@@ -927,13 +927,6 @@ class KTOTrainer(_BaseTrainer):
             self.liger_loss = LigerFusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
 
         if self.precompute_ref_logps:
-            if isinstance(self.train_dataset, IterableDataset) or isinstance(
-                self.eval_dataset, (IterableDataset, IterableDatasetDict)
-            ):
-                raise ValueError(
-                    "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
-                    "Dataset or set `precompute_ref_log_probs=False`."
-                )
             self.train_dataset = self._precompute_ref_logps(
                 self.train_dataset,
                 "train",
@@ -1203,6 +1196,11 @@ class KTOTrainer(_BaseTrainer):
         return super()._get_train_sampler(train_dataset)
 
     def _precompute_ref_logps(self, dataset: Dataset, name: str, batch_size: int) -> Dataset:
+        if isinstance(dataset, IterableDataset):
+            raise ValueError(
+                "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
+                "Dataset or set `precompute_ref_log_probs=False`."
+            )
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash, self.calculate_KL))
         cache_file = dataset._get_cache_file_path(fingerprint)


### PR DESCRIPTION
This PR makes DPOTrainer and KTOTrainer raise a clear error when `precompute_ref_log_probs=True` is used with an evaluation dataset that is a dict of `IterableDataset` or an `IterableDatasetDict`.

### Motivation

The existing guard was meant to reject iterable datasets, but it only matched a single IterableDataset. Dataset preparation rebuilds any dict into a plain dict before the guard runs, so an `IterableDatasetDict` was silently converted and a plain `dict` of `IterableDataset` was never inspected. Both cases slipped through and later failed with a confusing AttributeError about a missing _fingerprint attribute.

### Solution

Move the check into `_precompute_ref_logps`, which every dataset passes through (the train dataset, each eval dataset value, and datasets passed directly to evaluate). This raises a clear, consistent error for every iterable dataset shape and removes the separate up-front guard along with its per-type checks.

### Changes

- Move the iterable dataset rejection from the up-front guard into _precompute_ref_logps in DPOTrainer and KTOTrainer
- Remove the now unused `IterableDatasetDict` import in both trainers
- Add parametrized tests covering iterable train and eval datasets, dicts of iterable datasets, and `IterableDatasetDict`




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change with clearer errors; map-style datasets and training without precompute are unchanged.
> 
> **Overview**
> **DPOTrainer** and **KTOTrainer** now reject `precompute_ref_log_probs=True` with streaming data in all shapes that reach precompute, not only a top-level train/eval `IterableDataset`.
> 
> The old init-time guard missed iterable eval data inside a plain `dict` or an `IterableDatasetDict` (after dataset prep), which could fail later with a missing `_fingerprint` **AttributeError**. The check moves into **`_precompute_ref_logps`**, which every train/eval split passes through, so each dataset gets the same clear **ValueError**. The redundant upfront guard and **`IterableDatasetDict`** trainer imports are removed.
> 
> Parametrized tests in **`test_dpo_trainer.py`** and **`test_kto_trainer.py`** cover iterable train, eval, `{"eval": iterable}`, and **`IterableDatasetDict`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532f5426a45dfae56e7e2aa20547d7cb5790288b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->