### PR TITLE
Fix missing eos_token_id in non-vLLM on-policy GOLD test stubs

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -694,7 +694,7 @@ def test_non_vllm_on_policy_budgets_prompt_before_generation(monkeypatch):
     trainer.use_uld_loss = False
     trainer.teacher_tokenizer = None
     trainer.uld_loss_fn = None
-    trainer.generation_config = SimpleNamespace(max_new_tokens=1)
+    trainer.generation_config = SimpleNamespace(max_new_tokens=1, eos_token_id=None)
     trainer._buffered_inputs = [None]
     trainer._buffered_text_logs = [None]
 
@@ -753,7 +753,7 @@ def test_non_vllm_on_policy_does_not_trim_padded_width_when_real_prompt_fits(mon
     trainer.use_uld_loss = False
     trainer.teacher_tokenizer = None
     trainer.uld_loss_fn = None
-    trainer.generation_config = SimpleNamespace(max_new_tokens=1)
+    trainer.generation_config = SimpleNamespace(max_new_tokens=1, eos_token_id=None)
     trainer._buffered_inputs = [None]
     trainer._buffered_text_logs = [None]
 


### PR DESCRIPTION
The two non-vLLM on-policy tests added in #6359 use a stub generation_config without eos_token_id, while #6357 (merged just before) made generate_on_policy_outputs read generation_config.eos_token_id. Each PR was green on its own CI, but combined on main the tests fail with AttributeError. The experimental suite only runs on pull_request, so the push CI on main did not catch it.

This adds eos_token_id=None to the two stubs; both tests pass again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only stub updates with no production code changes.
> 
> **Overview**
> Aligns two non-vLLM on-policy GOLD trainer tests with **`generate_on_policy_outputs`**, which now reads **`generation_config.eos_token_id`** when masking completions after generation.
> 
> Each test’s **`SimpleNamespace`** stub for **`generation_config`** gains **`eos_token_id=None`**, matching other tests in the same file and avoiding **`AttributeError`** when the non-vLLM path runs through on-policy output handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5391902ea4a1fb8052f1bb065264f9dd7068cd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->