### PR TITLE
Auto-load `processing_class` in PRMTrainer when omitted

### DIFF
--- a/tests/experimental/test_prm_trainer.py
+++ b/tests/experimental/test_prm_trainer.py
@@ -347,6 +347,30 @@ class TestPRMTrainer(TrlTestCase):
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
 
+    def test_processing_class_autoloaded(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_stepwise_supervision", split="train")
+        args = PRMConfig(output_dir=self.tmp_dir, max_steps=1, save_strategy="no", report_to="none")
+        trainer = PRMTrainer(model=self.model, args=args, train_dataset=dataset)
+
+        assert trainer.processing_class is not None
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.parametrize("pretokenized", [False, True])
+    def test_processing_class_autoloaded_with_custom_collator(self, pretokenized):
+        if pretokenized:
+            dataset = Dataset.from_dict({"input_ids": [[0, 1]], "labels": [[-100, 1]]})
+        else:
+            dataset = load_dataset("trl-internal-testing/zen", "standard_stepwise_supervision", split="train")
+
+        trainer = PRMTrainer(
+            model=self.model,
+            args=PRMConfig(output_dir=self.tmp_dir, report_to="none"),
+            data_collator=object(),
+            train_dataset=dataset,
+        )
+        assert trainer.processing_class is not None
+
     @require_peft
     def test_train_lora(self):
         peft_config = LoraConfig(

--- a/trl/experimental/prm/prm_config.py
+++ b/trl/experimental/prm/prm_config.py
@@ -42,6 +42,8 @@ class PRMConfig(_BaseConfig):
             Separator used to separate each step of the reasoning process.
         train_on_last_step_only (`bool`, *optional*, defaults to `False`):
             Whether to train only on the last step.
+        trust_remote_code (`bool`, *optional*, defaults to `False`):
+            Whether to allow loading tokenizers that ship custom Python code from the Hub.
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
 
@@ -81,6 +83,10 @@ class PRMConfig(_BaseConfig):
     train_on_last_step_only: bool = field(
         default=False,
         metadata={"help": "Whether to train only on the last step."},
+    )
+    trust_remote_code: bool = field(
+        default=False,
+        metadata={"help": "Whether to allow loading tokenizers that ship custom Python code from the Hub."},
     )
     dataset_num_proc: int | None = field(
         default=None,

--- a/trl/experimental/prm/prm_trainer.py
+++ b/trl/experimental/prm/prm_trainer.py
@@ -27,6 +27,7 @@ from accelerate.utils import is_peft_model
 from datasets import Dataset, features
 from packaging.version import Version
 from transformers import (
+    AutoTokenizer,
     BaseImageProcessor,
     DataCollator,
     DataCollatorForTokenClassification,
@@ -40,7 +41,7 @@ from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
 
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import disable_dropout_in_model
+from ...trainer.utils import disable_dropout_in_model, get_config_model_id
 from ..utils import prepare_peft_model
 from .prm_config import PRMConfig
 
@@ -117,7 +118,7 @@ class PRMTrainer(_BaseTrainer):
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.BaseImageProcessor`], [`~transformers.FeatureExtractionMixin`] or [`~transformers.ProcessorMixin`], *optional*):
             Processing class used to process the data. If provided, will be used to automatically process the inputs
             for the model, and it will be saved along the model to make it easier to rerun an interrupted training or
-            reuse the fine-tuned model.
+            reuse the fine-tuned model. If `None`, the tokenizer is loaded from the model.
         model_init (`Callable[[], transformers.PreTrainedModel]`):
             The model initializer to use for training. If None is specified, the default model initializer will be
             used.
@@ -194,14 +195,15 @@ class PRMTrainer(_BaseTrainer):
         if args.disable_dropout:
             disable_dropout_in_model(model)
 
+        if processing_class is None:
+            processing_class = AutoTokenizer.from_pretrained(
+                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
+            )
+
         if compute_metrics is None:
             compute_metrics = compute_accuracy
 
         if data_collator is None:
-            if processing_class is None:
-                raise ValueError(
-                    "A processing_class must be specified when using the default DataCollatorForTokenClassification"
-                )
             data_collator = DataCollatorForTokenClassification(processing_class)
 
         if "input_ids" not in train_dataset.column_names:


### PR DESCRIPTION
## What does this PR do?

Auto-loads `processing_class` from the model when it is omitted, matching SFT, DPO, and Reward trainers. This applies with either the default or a custom data collator and for both raw and pre-tokenized datasets.

`PRMConfig` now exposes `trust_remote_code` for tokenizer loading.

## Tests

- processing-class autoload coverage for all three dataset/collator paths (3 passed)
- Ruff check and format check on the changed files

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.