### PR TITLE
Fix OpenEnv docker-image example bootstrap

### DIFF
--- a/examples/scripts/openenv/catch.py
+++ b/examples/scripts/openenv/catch.py
@@ -215,7 +215,6 @@ def main():
         server_process = None
         print(f"🌍 Using existing OpenSpiel Environment (Docker) at: {env_url}")
     elif args.env_mode == "docker-image":
-        # Start the container and get its URL; the rollout clients connect to it via base_url.
         provider = LocalDockerProvider()
         env_url = provider.start_container(args.env_image)
         provider.wait_for_ready(env_url)

--- a/examples/scripts/openenv/catch.py
+++ b/examples/scripts/openenv/catch.py
@@ -79,6 +79,7 @@ from pathlib import Path
 
 import requests
 from datasets import Dataset
+from openenv.core.containers.runtime import LocalDockerProvider
 from openspiel_env import OpenSpielEnv
 from openspiel_env.models import OpenSpielAction
 
@@ -93,9 +94,9 @@ def parse_args():
     parser.add_argument("--env-port", type=int, default=8001, help="Port for the environment server.")
     parser.add_argument(
         "--env-mode",
-        choices=["local", "docker-local", "docker-image", "docker-hub", "space"],
+        choices=["local", "docker-local", "docker-image", "space"],
         default="docker-image",
-        help="Where to run the environment: 'local' to launch it, 'docker-local' if already running locally, 'docker-image' to run from a Docker image, 'docker-hub' to run from Docker Hub, or 'space' to use a remote Space URL.",
+        help="Where to run the environment: 'local' to launch it, 'docker-local' if already running locally, 'docker-image' to run from a Docker image, or 'space' to use a remote Space URL.",
     )
     # --- Generation and model config ---
     parser.add_argument(
@@ -214,15 +215,12 @@ def main():
         server_process = None
         print(f"🌍 Using existing OpenSpiel Environment (Docker) at: {env_url}")
     elif args.env_mode == "docker-image":
-        _bootstrap = OpenSpielEnv.from_docker_image(args.env_image)
-        env_url = _bootstrap.base_url
+        # Start the container and get its URL; the rollout clients connect to it via base_url.
+        provider = LocalDockerProvider()
+        env_url = provider.start_container(args.env_image)
+        provider.wait_for_ready(env_url)
         server_process = None
         print("🌍 Using OpenSpiel Environment (Docker) from local Image")
-    elif args.env_mode == "docker-hub":
-        _bootstrap = OpenSpielEnv.from_hub(args.env_image)
-        env_url = _bootstrap.base_url
-        server_process = None
-        print("🌍 Using existing OpenSpiel Environment (Docker) from Hub Image")
     elif args.env_mode == "space":
         env_url = args.env_host
         server_process = None

--- a/examples/scripts/openenv/sudoku.py
+++ b/examples/scripts/openenv/sudoku.py
@@ -92,6 +92,7 @@ from datetime import datetime
 from pathlib import Path
 
 from datasets import Dataset
+from openenv.core.containers.runtime import LocalDockerProvider
 
 from trl import GRPOConfig, GRPOTrainer, RichProgressCallback
 
@@ -116,7 +117,7 @@ def parse_args() -> argparse.Namespace:
     # Environment
     parser.add_argument("--env-host", type=str, default="https://openenv-sudoku.hf.space")
     parser.add_argument("--env-port", type=int, default=8001)
-    parser.add_argument("--env-mode", choices=["docker-local", "docker-image", "docker-hub", "space"], default="space")
+    parser.add_argument("--env-mode", choices=["docker-local", "docker-image", "space"], default="space")
     parser.add_argument("--env-image", type=str, default="textarena-env:latest")
 
     # Prompts
@@ -378,11 +379,10 @@ def main() -> None:
     if args.env_mode == "docker-local":
         env_url = f"http://{args.env_host}:{args.env_port}"
     elif args.env_mode == "docker-image":
-        _bootstrap = TextArenaEnv.from_docker_image(args.env_image)
-        env_url = _bootstrap.base_url
-    elif args.env_mode == "docker-hub":
-        _bootstrap = TextArenaEnv.from_hub(args.env_image)
-        env_url = _bootstrap.base_url
+        # Start the container and get its URL; the rollout clients connect to it via base_url.
+        provider = LocalDockerProvider()
+        env_url = provider.start_container(args.env_image)
+        provider.wait_for_ready(env_url)
     elif args.env_mode == "space":
         env_url = args.env_host
     else:

--- a/examples/scripts/openenv/sudoku.py
+++ b/examples/scripts/openenv/sudoku.py
@@ -379,7 +379,6 @@ def main() -> None:
     if args.env_mode == "docker-local":
         env_url = f"http://{args.env_host}:{args.env_port}"
     elif args.env_mode == "docker-image":
-        # Start the container and get its URL; the rollout clients connect to it via base_url.
         provider = LocalDockerProvider()
         env_url = provider.start_container(args.env_image)
         provider.wait_for_ready(env_url)


### PR DESCRIPTION
# What does this PR do?

Fixes the `--env-mode docker-image` bootstrap in the OpenEnv `catch.py` and `sudoku.py` examples, broken by two OpenEnv changes:

- `from_docker_image()` is async-first, so calling it synchronously returned a coroutine (auto-detection in [OpenEnv#874](https://github.com/huggingface/OpenEnv/pull/874) covers `reset()`/`step()` but not the classmethod constructors, as noted by @burtenshaw in #6194).
- The public `EnvClient.base_url` property was removed (added in OpenEnv [`0041641c`](https://github.com/huggingface/OpenEnv/commit/0041641c), gone after the `core` refactor), so `_bootstrap.base_url` raised `AttributeError`.

The `docker-image` bootstrap only needs the container URL, so it now uses `LocalDockerProvider().start_container()` (the provider exposes a public `base_url`), mirroring OpenEnv's own [`examples/browsergym_harness_eval_common.py`](https://github.com/huggingface/OpenEnv/blob/main/examples/browsergym_harness_eval_common.py). Verified end-to-end against a local `textarena-env` container.

Also drops the `docker-hub` mode: it relied on `Env.from_hub()`, which no longer exists in OpenEnv.

Follow-up to #6194 (the `.sync()` PR, superseded by OpenEnv 0.4.0) and #6138.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Discussed in #6194.

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@burtenshaw @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only CLI and bootstrap changes; no training library or auth paths affected.
> 
> **Overview**
> Repairs **`--env-mode docker-image`** in the OpenEnv **`catch.py`** and **`sudoku.py`** GRPO examples so they work with current OpenEnv instead of broken `from_docker_image()` / `base_url` usage.
> 
> **`docker-image`** now starts the env with **`LocalDockerProvider`**: `start_container(args.env_image)` for the URL, then **`wait_for_ready(env_url)`**, matching OpenEnv’s recommended container bootstrap.
> 
> **`docker-hub`** is removed from CLI choices and setup branches because **`Env.from_hub()`** is no longer available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2994f8f1c3c44264cfa4513e34bd227b98c4b89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->