### PR TITLE
Fix incorrect arXiv link for the RLOO paper in the KL-penalty comment

### DIFF
--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1412,7 +1412,7 @@ class RLOOTrainer(_BaseTrainer):
         # Include the KL penalty in the reward
         if self.beta != 0.0:
             # RLOO uses the first-order log ratio for the per-token KL estimate, following the original RLOO paper
-            # (Ahmadian et al., 2024, https://huggingface.co/papers/2405.14782). Unlike GRPOTrainer's Schulman
+            # (Ahmadian et al., 2024, https://huggingface.co/papers/2402.14740). Unlike GRPOTrainer's Schulman
             # approximation (always >= 0), this can be negative per token. The divergence is intentional: RLOO applies
             # KL as a reward penalty (summed across tokens per sequence), while GRPO adds it to the per-token loss.
             per_token_kl = old_per_token_logps - ref_per_token_logps


### PR DESCRIPTION
## Status

Closed to reduce the uncoordinated PR backlog. I will raise an issue first if the change still needs to be revisited.

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
