### PR TITLE
Fix FileNotFoundError in DPO/KTO precompute_ref_log_probs

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1120,6 +1120,7 @@ class DPOTrainer(_BaseTrainer):
                 batched=True,
                 remove_columns=dataset.column_names,
                 new_fingerprint=fingerprint,
+                cache_file_name=cache_file,
                 desc=f"Caching reference log probs for {name} dataset",
             )
         self.accelerator.wait_for_everyone()

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1228,6 +1228,7 @@ class KTOTrainer(_BaseTrainer):
                 batched=True,
                 remove_columns=dataset.column_names,
                 new_fingerprint=fingerprint,
+                cache_file_name=cache_file,
                 desc=f"Caching reference log probs for {name} dataset",
             )
         self.accelerator.wait_for_everyone()


### PR DESCRIPTION
## What does this PR do?

Fixes #6291. When precompute_ref_log_probs=True, the computed cache_file path wasn't passed to dataset.map(), so datasets writes to a different random path than TRL reads from -- causing FileNotFoundError. Fixed in both DPOTrainer and KTOTrainer.

## Before submitting
- [x] This PR fixes a bug
- [x] Discussed via GitHub issue: #6291
- [ ] Documentation update needed? No
- [ ] New tests needed? No

## AI writing disclosure
- [x] AI-assisted

## Who can review?
Anyone in the community.