### PR TITLE
Document that max_steps is required for iterable train datasets

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -461,6 +461,10 @@ class DPOTrainer(_BaseTrainer):
             - [Standard](dataset_formats#standard): Each sample contains plain text.
             - [Conversational](dataset_formats#conversational): Each sample contains structured messages (e.g., role
               and content).
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`], *optional*):

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -514,6 +514,10 @@ class KTOTrainer(_BaseTrainer):
             - [Standard](dataset_formats#standard): Each sample contains plain text.
             - [Conversational](dataset_formats#conversational): Each sample contains structured messages (e.g., role
               and content).
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`] or [`~transformers.ProcessorMixin`], *optional*):

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -273,6 +273,10 @@ class RewardTrainer(_BaseTrainer):
 
             The trainer also supports processed datasets (tokenized) as long as they contain `chosen_ids` and
             `rejected_ids` fields.
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], *optional*):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -844,6 +844,10 @@ class SFTTrainer(_BaseTrainer):
             `completion_mask` only when `completion_only_loss=True`), or default to a copy of `input_ids`. Sequences
             are truncated to `max_length` during preparation. With `skip_prepare_dataset=True`, preparation is skipped
             and the collator is expected to handle the dataset as is.
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):


### PR DESCRIPTION
This PR documents, in the trainer docstrings, that `max_steps` must be set when `train_dataset` is an iterable (streaming) dataset.

### Motivation

When `train_dataset` is an `IterableDataset`, it has no length, and Trainer raises `ValueError: The train_dataset does not implement __len__, max_steps has to be specified.` at initialization. The requirement was undocumented, so users hit the error with no upfront guidance. This is the TRL-side counterpart to the transformers PR that clarifies the same requirement:
- https://github.com/huggingface/transformers/pull/47155

### Solution

Add a note to the `train_dataset` docstring of the trainers that actually accept iterable datasets, stating that `max_steps` must be set in the training arguments. GRPO and RLOO are intentionally excluded, since they reject iterable datasets with NotImplementedError, so the note would not apply there.

### Changes

- Add the `max_steps` note to the train_dataset docstring in SFTTrainer, DPOTrainer, KTOTrainer and RewardTrainer

### TODO
First merge:
- [ ] #6322


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to trainer docstrings; no runtime or API behavior changes.
> 
> **Overview**
> Documents that **`max_steps` must be set in training arguments** when `train_dataset` is an [`IterableDataset`](https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.IterableDataset) (e.g. streaming), because length cannot be inferred and Hugging Face `Trainer` needs a fixed step count for the loop and LR scheduler.
> 
> The same note is added under **`train_dataset`** in **SFTTrainer**, **DPOTrainer**, **KTOTrainer**, and **RewardTrainer** docstrings. **GRPO** and **RLOO** are unchanged—they reject iterable datasets at runtime, so the note would not apply. This mirrors the transformers-side documentation update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e5cc059187c8cb199cb13ffc6a7d94695f43cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->