### PR TITLE
Fix stale experimental.kto docstring cross-references in KTOTrainer/KTOConfig

### DIFF
--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -22,7 +22,7 @@ from .base_config import _BaseConfig
 class KTOConfig(_BaseConfig):
     # docstyle-ignore
     r"""
-    Configuration class for the [`experimental.kto.KTOTrainer`].
+    Configuration class for the [`KTOTrainer`].
 
     This class includes only the parameters that are specific to KTO training. For a full list of training arguments,
     please refer to the [`~transformers.TrainingArguments`] documentation. Note that default values in this class may

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -499,12 +499,12 @@ class KTOTrainer(_BaseTrainer):
             - If provided, this model is used directly as the reference policy.
             - If `None`, the trainer will automatically use the initial policy corresponding to `model`, i.e. the model
               state before KTO training starts.
-        args ([`experimental.kto.KTOConfig`], *optional*):
+        args ([`KTOConfig`], *optional*):
             Configuration for this trainer. If `None`, a default configuration is used.
         data_collator ([`~transformers.DataCollator`], *optional*):
             Function to use to form a batch from a list of elements of the processed `train_dataset` or `eval_dataset`.
-            Will default to [`~experimental.kto.kto_trainer.DataCollatorForUnpairedPreference`] if the model is a
-            language model and [`~experimental.kto.kto_trainer.DataCollatorForVisionUnpairedPreference`] if the model
+            Will default to [`~trainer.kto_trainer.DataCollatorForUnpairedPreference`] if the model is a
+            language model and [`~trainer.kto_trainer.DataCollatorForVisionUnpairedPreference`] if the model
             is a vision-language model. Custom collators must truncate sequences before padding; the trainer does not
             apply post-collation truncation.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`]):


### PR DESCRIPTION
# What does this PR do?

PR #6175 promoted KTO from `trl.experimental.kto` to the stable `trl.trainer` API — it moved `kto_trainer.py`/`kto_config.py` and updated the `>>> from trl.experimental.kto import ...` code examples, but left four docstring cross-references still pointing at the old experimental path.

In `KTOTrainer.__init__`'s docstring:
```
args ([`experimental.kto.KTOConfig`], *optional*):
...
Will default to [`~experimental.kto.kto_trainer.DataCollatorForUnpairedPreference`] if the model is a
language model and [`~experimental.kto.kto_trainer.DataCollatorForVisionUnpairedPreference`] if the model
```

And in `KTOConfig`'s class docstring:
```
Configuration class for the [`experimental.kto.KTOTrainer`].
```

`trl/experimental/kto/` now contains only a deprecation shim `__init__.py` (the `kto_trainer` submodule itself was deleted), so:
- the two collator references point at a module path that no longer exists (`experimental.kto.kto_trainer` isn't importable), and
- the `KTOConfig`/`KTOTrainer` references resolve only to shim subclasses whose `__post_init__`/`__init__` raise `FutureWarning: ... Update your imports to `from trl import KTOConfig``.

So the stable class's own docstring points readers at the exact import path its own code warns against.

This PR updates all four references to the stable self-referential form, matching `DPOTrainer`'s already-correct pattern:
```
args ([`DPOConfig`], *optional*):
...
Will default to [`~trainer.dpo_trainer.DataCollatorForPreference`] if the model is a language model and
```
and
```
Configuration class for the [`DPOTrainer`].
```

Docstring-only change, no behavior change.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no code or behavior changes.
> 
> **Overview**
> After KTO moved to the stable `trl.trainer` API, **four docstring links** still pointed at `experimental.kto` paths that no longer exist or only resolve through deprecation shims.
> 
> This PR retargets them to match **`DPOTrainer` / `DPOConfig`**: `KTOConfig` now references [`KTOTrainer`]; `KTOTrainer.__init__` references [`KTOConfig`] and the default collators under [`~trainer.kto_trainer.*`]. **Docstrings only** — no runtime or API behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29942a4fb7fc0672f74592d4147310f36380da24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->