### PR TITLE
Destroy vLLM colocate mode process group after each CI test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,3 +134,22 @@ def cleanup_gpu():
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_vllm_dist_env():
+    """
+    Destroy the torch.distributed process group left behind by vLLM colocate mode after each test.
+
+    vLLM colocate mode initializes `torch.distributed` internally (`distributed_executor_backend="external_launcher"`)
+    but the offline `LLM` class never tears it down: neither `LLM` nor `LLMEngine` calls vLLM's own
+    `cleanup_dist_env_and_memory()` on exit. Left undestroyed, PyTorch warns at interpreter shutdown (e.g.
+    `TestGRPOTrainerSlow::test_vlm_processor_vllm_colocate_mode`). We call vLLM's own cleanup helper rather than a bare
+    `torch.distributed.destroy_process_group()` so that vLLM's internal parallel-state globals (`_TP`, `_WORLD`, ...)
+    are reset too, letting the next colocate test reinitialize cleanly.
+    """
+    yield
+    if torch.distributed.is_initialized():
+        from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
+        cleanup_dist_env_and_memory()


### PR DESCRIPTION
This PR adds a test fixture that cleans up the `torch.distributed` process group left behind by vLLM colocate mode after each test.

### Motivation

vLLM colocate mode (`distributed_executor_backend="external_launcher"`) initializes `torch.distributed` internally, but the offline `LLM` class never tears it down: neither `LLM` nor `LLMEngine` calls vLLM's own `cleanup_dist_env_and_memory()` on exit. Left undestroyed, PyTorch warns at interpreter shutdown:

> [rank0]:[W...] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources.

This can be reproduced on `main` today by running 
```shell
RUN_SLOW=1 pytest -sv tests/test_grpo_trainer.py::TestGRPOTrainerSlow::test_vlm_processor_vllm_colocate_mode
```

### Solution

Add an autouse pytest fixture that, after each test, destroys the process group via vLLM's own `cleanup_dist_env_and_memory()` helper (rather than a bare `torch.distributed.destroy_process_group()`), so that vLLM's internal parallel-state globals (`_TP`, `_WORLD`, ...) are reset too, letting the next colocate test reinitialize cleanly. This mirrors the pattern vLLM's own test suite uses for the same purpose.

### Changes
- Add `cleanup_vllm_dist_env` autouse fixture to `tests/conftest.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `conftest.py`; no production or training runtime behavior is modified.
> 
> **Overview**
> Adds an **autouse** pytest fixture `cleanup_vllm_dist_env` in `tests/conftest.py` that runs after every test.
> 
> When vLLM colocate mode has left `torch.distributed` initialized, the fixture calls vLLM's `cleanup_dist_env_and_memory()` instead of only `destroy_process_group()`, so internal parallel-state globals are reset and later colocate tests can start cleanly. This avoids PyTorch shutdown warnings (e.g. from `test_vlm_processor_vllm_colocate_mode`) and follows the same teardown pattern vLLM uses in its own tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df48ba287e2c3ceafab0b5a28fda27b87ded1c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->