### PR TITLE
Exclude zero-variance groups from GRPO loss denominator and increase your accuracy

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -682,6 +682,20 @@ training_args = GRPOConfig(
 ```
 
 
+### Adaptive Group Policy Optimization: Towards Stable Training and Token-Efficient Reasoning
+
+**📜 Paper**: https://arxiv.org/abs/2503.15952
+
+AGPO observes that GRPO's loss normalizes over all sampled completions, including those from zero-variance groups (every completion in the group received the identical reward, so the group's advantage is exactly 0 for everyone). Since these completions already contribute nothing to the loss numerator, including them in the denominator only dilutes the average, silently shrinking the effective learning rate in proportion to how many groups tie in a given batch. AGPO's loss mask excludes these zero-advantage samples from the mean operation. TRL implements this specific piece of AGPO (not the paper's other adaptive-loss / token-efficiency contributions) as the `"dapo_zv"` loss type: identical to `"dapo"` in every way except the denominator excludes zero-variance-group tokens.
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    loss_type="dapo_zv",
+)
+```
+
 ### Rethinking the Trust Region in LLM Reinforcement Learning
 
 **📜 Paper**: https://huggingface.co/papers/2602.04879

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -394,8 +394,11 @@ class TestGRPOTrainer(TrlTestCase):
         assert type(trainer.model).__name__ == "RemoteForCausalLM"
 
     @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
-    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo"])
+    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "dapo_zv", "cispo", "sapo", "luspo", "vespo"])
     def test_train_loss_types(self, loss_type, use_liger_kernel):
+        if loss_type == "dapo_zv" and use_liger_kernel:
+            pytest.skip("loss_type='dapo_zv' is not supported together with use_liger_kernel=True")
+
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -427,6 +430,144 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_dapo_zv_uses_dapo_when_no_zero_variance_groups(self):
+        """`loss_type="dapo_zv"` must be bit-identical to `"dapo"` when no group in the batch is zero-variance."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        num_generations = 3
+
+        def reward_func(prompts, completions, **kwargs):
+            # A distinct reward per row guarantees every group of `num_generations` rows has nonzero variance.
+            return [float(i) for i in range(len(completions))]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,  # 2 groups of 3, both non-zero-variance
+            num_generations=num_generations,
+            max_completion_length=8,
+            loss_type="dapo_zv",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            if "loss_dapo" not in captured:
+                with torch.no_grad():
+                    trainer.loss_type = "dapo"
+                    captured["loss_dapo"] = original_compute_loss(model, inputs).clone()
+                    trainer.loss_type = "dapo_zv"
+                    captured["loss_dapo_zv"] = original_compute_loss(model, inputs).clone()
+                captured["num_items_in_batch"] = inputs["num_items_in_batch"]
+                captured["num_items_in_batch_zv"] = inputs["num_items_in_batch_zv"]
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        assert captured["num_items_in_batch_zv"] == captured["num_items_in_batch"]
+        assert captured["loss_dapo_zv"].item() == pytest.approx(captured["loss_dapo"].item(), abs=1e-8)
+
+    def test_dapo_zv_denominator_excludes_zero_variance_groups(self):
+        """With a batch that mixes a zero-variance group and a varied group, `"dapo_zv"`'s loss must equal `"dapo"`'s
+        loss rescaled by exactly `num_items_in_batch / num_items_in_batch_zv` -- i.e. the same numerator, over a
+        denominator that excludes the zero-variance group's tokens. This checks the exact arithmetic, not just that
+        the loss value changes.
+
+        Note: this builds `inputs` by hand instead of going through real generation. Advantages are mean-centered
+        *within* a group by construction, so a complete group whose rows all have the SAME active-token count always
+        sums to exactly 0 in the loss numerator regardless of loss_type or of any bug in the denominator -- real
+        generation with this tiny, untrained model never emits an early EOS, so every row ends up at the same
+        `max_completion_length`, which would make this check vacuously "0 == 0" no matter what `dapo_zv` computes.
+        Constructing the varied group's completion_mask with UNEQUAL row lengths breaks that cancellation and makes
+        the check load-bearing.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.0,
+                num_generations=3,
+                per_device_train_batch_size=3,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        # 2 groups of 3 rows: group 0 is zero-variance (advantage 0 for every row); group 1 is varied, with
+        # DELIBERATELY unequal completion lengths (6, 3, 8) so its advantage-weighted token sum doesn't cancel.
+        prompt_ids = torch.randint(0, 8, (6, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_lens = [5, 5, 5, 6, 3, 8]
+        completion_ids = torch.randint(0, 8, (6, max(completion_lens)), device=device)
+        completion_mask = torch.zeros((6, max(completion_lens)), dtype=torch.long, device=device)
+        for i, length in enumerate(completion_lens):
+            completion_mask[i, :length] = 1
+        advantages = torch.tensor([0.0, 0.0, 0.0, -1.0, 0.0, 1.0], device=device)
+
+        num_items_in_batch = torch.tensor(float(sum(completion_lens)), device=device)
+        num_items_in_batch_zv = torch.tensor(float(sum(completion_lens[3:])), device=device)  # group 1 tokens only
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "num_items_in_batch": num_items_in_batch,
+            "num_items_in_batch_zv": num_items_in_batch_zv,
+        }
+
+        with torch.no_grad():
+            trainer.loss_type = "dapo"
+            loss_dapo = trainer._compute_loss(model, inputs).clone()
+            trainer.loss_type = "dapo_zv"
+            loss_dapo_zv = trainer._compute_loss(model, inputs).clone()
+
+        # Sanity check that the construction above actually produced a genuinely nonzero numerator (i.e. that this
+        # test isn't accidentally checking "0 == 0", as explained in the docstring).
+        assert abs(loss_dapo.item()) > 1e-6
+
+        expected_rescale = num_items_in_batch.item() / num_items_in_batch_zv.item()
+        expected_loss_dapo_zv = loss_dapo.item() * expected_rescale
+        assert loss_dapo_zv.item() == pytest.approx(expected_loss_dapo_zv, rel=1e-5)
+
+    def test_dapo_zv_raises_with_liger_kernel(self):
+        """`loss_type="dapo_zv"` has no fused-kernel equivalent yet; using it with `use_liger_kernel=True` must raise
+        a clear error at trainer construction time rather than silently mis-normalizing inside the fused kernel."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def dummy_reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            use_liger_kernel=True,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=dummy_reward_func,
+                args=training_args,
+                train_dataset=dataset,
+            )
 
     def test_train_with_eval(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -1603,7 +1744,7 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "luspo"])
+    @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "dapo_zv", "luspo"])
     def test_entropy_bonus_scale(self, loss_type):
         # Regression test: the entropy bonus is the mean per-token entropy H for every loss type (documented
         # objective L = L_policy - entropy_coef * H), so it must not inherit any loss-type-specific policy
@@ -2135,7 +2276,7 @@ class TestGRPOTrainer(TrlTestCase):
         expected_warning = "All reward functions returned None for the following kwargs:"
         assert expected_warning in caplog.text
 
-    @pytest.mark.parametrize("loss_type", ["grpo", "bnpo", "dr_grpo", "dapo", "cispo"])
+    @pytest.mark.parametrize("loss_type", ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "cispo"])
     def test_warning_raised_sequence_level_with_token_summed_loss(self, caplog, loss_type):
         """Test that a warning is raised when sequence-level importance sampling is combined with a loss type that
         sums per-token contributions (length-weighting each sequence instead of following the GSPO objective)."""

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -253,6 +253,13 @@ class GRPOConfig(_BaseConfig):
             - `"dapo"` (default): Aggregates token-level losses by normalizing with the number of active token in the
               global accumulated batch. This method was introduced in the [DAPO
               paper](https://huggingface.co/papers/2503.14476) to eliminate length bias.
+            - `"dapo_zv"`: Identical to `"dapo"` except tokens belonging to a zero-variance group (every completion
+              in the group received the identical reward, so the group's advantage is exactly 0 for everyone) are
+              excluded from the loss denominator. Those tokens already contribute exactly 0 to the numerator, so
+              this only removes their diluting effect on the average; when a batch has no zero-variance groups,
+              `"dapo_zv"` is identical to `"dapo"`. Implements the loss-mask idea from the [AGPO
+              paper](https://arxiv.org/abs/2503.15952) (their adaptive, token-efficiency-shaping loss is out
+              of scope here; only the zero-advantage exclusion is implemented).
             - `"bnpo"`: Aggregates token-level losses by normalizing with the number of active token in the local
               batch. Note that normalization is performed over the local batch only, so results may slightly vary
               depending on the local batch size, despite a constant effective batch size. When using
@@ -821,6 +828,10 @@ class GRPOConfig(_BaseConfig):
             "'vespo': Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth, "
             "asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in "
             "the [VESPO paper](https://huggingface.co/papers/2602.10693)."
+            "'dapo_zv': Identical to 'dapo' except tokens belonging to a zero-variance group (every completion in "
+            "the group received the identical reward) are excluded from the loss denominator; identical to 'dapo' "
+            "when a batch has no zero-variance groups. Implements the loss-mask idea from the AGPO paper "
+            "(https://arxiv.org/abs/2503.15952)."
         },
     )
     mask_truncated_completions: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -833,7 +833,13 @@ class GRPOTrainer(_BaseTrainer):
                 "set to `'token'` (the default)."
             )
 
-        if args.importance_sampling_level == "sequence" and args.loss_type in ["bnpo", "dr_grpo", "dapo", "cispo"]:
+        if args.importance_sampling_level == "sequence" and args.loss_type in [
+            "bnpo",
+            "dr_grpo",
+            "dapo",
+            "dapo_zv",
+            "cispo",
+        ]:
             logger.warning(
                 f"When using `importance_sampling_level='sequence'`, the `'{args.loss_type}'` loss sums per-token "
                 "contributions, which effectively weights each sequence by its completion length instead of "
@@ -939,6 +945,12 @@ class GRPOTrainer(_BaseTrainer):
 
         # Liger loss
         if self.use_liger_kernel:
+            if self.loss_type == "dapo_zv":
+                raise NotImplementedError(
+                    "`loss_type='dapo_zv'` is not supported together with `use_liger_kernel=True`: the "
+                    "zero-variance denominator mask has no fused-kernel equivalent yet. Set `use_liger_kernel=False`, "
+                    "or use a different `loss_type`."
+                )
             if not is_liger_kernel_available():
                 raise ImportError(
                     "Liger is required to use `use_liger_kernel` as the GRPO loss. Run `pip install liger-kernel`."
@@ -2581,6 +2593,22 @@ class GRPOTrainer(_BaseTrainer):
                 "'sum_then_normalize' or 'normalize_then_sum'."
             )
 
+        # Sequences belonging to a zero-variance ("dead") group -- every completion in the group received the
+        # identical combined reward, so the group's GRPO advantage is exactly 0 for every member -- already
+        # contribute nothing to the "dapo"-family loss numerator; `loss_type="dapo_zv"` additionally excludes them
+        # from the loss denominator (see `_compute_loss`). Derived directly from `rewards` (max - min over each
+        # group of `num_generations` rows), NOT from `is_std_zero` above: `is_std_zero` is only a per-GROUP signal
+        # when `scale_rewards` is `"group"` or `"none"`; under `scale_rewards="batch"` it instead answers "is the
+        # WHOLE BATCH zero-variance," which would silently degrade `dapo_zv` to plain `dapo` under that mode. This
+        # check is independent of `scale_rewards` and of `multi_objective_aggregation`, since `rewards` (the
+        # already-combined, pre-slice, per-row reward) has the same shape and grouping in both aggregation branches
+        # above. A group containing an unscorable (NaN-reward) row is conservatively treated as NOT zero-variance
+        # (NaN comparisons are always False), which matches plain "dapo" behavior for that row.
+        row_is_zero_variance = (
+            (rewards.view(-1, num_generations).amax(dim=1) - rewards.view(-1, num_generations).amin(dim=1)).abs()
+            <= 1e-6
+        ).repeat_interleave(num_generations)
+
         # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
         # so zero their advantage to keep them from moving the policy.
         advantages = torch.nan_to_num(advantages, nan=0.0)
@@ -2592,6 +2620,18 @@ class GRPOTrainer(_BaseTrainer):
         )
         all_process_advantages = advantages.clone()  # keep the aggregated advantages for logging
         advantages = advantages[process_slice]
+
+        # `num_items_in_batch_zv`: the "dapo_zv" analogue of `total_completion_tokens`/`num_items_in_batch` above
+        # (the global count of active completion tokens), restricted to non-zero-variance rows. This can't be
+        # computed alongside `num_items_in_batch` in the earlier generation helper, because the zero-variance
+        # signal requires rewards, which don't exist yet at that point. Gathering here mirrors that same
+        # gather-then-sum pattern, so it inherits the same across-`num_iterations`-reuse semantics as
+        # `num_items_in_batch` and `advantages` (both cached and reused as part of this same `output` dict).
+        local_row_is_zero_variance = row_is_zero_variance[process_slice]
+        local_contributing_tokens = (
+            completion_mask * (~local_row_is_zero_variance).to(completion_mask.dtype).unsqueeze(-1)
+        ).sum()
+        num_items_in_batch_zv = self.accelerator.gather(local_contributing_tokens.unsqueeze(0)).sum()
 
         # Calculate mean reward per function, but only for samples where the function was applied (non-NaN values)
         for i, reward_func_name in enumerate(self.reward_func_names):
@@ -2675,6 +2715,7 @@ class GRPOTrainer(_BaseTrainer):
             "completion_mask": completion_mask,
             "advantages": advantages,
             "num_items_in_batch": num_items_in_batch,
+            "num_items_in_batch_zv": num_items_in_batch_zv,
         }
         if old_per_token_logps is not None:
             output["old_per_token_logps"] = old_per_token_logps
@@ -2947,7 +2988,7 @@ class GRPOTrainer(_BaseTrainer):
         if self.loss_type == "cispo":
             clamped_ratios = torch.clamp(coef_1, max=self.epsilon_high).detach()
             per_token_loss = -clamped_ratios * advantages * per_token_logps
-        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "luspo"]:
             coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
             # Two-sided clipping
             if self.args.delta is not None:
@@ -3007,6 +3048,18 @@ class GRPOTrainer(_BaseTrainer):
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer
             policy_loss = loss.detach()
+        elif self.loss_type == "dapo_zv":
+            # Identical to "dapo" above (same per_token_loss, same numerator) except the denominator counts only
+            # tokens from non-zero-variance rows (`num_items_in_batch_zv`, gathered in
+            # `_generate_and_score_completions`). Zero-variance rows already contribute exactly 0 to the numerator
+            # (their advantage is 0), so this only removes their diluting effect on the average. The `.clamp(min=1.0)`
+            # guards the degenerate all-zero-variance batch (numerator is exactly 0 there too, so the result is a
+            # harmless 0, not a NaN); "dapo" itself has no such clamp because `num_items_in_batch` realistically
+            # never reaches 0. When there are no zero-variance groups, `num_items_in_batch_zv == num_items_in_batch`
+            # and this is bit-identical to "dapo".
+            normalizer = inputs["num_items_in_batch_zv"] / self.accelerator.num_processes
+            loss = (per_token_loss * mask).sum() / normalizer.clamp(min=1.0)
+            policy_loss = loss.detach()
         elif self.loss_type == "luspo":
             # Unless importance_sampling_level="token" (not recommended here), per_token_loss is expected to be (B, 1)
             loss = (per_token_loss * mask.sum(1, keepdim=True)).mean()
@@ -3027,8 +3080,8 @@ class GRPOTrainer(_BaseTrainer):
             # H does not depend on how each loss type normalizes its policy term. The term is computed so that
             # it accumulates to H over the optimizer step for every loss type and matches world_entropy below.
             # The only wrinkle is the normalizer: most loss types divide by the gradient accumulation step
-            # count, but cispo/dapo/vespo divide by a global token count.
-            if self.loss_type in ["cispo", "dapo", "vespo"]:
+            # count, but cispo/dapo/dapo_zv/vespo divide by a global token count.
+            if self.loss_type in ["cispo", "dapo", "dapo_zv", "vespo"]:
                 # normalizer is a global token count, so summing the entropies (instead of averaging them
                 # again) makes the term accumulate over the optimizer step to the global mean per-token
                 # entropy, like the other loss types.
@@ -3103,7 +3156,7 @@ class GRPOTrainer(_BaseTrainer):
         mean_entropy = masked_batch_mean(entropies)
         self._metrics[mode]["entropy"].append(self.accelerator.gather(mean_entropy).nanmean().item())
 
-        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "luspo"]:
             # Compute the clipped probability ratios
             is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)
             is_high_clipped = (coef_1 > 1 + self.epsilon_high) & (advantages > 0)


### PR DESCRIPTION
Adds a new opt-in GRPOConfig.loss_type value, `dapo_zv`, identical to `dapo` except that sequences belonging to a zero-variance group (every completion in the group received the identical reward, so the group's advantage is exactly 0 for everyone) are excluded from the loss denominator. The numerator is unchanged: those rows already contribute exactly 0 to it. Default ("dapo" and every other existing loss_type) is unchanged.

Implements the loss-mask idea from AGPO (arXiv:2503.15952), applied here only as the zero-advantage-exclusion piece (not AGPO's broader adaptive-loss / token-efficiency proposal).

# What does this PR do?
The denominator overcounts in many RLVR settings where there is a possibility of dead group. This PR implements a solution for it. My literature survey discovered that the same solution has been part of AGPO paper too. In my own experiments I saw better gradient dynamics and increase in accuracy when compared fairly against control and over multiple seeds.

A quick look at some other approved PRs, it seems that adding a separate loss type was a better choice. If you prefer a config change of adding a flag that affects existing losses, do let me know. I am willing to give it some time.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core GRPO loss normalization and advantage batching; mistakes could bias gradients, though default paths are untouched and behavior is heavily tested.
> 
> **Overview**
> Adds an opt-in **`GRPOConfig.loss_type="dapo_zv"`** that matches **`dapo`** policy loss and clipping, but normalizes by **`num_items_in_batch_zv`**—active completion tokens from groups where rewards are not all tied—so “dead” zero-advantage groups no longer shrink the effective learning rate. Zero-variance rows are detected from per-group reward min/max after advantages are computed; **`use_liger_kernel=True`** raises **`NotImplementedError`** at trainer init.
> 
> Existing loss types and default **`dapo`** behavior are unchanged. Docs add an AGPO paper index entry; tests cover parity with **`dapo`** when no dead groups, exact denominator rescaling, training smoke, and the Liger guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17988dead62e0feab6f6191d19b58099b691ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->