### PR TITLE
Fix GKD vocab_size check for multimodal model configs

### DIFF
--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -323,6 +323,24 @@ class TestGKDTrainer(TrlTestCase):
         assert trainer.generation_config.temperature == training_args.temperature
         assert trainer.generation_config.top_k == 0
 
+    def test_init_multimodal_model(self):
+        """Multimodal configs keep vocab_size in their text_config; the vocab check must handle them."""
+        model_id = "trl-internal-testing/tiny-Gemma3ForConditionalGeneration"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        training_args = GKDConfig(output_dir=self.tmp_dir, report_to="none")
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling")
+
+        trainer = GKDTrainer(
+            model=model_id,
+            teacher_model=model_id,
+            args=training_args,
+            train_dataset=dataset["train"],
+            processing_class=tokenizer,
+        )
+
+        student_vocab_size = trainer.model.config.get_text_config().vocab_size
+        assert student_vocab_size == trainer.teacher_model.config.get_text_config().vocab_size
+
     @require_liger_kernel
     def test_compute_loss_return_outputs_with_liger(self):
         """Test that return_outputs=True works correctly with Liger kernel path."""

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -189,10 +189,12 @@ class GKDTrainer(SFTTrainer):
             teacher_model_init_kwargs.setdefault("trust_remote_code", args.trust_remote_code)
             teacher_model = AutoModelForCausalLM.from_pretrained(teacher_model, **teacher_model_init_kwargs)
 
-        if self.model.config.vocab_size != teacher_model.config.vocab_size:
+        student_vocab_size = self.model.config.get_text_config().vocab_size
+        teacher_vocab_size = teacher_model.config.get_text_config().vocab_size
+        if student_vocab_size != teacher_vocab_size:
             raise ValueError(
-                f"The student model has vocab_size {self.model.config.vocab_size} but the teacher model has "
-                f"vocab_size {teacher_model.config.vocab_size}. GKD compares the teacher's full next-token "
+                f"The student model has vocab_size {student_vocab_size} but the teacher model has "
+                f"vocab_size {teacher_vocab_size}. GKD compares the teacher's full next-token "
                 f"distribution, which requires a shared vocabulary. Use a teacher with the same vocab_size, or "
                 f"GOLD for cross-tokenizer distillation."
             )


### PR DESCRIPTION
# What does this PR do?

Constructing a `GKDTrainer` with a multimodal (`...ForConditionalGeneration`) model crashes at the vocab_size check introduced in #6252:

```
AttributeError: 'Gemma3Config' object has no attribute 'vocab_size'
```

Composite/multimodal configs keep `vocab_size` in their `text_config` rather than at the top level (depending on the transformers version, the top-level attribute either raises or returns `None`, which silently skips the check). This reads the value through the canonical `config.get_text_config()` accessor, which returns the config itself for text-only models, so the check now works for both.

Repro:

```python
from datasets import load_dataset
from transformers import AutoTokenizer
from trl.experimental.gkd import GKDConfig, GKDTrainer

model_id = "trl-internal-testing/tiny-Gemma3ForConditionalGeneration"
trainer = GKDTrainer(
    model=model_id,
    teacher_model=model_id,
    args=GKDConfig(output_dir="/tmp/out"),
    train_dataset=load_dataset("trl-internal-testing/zen", "conversational_language_modeling")["train"],
    processing_class=AutoTokenizer.from_pretrained(model_id),
)  # AttributeError before this PR
```

Adds a construction test with a tiny multimodal model.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@kashif

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow init-time validation change with a regression test; behavior for standard causal LMs is unchanged via get_text_config().
> 
> **Overview**
> **Fixes `GKDTrainer` initialization for multimodal / composite model configs** (e.g. `...ForConditionalGeneration`) that do not expose `vocab_size` on the top-level config.
> 
> The student–teacher **shared vocabulary guard** now reads `vocab_size` via **`config.get_text_config()`** for both models (same pattern as distillation/GOLD elsewhere in TRL). Text-only configs still work because `get_text_config()` returns the root config. Error messages use the resolved sizes.
> 
> Adds **`test_init_multimodal_model`** with `trl-internal-testing/tiny-Gemma3ForConditionalGeneration` to ensure construction succeeds and student/teacher text vocab sizes match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14170207e9500533b09338f8c84cc60ec22cc214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->