### PR TITLE
Set explicit neutral top_p in GKD on-policy generation

### DIFF
--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -322,6 +322,7 @@ class TestGKDTrainer(TrlTestCase):
         assert trainer.generation_config.max_new_tokens == training_args.max_new_tokens
         assert trainer.generation_config.temperature == training_args.temperature
         assert trainer.generation_config.top_k == 0
+        assert trainer.generation_config.top_p == 1.0
 
     @require_liger_kernel
     def test_compute_loss_return_outputs_with_liger(self):

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -216,6 +216,7 @@ class GKDTrainer(SFTTrainer):
             "temperature": args.temperature,
             "do_sample": True,
             "top_k": 0,
+            "top_p": 1.0,
             "use_cache": False if args.gradient_checkpointing else True,
             "pad_token_id": self.processing_class.pad_token_id,
         }


### PR DESCRIPTION
# What does this PR do?

Since transformers v5, unset `GenerationConfig` fields default to `None`, which means "inherit the value from the model's `generation_config`" (huggingface/transformers#42702). `GKDTrainer` builds its on-policy generation config with an explicit `top_k=0` but no `top_p`, so models that ship sampling defaults (e.g. Qwen3 or Gemma with `top_p=0.95`) silently truncate the on-policy sampling distribution during training.

Repro (CPU):

```python
from transformers import AutoModelForCausalLM, GenerationConfig

model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen3ForCausalLM")
model.generation_config.top_p = 0.33
generation_config = GenerationConfig(max_new_tokens=4, temperature=0.9, do_sample=True, top_k=0)
prepared, _ = model._prepare_generation_config(generation_config)
print(prepared.top_p)  # 0.33 (inherited), expected 1.0
```

This sets an explicit neutral `top_p=1.0`, completing the intent of the explicit `top_k=0` and matching the sibling trainers (PPO hardcodes `top_p: 1.0`; GOLD, Distillation, SDFT, SSD and SDPO set `top_p` explicitly from their configs).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@kashif

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to GKD training-time generation kwargs; improves consistency with intended temperature-only sampling and aligns with other TRL trainers, with no auth or data-path impact.
> 
> **Overview**
> **GKD on-policy sampling** no longer inherits the student model’s default `top_p` (e.g. 0.95 on Qwen/Gemma). `GKDTrainer` now sets **`top_p=1.0`** alongside the existing **`top_k=0`**, so transformers v5’s “unset field inherits from `model.generation_config`” behavior cannot narrow the training-time sampling distribution.
> 
> `test_generation_config_init` asserts `trainer.generation_config.top_p == 1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf75eedc31e6222627ac9fba66052b7fd14de51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

