### PR TITLE
Fix incorrect examples in distillation docs

### DIFF
--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -31,7 +31,6 @@ messages). Important configuration flags on [`GOLDConfig`] include:
   sampling ratio.
 * `num_generations`, `generation_batch_size` – control buffered rollout generation across gradient accumulation windows.
   `generation_batch_size` is the number of unique prompts per worker per optimizer step.
-* `model_revision` – controls which student model revision GOLD loads for training and generation.
 
 A minimal end-to-end example:
 

--- a/docs/source/minillm_trainer.md
+++ b/docs/source/minillm_trainer.md
@@ -28,7 +28,7 @@ from trl.experimental.minillm import MiniLLMConfig
 training_args = MiniLLMConfig(
     rkl_advantage=True,
     single_step_decomposition=False,
-    gamma=False
+    gamma=0.0
 )
 ```
 

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1723,7 +1723,7 @@ training_args = GKDConfig(
 You can also use the [`GOLDTrainer`] and [`GOLDConfig`] to perform on-policy distillation with a similar configuration:
 
 ```python
-from trl.experimental import GOLDConfig
+from trl.experimental.gold import GOLDConfig
 
 config = GOLDConfig(
     lmbda=1.0, # student produces rollouts for all batches
@@ -1741,7 +1741,7 @@ MiniLLM is the first on-policy knowledge distillation method, which minimizes th
 
 It is a generalized version of [Think Machine Lab's On-Policy Distillation](https://thinkingmachines.ai/blog/on-policy-distillation/), with the option to add distribution-level single-step distillation signals (like GKD when `beta=1`) and long-context reverse KLD signals.
 
-Alternatively, you can use the [`experimental.MiniLLMTrainer`] and [`experimental.MiniLLMConfig`] to perform MiniLLM distillation as follows:
+Alternatively, you can use the [`experimental.minillm.MiniLLMTrainer`] and [`experimental.minillm.MiniLLMConfig`] to perform MiniLLM distillation as follows:
 
 ```python
 from datasets import load_dataset
@@ -1777,7 +1777,7 @@ training_args = SDPOConfig(
     use_successful_as_teacher=True,        # Use successful rollouts as teacher
     teacher_model_kind="ema",              # Supported: "base", "live", "ema"
     teacher_update_rate=0.05,              # EMA update rate
-    include_environment_feedback=False,    # Use dataset privileged_context when available
+    include_environment_feedback=True,     # required to use the dataset's privileged_context (defaults to False)
 )
 
 trainer = SDPOTrainer(

--- a/examples/scripts/sdft.py
+++ b/examples/scripts/sdft.py
@@ -48,7 +48,7 @@ python examples/scripts/sdft.py \
     --max_completion_length 512 \
     --teacher_model_kind ema \
     --teacher_sync_steps 1 \
-    --teacher_update_rate 0.01 \
+    --teacher_update_rate 0.05 \
     --eval_strategy steps \
     --eval_steps 50 \
     --report_to wandb


### PR DESCRIPTION
# What does this PR do?

Fixes several incorrect/misleading examples in the distillation documentation, all verified against the configs. Docs-only, no code changes.

1. **`paper_index.md` — GOLD snippet import fails.** `from trl.experimental import GOLDConfig` raises `ImportError` (`GOLDConfig` isn't re-exported there). Changed to `from trl.experimental.gold import GOLDConfig`, matching every other snippet and `examples/scripts/gold.py`.

2. **`paper_index.md` — SDPO snippet silently disables feedback.** The example set `include_environment_feedback=False` with the comment *"Use dataset privileged_context when available"* and lists `privileged_context` as an expected column. But the flag defaults to `False`, which gates off all environment feedback (`feedback_used_fraction=0`, `distillation_loss` stays 0) — the example looks wired up but trains on zero distillation signal. Set to `True` (matches `sdpo_trainer.md`).

3. **`paper_index.md` — broken MiniLLM cross-refs.** `[`experimental.MiniLLMTrainer`]` / `[`experimental.MiniLLMConfig`]` don't resolve; the autodoc anchors are `experimental.minillm.*` (see `minillm_trainer.md`).

4. **`gold_trainer.md` — stray config flag.** Removed `model_revision` from "configuration flags on `GOLDConfig`"; it is not a `GOLDConfig` field (only `teacher_model_revision` is) — it's a `ModelConfig`/CLI arg, so `GOLDConfig(model_revision=...)` would `TypeError`.

5. **`minillm_trainer.md` — `gamma=False` → `gamma=0.0`.** `gamma` is a `float` (default `0.0`) and the surrounding text says γ=0; `False` is type-inconsistent.

6. **`examples/scripts/sdft.py` — `--teacher_update_rate` 0.01 → 0.05.** The script used `0.01` while the `SDFTConfig` default, the `sdft_trainer.md` example, and the trainer test all use `0.05`. Aligned the script to `0.05`.

Fixes # (issue): n/a

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only edits; no library or training logic changes.
> 
> **Overview**
> Docs-only fixes so distillation examples match real TRL APIs and config fields.
> 
> **`paper_index.md`:** GOLD import is `from trl.experimental.gold import GOLDConfig` (the old `trl.experimental` import fails). MiniLLM doc links use `experimental.minillm.*` autodoc paths. The SDPO snippet sets **`include_environment_feedback=True`** so `privileged_context` is actually used (with `False`, distillation from feedback stays off).
> 
> **`gold_trainer.md`:** Drops **`model_revision`** from the `GOLDConfig` flag list—it belongs on model/CLI loading, not `GOLDConfig`.
> 
> **`minillm_trainer.md`:** Uses **`gamma=0.0`** instead of `gamma=False` for the γ=0 on-policy case.
> 
> **`examples/scripts/sdft.py`:** Example CLI uses **`--teacher_update_rate 0.05`** (was `0.01`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6b28a646599efb4d4361634b8d57c4c9f4c6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->