### PR TITLE
Fix CI test_chatml_collator_truncates_keeping_completion_end: no prompt tokens left after truncation

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -783,7 +783,7 @@ def test_chatml_collator_truncates_keeping_completion_end(llama_tokenizer):
         }
     ]
 
-    max_length = 256
+    max_length = 512  # large enough to keep prompt tokens after the completion
     collator = DataCollatorForChatML(tokenizer=llama_tokenizer, max_length=max_length)
     batch = collator(examples)
 


### PR DESCRIPTION
Fix CI test_chatml_collator_truncates_keeping_completion_end: no prompt tokens left after truncation.

Fix #6310 (authored by @qgallouedec, approved by @kashif).

This PR fixes the CI failure of `tests/experimental/test_gold_trainer.py::test_chatml_collator_truncates_keeping_completion_end` introduced by #6310: https://github.com/huggingface/trl/actions/runs/28826425612/job/85490444959?pr=6313
> FAILED tests/experimental/test_gold_trainer.py::test_chatml_collator_truncates_keeping_completion_end - ValueError: An example has no prompt tokens left after truncation to max_length=256. This happens when the completion alone fills the whole window, so the prompt is entirely dropped, leaving nothing to generate from. Increase `max_length`.


### Context

#6310 added a guard in `DataCollatorForChatML` that raises a `ValueError` when an example has no prompt tokens left after truncation to `max_length`: a completion that fills the whole window drops the prompt entirely, leaving an all-padding `prompts` row that GOLD/GKD would then feed to `model.generate` (crash on `transformers < 5.0` via transformers#42762, garbage on-policy samples on `>= 5.0`).

The guard is correct, but this test set `max_length = 256`, which is *smaller than the test's completion alone* (~300 tokens). Keeping the last `max_length` tokens therefore dropped the whole prompt, so the guard fired and the test failed. The test was manufacturing exactly the invalid, promptless window the guard is meant to reject.

### Solution

Bumping `max_length` to `512` keeps the window large enough to retain prompt tokens after the completion, so the test again exercises keep-end truncation as intended: the rendered message (~1.1k tokens) still exceeds `max_length`, truncation still happens, and the completion end (and its byte offsets) are still preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code paths modified.
> 
> **Overview**
> Restores CI for **`test_chatml_collator_truncates_keeping_completion_end`** after #6310 added a **`DataCollatorForChatML`** guard that raises when truncation leaves **no prompt tokens** (invalid for on-policy `generate`).
> 
> The test still uses a long user + assistant example meant to assert **keep-end** truncation (~1.1k tokens vs `max_length`), but **`max_length` was 256**, smaller than the completion alone, so keep-end truncation dropped the entire prompt and tripped the new guard. **`max_length` is now 512** with a short comment so some prompt survives while the sequence still truncates and the existing assertions (final token / byte offsets) remain meaningful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a806898a548e3fd3755f36e1c4ba94b6cc0f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->