### PR TITLE
Fix corrupted reasoning blocks in Qwen3-family training chat templates

### DIFF
--- a/trl/chat_templates/qwen3_5_nothink_training.jinja
+++ b/trl/chat_templates/qwen3_5_nothink_training.jinja
@@ -1,7 +1,5 @@
 {#- Training variant of the Qwen3.5 chat template, NoThink flavor (see qwen3_5_nothink.jinja for the original).
     Modifications vs the original:
-    - {%- if '</think>' in content %} → {%- if '<think>' in content and '</think>' in content %}
-      Always check for both tags to avoid edge cases where the model generates only one tag.
     - Removed the loop.index0 > ns.last_query_index conditional; always include thinking block.
       This makes the template prefix-preserving for the [user, assistant] → [user, assistant, tool] transition.
     - Added {% generation %} / {% endgeneration %} around assistant message output to support
@@ -100,7 +98,7 @@
         {%- if message.reasoning_content is string %}
             {%- set reasoning_content = message.reasoning_content %}
         {%- else %}
-            {%- if '<think>' in content and '</think>' in content %}
+            {%- if '</think>' in content %}
                 {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
                 {%- set content = content.split('</think>')[-1].lstrip('\n') %}
             {%- endif %}

--- a/trl/chat_templates/qwen3_5_think_training.jinja
+++ b/trl/chat_templates/qwen3_5_think_training.jinja
@@ -1,7 +1,5 @@
 {#- Training variant of the Qwen3.5 chat template, Think flavor (see qwen3_5_think.jinja for the original).
     Modifications vs the original:
-    - {%- if '</think>' in content %} → {%- if '<think>' in content and '</think>' in content %}
-      Always check for both tags to avoid edge cases where the model generates only one tag.
     - Removed the loop.index0 > ns.last_query_index conditional; always include thinking block.
       This makes the template prefix-preserving for the [user, assistant] → [user, assistant, tool] transition.
     - Added {% generation %} / {% endgeneration %} around assistant message output to support
@@ -100,7 +98,7 @@
         {%- if message.reasoning_content is string %}
             {%- set reasoning_content = message.reasoning_content %}
         {%- else %}
-            {%- if '<think>' in content and '</think>' in content %}
+            {%- if '</think>' in content %}
                 {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
                 {%- set content = content.split('</think>')[-1].lstrip('\n') %}
             {%- endif %}

--- a/trl/chat_templates/qwen3_6_training.jinja
+++ b/trl/chat_templates/qwen3_6_training.jinja
@@ -1,7 +1,5 @@
 {#- Training variant of the Qwen3.6 chat template (see qwen3_6.jinja for the original).
     Modifications vs the original:
-    - {%- if '</think>' in content %} → {%- if '<think>' in content and '</think>' in content %}
-      Always check for both tags to avoid edge cases where the model generates only one tag.
     - Removed the loop.index0 > ns.last_query_index conditional; always include thinking block.
       This makes the template prefix-preserving for the [user, assistant] → [user, assistant, tool] transition.
     - Added {% generation %} / {% endgeneration %} around assistant message output to support
@@ -100,7 +98,7 @@
         {%- if message.reasoning_content is string %}
             {%- set reasoning_content = message.reasoning_content %}
         {%- else %}
-            {%- if '<think>' in content and '</think>' in content %}
+            {%- if '</think>' in content %}
                 {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
                 {%- set content = content.split('</think>')[-1].lstrip('\n') %}
             {%- endif %}

--- a/trl/chat_templates/qwen3_training.jinja
+++ b/trl/chat_templates/qwen3_training.jinja
@@ -1,7 +1,5 @@
 {#- Training variant of the Qwen3 chat template (see qwen3.jinja for the original).
     Modifications vs the original:
-    - {%- if '</think>' in content %} → {%- if '<think>' in content and '</think>' in content %}
-      Always check for both tags to avoid edge cases where the model generates only one tag.
     - Removed the loop.index0 > ns.last_query_index conditional; always include thinking block.
       This makes the template prefix-preserving for the [user, assistant] → [user, assistant, tool] transition.
     - Added {% generation %} / {% endgeneration %} around assistant message output to support
@@ -44,7 +42,7 @@
         {%- if message.reasoning_content is string %}
             {%- set reasoning_content = message.reasoning_content %}
         {%- else %}
-            {%- if '<think>' in content and '</think>' in content %}
+            {%- if '</think>' in content %}
                 {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
                 {%- set content = content.split('</think>')[-1].lstrip('\n') %}
             {%- endif %}


### PR DESCRIPTION
Fixes #6361.

## Problem

The Qwen3-family training templates (`qwen3`, `qwen3.5-think`, `qwen3.5-nothink`, `qwen3.6`) guarded reasoning extraction on `'<think>' in content and '</think>' in content`. But a raw self-generated response only carries the closing `</think>`. The opening `<think>` is emitted by the generation prompt, so it isn't part of the completion.

Example:

```python
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-4B")

# The generation prompt already emits the opening <think>:
prompt = tokenizer.apply_chat_template(
    [{"role": "user", "content": "What is 2+2?"}], tokenize=False, add_generation_prompt=True
)
# '<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n<think>\n'

# So the model's completion only carries the closing </think>:
completion = "2+2 equals 4.\n</think>\n\nThe answer is 4."

# Feeding that completion back for training re-renders the assistant turn:
messages = [
    {"role": "user", "content": "What is 2+2?"},
    {"role": "assistant", "content": completion},
]
print(tokenizer.apply_chat_template(messages, tokenize=False))
```

Before the fix, the reasoning was never split out and the whole turn was re-wrapped in a fresh empty `<think></think>` — an empty think block, then the reasoning, then an orphaned `</think>`:

```
<|im_start|>assistant
<think>

</think>

2+2 equals 4.
</think>

The answer is 4.<|im_end|>
```

After the fix, it renders correctly:

```
<|im_start|>assistant
<think>
2+2 equals 4.
</think>

The answer is 4.<|im_end|>
```

This is the normal shape of self-generated thinking data (SFT / distillation on model traces), and the corruption lands inside the loss-masked region, silently teaching the model a malformed format.

## Fix

Revert the guard to the original template's `'</think>' in content`. The existing `split('<think>')[-1]` already no-ops when the opening tag is absent, so every other case stays byte-identical to the original.

The both-tags guard was never actually useful: it was meant to defend against a "model emits only one tag" edge case that doesn't occur in the intended round-trip, and in doing so it broke the exact shape the split branch exists to parse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training tokenization for Qwen3-family SFT on trace-style data; wrong formatting would silently affect loss masks and what the model learns, but the fix aligns with the non-training templates and intended completion shape.
> 
> **Overview**
> Fixes corrupted assistant turns when **SFT/distillation** replays model completions that only include a closing `</think>` (the opening tag lives in the generation prompt, not in stored `content`).
> 
> In **`qwen3_training.jinja`** and the Qwen3.5/Qwen3.6 training variants, reasoning split-out again runs when **`'</think>' in content`** instead of requiring both think tags. That restores the original split logic (`split('<think>')[-1]` still handles missing open tags) so reasoning lands inside `<think>…</think>` instead of an empty think block plus a stray `</think>` inside the loss-masked region.
> 
> Header comments that described the both-tags guard are removed to match behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c21c2844c114d3e9676ed812d4e558298618086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->