### PR TITLE
Add eval_dataset init tests for experimental SFT and distillation trainers

### DIFF
--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 import torch.nn.functional as F
-from datasets import Dataset, load_dataset
+from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trl.experimental.distillation import DistillationConfig, DistillationTrainer
@@ -480,6 +480,54 @@ class TestDistillationTrainer(TrlTestCase):
         assert trainer.state.log_history[0]["eval_loss"] is not None
         assert train_result.metrics["train_loss"] >= 0.0
         assert "model.safetensors" in os.listdir(self.tmp_dir + "/checkpoint-2")
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "iterable_dataset",
+            "dataset_dict",
+            "iterable_dataset_dict",
+            "dict_of_dataset",
+            "dict_of_iterable_dataset",
+            "none",
+        ],
+    )
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        train_dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            streaming = "iterable" in eval_dataset_type
+            eval_split = load_dataset(
+                "trl-internal-testing/zen", "conversational_language_modeling", split="test", streaming=streaming
+            )
+            if eval_dataset_type in ("dataset", "iterable_dataset"):
+                eval_dataset = eval_split
+            elif eval_dataset_type in ("dataset_dict", "iterable_dataset_dict"):
+                dataset_dict_cls = IterableDatasetDict if streaming else DatasetDict
+                eval_dataset = dataset_dict_cls({"data1": eval_split, "data2": eval_split})
+            else:  # "dict_of_dataset" or "dict_of_iterable_dataset"
+                eval_dataset = {"data1": eval_split, "data2": eval_split}
+
+        training_args = DistillationConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = DistillationTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            processing_class=self.tokenizer,
+        )
+
+        # The distillation collator consumes raw examples, so eval datasets are stored as-is (not tokenized).
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+        else:
+            assert trainer.eval_dataset is eval_dataset
 
     @pytest.mark.parametrize("loss_top_k", [0, 1])
     def test_loss_normalizes_by_num_items_in_batch(self, loss_top_k):

--- a/tests/experimental/test_gkd_trainer.py
+++ b/tests/experimental/test_gkd_trainer.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn.functional as F
-from datasets import Dataset, load_dataset
+from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
 from trl.experimental.gkd import GKDConfig, GKDTrainer
@@ -356,6 +356,54 @@ class TestGKDTrainer(TrlTestCase):
         assert trainer.state.log_history[(-1)]["train_loss"] is not None
         assert trainer.state.log_history[0]["eval_loss"] is not None
         assert "model.safetensors" in os.listdir(self.tmp_dir + "/checkpoint-2")
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "iterable_dataset",
+            "dataset_dict",
+            "iterable_dataset_dict",
+            "dict_of_dataset",
+            "dict_of_iterable_dataset",
+            "none",
+        ],
+    )
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        train_dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            streaming = "iterable" in eval_dataset_type
+            eval_split = load_dataset(
+                "trl-internal-testing/zen", "conversational_language_modeling", split="test", streaming=streaming
+            )
+            if eval_dataset_type in ("dataset", "iterable_dataset"):
+                eval_dataset = eval_split
+            elif eval_dataset_type in ("dataset_dict", "iterable_dataset_dict"):
+                dataset_dict_cls = IterableDatasetDict if streaming else DatasetDict
+                eval_dataset = dataset_dict_cls({"data1": eval_split, "data2": eval_split})
+            else:  # "dict_of_dataset" or "dict_of_iterable_dataset"
+                eval_dataset = {"data1": eval_split, "data2": eval_split}
+
+        training_args = GKDConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = GKDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            processing_class=self.tokenizer,
+        )
+
+        # GKD skips dataset preparation (`skip_prepare_dataset=True`), so eval datasets are stored as-is.
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+        else:
+            assert trainer.eval_dataset is eval_dataset
 
     @require_liger_kernel
     def test_gkd_trainer_with_liger(self):

--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from datasets import Dataset, load_dataset
+from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
 
 from trl.experimental.gold import GOLDConfig
@@ -3631,3 +3631,53 @@ class TestGOLDTrainerLoss(TrlTestCase):
         # Doubling the global count exactly halves the loss (sum / num_items is linear in 1/num_items).
         loss_double = trainer.compute_loss(trainer.model, batch, num_items_in_batch=num_valid * 2)
         torch.testing.assert_close(loss_double, loss_mean / 2, rtol=1e-4, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "iterable_dataset",
+            "dataset_dict",
+            "iterable_dataset_dict",
+            "dict_of_dataset",
+            "dict_of_iterable_dataset",
+            "none",
+        ],
+    )
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        train_dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            streaming = "iterable" in eval_dataset_type
+            eval_split = load_dataset(
+                "trl-internal-testing/zen", "conversational_prompt_completion", split="test", streaming=streaming
+            )
+            if eval_dataset_type in ("dataset", "iterable_dataset"):
+                eval_dataset = eval_split
+            elif eval_dataset_type in ("dataset_dict", "iterable_dataset_dict"):
+                dataset_dict_cls = IterableDatasetDict if streaming else DatasetDict
+                eval_dataset = dataset_dict_cls({"data1": eval_split, "data2": eval_split})
+            else:  # "dict_of_dataset" or "dict_of_iterable_dataset"
+                eval_dataset = {"data1": eval_split, "data2": eval_split}
+
+        training_args = GOLDConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            processing_class=self.tokenizer,
+        )
+
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+            # Each split was tokenized independently.
+            assert "input_ids" in next(iter(trainer.eval_dataset["data1"]))
+            assert "input_ids" in next(iter(trainer.eval_dataset["data2"]))
+        else:
+            assert "input_ids" in next(iter(trainer.eval_dataset))

--- a/tests/experimental/test_sdft_trainer.py
+++ b/tests/experimental/test_sdft_trainer.py
@@ -16,7 +16,7 @@ import importlib
 
 import pytest
 import torch
-from datasets import Dataset
+from datasets import Dataset, DatasetDict
 from transformers import TrainerCallback
 from transformers.utils import is_peft_available
 
@@ -133,6 +133,42 @@ class TestSDFTTrainer(TrlTestCase):
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
         self._assert_any_trainable_param_changed(trainer.model, previous_trainable_params)
+
+    @pytest.mark.parametrize("eval_dataset_type", ["dataset", "dataset_dict", "dict_of_dataset", "none"])
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # Streaming datasets are not yet supported in SDFT
+        train_dataset = Dataset.from_dict(
+            {
+                "prompt": ["Solve 2+2.", "Name the capital of France."],
+                "privileged_context": ["Example answer: 4.", "Example answer: Paris."],
+            }
+        )
+        eval_split = Dataset.from_dict({"prompt": ["Solve 3+3."], "privileged_context": ["Example answer: 6."]})
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        elif eval_dataset_type == "dataset":
+            eval_dataset = eval_split
+        elif eval_dataset_type == "dataset_dict":
+            eval_dataset = DatasetDict({"data1": eval_split, "data2": eval_split})
+        else:  # "dict_of_dataset"
+            eval_dataset = {"data1": eval_split, "data2": eval_split}
+
+        training_args = SDFTConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SDFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        # SDFT tokenizes prompts/completions on the fly during generation, so eval datasets are stored as-is.
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+        else:
+            assert trainer.eval_dataset is eval_dataset
 
     @require_liger_kernel
     @require_torch_accelerator

--- a/tests/experimental/test_ssd_trainer.py
+++ b/tests/experimental/test_ssd_trainer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from datasets import load_dataset
+from datasets import DatasetDict, load_dataset
 from transformers.utils import is_peft_available
 
 from trl.experimental.ssd import SSDConfig, SSDTrainer
@@ -52,6 +52,36 @@ class TestSSDTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.parametrize("eval_dataset_type", ["dataset", "dataset_dict", "dict_of_dataset", "none"])
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # Streaming datasets are not yet supported in SSD
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        elif eval_dataset_type == "dataset":
+            eval_dataset = dataset["test"]
+        elif eval_dataset_type == "dataset_dict":
+            eval_dataset = DatasetDict({"data1": dataset["test"], "data2": dataset["test"]})
+        else:  # "dict_of_dataset"
+            eval_dataset = {"data1": dataset["test"], "data2": dataset["test"]}
+
+        training_args = SSDConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SSDTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=eval_dataset,
+        )
+
+        # SSD tokenizes prompts on the fly during generation, so eval datasets are stored as-is.
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+        else:
+            assert trainer.eval_dataset is eval_dataset
 
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")


### PR DESCRIPTION
This PR adds a `test_init_with_eval_dataset` test to the experimental SFT-derived and distillation trainers, mirroring the coverage recently added to the core trainers:
- #6336

### Solution

Coverage matches each trainer's actual behavior:
- GOLD tokenizes the eval dataset at init and supports streaming, so it is tested across all input types (map-style and iterable) and asserts the tokenized output.
- GKD and Distillation store the eval dataset as-is (they skip dataset preparation / use a raw-example collator) and accept streaming, so all input types are tested and the dataset is asserted stored unchanged.
- SDFT and SSD tokenize on the fly during generation and reject iterable datasets, so only the supported map-style input types are tested.

### Changes

- Add `test_init_with_eval_dataset` to the GKD, GOLD, Distillation, SDFT and SSD test suites.
- Cover all input types (including iterable) for GKD, GOLD and Distillation, and the map-style types only for SDFT and SSD.
- Assert the tokenized output for GOLD and stored-as-is behavior for the others.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or trainer implementation modifications.
> 
> **Overview**
> Adds **`test_init_with_eval_dataset`** to the experimental **GKD**, **GOLD**, **Distillation**, **SDFT**, and **SSD** test suites, following the same pattern as core trainers (#6336).
> 
> Coverage is tailored per trainer: **GOLD** checks tokenized eval data (including streaming/iterable and multi-split dicts); **GKD** and **Distillation** assert eval sets stay **raw** (no prep / raw collator); **SDFT** and **SSD** only cover map-style eval inputs because streaming is unsupported, and assert eval is stored unchanged for on-the-fly generation tokenization.
> 
> Imports are extended where needed (`DatasetDict`, `IterableDatasetDict`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db9ffd32b2dea0b7b3eebff645defa15fcc4c50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->