### PR TITLE
Fix Upload PR Documentation: bump doc-builder pin

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       commit_sha: ${{ github.sha }}
       package: trl

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       package_name: trl
     secrets:


### PR DESCRIPTION
The `e60a538` revision of doc-builder's `upload_pr_documentation.yml` has a bug (`uv pip install --system` hits Permission denied on the runners), which is why every "Upload PR Documentation" run currently fails, e.g. https://github.com/huggingface/trl/actions/runs/28810540691/job/85437025416. Fixed in huggingface/doc-builder#804 — this bumps all three doc-builder workflow pins to its merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to external workflow commit SHAs; no application or runtime code affected.
> 
> **Overview**
> Updates all three documentation GitHub Actions workflows to pin **huggingface/doc-builder** reusable workflows at commit `4a384d0` instead of `e60a538`.
> 
> That newer revision fixes failing **Upload PR Documentation** runs caused by `uv pip install --system` hitting permission errors on CI runners (addressed upstream in doc-builder#804). **Build documentation**, **Build PR Documentation**, and **Upload PR Documentation** now share the same pin so PR doc build/upload stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed19839c8b8ee5e44384d109d8f57cf3d0b88f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->