### PR TITLE
Triton grpo v1.8.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.16.0` to `0.23.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.16.0` to `0.25.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.16.0,<=0.23.0",
+    "vllm>=0.16.0,<=0.25.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -54,6 +54,9 @@ from .testing_utils import (
 )
 
 
+if is_liger_kernel_available():
+    from liger_kernel.transformers.grpo_loss import triton_grpo_loss
+
 if is_peft_available():
     import peft
     from peft import LoraConfig, PeftModel, PromptTuningConfig, get_peft_model
@@ -1422,7 +1425,7 @@ class TestGRPOTrainer(TrlTestCase):
 
     @require_liger_kernel
     def test_compute_liger_loss_passes_vllm_is_ratio(self):
-        """Test that importance_sampling_ratio from inputs is passed to liger_grpo_loss as vllm_is_ratio."""
+        """Test that importance_sampling_ratio from inputs is passed to triton_grpo_loss as vllm_is_ratio."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
@@ -1454,12 +1457,12 @@ class TestGRPOTrainer(TrlTestCase):
 
         with (
             patch.object(trainer, "_generate_and_score_completions", side_effect=gen_with_is_ratio),
-            patch.object(trainer.liger_loss, "forward", wraps=trainer.liger_loss.forward) as mock_forward,
+            patch("trl.trainer.grpo_trainer.triton_grpo_loss", wraps=triton_grpo_loss) as mock_forward,
         ):
             trainer.train()
 
-            # Verify vllm_is_ratio was passed in every call to liger_grpo_loss
-            assert mock_forward.call_count > 0, "liger_grpo_loss.forward was never called"
+            # Verify vllm_is_ratio was passed in every call to triton_grpo_loss
+            assert mock_forward.call_count > 0, "triton_grpo_loss was never called"
             for call in mock_forward.call_args_list:
                 vllm_is_ratio = call.kwargs.get("vllm_is_ratio")
                 assert vllm_is_ratio is not None, (
@@ -3737,10 +3740,6 @@ class TestGRPOTrainerSlow(TrlTestCase):
             eval_dataset=self.eval_dataset,
             processing_class=tokenizer,
         )
-        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
-
-        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
-
         previous_trainable_params = {n: param.clone() for n, param in model.named_parameters()}
 
         trainer.train()
@@ -3796,10 +3795,6 @@ class TestGRPOTrainerSlow(TrlTestCase):
             processing_class=tokenizer,
             peft_config=peft_config,
         )
-        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
-
-        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
-
         # Verify PEFT adapter is properly initialized
         from peft import PeftModel
 
@@ -3847,10 +3842,6 @@ class TestGRPOTrainerSlow(TrlTestCase):
             eval_dataset=self.eval_dataset,
             processing_class=tokenizer,
         )
-        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
-
-        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
-
         previous_trainable_params = {n: param.clone() for n, param in model.named_parameters()}
 
         trainer.train()

--- a/tests/test_triton_grpo_loss_parity.py
+++ b/tests/test_triton_grpo_loss_parity.py
@@ -1,0 +1,145 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerical parity and dispatch tests for the custom Triton GRPO loss paths.
+
+`use_liger_kernel=True` routes through the Liger fork's non-chunked `triton_grpo_loss` on
+materialized logits; `use_liger_chunked_loss=True` additionally selects the fused-linear
+`chunked_triton_grpo_loss`. Both must agree numerically with TRL's reference torch loss.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from datasets import load_dataset
+
+from trl import GRPOConfig, GRPOTrainer
+
+from .testing_utils import TrlTestCase, require_liger_kernel, require_torch_accelerator
+
+
+def make_trainer(tmp_dir, loss_type="dapo", **config_kwargs):
+    dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+    training_args = GRPOConfig(
+        output_dir=tmp_dir,
+        per_device_train_batch_size=4,
+        num_generations=4,
+        max_completion_length=16,
+        loss_type=loss_type,
+        report_to="none",
+        logging_strategy="no",
+        **config_kwargs,
+    )
+    return GRPOTrainer(
+        model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+        reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+        args=training_args,
+        train_dataset=dataset,
+    )
+
+
+def make_loss_inputs(trainer, device, seed=0):
+    """Build a fixed synthetic batch shaped like `_generate_and_score_completions` output."""
+    generator = torch.Generator().manual_seed(seed)
+    batch, prompt_len, completion_len = 4, 6, 12
+    vocab_size = trainer.model.config.vocab_size
+    prompt_ids = torch.randint(0, vocab_size, (batch, prompt_len), generator=generator).to(device)
+    completion_ids = torch.randint(0, vocab_size, (batch, completion_len), generator=generator).to(device)
+    prompt_mask = torch.ones_like(prompt_ids)
+    completion_mask = torch.ones_like(completion_ids)
+    # Zero out a tail to exercise masking
+    completion_mask[0, -3:] = 0
+    completion_mask[2, -1:] = 0
+    advantages = torch.tensor([0.75, -0.25, 1.5, -1.0], device=device)
+    return {
+        "prompt_ids": prompt_ids,
+        "prompt_mask": prompt_mask,
+        "completion_ids": completion_ids,
+        "completion_mask": completion_mask,
+        "advantages": advantages,
+        "num_items_in_batch": completion_mask.sum(),
+    }
+
+
+def compute_loss_and_grad(trainer, inputs, probe_param="lm_head.weight"):
+    trainer.model.zero_grad(set_to_none=True)
+    loss = trainer.compute_loss(trainer.model, dict(inputs))
+    loss.backward()
+    grad = trainer.model.get_parameter(probe_param).grad.detach().clone()
+    trainer.model.zero_grad(set_to_none=True)
+    return loss.detach().clone(), grad
+
+
+@require_liger_kernel
+@require_torch_accelerator
+class TestTritonGRPOLossParity(TrlTestCase):
+    @pytest.mark.parametrize("loss_type", ["dapo", "grpo", "bnpo"])
+    def test_triton_loss_matches_torch_loss(self, loss_type):
+        device = torch.accelerator.current_accelerator()
+        torch_trainer = make_trainer(self.tmp_dir, loss_type=loss_type, use_liger_kernel=False)
+        torch_trainer.model.to(device)
+        inputs = make_loss_inputs(torch_trainer, device)
+        torch_loss, torch_grad = compute_loss_and_grad(torch_trainer, inputs)
+
+        liger_trainer = make_trainer(self.tmp_dir, loss_type=loss_type, use_liger_kernel=True)
+        liger_trainer.model.load_state_dict(torch_trainer.model.state_dict())
+        liger_trainer.model.to(device)
+        liger_loss, liger_grad = compute_loss_and_grad(liger_trainer, inputs)
+
+        assert torch.isfinite(liger_loss).all()
+        torch.testing.assert_close(liger_loss, torch_loss, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(liger_grad, torch_grad, atol=1e-3, rtol=1e-2)
+
+    def test_chunked_loss_matches_non_chunked(self):
+        device = torch.accelerator.current_accelerator()
+        base_trainer = make_trainer(self.tmp_dir, use_liger_kernel=True)
+        base_trainer.model.to(device)
+        inputs = make_loss_inputs(base_trainer, device)
+        base_loss, base_grad = compute_loss_and_grad(base_trainer, inputs)
+
+        chunked_trainer = make_trainer(self.tmp_dir, use_liger_kernel=True, use_liger_chunked_loss=True)
+        chunked_trainer.model.load_state_dict(base_trainer.model.state_dict())
+        chunked_trainer.model.to(device)
+        chunked_loss, chunked_grad = compute_loss_and_grad(chunked_trainer, inputs)
+
+        assert torch.isfinite(chunked_loss).all()
+        torch.testing.assert_close(chunked_loss, base_loss, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(chunked_grad, base_grad, atol=1e-3, rtol=1e-2)
+
+
+@require_liger_kernel
+class TestTritonGRPOLossDispatch(TrlTestCase):
+    def test_default_routes_to_non_chunked_triton_loss(self):
+        trainer = make_trainer(self.tmp_dir, use_liger_kernel=True)
+        assert trainer.use_liger_kernel
+        assert not trainer.use_liger_chunked_loss
+        with patch.object(trainer, "compute_liger_loss", return_value=torch.tensor(0.0)) as mock_loss:
+            trainer.compute_loss(trainer.model, {})
+        mock_loss.assert_called_once()
+
+    def test_chunked_flag_routes_to_chunked_loss(self):
+        trainer = make_trainer(self.tmp_dir, use_liger_kernel=True, use_liger_chunked_loss=True)
+        assert trainer.use_liger_chunked_loss
+        with patch.object(trainer, "compute_chunked_liger_loss", return_value=torch.tensor(0.0)) as mock_loss:
+            trainer.compute_loss(trainer.model, {})
+        mock_loss.assert_called_once()
+
+    def test_liger_disabled_ignores_chunked_flag(self):
+        trainer = make_trainer(self.tmp_dir, use_liger_kernel=False, use_liger_chunked_loss=True)
+        assert not trainer.use_liger_chunked_loss
+
+    def test_vespo_with_chunked_loss_raises(self):
+        with pytest.raises(ValueError, match="vespo"):
+            make_trainer(self.tmp_dir, loss_type="vespo", use_liger_kernel=True, use_liger_chunked_loss=True)

--- a/tests/test_triton_grpo_loss_parity.py
+++ b/tests/test_triton_grpo_loss_parity.py
@@ -30,7 +30,7 @@ from trl import GRPOConfig, GRPOTrainer
 from .testing_utils import TrlTestCase, require_liger_kernel, require_torch_accelerator
 
 
-def make_trainer(tmp_dir, loss_type="dapo", **config_kwargs):
+def make_trainer(tmp_dir, loss_type="dapo", model=None, processing_class=None, **config_kwargs):
     dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
     training_args = GRPOConfig(
         output_dir=tmp_dir,
@@ -43,11 +43,32 @@ def make_trainer(tmp_dir, loss_type="dapo", **config_kwargs):
         **config_kwargs,
     )
     return GRPOTrainer(
-        model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+        model=model if model is not None else "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
         reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
         args=training_args,
         train_dataset=dataset,
+        processing_class=processing_class,
     )
+
+
+def make_wide_model_and_tokenizer():
+    """Random-init tiny Qwen2 with hidden size 128: the chunked fused-linear kernel requires the
+    hidden dimension to be a multiple of its 64-wide K-blocking (production models satisfy this;
+    the hub tiny test model's hidden size of 8 does not)."""
+    from transformers import AutoTokenizer, Qwen2Config, Qwen2ForCausalLM
+
+    tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+    config = Qwen2Config(
+        vocab_size=len(tokenizer),
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=512,
+    )
+    torch.manual_seed(0)
+    return Qwen2ForCausalLM(config), tokenizer
 
 
 def make_loss_inputs(trainer, device, seed=0):
@@ -104,12 +125,22 @@ class TestTritonGRPOLossParity(TrlTestCase):
 
     def test_chunked_loss_matches_non_chunked(self):
         device = torch.accelerator.current_accelerator()
-        base_trainer = make_trainer(self.tmp_dir, use_liger_kernel=True)
+        base_model, tokenizer = make_wide_model_and_tokenizer()
+        base_trainer = make_trainer(
+            self.tmp_dir, model=base_model, processing_class=tokenizer, use_liger_kernel=True
+        )
         base_trainer.model.to(device)
         inputs = make_loss_inputs(base_trainer, device)
         base_loss, base_grad = compute_loss_and_grad(base_trainer, inputs)
 
-        chunked_trainer = make_trainer(self.tmp_dir, use_liger_kernel=True, use_liger_chunked_loss=True)
+        chunked_model, _ = make_wide_model_and_tokenizer()
+        chunked_trainer = make_trainer(
+            self.tmp_dir,
+            model=chunked_model,
+            processing_class=tokenizer,
+            use_liger_kernel=True,
+            use_liger_chunked_loss=True,
+        )
         chunked_trainer.model.load_state_dict(base_trainer.model.state_dict())
         chunked_trainer.model.to(device)
         chunked_loss, chunked_grad = compute_loss_and_grad(chunked_trainer, inputs)

--- a/tests/test_vllm_param_prefix.py
+++ b/tests/test_vllm_param_prefix.py
@@ -17,16 +17,22 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import torch.nn as nn
+
 from trl.generation.vllm_generation import VLLMGeneration, get_vllm_param_prefix
 
 
 def make_model(class_name: str, architectures=None, name_or_path=None, config=None):
-    """Build a minimal model stand-in whose class name and config drive the prefix detection."""
+    """Build a minimal model stand-in whose class name and config drive the prefix detection.
+
+    Must be a real `nn.Module`: `get_vllm_param_prefix` runs the model through accelerate's
+    `is_peft_model`, which walks module internals.
+    """
     if config is None:
         config = SimpleNamespace()
         if architectures is not None:
             config.architectures = architectures
-    cls = type(class_name, (), {})
+    cls = type(class_name, (nn.Module,), {})
     model = cls()
     model.config = config
     if name_or_path is not None:
@@ -66,7 +72,7 @@ class TestGetVllmParamPrefix:
         assert get_vllm_param_prefix(model) == ""
 
     def test_missing_config_is_passthrough(self):
-        cls = type("SomeModel", (), {})
+        cls = type("SomeModel", (nn.Module,), {})
         model = cls()
         assert get_vllm_param_prefix(model) == ""
 

--- a/tests/test_vllm_param_prefix.py
+++ b/tests/test_vllm_param_prefix.py
@@ -1,0 +1,115 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Qwen3.5 / Qwen3-VL weight-name prefix mapping used during vLLM weight sync."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from trl.generation.vllm_generation import VLLMGeneration, get_vllm_param_prefix
+
+
+def make_model(class_name: str, architectures=None, name_or_path=None, config=None):
+    """Build a minimal model stand-in whose class name and config drive the prefix detection."""
+    if config is None:
+        config = SimpleNamespace()
+        if architectures is not None:
+            config.architectures = architectures
+    cls = type(class_name, (), {})
+    model = cls()
+    model.config = config
+    if name_or_path is not None:
+        model.name_or_path = name_or_path
+    return model
+
+
+class TestGetVllmParamPrefix:
+    def test_qwen3_5_moe_text_trainer_gets_language_model_prefix(self):
+        # Trainer holds the text-only model; checkpoint architecture is the VLM wrapper.
+        model = make_model(
+            "Qwen3_5MoeForCausalLM", architectures=["Qwen3_5MoeForConditionalGeneration"]
+        )
+        assert get_vllm_param_prefix(model) == "language_model."
+
+    def test_qwen3_vl_moe_trainer_gets_language_model_prefix(self):
+        model = make_model("Qwen3MoeForCausalLM", architectures=["Qwen3VLMoeForConditionalGeneration"])
+        assert get_vllm_param_prefix(model) == "language_model."
+
+    def test_trainer_holding_the_wrapper_itself_needs_no_prefix(self):
+        model = make_model(
+            "Qwen3_5MoeForConditionalGeneration", architectures=["Qwen3_5MoeForConditionalGeneration"]
+        )
+        assert get_vllm_param_prefix(model) == ""
+
+    def test_non_qwen_vlm_passes_through(self):
+        # Unknown conditional-generation wrappers are NOT remapped (explicit allowlist only).
+        model = make_model("LlamaForCausalLM", architectures=["LlavaForConditionalGeneration"])
+        assert get_vllm_param_prefix(model) == ""
+
+    def test_plain_causal_lm_needs_no_prefix(self):
+        model = make_model("Qwen2ForCausalLM", architectures=["Qwen2ForCausalLM"])
+        assert get_vllm_param_prefix(model) == ""
+
+    def test_missing_architectures_without_name_or_path_is_passthrough(self):
+        model = make_model("Qwen3_5MoeForCausalLM", architectures=None)
+        assert get_vllm_param_prefix(model) == ""
+
+    def test_missing_config_is_passthrough(self):
+        cls = type("SomeModel", (), {})
+        model = cls()
+        assert get_vllm_param_prefix(model) == ""
+
+    def test_subconfig_without_architectures_refetches_checkpoint_config(self):
+        # model.config is a sub-config (e.g. text_config) lacking `architectures`; the checkpoint
+        # config must be re-fetched to see the wrapper architecture vLLM will load.
+        model = make_model("Qwen3_5MoeForCausalLM", architectures=None, name_or_path="org/qwen3.5-ckpt")
+        full_config = SimpleNamespace(architectures=["Qwen3_5MoeForConditionalGeneration"])
+        with patch("transformers.AutoConfig.from_pretrained", return_value=full_config) as mock_fetch:
+            assert get_vllm_param_prefix(model) == "language_model."
+        mock_fetch.assert_called_once_with("org/qwen3.5-ckpt")
+
+    def test_refetch_failure_is_passthrough(self):
+        model = make_model("Qwen3_5MoeForCausalLM", architectures=None, name_or_path="org/missing")
+        with patch("transformers.AutoConfig.from_pretrained", side_effect=OSError("gone")):
+            assert get_vllm_param_prefix(model) == ""
+
+
+class TestFixParamNameToVllm:
+    def make_generation(self, prefix: str) -> VLLMGeneration:
+        # _fix_param_name_to_vllm only reads `_vllm_param_prefix`; skip the heavy __init__.
+        generation = VLLMGeneration.__new__(VLLMGeneration)
+        generation._vllm_param_prefix = prefix
+        return generation
+
+    def test_model_weights_map_under_language_model(self):
+        generation = self.make_generation("language_model.")
+        name = generation._fix_param_name_to_vllm("model.layers.0.self_attn.q_proj.weight")
+        assert name == "language_model.model.layers.0.self_attn.q_proj.weight"
+
+    def test_lm_head_maps_under_language_model(self):
+        generation = self.make_generation("language_model.")
+        assert generation._fix_param_name_to_vllm("lm_head.weight") == "language_model.lm_head.weight"
+
+    def test_wrapper_prefixes_are_stripped_before_prefixing(self):
+        generation = self.make_generation("language_model.")
+        name = generation._fix_param_name_to_vllm(
+            "model.layers.0._checkpoint_wrapped_module.mlp.gate_proj.weight",
+            extra_prefixes=["_fsdp_wrapped_module."],
+        )
+        assert name == "language_model.model.layers.0.mlp.gate_proj.weight"
+
+    def test_no_prefix_passthrough(self):
+        generation = self.make_generation("")
+        name = generation._fix_param_name_to_vllm("model.layers.0.self_attn.q_proj.weight")
+        assert name == "model.layers.0.self_attn.q_proj.weight"

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -51,6 +51,7 @@ from transformers.utils import is_peft_available, is_sagemaker_mp_enabled
 from ...data_utils import apply_chat_template, is_conversational, maybe_apply_chat_template
 from ...extras.profiling import profiling_context
 from ...generation.vllm_client import VLLMClient
+from ...generation.vllm_generation import get_vllm_param_prefix
 from ...import_utils import is_vllm_available
 from ...models.utils import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ...trainer.base_trainer import _BaseTrainer
@@ -416,6 +417,10 @@ class OnlineDPOTrainer(_BaseTrainer):
             self.model.add_model_tags(self._tag_names)
 
         self._beta = args.beta
+
+        # Weight-name prefix for checkpoints that vLLM loads as a conditional-generation wrapper
+        # while the trainer holds the text-only inner model (e.g. Qwen3.5 / Qwen3-VL).
+        self._vllm_param_prefix = get_vllm_param_prefix(model)
 
         # Set up generation configuration and vLLM after super().__init__
         if self.use_vllm:
@@ -871,6 +876,8 @@ class OnlineDPOTrainer(_BaseTrainer):
         prefixes = ["_checkpoint_wrapped_module."] + extra_prefixes
         for prefix in prefixes:
             name = name.replace(prefix, "")
+        if self._vllm_param_prefix:
+            name = self._vllm_param_prefix + name
         return name
 
     def process_vision_row(

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -108,6 +108,56 @@ if is_bitsandbytes_available():
     import bitsandbytes as bnb
 
 
+# vLLM loads these checkpoints by their top-level `architectures` entry as the full
+# conditional-generation (multimodal) wrapper, which nests the text decoder under a
+# `language_model` attribute. When the trainer instead holds the text-only inner model loaded
+# from the same checkpoint, every weight name from the trainer must be prefixed during sync
+# (`model.*` -> `language_model.model.*`, `lm_head.*` -> `language_model.lm_head.*`). Only
+# architectures listed here are remapped; unknown wrappers pass through unchanged.
+VLLM_LANGUAGE_MODEL_PREFIXED_ARCHITECTURES = {
+    "Qwen3_5MoeForConditionalGeneration": "language_model.",
+    "Qwen3_5ForConditionalGeneration": "language_model.",
+    "Qwen3VLForConditionalGeneration": "language_model.",
+    "Qwen3VLMoeForConditionalGeneration": "language_model.",
+}
+
+
+def get_vllm_param_prefix(model) -> str:
+    """Determine the weight-name prefix required when syncing trainer weights into vLLM.
+
+    Returns the `language_model.` prefix when the checkpoint's top-level architecture is a known
+    conditional-generation wrapper (see `VLLM_LANGUAGE_MODEL_PREFIXED_ARCHITECTURES`) while the
+    trainer holds a different (text-only) class, and `""` otherwise (non-VLM models, unknown
+    wrappers, or a trainer that already holds the wrapper class).
+    """
+    unwrapped = model.base_model.model if is_peft_model(model) else model
+    config = getattr(unwrapped, "config", None)
+    if config is None:
+        return ""
+    archs = getattr(config, "architectures", None) or []
+    if not archs:
+        # model.config may be a sub-config (e.g. text_config for VLM checkpoints) that lacks
+        # architectures. Re-fetch the full checkpoint config to see what vLLM will load.
+        model_id = getattr(unwrapped, "name_or_path", None) or getattr(config, "_name_or_path", None)
+        if model_id:
+            from transformers import AutoConfig
+
+            try:
+                full_config = AutoConfig.from_pretrained(model_id)
+                archs = getattr(full_config, "architectures", None) or []
+            except Exception:
+                pass
+    vllm_arch = archs[0] if archs else ""
+    prefix = VLLM_LANGUAGE_MODEL_PREFIXED_ARCHITECTURES.get(vllm_arch, "")
+    if prefix and type(unwrapped).__name__ != vllm_arch:
+        logger.info(
+            f"VLM architecture mismatch: trainer={type(unwrapped).__name__}, vLLM will load {vllm_arch}. "
+            f"Prepending '{prefix}' to weight names during sync."
+        )
+        return prefix
+    return ""
+
+
 class VLLMGeneration:
     """Handles vLLM-based generation for trainers.
 
@@ -288,6 +338,10 @@ class VLLMGeneration:
         self.logprobs = logprobs
         self.generation_kwargs = generation_kwargs or {}
 
+        # Weight-name prefix for checkpoints that vLLM loads as a conditional-generation wrapper
+        # while the trainer holds the text-only inner model (e.g. Qwen3.5 / Qwen3-VL).
+        self._vllm_param_prefix = get_vllm_param_prefix(model)
+
         self._init_vllm()
 
     def _init_vllm(self):
@@ -382,6 +436,8 @@ class VLLMGeneration:
         prefixes = ["_checkpoint_wrapped_module."] + extra_prefixes
         for prefix in prefixes:
             name = name.replace(prefix, "")
+        if self._vllm_param_prefix:
+            name = self._vllm_param_prefix + name
         return name
 
     def _push_param_to_vllm(self, name: str, param) -> None:

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -113,9 +113,9 @@ def is_uvicorn_available() -> bool:
 def is_vllm_available(min_version: str | None = None) -> bool:
     _vllm_available, _vllm_version = _is_package_available("vllm", return_version=True)
     if _vllm_available:
-        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.23.0")):
+        if not (Version("0.16.0") <= Version(_vllm_version) <= Version("0.25.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.16.0 to 0.23.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.16.0 to 0.25.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -198,6 +198,11 @@ class ScriptArguments:
         enable_expert_parallel (`bool`, *optional*):
             Whether to enable expert parallelism in vLLM for MoE models. If set to `True`, experts will be distributed
             across tensor parallel workers.
+        moe_backend (`str`, *optional*):
+            MoE kernel backend override, forwarded to vLLM's `--moe-backend` engine arg (e.g. `"triton"`,
+            `"flashinfer_trtllm"`). When unset, vLLM selects a backend automatically. RL weight sync requires a
+            backend that keeps expert weights in the standard layout (e.g. `"triton"`): backends that re-lay-out
+            expert weights into kernel block formats after loading crash on incremental expert-weight updates.
         enforce_eager (`bool`, *optional*, defaults to `False`):
             Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute the
             model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid.
@@ -292,6 +297,14 @@ class ScriptArguments:
             "be distributed across tensor parallel workers."
         },
     )
+    moe_backend: str | None = field(
+        default=None,
+        metadata={
+            "help": "MoE kernel backend override, forwarded to vLLM's `--moe-backend` engine arg (e.g. 'triton', "
+            "'flashinfer_trtllm'). When unset, vLLM selects a backend automatically. RL weight sync requires a "
+            "backend that keeps expert weights in the standard layout (e.g. 'triton')."
+        },
+    )
     enforce_eager: bool | None = field(
         default=False,
         metadata={
@@ -375,6 +388,8 @@ def llm_worker(
     optional_engine_kwargs = {}
     if script_args.enable_expert_parallel is not None:
         optional_engine_kwargs["enable_expert_parallel"] = script_args.enable_expert_parallel
+    if script_args.moe_backend is not None:
+        optional_engine_kwargs["moe_backend"] = script_args.moe_backend
     if script_args.language_model_only:
         optional_engine_kwargs["language_model_only"] = True
     if script_args.limit_mm_per_prompt:

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -195,6 +195,9 @@ class ScriptArguments:
         enable_prefix_caching (`bool`, *optional*):
             Whether to enable prefix caching in vLLM. If set to `True`, ensure that the model and the hardware support
             this feature.
+        enable_expert_parallel (`bool`, *optional*):
+            Whether to enable expert parallelism in vLLM for MoE models. If set to `True`, experts will be distributed
+            across tensor parallel workers.
         enforce_eager (`bool`, *optional*, defaults to `False`):
             Whether to enforce eager execution. If set to `True`, we will disable CUDA graph and always execute the
             model in eager mode. If `False` (default behavior), we will use CUDA graph and eager execution in hybrid.
@@ -207,6 +210,12 @@ class ScriptArguments:
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to trust remote code when loading models. Set to `True` to allow executing code from model
             repositories. This is required for some custom models but introduces security risks.
+        language_model_only (`bool`, *optional*, defaults to `False`):
+            Whether to force vLLM to load the model in language-model-only mode. Disables all multimodal inputs by
+            setting every modality limit to 0, so a multimodal checkpoint serves as a text-only model.
+        limit_mm_per_prompt (`str`, *optional*):
+            Limits on multimodal items per prompt, as comma-separated key=value pairs (e.g., `"image=0,video=0"`).
+            Passed through to vLLM's EngineArgs to restrict the number of multimodal inputs.
         log_level (`str`, *optional*, defaults to `"info"`):
             Log level for uvicorn. Possible choices: `"critical"`, `"error"`, `"warning"`, `"info"`, `"debug"`,
             `"trace"`.
@@ -276,6 +285,13 @@ class ScriptArguments:
             "hardware support this feature."
         },
     )
+    enable_expert_parallel: bool | None = field(
+        default=None,
+        metadata={
+            "help": "Whether to enable expert parallelism in vLLM for MoE models. If set to `True`, experts will "
+            "be distributed across tensor parallel workers."
+        },
+    )
     enforce_eager: bool | None = field(
         default=False,
         metadata={
@@ -295,6 +311,20 @@ class ScriptArguments:
         metadata={
             "help": "Whether to trust remote code when loading models. Set to True to allow executing code from model "
             "repositories. This is required for some custom models but introduces security risks."
+        },
+    )
+    language_model_only: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to force vLLM to load the model in language-model-only mode. Disables all multimodal "
+            "inputs by setting every modality limit to 0, so a multimodal checkpoint serves as a text-only model."
+        },
+    )
+    limit_mm_per_prompt: str | None = field(
+        default=None,
+        metadata={
+            "help": "Limits on multimodal items per prompt, as comma-separated key=value pairs "
+            "(e.g., 'image=0,video=0'). Passed through to vLLM's EngineArgs."
         },
     )
     log_level: str = field(
@@ -340,6 +370,20 @@ def llm_worker(
     os.environ["VLLM_DP_SIZE"] = str(script_args.data_parallel_size)
     os.environ["VLLM_DP_MASTER_PORT"] = str(master_port)
 
+    # Optional engine args: only forward when explicitly set, so vLLM's config validation never
+    # sees `None` where it expects a bool/dict and engine defaults are preserved otherwise.
+    optional_engine_kwargs = {}
+    if script_args.enable_expert_parallel is not None:
+        optional_engine_kwargs["enable_expert_parallel"] = script_args.enable_expert_parallel
+    if script_args.language_model_only:
+        optional_engine_kwargs["language_model_only"] = True
+    if script_args.limit_mm_per_prompt:
+        limit_mm_per_prompt = {}
+        for item in script_args.limit_mm_per_prompt.split(","):
+            key, value = item.split("=")
+            limit_mm_per_prompt[key.strip()] = int(value.strip())
+        optional_engine_kwargs["limit_mm_per_prompt"] = limit_mm_per_prompt
+
     llm = LLM(
         model=script_args.model,
         revision=script_args.revision,
@@ -360,6 +404,7 @@ def llm_worker(
         # Important so temperature scaling/logit tweaking affects the TIS log probs
         logprobs_mode="processed_logprobs",
         speculative_config=json.loads(script_args.speculative_config) if script_args.speculative_config else None,
+        **optional_engine_kwargs,
     )
 
     # Send ready signal to parent process

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -323,6 +323,13 @@ class GRPOConfig(_BaseConfig):
             collapse); set it close to the entropy you observe early in training (logged as the `entropy`
             metric) so the bonus engages before the policy collapses (and account for the token subset when
             using `top_entropy_quantile`).
+        use_liger_chunked_loss (`bool`, *optional*, defaults to `False`):
+            Only used when `use_liger_kernel` is `True`. If `True`, use Liger's chunked Triton GRPO loss, which
+            fuses the lm_head projection into the loss so the (B, L, vocab) logits tensor is never materialized
+            (flat loss-stage memory at any context length). If `False` (default), use Liger's non-chunked Triton
+            loss on materialized logits (faster, O(logits) memory — preferable while completion lengths keep the
+            logits tensor small relative to the model's activation footprint). The chunked path requires a Liger
+            build with `liger_kernel.transformers.chunked_grpo_loss` and a model whose lm_head has no bias.
         max_tool_calling_iterations (`int`, *optional*):
             Maximum number of tool-calling turns when training an agent. If `None`, there is no limit and generation
             stops when the model generates a response turn with no tool calls or when the total response length reaches
@@ -899,6 +906,17 @@ class GRPOConfig(_BaseConfig):
             "Typical language models have per-token entropies of 2–10 nats, so the default of 0.2 almost never "
             "triggers regularization (only on near-complete collapse); set it close to the entropy observed "
             "early in training and tune from there."
+        },
+    )
+    use_liger_chunked_loss: bool = field(
+        default=False,
+        metadata={
+            "help": "Only used when `use_liger_kernel` is `True`. If `True`, use Liger's chunked Triton GRPO "
+            "loss, which fuses the lm_head projection into the loss so the (B, L, vocab) logits tensor is never "
+            "materialized (flat loss-stage memory at any context length). If `False` (default), use "
+            "Liger's non-chunked Triton loss on materialized logits (faster, O(logits) memory). The chunked path "
+            "requires a Liger build with `liger_kernel.transformers.chunked_grpo_loss` and a model whose lm_head "
+            "has no bias."
         },
     )
     max_tool_calling_iterations: int | None = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -26,7 +26,6 @@ import time
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -100,7 +99,12 @@ from .utils import (
 
 
 if is_liger_kernel_available():
-    from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
+    from liger_kernel.transformers.grpo_loss import triton_grpo_loss
+
+    try:
+        from liger_kernel.transformers.chunked_grpo_loss import chunked_triton_grpo_loss
+    except ImportError:  # Liger build without the chunked Triton GRPO loss
+        chunked_triton_grpo_loss = None
 
 
 if is_peft_available():
@@ -937,33 +941,39 @@ class GRPOTrainer(_BaseTrainer):
             if self.ref_model is not None:
                 _cast_lm_head_to_fp32(self.ref_model)
 
-        # Liger loss
+        # Liger loss: `use_liger_kernel=True` selects the custom Triton GRPO loss on materialized
+        # logits; `use_liger_chunked_loss=True` additionally fuses the lm_head projection into the
+        # loss so the (B, L, vocab) logits tensor is never materialized.
         if self.use_liger_kernel:
             if not is_liger_kernel_available():
                 raise ImportError(
                     "Liger is required to use `use_liger_kernel` as the GRPO loss. Run `pip install liger-kernel`."
                 )
-            # redirect the model.module forward to the model forward to ensure pre-forward hooks are called
+        self.use_liger_chunked_loss = self.use_liger_kernel and args.use_liger_chunked_loss
+        if self.use_liger_chunked_loss:
+            if chunked_triton_grpo_loss is None:
+                raise ImportError(
+                    "`use_liger_chunked_loss=True` requires a liger-kernel build that provides "
+                    "`liger_kernel.transformers.chunked_grpo_loss`. Upgrade liger-kernel or set "
+                    "`use_liger_chunked_loss=False` to use the non-chunked Triton loss."
+                )
+            if args.cast_lm_head_to_fp32:
+                raise ValueError(
+                    "`use_liger_chunked_loss=True` is incompatible with `cast_lm_head_to_fp32=True`: the chunked "
+                    "loss consumes lm_head.weight directly and requires it in the hidden-state dtype. Set "
+                    "`use_liger_chunked_loss=False`."
+                )
+            if self.loss_type == "vespo":
+                raise ValueError(
+                    "`use_liger_chunked_loss=True` does not support `loss_type='vespo'`: the chunked Triton GRPO "
+                    "loss has no VESPO smoothing path. Set `use_liger_chunked_loss=False` to use the non-chunked "
+                    "Triton loss."
+                )
+        if self.use_liger_kernel:
+            # The chunked loss reads lm_head.weight outside lm_head.forward(). Route the whole loss
+            # computation through the wrapper's forward (DeepSpeed engine / DDP) so that ZeRO-3's
+            # automatic external-parameter handling gathers the weight and reduce-scatters its grad.
             self._forward_redirection = _ForwardRedirection()
-
-            self.liger_loss = LigerFusedLinearGRPOLoss(
-                beta=self.beta,
-                epsilon_low=self.epsilon_low,
-                epsilon_high=self.epsilon_high,
-                temperature=self.temperature,
-                use_ref_model=self.beta != 0.0,
-                loss_type=self.loss_type,
-                max_completion_length=self.max_completion_length,
-                importance_sampling_level=self.importance_sampling_level,
-                delta=args.delta,
-                use_bias_correction_kl=args.use_bias_correction_kl,
-                sapo_temperature_pos=args.sapo_temperature_pos,
-                sapo_temperature_neg=args.sapo_temperature_neg,
-                vespo_k_pos=args.vespo_k_pos,
-                vespo_lambda_pos=args.vespo_lambda_pos,
-                vespo_k_neg=args.vespo_k_neg,
-                vespo_lambda_neg=args.vespo_lambda_neg,
-            )
 
         # Initialize the metrics
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
@@ -2707,15 +2717,107 @@ class GRPOTrainer(_BaseTrainer):
             output["tool_mask"] = tool_mask
         return output
 
-    def compute_liger_loss(self, unwrapped_model, inputs):
-        # Compute the per-token log probabilities for the model
+    def compute_liger_loss(self, model, inputs):
+        """Non-chunked Triton GRPO loss on materialized logits (faster at short contexts)."""
         prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
-        completion_ids, completion_mask = inputs["completion_ids"], inputs["completion_mask"]
+        completion_ids = inputs["completion_ids"].contiguous()
+        completion_mask = inputs["completion_mask"].contiguous()
         input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
-        logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
+        logits_to_keep = completion_ids.size(1)
 
-        # Get the last hidden state of the model
+        model_inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+        optional_keys = [
+            "pixel_values",
+            "image_grid_thw",
+            "pixel_attention_mask",
+            "spatial_shapes",
+            "image_sizes",
+            "image_position_ids",
+            "token_type_ids",
+            "mm_token_type_ids",
+        ]
+        for key in optional_keys:
+            if key in inputs:
+                model_inputs[key] = inputs[key]
+        model_inputs["use_cache"] = False
+        if "logits_to_keep" in self.model_kwarg_keys:
+            model_inputs["logits_to_keep"] = logits_to_keep + 1
+
+        # Apply tool_mask (from env_mask) for loss computation in multi-turn training scenarios
+        loss_mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
+        # For dapo/cispo, match the torch path (_compute_loss): normalize by the total active tokens
+        # across the entire generation batch (num_items_in_batch / num_processes) instead of the
+        # current micro-batch's mask sum. Liger's kernel applies the num_items_in_batch / world_size
+        # normalizer internally when it is provided.
+        global_normalizer_loss_types = ["dapo", "cispo"]
+        num_items_in_batch = (
+            inputs.get("num_items_in_batch") if self.loss_type in global_normalizer_loss_types else None
+        )
+        loss, metrics = triton_grpo_loss(
+            model(**model_inputs).logits,
+            inputs.get("old_per_token_logps"),
+            inputs.get("ref_per_token_logps"),
+            completion_ids,
+            inputs["advantages"],
+            completion_mask=loss_mask,
+            temperature=self.temperature,
+            beta=self.beta,
+            eps_low=self.epsilon_low,
+            eps_high=self.epsilon_high,
+            inplace=True,
+            loss_type=self.loss_type,
+            max_completion_length=self.max_completion_length,
+            importance_sampling_level=self.importance_sampling_level,
+            reduce=True,
+            vllm_is_ratio=inputs.get("importance_sampling_ratio"),
+            sapo_temperature_pos=self.args.sapo_temperature_pos,
+            sapo_temperature_neg=self.args.sapo_temperature_neg,
+            delta=self.args.delta,
+            use_bias_correction_kl=self.args.use_bias_correction_kl,
+            num_items_in_batch=num_items_in_batch,
+            vespo_k_pos=self.args.vespo_k_pos,
+            vespo_lambda_pos=self.args.vespo_lambda_pos,
+            vespo_k_neg=self.args.vespo_k_neg,
+            vespo_lambda_neg=self.args.vespo_lambda_neg,
+        )
+
+        mode = "train" if self.model.training else "eval"
+        metric_offset = 0
+        if self.beta != 0.0:
+            kl_metric = metrics[0]
+            self._metrics[mode]["kl"].append(self.accelerator.gather(kl_metric).mean().item())
+            metric_offset = 1
+        clip_ratio = metrics[metric_offset]
+        self._metrics[mode]["clip_ratio"].append(self.accelerator.gather(clip_ratio).mean().item())
+        if num_items_in_batch is not None:
+            # Loss is already normalized by the global token count, so micro-batch losses must sum
+            # across gradient-accumulation steps (the torch path likewise skips the accum divisor).
+            return loss
+        normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
+        return loss / normalizer
+
+    def compute_chunked_liger_loss(self, unwrapped_model, inputs):
+        """Chunked Triton GRPO loss: fuses the lm_head projection into the loss so the
+        (B, L, vocab) logits tensor is never materialized.
+
+        Sharding contract: ZeRO-3/FSDP manage parameter lifetime per *module* window (gather at
+        the owning module's forward, re-gather for its backward, reduce-scatter its grad). The
+        fused loss consumes `lm_head.weight` as a raw GEMM operand and saves it for backward, so
+        the call below is redirected through `lm_head`'s own forward: from the wrapper's
+        perspective the chunked loss is then an ordinary lm_head invocation (module in,
+        activations out) whose backward window covers the fused Function's backward — the same
+        contract the non-chunked path gets from the real lm_head matmul. This method itself is
+        additionally invoked through the top-level forward redirection (see `compute_loss`) so
+        the base-model call also runs inside the wrapper's forward scope.
+        """
+        prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
+        completion_ids = inputs["completion_ids"].contiguous()
+        completion_mask = inputs["completion_mask"].contiguous()
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+        logits_to_keep = completion_ids.size(1)
+
         last_hidden_state = self._get_last_hidden_state(
             unwrapped_model,
             input_ids,
@@ -2729,46 +2831,61 @@ class GRPOTrainer(_BaseTrainer):
             inputs.get("image_position_ids"),
         )
 
+        lm_head = unwrapped_model.lm_head
+        if lm_head.bias is not None:
+            raise NotImplementedError(
+                "`use_liger_chunked_loss=True` does not support models with an lm_head bias. Set "
+                "`use_liger_chunked_loss=False` to use the non-chunked Triton loss."
+            )
+
         # Apply tool_mask (from env_mask) for loss computation in multi-turn training scenarios
         loss_mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
-        lm_head_weight = unwrapped_model.lm_head.weight
-        lm_head_bias = unwrapped_model.lm_head.bias
-        # Liger reads `lm_head` directly instead of through `model.forward()`, so its ZeRO-3 gather hook never fires
-        # and the fused matmul gets an empty shard. Gather the weight/bias ourselves for the call (the weight grad is
-        # computed during this forward, so it isn't needed in the backward). Skip it when already gathered: with tied
-        # embeddings `embed_tokens` keeps the weight `AVAILABLE`, and re-partitioning on exit breaks its tracking.
-        deepspeed_plugin = self.accelerator.state.deepspeed_plugin
-        gather_ctx = nullcontext()
-        if deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3:
-            from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
-
-            params = [lm_head_weight] if lm_head_bias is None else [lm_head_weight, lm_head_bias]
-            if any(p.ds_status != ZeroParamStatus.AVAILABLE for p in params):
-                import deepspeed
-
-                gather_ctx = deepspeed.zero.GatheredParameters(params, modifier_rank=None)
-        with gather_ctx:
-            loss, metrics = self.liger_loss(
-                _input=last_hidden_state,
-                lin_weight=lm_head_weight,
-                selected_token_ids=completion_ids,
-                # The attention_mask parameter in liger loss is actually used as a loss mask (not model attention)
-                attention_mask=loss_mask,
-                advantages=inputs["advantages"],
-                bias=lm_head_bias,
-                old_per_token_logps=inputs.get("old_per_token_logps"),
-                ref_per_token_logps=inputs.get("ref_per_token_logps"),
-                vllm_is_ratio=inputs.get("importance_sampling_ratio"),
-            )
-        # Extract metrics from the liger_grpo_loss output
-        # KL divergence is the first metric when beta is non-zero
-        mean_kl = metrics[0] if self.beta != 0.0 else None
-        clip_ratio = metrics[-1]
+        # Same global dapo/cispo normalization as compute_liger_loss (matches the torch path).
+        global_normalizer_loss_types = ["dapo", "cispo"]
+        num_items_in_batch = (
+            inputs.get("num_items_in_batch") if self.loss_type in global_normalizer_loss_types else None
+        )
+        # Inner redirection: run the fused loss as lm_head's forward so the sharding wrapper
+        # opens a gather/backward window for lm_head.weight around it (see docstring).
+        loss, metrics = self._forward_redirection(
+            lm_head,
+            lm_head,
+            chunked_triton_grpo_loss,
+            last_hidden_state.contiguous(),
+            lm_head.weight,
+            inputs.get("old_per_token_logps"),
+            inputs.get("ref_per_token_logps"),
+            completion_ids,
+            inputs["advantages"],
+            completion_mask=loss_mask,
+            temperature=self.temperature,
+            beta=self.beta,
+            eps_low=self.epsilon_low,
+            eps_high=self.epsilon_high,
+            loss_type=self.loss_type,
+            max_completion_length=self.max_completion_length,
+            importance_sampling_level=self.importance_sampling_level,
+            reduce=True,
+            vllm_is_ratio=inputs.get("importance_sampling_ratio"),
+            sapo_temperature_pos=self.args.sapo_temperature_pos,
+            sapo_temperature_neg=self.args.sapo_temperature_neg,
+            delta=self.args.delta,
+            use_bias_correction_kl=self.args.use_bias_correction_kl,
+            num_items_in_batch=num_items_in_batch,
+        )
 
         mode = "train" if self.model.training else "eval"
+        metric_offset = 0
         if self.beta != 0.0:
-            self._metrics[mode]["kl"].append(self.accelerator.gather(mean_kl).mean().item())
+            kl_metric = metrics[0]
+            self._metrics[mode]["kl"].append(self.accelerator.gather(kl_metric).mean().item())
+            metric_offset = 1
+        clip_ratio = metrics[metric_offset]
         self._metrics[mode]["clip_ratio"].append(self.accelerator.gather(clip_ratio).mean().item())
+        if num_items_in_batch is not None:
+            # Loss is already normalized by the global token count, so micro-batch losses must sum
+            # across gradient-accumulation steps (the torch path likewise skips the accum divisor).
+            return loss
         normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
         return loss / normalizer
 
@@ -2777,9 +2894,12 @@ class GRPOTrainer(_BaseTrainer):
         if return_outputs:
             raise ValueError("The GRPOTrainer does not support returning outputs")
         if self.use_liger_kernel:
-            # Compute the loss using the liger grpo loss
-            unwrapped_model = self.accelerator.unwrap_model(model)
-            return self._forward_redirection(model, unwrapped_model, self.compute_liger_loss, unwrapped_model, inputs)
+            if self.use_liger_chunked_loss:
+                unwrapped_model = self.accelerator.unwrap_model(model)
+                return self._forward_redirection(
+                    model, unwrapped_model, self.compute_chunked_liger_loss, unwrapped_model, inputs
+                )
+            return self.compute_liger_loss(model, inputs)
         return self._compute_loss(model, inputs)
 
     @staticmethod


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch the GRPO training loss path and live vLLM weight sync for multimodal/MoE checkpoints; mis-prefixing or incompatible MoE backends could break generation during RL, though parity tests mitigate the loss refactor.
> 
> **Overview**
> **GRPO Liger integration** is reworked around Liger’s `triton_grpo_loss` on materialized logits instead of `LigerFusedLinearGRPOLoss`, with a new `use_liger_chunked_loss` flag that routes through fused `chunked_triton_grpo_loss` (no full vocab logits tensor). The trainer adds validation for incompatible combos (VESPO, `cast_lm_head_to_fp32`, missing chunked kernel, lm_head bias) and adjusts ZeRO-3/FSDP handling via forward redirection for the chunked path.
> 
> **vLLM** supported versions are widened to **0.25.0** (docs, `pyproject`, `is_vllm_available`). Weight sync into vLLM now prepends a `language_model.` prefix when the checkpoint is a known Qwen3.5 / Qwen3-VL conditional-generation wrapper but the trainer holds the text-only model (`get_vllm_param_prefix` in `VLLMGeneration` and Online DPO). `trl vllm-serve` gains optional **expert parallel**, **MoE backend**, **language-model-only**, and **per-prompt multimodal limits**, with notes that some MoE backends break incremental expert weight updates during RL sync.
> 
> New tests cover Triton loss parity/dispatch, vLLM param prefix mapping, and updated GRPO mocks for `triton_grpo_loss`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2310c7b9bf45186cace9d0cc0f3fd2411063675d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->