### PR TITLE
Add support for vLLM 0.24.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.16.0` to `0.23.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.16.0` to `0.24.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.16.0,<=0.23.0",
+    "vllm>=0.16.0,<=0.24.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.23.0")):
+        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.24.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.16.0 to 0.24.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,7 +113,10 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.24.0")):
+        # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
+        # above the plain release and would otherwise fail the upper-bound check.
+        _vllm_base_version = Version(Version(_vllm_version).base_version)
+        if not (Version("0.16.0") <= _vllm_base_version <= Version("0.24.0")):
             warnings.warn(
                 f"TRL currently supports vLLM versions from 0.16.0 to 0.24.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",


### PR DESCRIPTION
**Upgrade on the cluster**

```
pip install --no-deps https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl
```

Checked the v0.24.0 release notes against the vLLM surface TRL actually uses: **No breaking changes for TRL.**

### Relevant

* **`CUDA_VISIBLE_DEVICES` no longer set internally; new `device_ids` arg (vllm#45026)**: headline breaking change. TRL colocate uses `distributed_executor_backend="external_launcher"`, so devices come from the launcher, not vLLM — unaffected. Server mode (mp/ray) is the area to watch.
* **Sampling numerics**: FP32 Gumbel sampling + `min_tokens` off-by-one fix. No API change; only relevant if an exact-match test shifts (expected, not a regression).

### Not relevant / unaffected

* Transformers v4 deprecated — TRL is already v5-aligned (`transformers>=4.56.2`).
* Models removed (ERNIE, Xverse, Dots1, Bamba, Mono-InternVL) / Qwen-gen1 deprecated — not in TRL's tests.
* `sleep`/`collective_rpc`/`load_weights`/`update_named_param`/`reload_weights`: untouched.

**Net:** safe to upgrade; no logic changes required.

### Test results

```
$ pytest tests/test_vllm_client_server.py
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.13.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.13.0, datadir-1.8.0, xdist-3.8.0, rerunfailures-15.1, cov-7.1.0
collected 51 items                                                                                                                                                               

tests/test_vllm_client_server.py ..................x..................sssssssss.....                                                                                       [100%]

================================================================================ warnings summary ================================================================================
trl/generation/__init__.py:22
  /fsx/qgallouedec/trl/trl/generation/__init__.py:22: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

trl/generation/vllm_client.py:40
  /fsx/qgallouedec/trl/trl/generation/vllm_client.py:40: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

trl/generation/vllm_generation.py:42
  /fsx/qgallouedec/trl/trl/generation/vllm_generation.py:42: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

tests/testing_utils.py:66
  /fsx/qgallouedec/trl/tests/testing_utils.py:66: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    require_vllm = pytest.mark.skipif(not is_vllm_available(), reason="test requires vllm")

tests/test_vllm_client_server.py:39
  /fsx/qgallouedec/trl/tests/test_vllm_client_server.py:39: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if is_vllm_available():

tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_int
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_string
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_torch_device
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_with_token_ids_and_image
  /fsx/qgallouedec/trl/trl/generation/vllm_client.py:132: UserWarning: TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version 0.24.0+cu129 installed. We recommend installing a supported version to avoid compatibility issues.
    if not is_vllm_available():

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 41 passed, 9 skipped, 1 xfailed, 12 warnings in 723.50s (0:12:03) ========================================================
```

(warnings are just the pre-bump "supports 0.16.0 to 0.23.0" range check firing on 0.24.0; gone after this change.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bound and documentation updates plus a small version-parsing fix; no TRL vLLM integration logic changes.
> 
> **Overview**
> Extends TRL’s supported vLLM range from **0.23.0** to **0.24.0** in docs, the `trl[vllm]` optional dependency in `pyproject.toml`, and the `is_vllm_available()` warning text.
> 
> **`is_vllm_available()`** now compares the installed version’s **`base_version`** (PEP 440) for the supported-range check so wheels like `0.24.0+cu129` are treated as 0.24.0 instead of failing the upper bound. The optional `min_version` check still uses the full reported version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b8d9cf29348aa2574e6002364ea49ff595334b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->