### PR TITLE
Batch vLLM weight sync into size-capped buckets

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -14,15 +14,18 @@
 
 import os
 import subprocess
+from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
+import torch
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
 from transformers.testing_utils import torch_device
 
 from trl.generation.vllm_client import VLLMClient
-from trl.generation.vllm_generation import extract_logprobs
+from trl.generation.vllm_generation import VLLMGeneration, extract_logprobs
 from trl.import_utils import is_vllm_available
 from trl.scripts.vllm_serve import chunk_list
 
@@ -122,6 +125,124 @@ class TestExtractLogprobs(TrlTestCase):
 
         assert all_logprobs is None
         assert all_token_ids is None
+
+
+class TestVLLMClientUpdateNamedParams(TrlTestCase):
+    """Unit tests for the batched ``VLLMClient.update_named_params`` method."""
+
+    def _make_client(self):
+        client = VLLMClient.__new__(VLLMClient)
+        client.base_url = "http://localhost:8000"
+        client.session = MagicMock()
+        client.session.post.return_value = MagicMock(status_code=200)
+        client.communicator = MagicMock()
+        client.rank = 0
+        return client
+
+    def test_sends_single_post_for_multiple_tensors(self):
+        client = self._make_client()
+        weights = [torch.zeros(4), torch.ones(8), torch.full((2, 3), 2.0)]
+        names = ["a", "b", "c"]
+
+        client.update_named_params(names, weights)
+
+        assert client.session.post.call_count == 1
+        url = client.session.post.call_args.args[0]
+        assert url.endswith("/update_named_params/")
+        payload = client.session.post.call_args.kwargs["json"]
+        assert payload["names"] == names
+        assert payload["shapes"] == [[4], [8], [2, 3]]
+        assert all(d.startswith("torch.") for d in payload["dtypes"])
+
+        assert client.communicator.broadcast.call_count == len(weights)
+        for w, call in zip(weights, client.communicator.broadcast.call_args_list, strict=True):
+            assert torch.equal(w, call.args[0])
+
+    def test_raises_on_http_error(self):
+        client = self._make_client()
+        client.session.post.return_value = MagicMock(status_code=500, text="boom")
+
+        with pytest.raises(Exception, match="500"):
+            client.update_named_params(["a"], [torch.zeros(2)])
+
+        # No broadcast on failure
+        client.communicator.broadcast.assert_not_called()
+
+    def test_update_model_params_uses_batched_path(self):
+        client = self._make_client()
+        model = MagicMock()
+        model.named_parameters.return_value = [("a", torch.zeros(2)), ("b", torch.zeros(3))]
+
+        client.update_model_params(model)
+
+        assert client.session.post.call_count == 1
+        payload = client.session.post.call_args.kwargs["json"]
+        assert payload["names"] == ["a", "b"]
+
+
+class TestVLLMGenerationBucketPush(TrlTestCase):
+    """Unit tests for the bucketing helper in ``VLLMGeneration``."""
+
+    def _make_gen(self, buffer_bytes: int):
+        gen = VLLMGeneration.__new__(VLLMGeneration)
+        gen.accelerator = MagicMock()
+        gen.accelerator.is_main_process = True
+        gen._weight_sync_buffer_bytes = buffer_bytes
+        gen._push_params_to_vllm = MagicMock()
+        gen._dist = MagicMock()
+
+        @contextmanager
+        def _noop_gather(params):
+            yield
+
+        gen._dist.gather_params.side_effect = _noop_gather
+        return gen
+
+    def test_single_bucket_when_under_limit(self):
+        gen = self._make_gen(buffer_bytes=10_000)
+        items = [("a", torch.zeros(8)), ("b", torch.zeros(16))]
+
+        gen._bucket_push(items)
+
+        assert gen._push_params_to_vllm.call_count == 1
+        names, _ = gen._push_params_to_vllm.call_args.args
+        assert names == ["a", "b"]
+
+    def test_each_tensor_alone_when_exceeds_buffer(self):
+        gen = self._make_gen(buffer_bytes=100)
+        items = [("a", torch.zeros(32)), ("b", torch.zeros(32)), ("c", torch.zeros(8))]
+
+        gen._bucket_push(items)
+
+        assert gen._push_params_to_vllm.call_count == 3
+        assert [c.args[0] for c in gen._push_params_to_vllm.call_args_list] == [["a"], ["b"], ["c"]]
+
+    def test_fills_bucket_before_splitting(self):
+        gen = self._make_gen(buffer_bytes=300)
+        items = [("a", torch.zeros(8)), ("b", torch.zeros(8)), ("c", torch.zeros(8)), ("d", torch.zeros(8))]
+
+        gen._bucket_push(items)
+
+        assert gen._push_params_to_vllm.call_count == 1
+        names, _ = gen._push_params_to_vllm.call_args.args
+        assert names == ["a", "b", "c", "d"]
+
+    def test_empty_input_does_nothing(self):
+        gen = self._make_gen(buffer_bytes=1000)
+        gen._bucket_push([])
+        gen._push_params_to_vllm.assert_not_called()
+
+    def test_gathers_each_bucket(self):
+        gen = self._make_gen(buffer_bytes=100)
+        items = [("a", torch.zeros(32)), ("b", torch.zeros(32))]
+
+        gen._bucket_push(items)
+
+        # One gather per bucket, in order
+        gathered = [c.args[0] for c in gen._dist.gather_params.call_args_list]
+        assert len(gathered) == 2
+        assert len(gathered[0]) == 1 and gathered[0][0] is items[0][1]
+        assert len(gathered[1]) == 1 and gathered[1][0] is items[1][1]
 
 
 @pytest.mark.slow

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -511,17 +511,52 @@ class VLLMClient:
             self.communicator.broadcast(weights, src=self.rank)
             self.communicator.group.barrier()
 
+    def update_named_params(self, names: list[str], weights: list[torch.Tensor]):
+        """
+        Updates a batch of named parameters in a single HTTP request + single server-side `load_weights` call. Sends
+        only one POST regardless of the batch size, instead of one POST per tensor as `update_named_param` does.
+
+        Args:
+            names (`list[str]`):
+                Names of the layers whose weights are being updated.
+            weights (`list[torch.Tensor]`):
+                Tensors containing the updated weights, one per name.
+        """
+        payload = {
+            "names": names,
+            "dtypes": [str(w.dtype) for w in weights],
+            "shapes": [list(w.shape) for w in weights],
+        }
+        url = f"{self.base_url}/update_named_params/"
+        response = self.session.post(url, json=payload)
+        if response.status_code != 200:
+            raise Exception(f"Request failed: {response.status_code}, {response.text}")
+
+        # NCCL/XCCL broadcasts within a single process group must be called in the same order on all ranks, so loop
+        # sequentially. A single collective barrier at the end keeps the workers in step.
+        if is_torch_xpu_available():
+            for w in weights:
+                self.communicator.broadcast(w, root=self.rank)
+            self.communicator.barrier()
+        else:
+            for w in weights:
+                self.communicator.broadcast(w, src=self.rank)
+            self.communicator.group.barrier()
+
     def update_model_params(self, model: nn.Module):
         """
-        Updates all parameters of the given model by calling `update_named_param` for each parameter in the model.
+        Updates all parameters of the given model by sending batched `update_named_params` requests.
 
         Args:
             model (`nn.Module`):
                 Model whose parameters (weights/biases) are to be updated.
         """
+        names, params = [], []
         for name, param in model.named_parameters():
-            # Update each parameter individually
-            self.update_named_param(name, param.data)
+            names.append(name)
+            params.append(param.data)
+        if names:
+            self.update_named_params(names, params)
 
     def get_sequence_logprobs(
         self,

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -288,6 +288,10 @@ class VLLMGeneration:
         self.logprobs = logprobs
         self.generation_kwargs = generation_kwargs or {}
 
+        # Size in bytes of each per-push weight bucket. Reduces the number of HTTP round trips (server mode) and
+        # NCCL/XCCL broadcasts when syncing weights to vLLM.
+        self._weight_sync_buffer_bytes = 256 * 1024 * 1024
+
         self._init_vllm()
 
     def _init_vllm(self):
@@ -384,12 +388,46 @@ class VLLMGeneration:
             name = name.replace(prefix, "")
         return name
 
-    def _push_param_to_vllm(self, name: str, param) -> None:
-        """Push a single parameter tensor to the vLLM engine (server or colocate mode)."""
+    def _push_params_to_vllm(self, names: list[str], params: list[torch.Tensor]) -> None:
+        """Push a batch of parameter tensors to the vLLM engine (server or colocate mode)."""
         if self.mode == "server" and self.accelerator.is_main_process:
-            self.vllm_client.update_named_param(name, param)
+            self.vllm_client.update_named_params(names, params)
         elif self.mode == "colocate":
-            self.llm.llm_engine.model_executor.driver_worker.model_runner.model.load_weights([(name, param)])
+            self.llm.llm_engine.model_executor.driver_worker.model_runner.model.load_weights(
+                list(zip(names, params, strict=True))
+            )
+
+    def _bucket_push(self, named_params) -> None:
+        """Accumulate `(name, param)` pairs up to ``_weight_sync_buffer_bytes`` and push each bucket to vLLM.
+
+        For each bucket, gathers the params (no-op for non-sharded backends, FSDP, and params already gathered by an
+        outer ``gather_params`` context) and calls ``_push_params_to_vllm`` once for the whole batch.
+        """
+        names: list[str] = []
+        params: list[torch.Tensor] = []
+        bytes_used = 0
+        for name, param in named_params:
+            size = param.numel() * param.element_size()
+            if bytes_used + size > self._weight_sync_buffer_bytes and names:
+                with self._dist.gather_params(params):
+                    self._push_params_to_vllm(names, [p.data for p in params])
+                names, params, bytes_used = [], [], 0
+            names.append(name)
+            params.append(param)
+            bytes_used += size
+        if names:
+            with self._dist.gather_params(params):
+                self._push_params_to_vllm(names, [p.data for p in params])
+
+    def _iter_peft_named_params(self, model: nn.Module):
+        """Yield ``(fixed_name, param)`` pairs for a PEFT model, skipping adapter-only/original-module entries."""
+        for name, param in model.named_parameters():
+            name = name.removeprefix("base_model.model.").replace(".base_layer", "")
+            if model.prefix in name:
+                continue
+            if "original_module" in name:
+                continue
+            yield self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."]), param
 
     def _sync_fsdp1_params_to_vllm(self, module: nn.Module, prefix: str = "", visited: set[str] | None = None):
         """Memory-efficient post-order traversal of FSDP modules to extract full parameters and sync with vLLM."""
@@ -404,6 +442,7 @@ class VLLMGeneration:
 
         if isinstance(module, FSDP):
             with FSDP.summon_full_params(module, recurse=False, writeback=False):
+                items = []
                 for param_name, param in module.named_parameters():
                     full_name = f"{prefix}.{param_name}" if prefix else param_name
                     full_name = self._fix_param_name_to_vllm(full_name, extra_prefixes=["_fsdp_wrapped_module."])
@@ -411,28 +450,31 @@ class VLLMGeneration:
                     if full_name in visited:
                         continue  # skip FSDP subtrees already traversed
                     visited.add(full_name)
-
-                    self._push_param_to_vllm(full_name, param.data)
+                    items.append((full_name, param))
+                self._bucket_push(items)
 
     def _sync_fsdp2_params_to_vllm(self, module: nn.Module):
         """FSDP2-specific parameter synchronization."""
-        # For FSDP2, module.state_dict() already covers all parameters, so no need for recursion
-        for name, param in module.state_dict().items():
-            # When using PEFT, we need to recover the original parameter name
-            name = name.removeprefix("base_model.model.").replace(".base_layer", "")
-            # Skip PEFT layers: they don't exist in vLLM, and they are merged already.
-            if is_peft_model(module) and module.prefix in name:
-                continue
-            # When module to save, remove its prefix and discard the original module
-            if "original_module" in name:
-                continue
-            name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
 
-            if param.is_cpu:
-                param = param.to(torch.device("cuda"))
-            param = param.full_tensor()
+        # For FSDP2, module.state_dict() already covers all parameters, so no need for recursion. Materialize the
+        # full tensors lazily so at most one bucket of unsharded params is alive at a time.
+        def iter_full_params():
+            for name, param in module.state_dict().items():
+                # When using PEFT, we need to recover the original parameter name
+                name = name.removeprefix("base_model.model.").replace(".base_layer", "")
+                # Skip PEFT layers: they don't exist in vLLM, and they are merged already.
+                if is_peft_model(module) and module.prefix in name:
+                    continue
+                # When module to save, remove its prefix and discard the original module
+                if "original_module" in name:
+                    continue
+                name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
 
-            self._push_param_to_vllm(name, param)
+                if param.is_cpu:
+                    param = param.to(torch.device("cuda"))
+                yield name, param.full_tensor()
+
+        self._bucket_push(iter_full_params())
 
     def _sync_fsdp_params_to_vllm(self, model: nn.Module):
         """Dispatch FSDP weight sync to the version-appropriate method."""
@@ -469,18 +511,7 @@ class VLLMGeneration:
                     self._sync_fsdp_params_to_vllm(model)
                 else:
                     # DeepSpeed ZeRO-3 with PEFT
-                    for name, param in model.named_parameters():
-                        # When using PEFT, we need to recover the original parameter name
-                        name = name.removeprefix("base_model.model.").replace(".base_layer", "")
-                        # Skip PEFT layers: they don't exist in vLLM, and they are merged already.
-                        if model.prefix in name:
-                            continue
-                        # When module to save, remove its prefix and discard the original module
-                        if "original_module" in name:
-                            continue
-                        name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
-
-                        self._push_param_to_vllm(name, param.data)
+                    self._bucket_push(self._iter_peft_named_params(model))
                 # Unmerge adapters while parameters are still gathered
                 model.unmerge_adapter()
                 # Parameters will automatically be repartitioned when exiting the context
@@ -489,10 +520,9 @@ class VLLMGeneration:
             if self._dist.is_fsdp:
                 self._sync_fsdp_params_to_vllm(model)
             else:
-                for name, param in model.named_parameters():
-                    name = self._fix_param_name_to_vllm(name)
-                    with self._dist.gather_params([param]):
-                        self._push_param_to_vllm(name, param.data)
+                self._bucket_push(
+                    ((self._fix_param_name_to_vllm(name), param) for name, param in model.named_parameters())
+                )
 
         # Reset cache on vLLM
         if self.mode == "server" and accelerator.is_main_process:

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -148,6 +148,44 @@ class WeightSyncWorkerExtension:
         # Load the received weights into the model.
         self.model_runner.model.load_weights(weights=[(name, weight)])
 
+    def update_named_params(self, names: list[str], dtypes: list[str], shapes: list[Sequence[int]]) -> None:
+        """
+        Receives a batch of updated weights from the client process and loads them into the model in a single
+        `load_weights` call. Reduces the number of NCCL/XCCL broadcasts and HTTP round trips compared to calling
+        `update_named_param` once per tensor.
+
+        Args:
+            names (`list[str]`):
+                Names of the weight tensors being updated.
+            dtypes (`list[str]`):
+                Data types of the weight tensors, one per name (e.g., `"torch.float32"`).
+            shapes (`list[Sequence[int]]`):
+                Shapes of the weight tensors, one per name.
+        """
+        import torch
+        from transformers import is_torch_xpu_available
+
+        if self.communicator is None:
+            raise RuntimeError("Communicator not initialized. Call `init_communicator` first.")
+
+        weights = [
+            torch.empty(tuple(shape), dtype=getattr(torch, dtype.split(".")[-1]), device=self.device)
+            for dtype, shape in zip(dtypes, shapes, strict=True)
+        ]
+
+        # NCCL/XCCL broadcasts within a single process group must be called in the same order on all ranks, so loop
+        # sequentially. A single collective barrier at the end keeps the workers in step.
+        if is_torch_xpu_available():
+            for weight in weights:
+                self.communicator.broadcast(weight, root=self.client_rank)
+            self.communicator.barrier()
+        else:
+            for weight in weights:
+                self.communicator.broadcast(weight, src=self.client_rank)
+            self.communicator.group.barrier()
+
+        self.model_runner.model.load_weights(weights=list(zip(names, weights, strict=True)))
+
     def close_communicator(self) -> None:
         """
         Closes the communicator when weight synchronization is no longer needed.
@@ -1175,6 +1213,34 @@ def main(script_args: ScriptArguments):
             connection.send({"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs})
 
         return {"message": "Request received, updating named parameter"}
+
+    class UpdateNamedParamsRequest(BaseModel):
+        names: list[str]
+        dtypes: list[str]
+        shapes: list[list[int]]
+
+    @app.post("/update_named_params/")
+    async def update_named_params(request: UpdateNamedParamsRequest):
+        """
+        Updates the model weights with a batch of tensors in a single server-side call. The client process broadcasts
+        each tensor to all server workers in order, then the workers load the full batch in one `load_weights` call.
+
+        Args:
+            request (`UpdateNamedParamsRequest`):
+                - `names` (`list[str]`): Names of the weight tensors being updated.
+                - `dtypes` (`list[str]`): Data types of the weight tensors, one per name.
+                - `shapes` (`list[list[int]]`): Shapes of the weight tensors, one per name.
+        """
+        # The function update_named_params is called this way:
+        # update_named_params(["w1", "w2"], ["torch.float32", "torch.float32"], [(10, 10), (5, 5)])
+        kwargs = {
+            "method": "update_named_params",
+            "args": (request.names, request.dtypes, [tuple(s) for s in request.shapes]),
+        }
+        for connection in connections:
+            connection.send({"type": "fire_and_forget", "method": "collective_rpc", "kwargs": kwargs})
+
+        return {"message": "Request received, updating named parameters", "count": len(request.names)}
 
     @app.post("/reset_prefix_cache/")
     async def reset_prefix_cache():


### PR DESCRIPTION
Weight sync to vLLM currently does one HTTP request, one collective_rpc and one NCCL broadcast per parameter. For models with hundreds of tensors and per-step syncing this fixed overhead adds up.

This PR batches the sync path:

- new batched `/update_named_params/` endpoint and worker method that receives a list of tensors per request and loads them in a single `load_weights` call (the vLLM model API already takes an iterable of pairs)
- `VLLMGeneration` accumulates params into 256 MB buckets before pushing, so peak transient memory (client-side gathers, server receive buffers) stays bounded regardless of model size
- FSDP2 sync now materializes `full_tensor()` lazily inside the bucket loop instead of building the whole unsharded model up front
- unit tests for the bucketing and the batched update path

Same bucketing pattern as other RL stacks (slime and miles use a 512 MB buffer, NeMo-RL a configurable refit buffer). All trainers using `VLLMGeneration` pick this up through the unchanged `sync_weights()` interface.

Extracted from #6126, which no longer needs to carry it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the distributed weight-sync protocol (HTTP + NCCL/XCCL ordering); mistakes could desync trainer and vLLM weights, though behavior is covered by new unit tests and existing integration tests still call `update_model_params`.
> 
> **Overview**
> **Weight sync to vLLM is batched** instead of one HTTP request, `collective_rpc`, and broadcast per parameter.
> 
> The client adds **`update_named_params`** (single POST, ordered broadcasts, one barrier) and **`update_model_params`** now sends all tensors through that path. The serve worker and **`/update_named_params/`** endpoint load each batch in one **`load_weights`** call.
> 
> **`VLLMGeneration`** groups parameters into **256 MB buckets** via **`_bucket_push`**, uses batched **`_push_params_to_vllm`**, and routes FSDP/PEFT/non-PEFT **`sync_weights`** through bucketing. **FSDP2** materializes **`full_tensor()`** lazily per bucket rather than unsharding the full model up front.
> 
> Unit tests cover the client batch API and bucketing behavior; **`sync_weights()`**’s public interface is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c165c11f4042803a787baedc9086f53ac4a17fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->