### PR TITLE
pip install -e ".[dev]" fails on macOS: liger-kernel requires triton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.
     "transformers[hub-kernels]",  # transformers < 5.1.0
 ]
 liger = [
-    "liger-kernel>=0.8.0"
+    "liger-kernel>=0.8.0; sys_platform == 'linux'",  # requires triton, which is Linux-only
 ]
 peft = [
     "peft>=0.8.0"
@@ -111,7 +111,7 @@ dev = [
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
     # liger
-    "liger-kernel>=0.8.0",
+    "liger-kernel>=0.8.0; sys_platform == 'linux'",  # requires triton, which is Linux-only
     # openreward (requires Python 3.11+)
     "openreward>=0.1.109; python_version >= '3.11'",
     # peft


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

The `liger`and `dev` extras list liger-kernel unconditionally. liger-kernel is pure Python, but requires
`triton>=2.3.1`, and triton ships manylinux wheels only, no sdist, no macOS/Windows wheels. With nothing to install and
nothing to build, the resolver fails before the install phase, so nothing lands at all.
Windows is affected too.

Skipping liger-kernel on macOS costs nothing: Triton kernels can't run there,
`is_liger_kernel_available()` already guards the runtime path, and `require_liger_kernel`
already skips the tests.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime code paths modified; Linux installs keep the same dependency set.
> 
> **Overview**
> **Fixes `pip install -e ".[dev]"` (and `.[liger]`) failing on macOS and Windows** by adding a `sys_platform == 'linux'` marker on `liger-kernel` in both the `liger` and `dev` optional dependency groups.
> 
> `liger-kernel` pulls in Triton, which only publishes Linux wheels, so unconditional inclusion made the resolver fail before any packages installed. On non-Linux platforms this matches existing behavior: Liger/Triton kernels are not usable there, and availability checks plus `require_liger_kernel` already skip runtime and test paths when the package is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18adad04f611a4caf384d423edc3ff107e2982f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->