### PR TITLE
Simplify tokenization [5/N]: Pass chat_template as apply_chat_template_kwargs

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -399,7 +399,6 @@ def maybe_apply_chat_template(
 def _tokenize(
     processing_class: PreTrainedTokenizerBase | ProcessorMixin,
     input: str | list,
-    chat_template: str | None = None,
     **apply_chat_template_kwargs,
 ) -> dict[str, list]:
     """
@@ -414,10 +413,9 @@ def _tokenize(
             The tokenizer or processor to use.
         input (`str` or `list`):
             A string for non-conversational input, or a list of message dicts for conversational input.
-        chat_template (`str`, *optional*):
-            Chat template forwarded to `apply_chat_template` for conversational input.
         **apply_chat_template_kwargs:
-            Forwarded to `apply_chat_template` (e.g. `add_generation_prompt`, `return_assistant_tokens_mask`, `tools`).
+            Forwarded to `apply_chat_template` (e.g. `chat_template`, `tools`, `add_generation_prompt`,
+            `return_assistant_tokens_mask`,...).
 
     Returns:
         `dict` with at least an `"input_ids"` key mapping to a flat `list[int]`.
@@ -427,7 +425,7 @@ def _tokenize(
         if is_vlm:
             input = prepare_multimodal_messages(input)
         result = processing_class.apply_chat_template(
-            input, tokenize=True, return_dict=True, chat_template=chat_template, **apply_chat_template_kwargs
+            input, tokenize=True, return_dict=True, **apply_chat_template_kwargs
         )
     else:  # non-conversational: plain text string
         result = processing_class(text=input)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1449,21 +1449,23 @@ class SFTTrainer(_BaseTrainer):
                 def tokenize_fn(example, processing_class, dataset_text_field, assistant_only_loss, chat_template):
                     tools = example.get("tools")
                     tools = json.loads(tools) if isinstance(tools, str) else tools
-                    apply_chat_template_kwargs = {"tools": tools, **example.get("chat_template_kwargs", {})}
+                    apply_chat_template_kwargs = {
+                        "chat_template": chat_template,
+                        "tools": tools,
+                        **example.get("chat_template_kwargs", {}),
+                    }
                     if "prompt" in example:  # prompt-completion case
                         output = {}
                         if is_conversational(example):
                             prompt_ids = _tokenize(
                                 processing_class,
                                 example["prompt"],
-                                chat_template=chat_template,
                                 add_generation_prompt=True,
                                 **apply_chat_template_kwargs,
                             )["input_ids"]
                             prompt_completion_processed = _tokenize(
                                 processing_class,
                                 example["prompt"] + example["completion"],
-                                chat_template=chat_template,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **apply_chat_template_kwargs,
                             )
@@ -1498,7 +1500,6 @@ class SFTTrainer(_BaseTrainer):
                             processed = _tokenize(
                                 processing_class,
                                 example["messages"],
-                                chat_template=chat_template,
                                 return_assistant_tokens_mask=assistant_only_loss,
                                 **apply_chat_template_kwargs,
                             )


### PR DESCRIPTION
Simplify tokenization [5/N]: Pass chat_template as apply_chat_template_kwargs.

Follow-up (required):
- #6305

As suggested by @qgallouedec (https://github.com/huggingface/trl/pull/6305#discussion_r3530199547), this PR refactors how the `chat_template` argument is handled in the data preprocessing and tokenization pipeline, making the API more consistent and reducing redundancy. The main changes involve passing `chat_template` through `**apply_chat_template_kwargs` instead of as a separate argument, which simplifies function signatures and their usage.

### Changes

**Refactoring argument handling:**

* The `chat_template` parameter was removed from the `_tokenize` function signature in `trl/data_utils.py`, and is now expected to be passed via `**apply_chat_template_kwargs` for greater flexibility and consistency.
* All calls to `_tokenize` in `trl/trainer/sft_trainer.py` were updated to remove the explicit `chat_template=chat_template` argument, relying instead on `apply_chat_template_kwargs` to provide `chat_template` when needed. 
* The docstring for `_tokenize` was updated to clarify that `chat_template` and related arguments should be passed via `**apply_chat_template_kwargs`.

**Code simplification:**

* The call to `processing_class.apply_chat_template` in `_tokenize` was simplified by removing the explicit `chat_template=chat_template` argument, since it is now included in `**apply_chat_template_kwargs`.
* The construction of `apply_chat_template_kwargs` in `tokenize_fn` was updated to always include `chat_template`, ensuring it is available downstream without explicit argument passing.

These changes make the codebase easier to maintain and extend by centralizing how chat template parameters are passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small signature and call-site refactor in the SFT preprocessing path; conversational tokenization behavior should be equivalent when `chat_template` is set in the kwargs dict.
> 
> **Overview**
> Part of the tokenization simplification series: **`chat_template` is no longer a dedicated parameter on `_tokenize`** in `data_utils.py`. It is forwarded with other template options through `**apply_chat_template_kwargs` into `processing_class.apply_chat_template`.
> 
> In **`SFTTrainer`’s `tokenize_fn`**, `apply_chat_template_kwargs` is built to always include `chat_template` (along with `tools` and per-example `chat_template_kwargs`). Conversational `_tokenize` calls drop the explicit `chat_template=` argument and rely on that dict instead.
> 
> The `_tokenize` docstring is updated to document that `chat_template` belongs in the kwargs bundle. Behavior for conversational SFT preprocessing should be unchanged; the API is just aligned with how Transformers expects `apply_chat_template` arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a82142fbcc0b03300b7620cac55d6c10d17dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->