### PR TITLE
Raise clear error when ChatML collator truncates the whole prompt

### DIFF
--- a/trl/experimental/utils.py
+++ b/trl/experimental/utils.py
@@ -377,6 +377,13 @@ class DataCollatorForChatML:
                     current_prompt_ids = tokenized_prompt["input_ids"][: len(sample_ids)]
                 byte_offsets.append(example.get("byte_offsets", [(0, 0)] * len(sample_ids)))
 
+            if len(current_prompt_ids) == 0:
+                raise ValueError(
+                    f"An example has no prompt tokens left after truncation to max_length={self.max_length}. This "
+                    "happens when the completion alone fills the whole window, so the prompt is entirely dropped, "
+                    "leaving nothing to generate from. Increase `max_length`."
+                )
+
             prompts_input_ids.append(current_prompt_ids)
             prompt_attention_mask.append([1] * len(current_prompt_ids))
 


### PR DESCRIPTION
`DataCollatorForChatML` truncates by keeping the **last** `max_length` tokens of the prompt+completion sequence. When the completion fills the whole window (e.g. long reasoning traces like OpenThoughts3-1.2M), the prompt is entirely dropped (`current_prompt_len == 0`) and the collator emits an all-padding `prompts` row.

That empty row is then passed to `model.generate` in GKD/GOLD:
- on `transformers < 5.0` it crashes with a cryptic `apply_rotary_pos_emb` size mismatch (via config-merge bug `transformers#42762`);
- on `transformers >= 5.0` it does not crash but silently generates from an empty prompt, training on garbage on-policy samples.

This PR raises a clear, actionable `ValueError` when an example is left with no prompt tokens after truncation, telling the user to increase `max_length`.

The guard lives in the shared `DataCollatorForChatML`, so it covers both GKD and GOLD. Experimental code only; stable trainers are untouched.

Closes #4725

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single validation guard in experimental shared collator; fails fast with a clear message and does not change truncation behavior when prompts remain non-empty.
> 
> **Overview**
> **`DataCollatorForChatML`** now raises a **`ValueError`** when truncation leaves an example with **no prompt tokens** (`current_prompt_len == 0`), instead of emitting an all-padding `prompts` row for on-policy `generate`.
> 
> The error explains that a completion-only window (common with long reasoning traces under a small **`max_length`**) drops the whole prompt and tells users to **increase `max_length`**. This applies on both code paths that build **`current_prompt_ids`** (fresh tokenization and precomputed **`input_ids`** / **`completion_mask`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513bbd706bb604e0d075feb16e3347dbef84f5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->