### PR TITLE
Auto-load `processing_class` in OnlineDPO/NashMD/XPO trainers when omitted

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -113,8 +113,9 @@ class TestNashMDTrainer(TrlTestCase):
         assert "train_loss" in trainer.state.log_history[-1]
 
     def test_nash_md_trainer_training_processing_class_autoloaded(self):
-        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
-        # consistent with OnlineDPOTrainer (which NashMDTrainer subclasses) and CPO/ORPO/BCO trainers.
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model using
+        # `AutoProcessor.from_pretrained`, consistent with OnlineDPOTrainer (which NashMDTrainer subclasses) and
+        # GRPO/DPO/SFT.
         training_args = NashMDConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,

--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -112,6 +112,33 @@ class TestNashMDTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
+    def test_nash_md_trainer_training_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
+        # consistent with OnlineDPOTrainer (which NashMDTrainer subclasses) and CPO/ORPO/BCO trainers.
+        training_args = NashMDConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            remove_unused_columns=False,
+            gradient_accumulation_steps=1,
+            learning_rate=9e-1,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        trainer = NashMDTrainer(
+            model=self.model,
+            ref_model=self.ref_model,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert trainer.processing_class is not None
+        trainer.train()
+
+        assert "train_loss" in trainer.state.log_history[-1]
+
     @require_peft
     def test_train_with_peft(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -115,6 +115,54 @@ class TestOnlineDPOTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
+    def test_train_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
+        # consistent with CPO/ORPO/BCO trainers.
+        training_args = OnlineDPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            learning_rate=5.0e-7,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        trainer = OnlineDPOTrainer(
+            model=self.model,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+            reward_processing_classes=self.reward_tokenizer,
+        )
+        assert trainer.processing_class is not None
+        trainer.train()
+
+        assert "train_loss" in trainer.state.log_history[-1]
+
+    def test_train_model_str_processing_class_autoloaded(self):
+        # Same as above, but with `model` passed as a string id. The auto-load must happen after `model` is
+        # resolved from a string to an instantiated model, otherwise `model.config` would not yet be available.
+        training_args = OnlineDPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            learning_rate=5.0e-7,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        trainer = OnlineDPOTrainer(
+            model=self.model_id,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+            reward_processing_classes=self.reward_tokenizer,
+        )
+        assert trainer.processing_class is not None
+        trainer.train()
+
+        assert "train_loss" in trainer.state.log_history[-1]
+
     def test_train_with_ref_model(self):
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 from datasets import Dataset, features, load_dataset
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, ProcessorMixin
 from transformers.utils import is_peft_available, is_vision_available
 
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
@@ -116,8 +116,9 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert "train_loss" in trainer.state.log_history[-1]
 
     def test_train_processing_class_autoloaded(self):
-        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
-        # consistent with CPO/ORPO/BCO trainers.
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model using
+        # `AutoProcessor.from_pretrained`, consistent with GRPO/DPO/SFT. Unlike CPO/ORPO/BCO, this trainer also
+        # supports VLMs, so loading via `AutoTokenizer` would break image inputs (see the VLM test below).
         training_args = OnlineDPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,
@@ -504,6 +505,58 @@ class TestOnlineDPOVisionTrainer(TrlTestCase):
             eval_dataset=dataset,
             reward_processing_classes=reward_tokenizer,
         )
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Idefics2ForConditionalGeneration",
+            "trl-internal-testing/tiny-LlavaForConditionalGeneration",
+        ],
+    )
+    def test_online_dpo_vlm_trainer_processing_class_autoloaded(self, model_id):
+        # Same as test_online_dpo_vlm_trainer, but processing_class is omitted. For VLMs, the auto-load must use
+        # `AutoProcessor.from_pretrained`, not `AutoTokenizer.from_pretrained`: a plain tokenizer can't handle the
+        # `images` kwarg that `_generate` passes to `processing_class(...)` for vision models.
+        dataset_dict = {
+            "prompt": [
+                [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Describe the image."}]}],
+                [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "What do you see?"}]}],
+            ],
+            "images": [
+                [Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8))],
+                [Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8))],
+            ],
+        }
+        dataset = Dataset.from_dict(dataset_dict)
+        dataset = dataset.cast_column("images", features.Sequence(features.Image()))
+
+        model = AutoModelForImageTextToText.from_pretrained(model_id, dtype="float32")
+        reward_model = AutoModelForSequenceClassification.from_pretrained(
+            "trl-internal-testing/tiny-LlamaForCausalLM-3.2", num_labels=1
+        )
+        reward_tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-LlamaForCausalLM-3.2")
+        reward_tokenizer.pad_token = reward_tokenizer.eos_token
+
+        training_args = OnlineDPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=1,
+            max_steps=2,
+            learning_rate=0.01,
+            report_to="none",
+        )
+        trainer = OnlineDPOTrainer(
+            model=model,
+            reward_funcs=reward_model,
+            args=training_args,
+            train_dataset=dataset,
+            eval_dataset=dataset,
+            reward_processing_classes=reward_tokenizer,
+        )
+        assert isinstance(trainer.processing_class, ProcessorMixin)
 
         trainer.train()
 

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -63,8 +63,9 @@ class TestXPOTrainer(TrlTestCase):
         assert "train_loss" in trainer.state.log_history[-1]
 
     def test_xpo_trainer_training_processing_class_autoloaded(self):
-        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
-        # consistent with OnlineDPOTrainer (which XPOTrainer subclasses) and CPO/ORPO/BCO trainers.
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model using
+        # `AutoProcessor.from_pretrained`, consistent with OnlineDPOTrainer (which XPOTrainer subclasses) and
+        # GRPO/DPO/SFT.
         training_args = XPOConfig(
             output_dir=self.tmp_dir,
             per_device_train_batch_size=2,

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -62,6 +62,33 @@ class TestXPOTrainer(TrlTestCase):
 
         assert "train_loss" in trainer.state.log_history[-1]
 
+    def test_xpo_trainer_training_processing_class_autoloaded(self):
+        # processing_class is documented as optional: when omitted it should be auto-loaded from the model,
+        # consistent with OnlineDPOTrainer (which XPOTrainer subclasses) and CPO/ORPO/BCO trainers.
+        training_args = XPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            max_steps=3,
+            remove_unused_columns=False,
+            gradient_accumulation_steps=1,
+            learning_rate=9e-1,
+            report_to="none",
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        trainer = XPOTrainer(
+            model=self.model,
+            ref_model=self.ref_model,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert trainer.processing_class is not None
+        trainer.train()
+
+        assert "train_loss" in trainer.state.log_history[-1]
+
     @require_peft
     def test_train_with_peft(self):
         lora_config = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -256,10 +256,6 @@ class OnlineDPOTrainer(_BaseTrainer):
         if args is None:
             raise ValueError("`args` must be provided.")
 
-        # Check that the processing_class is provided
-        if processing_class is None:
-            raise ValueError("`processing_class` must be provided.")
-
         model_init_kwargs = args.model_init_kwargs or {}
         if isinstance(model, str):
             model_id = model
@@ -288,6 +284,14 @@ class OnlineDPOTrainer(_BaseTrainer):
                 )
         self.is_encoder_decoder = model.config.is_encoder_decoder
         self.is_vision_model = model.config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.keys()
+
+        # Handle the processing_class: load the tokenizer from the model if not provided. This is done here, after
+        # `model` has been resolved from a string to an instantiated model above, so that `model.config` is always
+        # available regardless of whether `model` was originally passed as a string or an instance.
+        if processing_class is None:
+            processing_class = AutoTokenizer.from_pretrained(
+                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
+            )
 
         # PEFT
         if peft_config is not None:

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -34,6 +34,7 @@ from torch.utils.data import IterableDataset
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForSequenceClassification,
+    AutoProcessor,
     AutoTokenizer,
     DataCollator,
     GenerationConfig,
@@ -285,11 +286,15 @@ class OnlineDPOTrainer(_BaseTrainer):
         self.is_encoder_decoder = model.config.is_encoder_decoder
         self.is_vision_model = model.config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.keys()
 
-        # Handle the processing_class: load the tokenizer from the model if not provided. This is done here, after
-        # `model` has been resolved from a string to an instantiated model above, so that `model.config` is always
-        # available regardless of whether `model` was originally passed as a string or an instance.
+        # Handle the processing_class: load the processing class from the model if not provided. This is done here,
+        # after `model` has been resolved from a string to an instantiated model above, so that `model.config` is
+        # always available regardless of whether `model` was originally passed as a string or an instance. We use
+        # `AutoProcessor` rather than `AutoTokenizer` because this trainer also supports VLMs (see
+        # `self.is_vision_model` above): `AutoProcessor` transparently falls back to a plain tokenizer for text-only
+        # models, but the reverse isn't true, and a tokenizer can't handle the `images` kwarg passed to
+        # `processing_class(...)` in `_generate` for vision models.
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
+            processing_class = AutoProcessor.from_pretrained(
                 get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
             )
 


### PR DESCRIPTION
## Status

Closed to reduce the uncoordinated PR backlog. I will raise an issue first if the change still needs to be revisited.

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
