### PR TITLE
Fix Upload PR Documentation: bump doc-builder pin

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       commit_sha: ${{ github.sha }}
       package: trl

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@4a384d0ccdeb8502a57f1003acee938b42a5592a  # main
     with:
       package_name: trl
     secrets:


### PR DESCRIPTION
# What does this PR do?

Every "Upload PR Documentation" run currently fails (e.g. https://github.com/huggingface/trl/actions/runs/28810540691/job/85437025416): the `e60a538` revision of doc-builder's shared `upload_pr_documentation.yml` that trl pins has a bug — `uv pip install --system` hits `Permission denied` on the runners. It was fixed upstream in huggingface/doc-builder#804, and this PR bumps trl's three doc-builder workflow pins to that fix's merge commit (`4a384d0`), keeping all three consistent.

Companion to the doc-builder tracker: huggingface/doc-builder#802

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (Upstream fix: huggingface/doc-builder#804, tracker: huggingface/doc-builder#802)
- [ ] Did you make sure to update the documentation with your changes? (N/A — CI workflow pins only)
- [ ] Did you write any new necessary tests? (N/A — CI workflow pins only)

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pin bumps to shared doc-builder workflows; no application or runtime code changes.
> 
> **Overview**
> **Upload PR Documentation** was failing because trl pinned an older **huggingface/doc-builder** revision where `uv pip install --system` hit **Permission denied** on runners; upstream fixed that in doc-builder#804.
> 
> This PR moves all three reusable workflow references from `e60a538…` to **`4a384d0…`** in `build_documentation.yml`, `build_pr_documentation.yml`, and `upload_pr_documentation.yml` so main, PR build, and PR upload stay on the same doc-builder commit. `upload_pr_documentation.yml` also gets a trailing newline after the `comment_bot_secret_pem` secret line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed19839c8b8ee5e44384d109d8f57cf3d0b88f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->