### PR TITLE
Gather the lm_head during evaluation in the Liger distillation trainers

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -3572,6 +3572,30 @@ class TestGOLDTrainerLoss(TrlTestCase):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
+    def test_prediction_step_gathers_liger_zero3_lm_head_like_training_step(self, monkeypatch):
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion")
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=GOLDConfig(output_dir=self.tmp_dir, report_to="none", per_device_eval_batch_size=2),
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            processing_class=self.tokenizer,
+        )
+
+        call_count = 0
+        original_gather_ctx = trainer._get_liger_zero3_lm_head_gather_ctx
+
+        def counting_gather_ctx(model):
+            nonlocal call_count
+            call_count += 1
+            return original_gather_ctx(model)
+
+        monkeypatch.setattr(trainer, "_get_liger_zero3_lm_head_gather_ctx", counting_gather_ctx)
+
+        trainer.evaluate()
+        assert call_count > 0
+
     def test_loss_normalizes_by_num_items_in_batch(self):
         # When `num_items_in_batch` is passed (as under gradient accumulation), the JSD loss must be reduced as
         # sum / num_items_in_batch rather than the local per-microbatch mean. The batch uses variable-length prompts

--- a/tests/experimental/test_iw_opd_trainer.py
+++ b/tests/experimental/test_iw_opd_trainer.py
@@ -629,6 +629,30 @@ class TestIWOPDTrainer(TrlTestCase):
         finally:
             importlib.reload(importlib.import_module(trainer.model.__module__))
 
+    def test_prediction_step_gathers_liger_zero3_lm_head_like_training_step(self, monkeypatch):
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling")
+        trainer = IWOPDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=self._make_args(per_device_eval_batch_size=2),
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            processing_class=self.tokenizer,
+        )
+
+        call_count = 0
+        original_gather_ctx = trainer._get_liger_zero3_lm_head_gather_ctx
+
+        def counting_gather_ctx(model):
+            nonlocal call_count
+            call_count += 1
+            return original_gather_ctx(model)
+
+        monkeypatch.setattr(trainer, "_get_liger_zero3_lm_head_gather_ctx", counting_gather_ctx)
+
+        trainer.evaluate()
+        assert call_count > 0
+
     def test_sampled_mode_matches_between_local_and_external_teachers(self, monkeypatch):
         import trl.generation.vllm_client as vllm_client_module
 

--- a/tests/experimental/test_sdft_trainer.py
+++ b/tests/experimental/test_sdft_trainer.py
@@ -227,6 +227,45 @@ class TestSDFTTrainer(TrlTestCase):
             atol=1e-6,
         )
 
+    def test_prediction_step_gathers_liger_zero3_lm_head_like_training_step(self, monkeypatch):
+        dataset = Dataset.from_dict(
+            {
+                "prompt": ["Solve 2+2.", "Name the capital of France."],
+                "privileged_context": ["Example answer: 4.", "Example answer: Paris."],
+            }
+        )
+
+        training_args = SDFTConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,
+            per_device_eval_batch_size=2,
+            max_completion_length=8,
+            max_steps=1,
+            num_generations=1,
+            report_to="none",
+            use_cpu=True,
+            bf16=False,
+        )
+        trainer = SDFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
+            eval_dataset=dataset,
+        )
+
+        call_count = 0
+        original_gather_ctx = trainer._get_liger_zero3_lm_head_gather_ctx
+
+        def counting_gather_ctx(model):
+            nonlocal call_count
+            call_count += 1
+            return original_gather_ctx(model)
+
+        monkeypatch.setattr(trainer, "_get_liger_zero3_lm_head_gather_ctx", counting_gather_ctx)
+
+        trainer.evaluate()
+        assert call_count > 0
+
     def test_train_rejects_none_privileged_context(self):
         dataset = Dataset.from_dict(
             {

--- a/tests/experimental/test_sdpo_trainer.py
+++ b/tests/experimental/test_sdpo_trainer.py
@@ -264,6 +264,44 @@ class TestSDPOTrainer(TrlTestCase):
             atol=1e-6,
         )
 
+    def test_prediction_step_gathers_liger_zero3_lm_head_like_training_step(self, monkeypatch):
+        eval_dataset = Dataset.from_dict({"prompt": ["Alpha prompt", "Beta prompt", "Gamma prompt", "Delta prompt"]})
+
+        training_args = SDPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,
+            per_device_eval_batch_size=4,
+            generation_batch_size=3,
+            num_generations=3,
+            num_generations_eval=2,
+            max_completion_length=8,
+            distillation_is_clip=None,
+            max_steps=1,
+            report_to="none",
+            use_cpu=True,
+            bf16=False,
+        )
+        trainer = SDPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda **kwargs: [0.0] * len(kwargs["prompts"]),
+            args=training_args,
+            train_dataset=eval_dataset.select(range(1)),
+            eval_dataset=eval_dataset,
+        )
+
+        call_count = 0
+        original_gather_ctx = trainer._get_liger_zero3_lm_head_gather_ctx
+
+        def counting_gather_ctx(model):
+            nonlocal call_count
+            call_count += 1
+            return original_gather_ctx(model)
+
+        monkeypatch.setattr(trainer, "_get_liger_zero3_lm_head_gather_ctx", counting_gather_ctx)
+
+        trainer.evaluate()
+        assert call_count > 0
+
     def test_train_without_successful_rollouts(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -2522,6 +2522,10 @@ class GOLDTrainer(SFTTrainer):
                 student_hidden = student_outputs.last_hidden_state[:, :-1]
                 teacher_hidden = teacher_outputs.last_hidden_state[:, :-1]
 
+                # The shared return below hands these back when `return_outputs=True`, and
+                # `Trainer.prediction_step` slices `outputs[1:]` when `prediction_loss_only=False`; neither works on
+                # a name this branch never bound.
+                outputs_student = student_outputs
                 del student_outputs, teacher_outputs
 
                 student_hidden = student_hidden.reshape(-1, student_hidden.shape[-1])
@@ -2762,7 +2766,10 @@ class GOLDTrainer(SFTTrainer):
         inputs = self._prepare_inputs(inputs)
         with torch.no_grad():
             with self.compute_loss_context_manager():
-                loss = self.compute_loss(model, inputs)
+                # Same gather as `training_step`: the fused JSD projects through the lm_head, which stays sharded
+                # under Liger + ZeRO-3 unless it is gathered first.
+                with self._get_liger_zero3_lm_head_gather_ctx(model):
+                    loss = self.compute_loss(model, inputs)
             loss = loss.mean().detach()
         return loss, None, None
 

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -1580,8 +1580,9 @@ class IWOPDTrainer(_BaseTrainer):
         self._raise_if_local_teacher_tokenizer_mismatch()
 
         if self.use_liger_loss:
-            loss = self._compute_liger_loss(model, inputs, num_items_in_batch=num_items_in_batch)
-            return (loss, None) if return_outputs else loss
+            return self._compute_liger_loss(
+                model, inputs, num_items_in_batch=num_items_in_batch, return_outputs=return_outputs
+            )
 
         # Student forward pass
         student_outputs = model(
@@ -1695,7 +1696,7 @@ class IWOPDTrainer(_BaseTrainer):
             use_cache=False,
         )
 
-    def _compute_liger_loss(self, model, inputs, num_items_in_batch=None):
+    def _compute_liger_loss(self, model, inputs, num_items_in_batch=None, return_outputs=False):
         """Memory-efficient JSD using Liger kernel (operates on hidden states, not full logits)."""
         # Route through the DDP/FSDP wrapper via _forward_redirection so that
         # DDP.forward() is called and prepare_for_backward() fires correctly.
@@ -1721,7 +1722,7 @@ class IWOPDTrainer(_BaseTrainer):
 
         student_hidden = student_outputs.last_hidden_state[:, :-1]
         teacher_hidden = teacher_outputs.last_hidden_state[:, :-1]
-        del student_outputs, teacher_outputs
+        del teacher_outputs
 
         student_hidden = student_hidden.reshape(-1, student_hidden.shape[-1])
         teacher_hidden = teacher_hidden.reshape(-1, teacher_hidden.shape[-1])
@@ -1752,7 +1753,7 @@ class IWOPDTrainer(_BaseTrainer):
             loss = loss * num_valid_local / num_items_in_batch
 
         del student_hidden, teacher_hidden, true_labels
-        return loss
+        return (loss, student_outputs) if return_outputs else loss
 
     def _get_liger_zero3_lm_head_gather_ctx(self, model: nn.Module):
         """Context manager for gathering lm_head parameters under Liger + ZeRO-3."""
@@ -1826,6 +1827,18 @@ class IWOPDTrainer(_BaseTrainer):
             self._off_policy_step_equiv += step_equiv
 
         return loss
+
+    def prediction_step(
+        self,
+        model: nn.Module,
+        inputs: dict[str, torch.Tensor | Any],
+        prediction_loss_only: bool,
+        ignore_keys: list[str] | None = None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        # Same gather as `training_step`: the fused JSD projects through the lm_head, which stays sharded under
+        # Liger + ZeRO-3 unless it is gathered first.
+        with self._get_liger_zero3_lm_head_gather_ctx(model):
+            return super().prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -617,7 +617,10 @@ class SDFTTrainer(_BaseTrainer):
             inputs = self._prepare_inputs(inputs)
         with torch.no_grad():
             with self.compute_loss_context_manager():
-                loss = self.compute_loss(model, inputs)
+                # Same gather as `training_step`: the fused JSD projects through the lm_head, which stays sharded
+                # under Liger + ZeRO-3 unless it is gathered first.
+                with self._get_liger_zero3_lm_head_gather_ctx(model):
+                    loss = self.compute_loss(model, inputs)
         return loss.detach(), None, None
 
     def _prepare_inputs(self, generation_batch):

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -822,7 +822,10 @@ class SDPOTrainer(_BaseTrainer):
             inputs = self._prepare_inputs(inputs)
         with torch.no_grad():
             with self.compute_loss_context_manager():
-                loss = self.compute_loss(model, inputs)
+                # Same gather as `training_step`: the fused JSD projects through the lm_head, which stays sharded
+                # under Liger + ZeRO-3 unless it is gathered first.
+                with self._get_liger_zero3_lm_head_gather_ctx(model):
+                    loss = self.compute_loss(model, inputs)
         return loss.detach(), None, None
 
     def _prepare_inputs(self, generation_batch):


### PR DESCRIPTION
## What does this PR do?

`training_step` in the Liger distillation trainers wraps the step in `_get_liger_zero3_lm_head_gather_ctx`, because the fused JSD projects through the `lm_head` and that projection needs the head gathered under Liger + ZeRO-3. Evaluation goes through `prediction_step`, which does the same projection but without the gather, so eval on a ZeRO-3 run sees a sharded `lm_head`.

This adds the same gather to the evaluation path:

- `SDFTTrainer.prediction_step` and `SDPOTrainer.prediction_step` — both already had the gather in `training_step` only.
- `IWOPDTrainer` — had no `prediction_step` override at all, so it now gets one mirroring the other two.
- `GOLDTrainer` — has its own `prediction_step` override that calls `compute_loss` directly rather than `super()`, so the gather wraps that call.

It also makes the Liger path return the student outputs when `return_outputs=True`, in both `IWOPDTrainer.compute_loss` and `GOLDTrainer.compute_loss`. The non-Liger path a few lines below already returns them; the Liger path returned `(loss, None)` in IWOPD and never bound the name it returns in GOLD. `Trainer.prediction_step` slices `outputs[1:]` when `prediction_loss_only=False`, which works on neither.

## Correction to an earlier revision of this description

An earlier revision of this description claimed `GOLDTrainer` had changed on `main` and no longer needed anything here. That was wrong. Cursor Bugbot flagged it on this PR and was right on both counts. Checked against current `main` (`2396dfe`):

- `GOLDTrainer.prediction_step` (`gold_trainer.py` L2761) calls `self.compute_loss` with no gather, while `training_step` (L2786) has one. `_get_liger_zero3_lm_head_gather_ctx` is defined 25 lines above the override and used only by `training_step`.
- In `compute_loss`, the Liger branch binds `student_outputs`, deletes it at L2525, and never binds `outputs_student`, so the shared `return (loss, outputs_student) if return_outputs else loss` at L2631 raises `UnboundLocalError` on that path.

`GOLDTrainer` subclasses `SFTTrainer` and declares exactly one `prediction_step`, so nothing else covers it. Both fixes are included here now.

The `DistillationTrainer` half of that earlier note still holds, re-checked at the same commit: it routes the whole loss through `_forward_redirection` into a unified `_compute_loss`, has no `_get_liger_zero3_lm_head_gather_ctx` at all, and its `(loss, None)` is deliberate because the chunked path never materializes student logits.

The branch was rebuilt on current `main` rather than merged, since the original diff no longer applied.

## Tests

Each new test counts calls to `_get_liger_zero3_lm_head_gather_ctx` during `trainer.evaluate()`. All four fail without the corresponding source change (0 calls) and pass with it.

- `pytest tests/experimental/test_sdft_trainer.py tests/experimental/test_sdpo_trainer.py tests/experimental/test_iw_opd_trainer.py -k prediction_step_gathers`: 3 passed
- `pytest tests/experimental/test_sdft_trainer.py tests/experimental/test_sdpo_trainer.py tests/experimental/test_iw_opd_trainer.py`: 77 passed, 3 skipped
- `pytest tests/experimental/test_gold_trainer.py -k prediction_step_gathers`: 1 passed; reverting only `gold_trainer.py` makes it fail, so the test is anchored to the fix
- `pytest tests/experimental/test_gold_trainer.py`: 67 passed, 4 skipped
- `ruff check` and `ruff format --check` on the changed files

Two limits worth stating rather than leaving implied:

- The `return_outputs=True` fixes have no dedicated test in either trainer. Reaching that branch needs the Liger kernel path, which the CPU test environment here does not exercise; the change is argued from control flow, where the branch plainly never binds the name it returns.
- The ZeRO-3 branch of the gather itself still needs a multi-GPU DeepSpeed run. The tests cover that the context is entered on the eval path, not the DeepSpeed behaviour inside it.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval loss computation for Liger + DeepSpeed ZeRO-3 runs and touches multiple experimental trainers; behavior is intentionally aligned with training but affects reported eval metrics and any code relying on Liger `return_outputs`.
> 
> **Overview**
> Evaluation for **Liger** distillation trainers now wraps `prediction_step` in `_get_liger_zero3_lm_head_gather_ctx`, matching `training_step`, so fused JSD can project through a gathered `lm_head` under ZeRO-3 instead of a sharded one.
> 
> **SDFTTrainer**, **SDPOTrainer**, and **GOLDTrainer** add the gather around `compute_loss` in their existing `prediction_step` overrides. **GOLDTrainer** also sets `outputs_student` on the Liger branch so `return_outputs=True` does not reference an unbound name.
> 
> **IWOPDTrainer** adds a `prediction_step` override with the same gather, routes Liger `compute_loss` through `_compute_liger_loss` with `return_outputs`, and returns `(loss, student_outputs)` from the Liger path when outputs are requested (aligned with the non-Liger path).
> 
> Regression tests in the GOLD, IW-OPD, SDFT, and SDPO test modules assert `_get_liger_zero3_lm_head_gather_ctx` is invoked during `trainer.evaluate()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558cabb3d055f47c8c4494e560894d8539fc328e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->