### PR TITLE
Stop overcounting dead groups and increase your accuracy

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -682,6 +682,20 @@ training_args = GRPOConfig(
 ```
 
 
+### Adaptive Group Policy Optimization: Towards Stable Training and Token-Efficient Reasoning
+
+**📜 Paper**: https://arxiv.org/abs/2503.15952
+
+AGPO observes that GRPO's loss normalizes over all sampled completions, including those from zero-variance groups (every completion in the group received the identical reward, so the group's advantage is exactly 0 for everyone). Since these completions already contribute nothing to the loss numerator, including them in the denominator only dilutes the average, silently shrinking the effective learning rate in proportion to how many groups tie in a given batch. AGPO's loss mask excludes these zero-advantage samples from the mean operation. TRL implements this specific piece of AGPO (not the paper's other adaptive-loss / token-efficiency contributions) as the `"dapo_zv"` loss type: identical to `"dapo"` in every way except the denominator excludes zero-variance-group tokens.
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    loss_type="dapo_zv",
+)
+```
+
 ### Rethinking the Trust Region in LLM Reinforcement Learning
 
 **📜 Paper**: https://huggingface.co/papers/2602.04879

--- a/tests/experimental/test_gmpo_trainer.py
+++ b/tests/experimental/test_gmpo_trainer.py
@@ -116,3 +116,25 @@ class TestGMPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_dapo_zv_raises_not_implemented(self):
+        """`loss_type="dapo_zv"` has no effect on this trainer's overridden `_compute_loss` (it never reads
+        `self.loss_type`, always computing the GMPO geometric-mean loss); using it must raise a clear error at
+        construction rather than silently ignoring the requested loss_type."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GMPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            GMPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )

--- a/tests/experimental/test_grpo_with_replay_buffer_trainer.py
+++ b/tests/experimental/test_grpo_with_replay_buffer_trainer.py
@@ -290,3 +290,29 @@ class TestGRPOWithReplayBufferTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+
+@pytest.mark.low_priority
+class TestGRPOWithReplayBufferTrainerDapoZv(TrlTestCase):
+    def test_dapo_zv_raises_not_implemented(self):
+        """`loss_type="dapo_zv"` has no defined semantics for this trainer's replay-buffer group mixing yet, and
+        its overridden `_generate_and_score_completions` never sets `num_items_in_batch_zv`; using it must raise a
+        clear error at trainer construction time rather than a bare `KeyError` at the first training step."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOWithReplayBufferConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            per_device_train_batch_size=4,
+            num_generations=4,
+            max_completion_length=8,
+            replay_buffer_size=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            GRPOWithReplayBufferTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=lambda completions, **kwargs: [0.0] * len(completions),
+                args=training_args,
+                train_dataset=dataset,
+            )

--- a/tests/experimental/test_gspo_token_trainer.py
+++ b/tests/experimental/test_gspo_token_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import pytest
 import torch
 from datasets import load_dataset
 
@@ -53,3 +54,26 @@ class TestGSPOTokenTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_dapo_zv_raises_not_implemented(self):
+        """`loss_type="dapo_zv"` has no branch in this trainer's overridden `_compute_loss` (its own
+        loss_type dispatch was never extended for it); using it must raise a clear error at trainer
+        construction time rather than a generic `ValueError("Unknown loss type")` after a full,
+        potentially expensive generation/reward pass."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            GSPOTokenTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=lambda completions, **kwargs: [0.0] * len(completions),
+                args=training_args,
+                train_dataset=dataset,
+            )

--- a/tests/experimental/test_minillm_trainer.py
+++ b/tests/experimental/test_minillm_trainer.py
@@ -50,3 +50,48 @@ class TestMiniLLMTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_dapo_zv_with_rkl_advantage_raises_not_implemented(self):
+        """`loss_type="dapo_zv"` combined with `rkl_advantage=True` (the default) must raise a clear error at
+        construction: `compute_loss` mutates `inputs["advantages"]` with a reverse-KL term AFTER
+        `num_items_in_batch_zv` has already been computed from the pre-mutation reward-tie signal, which would
+        silently break the invariant `dapo_zv`'s denominator exclusion depends on."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = MiniLLMConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            rkl_advantage=True,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            MiniLLMTrainer(
+                model="trl-internal-testing/small-Qwen3ForCausalLM",
+                teacher_model="trl-internal-testing/tiny-Qwen3ForCausalLM",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    def test_dapo_zv_without_rkl_advantage_does_not_raise(self):
+        """`loss_type="dapo_zv"` with `rkl_advantage=False` must NOT be blocked: `inputs["advantages"]` is never
+        mutated in that case, so `dapo_zv` behaves exactly as it does on the base trainer."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = MiniLLMConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            rkl_advantage=False,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        MiniLLMTrainer(
+            model="trl-internal-testing/small-Qwen3ForCausalLM",
+            teacher_model="trl-internal-testing/tiny-Qwen3ForCausalLM",
+            args=training_args,
+            train_dataset=dataset,
+        )

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -838,6 +838,79 @@ class TestGRPOTrainer(TrlTestCase):
         # 3 * 4 = 12, which is what a tool_mask-blind denominator would compute instead.
         assert captured["num_items_in_batch_zv"] == pytest.approx(6.0)
 
+    def test_dapo_zv_zero_variance_detection_correct_under_normalize_then_sum(self):
+        """Under `multi_objective_aggregation="normalize_then_sum"`, the zero-variance predicate is computed
+        from the per-row combined reward, which is itself per-group-per-function centered before being summed
+        and again globally centered when advantages are computed. A group tied on every reward function is
+        forced to a combined reward of exactly 0 by the first centering step, and the batch-wide mean subtracted
+        by the second is therefore also exactly 0 (it averages every group's already-zero group-sum) -- so the
+        group's advantage must land at 0 too, not merely have equal max/min combined reward for an unrelated
+        reason. This checks that directly: if a tied group's *advantage* ever came out nonzero here, its tokens
+        would still be (correctly) excluded from `num_items_in_batch_zv` while (incorrectly) still contributing
+        a nonzero term to the loss numerator, silently mis-scaling the loss.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        num_generations = 3
+
+        def rollout_func(prompts, trainer):
+            n = len(prompts)
+            return {
+                "prompt_ids": [[5, 6] for _ in range(n)],
+                "completion_ids": [[1, 2, 3, 4] for _ in range(n)],
+                "logprobs": [[0.0, 0.0, 0.0, 0.0] for _ in range(n)],
+            }
+
+        def reward_func1(prompts, completions, **kwargs):
+            # Group 0 (rows 0-2) tied at 5.0; group 1 (rows 3-5) varied.
+            return [5.0 if i < num_generations else float(i - num_generations) for i in range(len(completions))]
+
+        def reward_func2(prompts, completions, **kwargs):
+            # Group 0 tied at a different constant (still tied group-wide, on this function too); group 1
+            # varied with the opposite ordering, so the two functions don't cancel degenerately for group 1.
+            return [
+                3.0 if i < num_generations else float(num_generations - 1 - (i - num_generations))
+                for i in range(len(completions))
+            ]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,  # 2 groups of 3
+            num_generations=num_generations,
+            max_completion_length=8,
+            loss_type="dapo_zv",
+            beta=0.0,
+            reward_weights=[0.7, 0.3],
+            multi_objective_aggregation="normalize_then_sum",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=[reward_func1, reward_func2],
+            args=training_args,
+            train_dataset=dataset,
+            rollout_func=rollout_func,
+        )
+
+        # Call the scoring step directly with a hand-built, single-generation-call input instead of going
+        # through trainer.train(): the RepeatSampler/dataloader reorders rows across the accumulation pipeline,
+        # which would decouple "row i" from "group 0 vs group 1" and make the indexing below meaningless.
+        prompt = dataset[0]["prompt"]
+        inputs = [{"prompt": prompt} for _ in range(6)]
+        out = trainer._generate_and_score_completions(inputs)
+
+        # Every row has 4 completion tokens, all active. Group 0 is excluded: only group 1's 3 rows * 4 tokens
+        # are counted in num_items_in_batch_zv.
+        assert out["num_items_in_batch"].item() == pytest.approx(24.0)
+        assert out["num_items_in_batch_zv"].item() == pytest.approx(12.0)
+
+        group0_advantages = out["advantages"][:num_generations]
+        group1_advantages = out["advantages"][num_generations:]
+        # Load-bearing check: group 0 is genuinely tied on BOTH reward functions, so its advantage must be ~0
+        # even after normalize_then_sum's additional batch-wide centering step.
+        assert group0_advantages.abs().max().item() < 1e-4
+        # Sanity: group 1 actually has spread, so the check above isn't vacuously true for a degenerate batch.
+        assert group1_advantages.std().item() > 1e-3
+
     def test_dapo_zv_consistent_with_dapo_under_mask_truncated_completions(self):
         """`num_items_in_batch_zv` must stay on the same basis as `num_items_in_batch` with respect to
         `mask_truncated_completions`: the latter is computed in `_generate()` BEFORE truncated rows get zeroed out

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -394,8 +394,11 @@ class TestGRPOTrainer(TrlTestCase):
         assert type(trainer.model).__name__ == "RemoteForCausalLM"
 
     @pytest.mark.parametrize("use_liger_kernel", [False, pytest.param(True, marks=require_liger_kernel)])
-    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "cispo", "sapo", "luspo", "vespo"])
+    @pytest.mark.parametrize("loss_type", ["bnpo", "dr_grpo", "dapo", "dapo_zv", "cispo", "sapo", "luspo", "vespo"])
     def test_train_loss_types(self, loss_type, use_liger_kernel):
+        if loss_type == "dapo_zv" and use_liger_kernel:
+            pytest.skip("loss_type='dapo_zv' is not supported together with use_liger_kernel=True")
+
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -427,6 +430,561 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_num_items_in_batch_zv_not_computed_for_other_loss_types(self):
+        """`num_items_in_batch_zv` is only read by `loss_type="dapo_zv"`; it must not be computed (or added to the
+        `inputs` dict passed to `_compute_loss`) for any other loss type, so the extra reward-spread pass it
+        requires isn't paid unconditionally on every step regardless of `loss_type`."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            loss_type="dapo",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            captured["has_zv_key"] = "num_items_in_batch_zv" in inputs
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        assert captured["has_zv_key"] is False
+
+    def test_dapo_zv_uses_dapo_when_no_zero_variance_groups(self):
+        """`loss_type="dapo_zv"` must be bit-identical to `"dapo"` when no group in the batch is zero-variance."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        num_generations = 3
+
+        def reward_func(prompts, completions, **kwargs):
+            # A distinct reward per row guarantees every group of `num_generations` rows has nonzero variance.
+            return [float(i) for i in range(len(completions))]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,  # 2 groups of 3, both non-zero-variance
+            num_generations=num_generations,
+            max_completion_length=8,
+            loss_type="dapo_zv",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            if "loss_dapo" not in captured:
+                with torch.no_grad():
+                    trainer.loss_type = "dapo"
+                    captured["loss_dapo"] = original_compute_loss(model, inputs).clone()
+                    trainer.loss_type = "dapo_zv"
+                    captured["loss_dapo_zv"] = original_compute_loss(model, inputs).clone()
+                captured["num_items_in_batch"] = inputs["num_items_in_batch"]
+                captured["num_items_in_batch_zv"] = inputs["num_items_in_batch_zv"]
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        assert captured["num_items_in_batch_zv"] == captured["num_items_in_batch"]
+        assert captured["loss_dapo_zv"].item() == pytest.approx(captured["loss_dapo"].item(), abs=1e-8)
+
+    def test_dapo_zv_denominator_excludes_zero_variance_groups(self):
+        """With a batch that mixes a zero-variance group and a varied group, `"dapo_zv"`'s loss must equal `"dapo"`'s
+        loss rescaled by exactly `num_items_in_batch / num_items_in_batch_zv` -- i.e. the same numerator, over a
+        denominator that excludes the zero-variance group's tokens. This checks the exact arithmetic, not just that
+        the loss value changes.
+
+        Note: this builds `inputs` by hand instead of going through real generation. Advantages are mean-centered
+        *within* a group by construction, so a complete group whose rows all have the SAME active-token count always
+        sums to exactly 0 in the loss numerator regardless of loss_type or of any bug in the denominator -- real
+        generation with this tiny, untrained model never emits an early EOS, so every row ends up at the same
+        `max_completion_length`, which would make this check vacuously "0 == 0" no matter what `dapo_zv` computes.
+        Constructing the varied group's completion_mask with UNEQUAL row lengths breaks that cancellation and makes
+        the check load-bearing.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.0,
+                num_generations=3,
+                per_device_train_batch_size=3,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        # 2 groups of 3 rows: group 0 is zero-variance (advantage 0 for every row); group 1 is varied, with
+        # DELIBERATELY unequal completion lengths (6, 3, 8) so its advantage-weighted token sum doesn't cancel.
+        prompt_ids = torch.randint(0, 8, (6, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_lens = [5, 5, 5, 6, 3, 8]
+        completion_ids = torch.randint(0, 8, (6, max(completion_lens)), device=device)
+        completion_mask = torch.zeros((6, max(completion_lens)), dtype=torch.long, device=device)
+        for i, length in enumerate(completion_lens):
+            completion_mask[i, :length] = 1
+        advantages = torch.tensor([0.0, 0.0, 0.0, -1.0, 0.0, 1.0], device=device)
+
+        num_items_in_batch = torch.tensor(float(sum(completion_lens)), device=device)
+        num_items_in_batch_zv = torch.tensor(float(sum(completion_lens[3:])), device=device)  # group 1 tokens only
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "num_items_in_batch": num_items_in_batch,
+            "num_items_in_batch_zv": num_items_in_batch_zv,
+        }
+
+        with torch.no_grad():
+            trainer.loss_type = "dapo"
+            loss_dapo = trainer._compute_loss(model, inputs).clone()
+            trainer.loss_type = "dapo_zv"
+            loss_dapo_zv = trainer._compute_loss(model, inputs).clone()
+
+        # Sanity check that the construction above actually produced a genuinely nonzero numerator (i.e. that this
+        # test isn't accidentally checking "0 == 0", as explained in the docstring).
+        assert abs(loss_dapo.item()) > 1e-6
+
+        expected_rescale = num_items_in_batch.item() / num_items_in_batch_zv.item()
+        expected_loss_dapo_zv = loss_dapo.item() * expected_rescale
+        assert loss_dapo_zv.item() == pytest.approx(expected_loss_dapo_zv, rel=1e-5)
+
+    def test_dapo_zv_all_dead_batch_with_kl_matches_dapo(self):
+        """When every group in the batch is zero-variance, `num_items_in_batch_zv` is exactly 0. If `beta != 0`,
+        the per-token loss numerator is NOT zero there -- the KL term (added to `per_token_loss` before the
+        loss_type branch runs) depends only on policy-vs-reference divergence, not on advantages, so it survives
+        even though the policy term is 0. An epsilon-clamped near-zero denominator would divide that real KL sum
+        by ~0 and explode the loss/gradients; `dapo_zv` must instead fall back to `num_items_in_batch` (dapo's own,
+        always-safe denominator), matching what "dapo" itself computes for the identical batch.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.1,  # KL regularization ON -- this is what makes the bug observable
+                num_generations=3,
+                per_device_train_batch_size=3,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        prompt_ids = torch.randint(0, 8, (3, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_ids = torch.randint(0, 8, (3, 5), device=device)
+        completion_mask = torch.ones((3, 5), dtype=torch.long, device=device)
+        advantages = torch.zeros(3, device=device)  # the whole (single) group is zero-variance
+        ref_per_token_logps = torch.randn(3, 5, device=device)  # generically nonzero KL vs the policy
+
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "ref_per_token_logps": ref_per_token_logps,
+            "num_items_in_batch": torch.tensor(15.0, device=device),  # 3 rows * 5 tokens
+            "num_items_in_batch_zv": torch.tensor(0.0, device=device),  # every row is zero-variance
+        }
+
+        with torch.no_grad():
+            trainer.loss_type = "dapo"
+            loss_dapo = trainer._compute_loss(model, inputs).clone()
+            trainer.loss_type = "dapo_zv"
+            loss_dapo_zv = trainer._compute_loss(model, inputs).clone()
+
+        # Sanity check the KL term is actually doing something here (i.e. this isn't accidentally "0 == 0").
+        assert abs(loss_dapo.item()) > 1e-4
+        # dapo_zv's denominator falls back to num_items_in_batch in this degenerate case, so it must match dapo
+        # exactly. Note this equality is itself sufficient to prove no explosion: `loss_dapo` uses the ordinary,
+        # always-safe `num_items_in_batch` denominator (15.0, never near-zero) and so cannot explode -- an
+        # epsilon-clamped near-zero denominator (the old, buggy behavior) would instead have inflated this same
+        # numerator by a factor of roughly `num_items_in_batch / 1e-8` (~1.5e9x here), which this equality rules
+        # out directly, without needing a separate (and dataset-dependent) absolute-magnitude assertion.
+        assert loss_dapo_zv.item() == pytest.approx(loss_dapo.item(), rel=1e-5)
+
+    def test_dapo_zv_kl_term_not_inflated_by_zero_variance_exclusion(self):
+        """Even in a healthy (non-degenerate) batch with SOME but not all zero-variance groups, the KL/beta
+        contribution to the loss must be normalized by `num_items_in_batch` (like "dapo"), NOT the
+        ZV-restricted `num_items_in_batch_zv` -- otherwise the effective KL coefficient is silently inflated by
+        `num_items_in_batch / num_items_in_batch_zv` every time this loss_type excludes any dead group, i.e.
+        every time it's doing its job. Isolates the KL contribution via `loss(beta=0.1) - loss(beta=0.0)` and
+        checks it matches "dapo"'s for the identical batch.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.1,
+                num_generations=3,
+                per_device_train_batch_size=6,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        # 2 groups of 3 rows: group 0 is zero-variance (tied advantage 0); group 1 is varied.
+        prompt_ids = torch.randint(0, 8, (6, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_ids = torch.randint(0, 8, (6, 5), device=device)
+        completion_mask = torch.ones((6, 5), dtype=torch.long, device=device)
+        advantages = torch.tensor([0.0, 0.0, 0.0, -1.0, 0.0, 1.0], device=device)
+        ref_per_token_logps = torch.randn(6, 5, device=device)
+
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "ref_per_token_logps": ref_per_token_logps,
+            "num_items_in_batch": torch.tensor(30.0, device=device),  # 6 rows * 5 tokens
+            "num_items_in_batch_zv": torch.tensor(15.0, device=device),  # group 1 tokens only
+        }
+
+        def kl_contribution(loss_type):
+            trainer.loss_type = loss_type
+            with torch.no_grad():
+                trainer.beta = 0.0
+                loss_no_kl = trainer._compute_loss(model, inputs).clone()
+                trainer.beta = 0.1
+                loss_with_kl = trainer._compute_loss(model, inputs).clone()
+            return (loss_with_kl - loss_no_kl).item()
+
+        contribution_dapo = kl_contribution("dapo")
+        contribution_dapo_zv = kl_contribution("dapo_zv")
+
+        assert abs(contribution_dapo) > 1e-6  # sanity: the KL term is actually doing something here
+        assert contribution_dapo_zv == pytest.approx(contribution_dapo, rel=1e-5)
+
+    def test_dapo_zv_raises_with_liger_kernel(self):
+        """`loss_type="dapo_zv"` has no fused-kernel equivalent yet; using it with `use_liger_kernel=True` must raise
+        a clear error at trainer construction time rather than silently mis-normalizing inside the fused kernel."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def dummy_reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="dapo_zv",
+            use_liger_kernel=True,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="dapo_zv"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=dummy_reward_func,
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    def test_dapo_zv_entropy_bonus_uses_full_token_count(self):
+        """The entropy bonus (`entropy_coef`) is documented as the mean per-token entropy over ALL active
+        completion tokens, independent of how each loss type normalizes its policy term. For `"dapo_zv"` it must
+        therefore be scaled by `num_items_in_batch`, NOT the zero-variance-restricted `num_items_in_batch_zv` used
+        for the policy loss. Isolates the entropy contribution via `loss(no entropy) - loss(with entropy)` and
+        checks it matches `"dapo"` for an identical batch where `num_items_in_batch_zv != num_items_in_batch`
+        (i.e. a genuine zero-variance group is present).
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.0,
+                entropy_coef=0.5,
+                num_generations=3,
+                per_device_train_batch_size=3,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        prompt_ids = torch.randint(0, 8, (3, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_ids = torch.randint(0, 8, (3, 5), device=device)
+        completion_mask = torch.ones((3, 5), dtype=torch.long, device=device)
+        advantages = torch.zeros(3, device=device)  # a single, entirely zero-variance group
+
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "num_items_in_batch": torch.tensor(15.0, device=device),  # 3 rows * 5 tokens
+            "num_items_in_batch_zv": torch.tensor(0.0, device=device),  # whole group is zero-variance
+        }
+
+        def entropy_contribution(loss_type):
+            trainer.loss_type = loss_type
+            with torch.no_grad():
+                trainer._entropy_bonus_enabled = False
+                loss_no_entropy = trainer._compute_loss(model, inputs).clone()
+                trainer._entropy_bonus_enabled = True
+                loss_with_entropy = trainer._compute_loss(model, inputs).clone()
+            return (loss_no_entropy - loss_with_entropy).item()
+
+        contribution_dapo = entropy_contribution("dapo")
+        contribution_dapo_zv = entropy_contribution("dapo_zv")
+
+        assert abs(contribution_dapo) > 1e-8  # sanity: the entropy term is actually nonzero here
+        assert contribution_dapo_zv == pytest.approx(contribution_dapo, rel=1e-5)
+
+    def test_dapo_zv_denominator_is_tool_mask_aware(self):
+        """`num_items_in_batch_zv` must exclude tool-result tokens the same way `num_items_in_batch` and the
+        `_compute_loss` numerator do, so a multi-turn batch with `tool_mask` doesn't skew `"dapo_zv"`'s
+        normalization relative to `"dapo"`'s.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        num_generations = 3
+
+        def rollout_func(prompts, trainer):
+            n = len(prompts)
+            return {
+                "prompt_ids": [[5, 6] for _ in range(n)],
+                "completion_ids": [[1, 2, 3, 4] for _ in range(n)],
+                "logprobs": [[0.0, 0.0, 0.0, 0.0] for _ in range(n)],
+                # Last two tokens of every completion are tool-result tokens (masked out of the loss).
+                "env_mask": [[1, 1, 0, 0] for _ in range(n)],
+            }
+
+        def reward_func(prompts, completions, **kwargs):
+            # Group 0 (rows 0-2) is tied -> zero-variance, excluded. Group 1 (rows 3-5) is varied -> kept.
+            return [5.0 if i < num_generations else float(i - num_generations) for i in range(len(completions))]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,  # 2 groups of 3
+            num_generations=num_generations,
+            max_completion_length=8,
+            loss_type="dapo_zv",
+            beta=0.0,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            rollout_func=rollout_func,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            if "num_items_in_batch" not in captured:
+                captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
+                captured["num_items_in_batch_zv"] = inputs["num_items_in_batch_zv"].item()
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        # Every row has 4 raw completion tokens but only 2 tool_mask-active tokens (env_mask = [1, 1, 0, 0]).
+        # num_items_in_batch counts active tokens from all 6 rows: 6 * 2 = 12.
+        assert captured["num_items_in_batch"] == pytest.approx(12.0)
+        # num_items_in_batch_zv must count active tokens from only the kept group 1 rows: 3 * 2 = 6 -- NOT
+        # 3 * 4 = 12, which is what a tool_mask-blind denominator would compute instead.
+        assert captured["num_items_in_batch_zv"] == pytest.approx(6.0)
+
+    def test_dapo_zv_consistent_with_dapo_under_mask_truncated_completions(self):
+        """`num_items_in_batch_zv` must stay on the same basis as `num_items_in_batch` with respect to
+        `mask_truncated_completions`: the latter is computed in `_generate()` BEFORE truncated rows get zeroed out
+        of `completion_mask`, so if `num_items_in_batch_zv` were computed from the (already zeroed) `completion_mask`
+        instead, the two would diverge even with zero zero-variance groups, breaking "no zero-variance groups =>
+        bit-identical to dapo". Uses a very short `max_completion_length` so the untrained model reliably produces
+        truncated (non-EOS) completions, and a reward func giving every row a distinct value so no group is
+        genuinely zero-variance.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func(prompts, completions, **kwargs):
+            return [float(i) for i in range(len(completions))]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,
+            num_generations=3,
+            max_completion_length=4,  # short enough that the untrained model won't emit EOS in time
+            mask_truncated_completions=True,
+            loss_type="dapo_zv",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            if "num_items_in_batch" not in captured:
+                captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
+                captured["num_items_in_batch_zv"] = inputs["num_items_in_batch_zv"].item()
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        assert captured["num_items_in_batch_zv"] == pytest.approx(captured["num_items_in_batch"])
+
+    def test_dapo_zv_matches_dapo_when_normalizer_is_below_one(self):
+        """The `dapo_zv` normalizer clamp exists only to guard the degenerate all-zero-variance batch (denominator
+        exactly 0); it must NOT engage for a genuinely nonzero-but-small `num_items_in_batch_zv` (e.g. a tiny
+        multi-process batch), or `dapo_zv` silently diverges from `dapo` for a reason unrelated to zero-variance
+        exclusion. Directly constructs a normalizer below 1.0 (as `num_items_in_batch / num_processes` can be for a
+        small enough batch on many processes) with a genuinely varied group (no zero-variance rows), so
+        `num_items_in_batch_zv == num_items_in_batch` and `dapo_zv` must be bit-identical to `dapo`.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda prompts, completions, **kwargs: [0.0] * len(completions),
+            args=GRPOConfig(
+                output_dir=self.tmp_dir,
+                loss_type="dapo_zv",
+                beta=0.0,
+                num_generations=3,
+                per_device_train_batch_size=3,
+                report_to="none",
+            ),
+            train_dataset=dataset,
+        )
+        model = trainer.model
+        device = model.device
+        torch.manual_seed(0)
+
+        prompt_ids = torch.randint(0, 8, (3, 4), device=device)
+        prompt_mask = torch.ones_like(prompt_ids)
+        completion_ids = torch.randint(0, 8, (3, 5), device=device)
+        completion_mask = torch.ones((3, 5), dtype=torch.long, device=device)
+        advantages = torch.tensor([-1.0, 0.0, 1.0], device=device)  # genuinely varied group, no zero-variance rows
+
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "num_items_in_batch": torch.tensor(0.5, device=device),
+            "num_items_in_batch_zv": torch.tensor(0.5, device=device),  # equal: no rows excluded
+        }
+
+        with torch.no_grad():
+            trainer.loss_type = "dapo"
+            loss_dapo = trainer._compute_loss(model, inputs).clone()
+            trainer.loss_type = "dapo_zv"
+            loss_dapo_zv = trainer._compute_loss(model, inputs).clone()
+
+        assert loss_dapo_zv.item() == pytest.approx(loss_dapo.item(), rel=1e-5)
+
+    def test_dapo_zv_excludes_tied_rows_when_group_has_unscorable_row(self):
+        """A group with an unscorable (NaN-reward) row must still exclude its OTHER, genuinely tied members from
+        the `dapo_zv` denominator. `torch.amax`/`amin` propagate NaN, so without NaN-safe handling, one NaN row
+        anywhere in a group silently keeps the WHOLE group -- including tied, zero-numerator-contribution rows --
+        in the denominator.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        num_generations = 3
+
+        def reward_func(prompts, completions, **kwargs):
+            n = len(completions)
+            rewards = []
+            for i in range(n):
+                if i < num_generations:
+                    # Group 0: rows 0 and 1 tied at 1.0; row 2 is unscorable (None -> NaN).
+                    rewards.append(None if i == 2 else 1.0)
+                else:
+                    # Group 1: varied -> genuinely non-zero-variance, stays fully in the denominator.
+                    rewards.append(float(i - num_generations))
+            return rewards
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=6,
+            num_generations=num_generations,
+            max_completion_length=8,
+            loss_type="dapo_zv",
+            beta=0.0,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def spy_compute_loss(model, inputs):
+            if "completion_mask" not in captured:
+                captured["completion_mask"] = inputs["completion_mask"].clone()
+                captured["num_items_in_batch_zv"] = inputs["num_items_in_batch_zv"].item()
+            return original_compute_loss(model, inputs)
+
+        trainer._compute_loss = spy_compute_loss
+        trainer.train()
+
+        # Single-process test: local rows 3-5 are group 1. num_items_in_batch_zv must equal EXACTLY group 1's
+        # token count -- i.e. group 0's rows (0, 1, and the unscorable row 2) are all excluded, not just row 2.
+        group1_tokens = captured["completion_mask"][3:6].sum().item()
+        assert captured["num_items_in_batch_zv"] == pytest.approx(group1_tokens)
 
     def test_train_with_eval(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
@@ -1603,7 +2161,7 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "luspo"])
+    @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "dapo_zv", "luspo"])
     def test_entropy_bonus_scale(self, loss_type):
         # Regression test: the entropy bonus is the mean per-token entropy H for every loss type (documented
         # objective L = L_policy - entropy_coef * H), so it must not inherit any loss-type-specific policy
@@ -2135,7 +2693,7 @@ class TestGRPOTrainer(TrlTestCase):
         expected_warning = "All reward functions returned None for the following kwargs:"
         assert expected_warning in caplog.text
 
-    @pytest.mark.parametrize("loss_type", ["grpo", "bnpo", "dr_grpo", "dapo", "cispo"])
+    @pytest.mark.parametrize("loss_type", ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "cispo"])
     def test_warning_raised_sequence_level_with_token_summed_loss(self, caplog, loss_type):
         """Test that a warning is raised when sequence-level importance sampling is combined with a loss type that
         sums per-token contributions (length-weighting each sequence instead of following the GSPO objective)."""

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -38,6 +38,16 @@ class GMPOTrainer(GRPOTrainer):
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             args = GMPOConfig(f"{model_name.split('/')[-1]}-GMPO")
 
+        # `_compute_loss` below never reads `self.loss_type` -- it always computes the GMPO geometric-mean loss
+        # regardless of `loss_type`, so `loss_type="dapo_zv"` would silently train with plain GMPO instead of
+        # the requested zero-variance-excluding behavior, with no error or warning. Checked before the
+        # expensive `super().__init__` below, same as the other GRPOTrainer subclasses with a comparable gap.
+        if args.loss_type == "dapo_zv":
+            raise NotImplementedError(
+                "`loss_type='dapo_zv'` is not supported by `GMPOTrainer`: `_compute_loss` here always computes "
+                "the GMPO geometric-mean loss and never reads `loss_type`. Use a different `loss_type`."
+            )
+
         super().__init__(model, reward_funcs, args=args, **kwargs)
 
     def _compute_loss(self, model, inputs):

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -60,6 +60,15 @@ class ReplayBuffer:
 
 class GRPOWithReplayBufferTrainer(GRPOTrainer):
     def __init__(self, args: GRPOWithReplayBufferConfig | None = None, **kwargs):
+        # Checked on `args.loss_type` (not `self.loss_type`) so this fails fast, before paying for the full
+        # GRPOTrainer construction (model load, accelerator/optimizer prep) that `super().__init__` below does.
+        if args is not None and args.loss_type == "dapo_zv":
+            raise NotImplementedError(
+                "`loss_type='dapo_zv'` is not supported by `GRPOWithReplayBufferTrainer`: this trainer fully "
+                "reimplements `_generate_and_score_completions` (it does not call the base class's version) and "
+                "never populates `num_items_in_batch_zv`, and the replay buffer's group-composition mixing has no "
+                "defined zero-variance-group semantics yet. Use a different `loss_type`."
+            )
         super().__init__(args=args, **kwargs)
         self.replay_buffer = ReplayBuffer(args.replay_buffer_size) if args.replay_buffer_size > 0 else None
 

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -14,11 +14,26 @@
 
 import torch
 
+from ...trainer.grpo_config import GRPOConfig
 from ...trainer.grpo_trainer import GRPOTrainer as _GRPOTrainer
 from ...trainer.utils import nanmax, nanmin
 
 
 class GRPOTrainer(_GRPOTrainer):
+    def __init__(self, args: GRPOConfig | None = None, **kwargs):
+        # Checked on `args.loss_type` (not `self.loss_type`) so this fails fast, before paying for the full
+        # GRPOTrainer construction (model load, accelerator/optimizer prep) that `super().__init__` below does --
+        # and before a full (expensive) generation/reward pass, since `_generate_and_score_completions` is
+        # inherited unchanged from the base trainer and would otherwise run before this class's own
+        # `_compute_loss` override discovers it has no "dapo_zv" branch.
+        if args is not None and args.loss_type == "dapo_zv":
+            raise NotImplementedError(
+                "`loss_type='dapo_zv'` is not supported by the `gspo_token` experimental `GRPOTrainer`: "
+                "`_compute_loss` here fully overrides the base trainer's loss_type dispatch and has not been "
+                "extended for `dapo_zv`. Use a different `loss_type`."
+            )
+        super().__init__(args=args, **kwargs)
+
     def _compute_loss(self, model, inputs):
         # Compute the per-token log probabilities for the model
         prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]

--- a/trl/experimental/minillm/minillm_trainer.py
+++ b/trl/experimental/minillm/minillm_trainer.py
@@ -195,6 +195,23 @@ class MiniLLMTrainer(GRPOTrainer):
             args.gradient_checkpointing_kwargs = args.gradient_checkpointing_kwargs or {}
             args.gradient_checkpointing_kwargs.setdefault("use_reentrant", False)
 
+        # `loss_type="dapo_zv"` + `rkl_advantage=True` (the default) is not supported: `compute_loss` below
+        # mutates `inputs["advantages"]` with a reverse-KL term AFTER the base trainer's
+        # `_generate_and_score_completions` has already computed `num_items_in_batch_zv` from the raw,
+        # pre-mutation reward-tie signal. `dapo_zv`'s denominator exclusion depends on excluded rows
+        # contributing exactly 0 to the loss numerator; the reverse-KL term (a student/teacher log-prob
+        # divergence, unrelated to reward variance) breaks that invariant, silently mis-scaling the loss.
+        # With `rkl_advantage=False`, `inputs["advantages"]` is never touched here, so `dapo_zv` behaves
+        # exactly as it does on the base trainer -- only the `True` (default) combination is blocked.
+        # Checked before the expensive `super().__init__` below, same as the other GRPOTrainer subclasses
+        # with a comparable gap.
+        if args.loss_type == "dapo_zv" and args.rkl_advantage:
+            raise NotImplementedError(
+                "`loss_type='dapo_zv'` is not supported together with `rkl_advantage=True` (the default): the "
+                "reverse-KL advantage term added in `compute_loss` breaks the invariant `dapo_zv`'s denominator "
+                "exclusion depends on. Use a different `loss_type`, or set `rkl_advantage=False`."
+            )
+
         super().__init__(
             model,
             reward_funcs,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -253,6 +253,13 @@ class GRPOConfig(_BaseConfig):
             - `"dapo"` (default): Aggregates token-level losses by normalizing with the number of active token in the
               global accumulated batch. This method was introduced in the [DAPO
               paper](https://huggingface.co/papers/2503.14476) to eliminate length bias.
+            - `"dapo_zv"`: Identical to `"dapo"` except tokens belonging to a zero-variance group (every completion
+              in the group received the identical reward, so the group's advantage is exactly 0 for everyone) are
+              excluded from the loss denominator. Those tokens already contribute exactly 0 to the numerator, so
+              this only removes their diluting effect on the average; when a batch has no zero-variance groups,
+              `"dapo_zv"` is identical to `"dapo"`. Implements the loss-mask idea from the [AGPO
+              paper](https://arxiv.org/abs/2503.15952) (their adaptive, token-efficiency-shaping loss is out
+              of scope here; only the zero-advantage exclusion is implemented).
             - `"bnpo"`: Aggregates token-level losses by normalizing with the number of active token in the local
               batch. Note that normalization is performed over the local batch only, so results may slightly vary
               depending on the local batch size, despite a constant effective batch size. When using
@@ -821,6 +828,10 @@ class GRPOConfig(_BaseConfig):
             "'vespo': Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth, "
             "asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in "
             "the [VESPO paper](https://huggingface.co/papers/2602.10693)."
+            "'dapo_zv': Identical to 'dapo' except tokens belonging to a zero-variance group (every completion in "
+            "the group received the identical reward) are excluded from the loss denominator; identical to 'dapo' "
+            "when a batch has no zero-variance groups. Implements the loss-mask idea from the [AGPO "
+            "paper](https://arxiv.org/abs/2503.15952)."
         },
     )
     mask_truncated_completions: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -833,7 +833,13 @@ class GRPOTrainer(_BaseTrainer):
                 "set to `'token'` (the default)."
             )
 
-        if args.importance_sampling_level == "sequence" and args.loss_type in ["bnpo", "dr_grpo", "dapo", "cispo"]:
+        if args.importance_sampling_level == "sequence" and args.loss_type in [
+            "bnpo",
+            "dr_grpo",
+            "dapo",
+            "dapo_zv",
+            "cispo",
+        ]:
             logger.warning(
                 f"When using `importance_sampling_level='sequence'`, the `'{args.loss_type}'` loss sums per-token "
                 "contributions, which effectively weights each sequence by its completion length instead of "
@@ -939,6 +945,12 @@ class GRPOTrainer(_BaseTrainer):
 
         # Liger loss
         if self.use_liger_kernel:
+            if self.loss_type == "dapo_zv":
+                raise NotImplementedError(
+                    "`loss_type='dapo_zv'` is not supported together with `use_liger_kernel=True`: the "
+                    "zero-variance denominator mask has no fused-kernel equivalent yet. Set `use_liger_kernel=False`, "
+                    "or use a different `loss_type`."
+                )
             if not is_liger_kernel_available():
                 raise ImportError(
                     "Liger is required to use `use_liger_kernel` as the GRPO loss. Run `pip install liger-kernel`."
@@ -1997,6 +2009,13 @@ class GRPOTrainer(_BaseTrainer):
 
         return tool_mask, completions, completion_ids, logprobs, tool_call_count, tool_failure_count, tool_images
 
+    def _completion_lengths(self, completion_ids: list, tool_mask: list | None) -> torch.Tensor:
+        # Active (non-tool-result) token count per completion. `tool_mask`, when present, marks model-generated
+        # tokens as 1 and external (tool-result) tokens as 0, so only those count.
+        if tool_mask is not None:
+            return torch.tensor([sum(mask) for mask in tool_mask], device=self.accelerator.device)
+        return torch.tensor([len(ids) for ids in completion_ids], device=self.accelerator.device)
+
     def _generate(self, prompts: list):
         device = self.accelerator.device
         mode = "train" if self.model.training else "eval"
@@ -2072,10 +2091,7 @@ class GRPOTrainer(_BaseTrainer):
 
         # Get completion length per sequence, used for logging
         prompt_lengths = torch.tensor([len(ids) for ids in prompt_ids], device=device)
-        if tool_mask is not None:  # count only model-generated tokens (tool_mask=1)
-            completion_lengths = torch.tensor([sum(mask) for mask in tool_mask], device=device)
-        else:
-            completion_lengths = torch.tensor([len(ids) for ids in completion_ids], device=device)
+        completion_lengths = self._completion_lengths(completion_ids, tool_mask)
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
@@ -2581,6 +2597,42 @@ class GRPOTrainer(_BaseTrainer):
                 "'sum_then_normalize' or 'normalize_then_sum'."
             )
 
+        # Sequences belonging to a zero-variance ("dead") group -- every completion in the group received the
+        # identical combined reward, so the group's GRPO advantage is exactly 0 for every member -- already
+        # contribute nothing to the "dapo"-family loss numerator; `loss_type="dapo_zv"` additionally excludes them
+        # from the loss denominator (see `_compute_loss`). Gated on loss_type: num_items_in_batch_zv is only read
+        # by "dapo_zv", so computing it for every other loss_type would cost an unconditional extra pass for no
+        # benefit.
+        if self.loss_type == "dapo_zv":
+            # Spread is computed NaN-safely (substitute +-inf for NaN before amax/amin) so one unscorable
+            # (NaN-reward) row in a group doesn't prevent its otherwise-tied siblings from being detected; an
+            # all-NaN group still safely resolves to spread=inf, i.e. NOT zero-variance. NOT derived from
+            # `is_std_zero` above, which is only a per-GROUP signal under `scale_rewards` "group"/"none" -- under
+            # "batch" it answers "is the WHOLE BATCH zero-variance" instead, silently degrading `dapo_zv` to plain
+            # `dapo`. Independent of `multi_objective_aggregation` too: under "normalize_then_sum", a group tied on
+            # raw `rewards` is tied at exactly 0 after its own per-function, per-group normalization (mean-
+            # centering a constant against itself is always 0), and since every function's within-group residuals
+            # are zero-mean, the final normalization step's batch-wide mean is also exactly 0 -- so the group's
+            # advantage is 0 there too, same as "sum_then_normalize"'s more direct group-mean-centering.
+            grouped_rewards = rewards.view(-1, num_generations)
+            group_max = torch.nan_to_num(grouped_rewards, nan=float("-inf")).amax(dim=1)
+            group_min = torch.nan_to_num(grouped_rewards, nan=float("inf")).amin(dim=1)
+            row_is_zero_variance = ((group_max - group_min).abs() <= 1e-6).repeat_interleave(num_generations)
+
+            # `num_items_in_batch_zv`: the "dapo_zv" analogue of `total_completion_tokens`/`num_items_in_batch`
+            # above, restricted to non-zero-variance rows. Uses `_completion_lengths` on `completion_ids_list`/
+            # `tool_mask_list` -- the RAW, pre-padding lists, unaffected by `mask_truncated_completions`'s later
+            # zeroing of the padded `completion_mask` tensor further below -- so this lands on the exact same basis
+            # as `num_items_in_batch`: tool_mask-aware like it, and matching its (separately tracked, pre-existing)
+            # behavior under `mask_truncated_completions` instead of silently diverging from it. That keeps "no
+            # zero-variance groups => num_items_in_batch_zv == num_items_in_batch, bit-identical to dapo" true
+            # exactly as documented/tested. This extra gather is paid only when `loss_type == "dapo_zv"`.
+            completion_lengths = self._completion_lengths(completion_ids_list, tool_mask_list)
+            agg_completion_lengths = self.accelerator.gather(completion_lengths)
+            num_items_in_batch_zv = (agg_completion_lengths * (~row_is_zero_variance)).sum()
+        else:
+            num_items_in_batch_zv = None
+
         # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
         # so zero their advantage to keep them from moving the policy.
         advantages = torch.nan_to_num(advantages, nan=0.0)
@@ -2676,6 +2728,8 @@ class GRPOTrainer(_BaseTrainer):
             "advantages": advantages,
             "num_items_in_batch": num_items_in_batch,
         }
+        if num_items_in_batch_zv is not None:
+            output["num_items_in_batch_zv"] = num_items_in_batch_zv
         if old_per_token_logps is not None:
             output["old_per_token_logps"] = old_per_token_logps
         if self.use_vllm and self.vllm_importance_sampling_correction:
@@ -2947,7 +3001,7 @@ class GRPOTrainer(_BaseTrainer):
         if self.loss_type == "cispo":
             clamped_ratios = torch.clamp(coef_1, max=self.epsilon_high).detach()
             per_token_loss = -clamped_ratios * advantages * per_token_logps
-        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        elif self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "luspo"]:
             coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
             # Two-sided clipping
             if self.args.delta is not None:
@@ -2984,7 +3038,7 @@ class GRPOTrainer(_BaseTrainer):
         if self.use_vllm and self.vllm_importance_sampling_correction and self.loss_type != "vespo":
             per_token_loss = per_token_loss * inputs["importance_sampling_ratio"]
 
-        if self.beta != 0.0:
+        if self.beta != 0.0 and self.loss_type != "dapo_zv":
             per_token_loss = per_token_loss + self.beta * per_token_kl
 
         mode = "train" if self.model.training else "eval"
@@ -3007,6 +3061,39 @@ class GRPOTrainer(_BaseTrainer):
             normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer
             policy_loss = loss.detach()
+        elif self.loss_type == "dapo_zv":
+            # Identical to "dapo" above (same per_token_loss, same numerator) except the denominator counts only
+            # tokens from non-zero-variance rows (`num_items_in_batch_zv`, gathered in
+            # `_generate_and_score_completions`). Zero-variance rows' contribution to the numerator is exactly 0
+            # (their advantage is 0), so restricting the denominator to non-zero-variance rows only removes their
+            # diluting effect on the average. When there are no zero-variance groups, `num_items_in_batch_zv ==
+            # num_items_in_batch` and this is bit-identical to "dapo".
+            #
+            # Degenerate case: if EVERY group in the batch is zero-variance, `num_items_in_batch_zv` is exactly 0
+            # and the (now KL-free, see below) numerator is also exactly 0 there -- `.clamp(min=1.0)` on the raw
+            # (integer-valued) count avoids a literal 0/0 NaN, giving 0/1.0 == 0 instead, matching the codebase's
+            # own idiom for this used elsewhere (e.g. `mask.sum(-1).clamp(min=1.0)` for "grpo"/"sapo"). Clamping
+            # the raw count (not the post-division normalizer) means this can only ever engage at exactly 0 --
+            # token counts have no value strictly between 0 and 1 -- so it never touches a genuinely small but
+            # nonzero normalizer, unlike clamping after the division would. A plain `== 0` branch here would work
+            # too, but forces a GPU-to-CPU sync on every step this loss_type is used; the clamp doesn't.
+            normalizer = inputs["num_items_in_batch_zv"].clamp(min=1.0) / self.accelerator.num_processes
+            loss = (per_token_loss * mask).sum() / normalizer
+            if self.beta != 0.0:
+                # The KL/beta term is intentionally NOT part of the numerator/denominator pairing above: per
+                # `entropy_coef`'s own documented rationale (the entropy bonus is independent of how the policy
+                # term is normalized -- same principle applied here), and per this PR's explicit "denominator-
+                # only, KL/beta path untouched" scoping (distinguishing it from #5588, which was declined for
+                # changing loss values under beta != 0), the KL/beta contribution must be normalized the same
+                # way "dapo" itself normalizes it: by `num_items_in_batch`, NOT `num_items_in_batch_zv`. Using
+                # the ZV-restricted denominator here would silently inflate the effective KL coefficient by
+                # `num_items_in_batch / num_items_in_batch_zv` whenever any group is zero-variance -- i.e. every
+                # time this loss_type is actually doing its job -- which is the same class of loss-value change
+                # #5588 was declined for, just reached through a different path. Mirrors how `aux_loss` below is
+                # also added with its own independent normalizer, not the policy term's.
+                kl_normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
+                loss = loss + self.beta * (per_token_kl * mask).sum() / kl_normalizer
+            policy_loss = loss.detach()
         elif self.loss_type == "luspo":
             # Unless importance_sampling_level="token" (not recommended here), per_token_loss is expected to be (B, 1)
             loss = (per_token_loss * mask.sum(1, keepdim=True)).mean()
@@ -3027,12 +3114,23 @@ class GRPOTrainer(_BaseTrainer):
             # H does not depend on how each loss type normalizes its policy term. The term is computed so that
             # it accumulates to H over the optimizer step for every loss type and matches world_entropy below.
             # The only wrinkle is the normalizer: most loss types divide by the gradient accumulation step
-            # count, but cispo/dapo/vespo divide by a global token count.
-            if self.loss_type in ["cispo", "dapo", "vespo"]:
+            # count, but cispo/dapo/dapo_zv/vespo divide by a global token count. For "dapo_zv" specifically,
+            # that global token count must be `num_items_in_batch` (all active completion tokens), NOT the
+            # ZV-restricted `num_items_in_batch_zv` used for the policy-loss `normalizer` above: the entropy bonus
+            # is defined as the mean per-token entropy over all active completion tokens regardless of loss_type
+            # (see `entropy_coef` docs), independent of how the policy term is normalized.
+            if self.loss_type in ["cispo", "dapo", "dapo_zv", "vespo"]:
                 # normalizer is a global token count, so summing the entropies (instead of averaging them
                 # again) makes the term accumulate over the optimizer step to the global mean per-token
-                # entropy, like the other loss types.
-                entropy_loss = (entropies * effective_mask).sum() / normalizer
+                # entropy, like the other loss types. For cispo/dapo/vespo, `normalizer` (computed in the
+                # policy-loss branch above) already equals `num_items_in_batch / num_processes`, so it's reused
+                # directly; only "dapo_zv" needs a different value, since its own `normalizer` there is the
+                # ZV-restricted `num_items_in_batch_zv`.
+                if self.loss_type == "dapo_zv":
+                    entropy_normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
+                else:
+                    entropy_normalizer = normalizer
+                entropy_loss = (entropies * effective_mask).sum() / entropy_normalizer
             else:
                 # Mean per-token entropy of active tokens, scaled for gradient accumulation.
                 entropy_loss = (entropies * effective_mask).sum() / effective_mask.sum().clamp(min=1.0) / normalizer
@@ -3103,7 +3201,7 @@ class GRPOTrainer(_BaseTrainer):
         mean_entropy = masked_batch_mean(entropies)
         self._metrics[mode]["entropy"].append(self.accelerator.gather(mean_entropy).nanmean().item())
 
-        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
+        if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "dapo_zv", "luspo"]:
             # Compute the clipped probability ratios
             is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)
             is_high_clipped = (coef_1 > 1 + self.epsilon_high) & (advantages > 0)


### PR DESCRIPTION
## What this PR do
[Closes #6367]

Adds one new opt-in value to `GRPOConfig.loss_type`: `"dapo_zv"`. Identical to `"dapo"` (the current default) in every way except the loss denominator excludes tokens belonging to zero-variance ("all completions in the group got the same reward") groups. Default (`"dapo"` and every other existing value) is completely unchanged.

## Why
Dividing by a token count that includes zero-signal rows silently shrinks the effective learning rate on the rows that DO carry signal, in proportion to how many groups are tied this step. We ran a fix and found immediate accuracy increase in all our experiments. Accuracy numbers on a public dataset  are as follows: `GSM8K with Qwen2.5-1.5B-Instruct (step 100, n=500, greedy eval)`

| Setup | Accuracy | Denominator |
|---|---|---|
| Plain binary (`loss_type="dapo"`) | 0.536 | all tokens, including dead groups |
| Binary + this fix (`loss_type="dapo_zv"`, equivalent) | 0.560 | dead-group tokens excluded |
| Dense reward model (`loss_type="dapo"`) | 0.590 | rarely hits zero-variance, so rarely diluted |

Fixing only the denominator (no reward change) recovered 2.4 points accuracy. A literature survey told us that this method is also part of broader set of methods proposed in AGPO (Adaptive Group Policy Optimization," arXiv:2503.15952).

## Relationship to prior TRL work on zero-std groups
- **#4060 (merged replay buffer)**: substitutes zero-std groups by iversampling. This is the orthogonal accounting remedy for runs not using it.
- **#5588 (closed not-a-bug) and its unmerged PRs #5597/#5640**: proposed masking the whole completion *including the KL term*; declined for changing loss values under `beta>0` and for departing from the canonical per-token-KL objective. This PR is scoped to avoid exactly those objections: **denominator only, KL/`beta` path untouched, opt-in `loss_type` value, no default changes** (the KL/beta term is now independently normalized specifically so this claim holds for the *loss value*, not just the KL computation, in every case, not only when there happen to be no dead groups.)


## Tests [AI generated]
Two layers, both passing:
- Standalone unit tests (pure `torch`, no GPU, no TRL import) — 10 tests covering the underlying arithmetic in isolation, including the default-unchanged property and an independently hand-computed expected-value check.
- `tests/test_grpo_trainer.py` — 11 dedicated tests plus 2 extended `loss_type` parametrizations (`test_train_loss_types[dapo_zv]`, `test_warning_raised_sequence_level_with_token_summed_loss[dapo_zv]`). Covers: bit-identical-to-`"dapo"` with no dead groups; exact-denominator-rescale with a mixed batch; the liger-kernel guard; `num_items_in_batch_zv` is tool_mask-aware and stays consistent under `mask_truncated_completions`; the normalizer clamp doesn't diverge from `"dapo"` for small-but-nonzero multi-process batches; NaN-in-group doesn't prevent detecting genuinely tied siblings; the all-dead-batch-with-KL-on case matches `"dapo"` exactly (no explosion); the KL/beta term isn't inflated by zero-variance exclusion in mixed batches either; and `num_items_in_batch_zv` is never computed for any other `loss_type` (no unconditional extra cost for non-`dapo_zv` users). Plus one guard test each in `test_grpo_with_replay_buffer_trainer.py`, `test_gspo_token_trainer.py`, and `test_gmpo_trainer.py` (`NotImplementedError` at construction), and two tests in `test_minillm_trainer.py` (raises with `rkl_advantage=True`, the default; does NOT raise with `rkl_advantage=False`, where `dapo_zv` behaves correctly).

## What still needs your call
1. Zero-variance status treated as fixed across `num_iterations` batch reuse (matching how `total_completion_tokens` is already treated)
2. Liger fused-loss path (`LigerFusedLinearGRPOLoss`): still not implemented; using `use_liger_kernel=True` with `loss_type="dapo_zv"` raises `NotImplementedError` at construction rather than silently mis-normalizing.

## Alternative API shape considered
This PR implements the fix as a new `loss_type` value (`"dapo_zv"`), matching the precedent CISPO (#4495) and LUSPO (#4988) both set for adding a loss variant to this same enum with motivation of small diff, narrow review surface, no interaction with any other option. An equally valid shape would be a boolean `GRPOConfig` flag (e.g. `exclude_zero_variance_from_loss`, default `False`) that composes with *every* existing `loss_type` rather than only `"dapo"`'s normalization family. Happy to reshape to the boolean-flag composition if maintainers prefer it. The new `loss_type` shape was chosen after reviewing CONTRIBUTING.md and how past PRs were accepted.

## Pre-empting "isn't this just `dr_grpo` / `bnpo` again?"
`dr_grpo` and `bnpo` change WHICH constant/count normalizes the loss (a global constant vs. local active-token count), orthogonal to whether zero-variance groups are included in that count. `"dapo_zv"` is `"dapo"`'s existing normalization scheme with dead-group tokens carved out of it.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure
- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

**Care is taken to keep PR simple, on the topic, with complete tests, and reference any closely related previous work including PR and issues**

## Who can review?
Anyone in the community is free to review the PR once the tests have passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GRPO loss normalization and KL/entropy scaling for an opt-in path; default `dapo` behavior is unchanged, but incorrect `num_items_in_batch_zv` logic would skew training gradients.
> 
> **Overview**
> Adds opt-in **`loss_type="dapo_zv"`** on **`GRPOConfig`** / **`GRPOTrainer`**: same policy term as **`dapo`**, but the loss mean uses **`num_items_in_batch_zv`** (active completion tokens from groups with non-identical rewards) instead of all tokens. **`num_items_in_batch_zv`** is computed only when this loss type is selected; zero-variance detection is NaN-safe and uses the same completion-length / **`tool_mask`** basis as **`dapo`**.
> 
> **KL (`beta`)**, **entropy bonus**, and the all–zero-variance batch case are handled so normalization matches **`dapo`** where intended (no inflated KL/entropy from the ZV denominator). **`use_liger_kernel=True`** with **`dapo_zv`** raises at construction.
> 
> Experimental trainers (**GMPO**, **gspo_token**, **GRPOWithReplayBuffer**) reject **`dapo_zv`** at init; **MiniLLM** rejects it with default **`rkl_advantage=True`** only. Docs add an AGPO paper index entry; tests cover equivalence, rescaling, edge cases, and guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d47c4094a53f8f95ace06b4e6ceaa494e42c823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->