### PR TITLE
Align log_multimodal in the DPPO and GRPO-with-replay-buffer experimental trainers

### DIFF
--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -1207,7 +1207,7 @@ class DPPOTrainer(GRPOTrainer):
             self._metrics[mode][name].append(global_mean)
         self._pending_metrics.clear()
 
-        if images is not None:
+        if images is not None and self.log_multimodal:
             self._logs["images"].extend(gather_object(images))
 
         output = {

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -396,7 +396,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             self._logs["rewards"][name].extend(rewards_per_func[:, i].tolist())
         self._logs["advantages"].extend(all_process_advantages.tolist())
 
-        if images is not None:
+        if images is not None and self.log_multimodal:
             self._logs["images"].extend(gather_object(images))
 
         if self.use_vllm and self.vllm_importance_sampling_correction:


### PR DESCRIPTION
This PR makes the `log_multimodal` option effective in the `DPPOTrainer` and `GRPOWithReplayBufferTrainer` experimental trainers.

Follow-up to:
- #5408

### Motivation

#5408 added the log_multimodal option to GRPOConfig (and RLOOConfig) to skip logging multimodal content and reduce log size. Because `DPPOConfig` and `GRPOWithReplayBufferConfig` inherit from `GRPOConfig`, the option was already exposed to users of these experimental trainers, but their trainers logged images unconditionally. As a result, setting log_multimodal=False on these configs was a silent no-op: images were still logged.

### Solution

Gate the image logging in both experimental trainers on `self.log_multimodal`, matching the pattern already used in `GRPOTrainer` and `RLOOTrainer`. Since both trainers subclass `GRPOTrainer` and call `super().__init__()`, `self.log_multimodal` is already available, so only the guard condition needs updating.

### Changes

- Gate image logging on `log_multimodal` in `DPPOTrainer`
- Gate image logging on `log_multimodal` in `GRPOWithReplayBufferTrainer`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line logging guards only; no changes to training, rewards, or multimodal forward passes.
> 
> **Overview**
> **`log_multimodal=False`** on `DPPOConfig` / `GRPOWithReplayBufferConfig` previously had no effect: both experimental trainers still pushed images into `_logs["images"]` whenever `images` was present.
> 
> Image logging in **`DPPOTrainer`** and **`GRPOWithReplayBufferTrainer`** now matches **`GRPOTrainer`**: entries are only gathered when `images is not None` **and** `self.log_multimodal` is true. Training and forward paths are unchanged; only optional completion logging is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e954f2140242470d64eba23067606e2960dd5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->