### PR TITLE
Add eval_dataset init tests for experimental BCO, CPO, ORPO and PRM trainers

### DIFF
--- a/tests/experimental/test_bco_trainer.py
+++ b/tests/experimental/test_bco_trainer.py
@@ -17,7 +17,7 @@ from functools import partial
 import pytest
 import torch
 from accelerate import Accelerator
-from datasets import load_dataset
+from datasets import DatasetDict, load_dataset
 from transformers import AutoModel, AutoModelForCausalLM, AutoTokenizer
 from transformers.utils import is_peft_available
 
@@ -101,6 +101,54 @@ class TestBCOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param.cpu(), new_param.cpu())
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "dataset_dict",
+            "none",
+        ],
+    )
+    @require_sklearn
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # BCO tokenizes the eval dataset at init by calling `.map()` directly on it, so streaming (iterable) and
+        # plain dict-of-datasets eval datasets are not yet supported; only `Dataset` and `DatasetDict` are tested.
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+        ref_model = AutoModelForCausalLM.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+        train_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            eval_split = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="test")
+            if eval_dataset_type == "dataset":
+                eval_dataset = eval_split
+            else:  # "dataset_dict"
+                eval_dataset = DatasetDict({"data1": eval_split, "data2": eval_split})
+
+        training_args = BCOConfig(output_dir=self.tmp_dir, remove_unused_columns=False, report_to="none")
+        trainer = BCOTrainer(
+            model=model,
+            ref_model=ref_model,
+            args=training_args,
+            processing_class=tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+            # Each split was tokenized independently.
+            assert "prompt_input_ids" in next(iter(trainer.eval_dataset["data1"]))
+            assert "prompt_input_ids" in next(iter(trainer.eval_dataset["data2"]))
+        else:
+            assert "prompt_input_ids" in next(iter(trainer.eval_dataset))
 
     @require_sklearn
     def test_train_processing_class_autoloaded(self):

--- a/tests/experimental/test_cpo_trainer.py
+++ b/tests/experimental/test_cpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import DatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
 
 from trl.experimental.cpo import CPOConfig, CPOTrainer
@@ -110,6 +110,47 @@ class TestCPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "dataset_dict",
+            "none",
+        ],
+    )
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # CPO tokenizes the eval dataset at init by calling `.map()` directly on it, so streaming (iterable) and
+        # plain dict-of-datasets eval datasets are not yet supported; only `Dataset` and `DatasetDict` are tested.
+        train_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            eval_split = load_dataset("trl-internal-testing/zen", "standard_preference", split="test")
+            if eval_dataset_type == "dataset":
+                eval_dataset = eval_split
+            else:  # "dataset_dict"
+                eval_dataset = DatasetDict({"data1": eval_split, "data2": eval_split})
+
+        training_args = CPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = CPOTrainer(
+            model=self.model,
+            args=training_args,
+            processing_class=self.tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+            # Each split was tokenized independently.
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset["data1"]))
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset["data2"]))
+        else:
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset))
 
     def test_cpo_trainer_processing_class_autoloaded(self):
         # processing_class is documented as optional: when omitted it should be

--- a/tests/experimental/test_orpo_trainer.py
+++ b/tests/experimental/test_orpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import DatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
 
 from trl.experimental.orpo import ORPOConfig, ORPOTrainer
@@ -105,6 +105,47 @@ class TestORPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
+
+    @pytest.mark.parametrize(
+        "eval_dataset_type",
+        [
+            "dataset",
+            "dataset_dict",
+            "none",
+        ],
+    )
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # ORPO tokenizes the eval dataset at init by calling `.map()` directly on it, so streaming (iterable) and
+        # plain dict-of-datasets eval datasets are not yet supported; only `Dataset` and `DatasetDict` are tested.
+        train_dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            eval_split = load_dataset("trl-internal-testing/zen", "standard_preference", split="test")
+            if eval_dataset_type == "dataset":
+                eval_dataset = eval_split
+            else:  # "dataset_dict"
+                eval_dataset = DatasetDict({"data1": eval_split, "data2": eval_split})
+
+        training_args = ORPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = ORPOTrainer(
+            model=self.model,
+            args=training_args,
+            processing_class=self.tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        elif isinstance(trainer.eval_dataset, dict):
+            assert set(trainer.eval_dataset.keys()) == {"data1", "data2"}
+            # Each split was tokenized independently.
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset["data1"]))
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset["data2"]))
+        else:
+            assert "chosen_input_ids" in next(iter(trainer.eval_dataset))
 
     def test_orpo_trainer_processing_class_autoloaded(self):
         # processing_class is documented as optional: when omitted it should be

--- a/tests/experimental/test_prm_trainer.py
+++ b/tests/experimental/test_prm_trainer.py
@@ -269,6 +269,31 @@ class TestPRMTrainer(TrlTestCase):
             if param.sum() != 0:  # ignore 0 biases
                 assert not torch.equal(param, new_param)
 
+    @pytest.mark.parametrize("eval_dataset_type", ["dataset", "none"])
+    def test_init_with_eval_dataset(self, eval_dataset_type):
+        # PRM tokenizes the eval dataset at init by calling `.map(..., remove_columns=eval_dataset.features)` directly
+        # on it, so streaming (iterable) and dict eval datasets are not yet supported; only a plain `Dataset` is tested.
+        train_dataset = load_dataset("trl-internal-testing/zen", "standard_stepwise_supervision", split="train")
+
+        if eval_dataset_type == "none":
+            eval_dataset = None
+        else:
+            eval_dataset = load_dataset("trl-internal-testing/zen", "standard_stepwise_supervision", split="test")
+
+        training_args = PRMConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = PRMTrainer(
+            model=self.model,
+            args=training_args,
+            processing_class=self.tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+
+        if eval_dataset_type == "none":
+            assert trainer.eval_dataset is None
+        else:
+            assert "input_ids" in next(iter(trainer.eval_dataset))
+
     def test_train_full_pretokenized(self):
         dataset = Dataset.from_dict(
             {


### PR DESCRIPTION
This PR adds a `test_init_with_eval_dataset` test to the experimental BCO, CPO, ORPO and PRM trainers, mirroring the coverage recently added to the core trainers:
- #6336

### Motivation

Unlike the core trainers, these four experimental trainers call `.map(...)` directly on `eval_dataset` in `__init__`. As a result they support fewer input types than the core trainers, and the tests document the current behavior rather than the full core matrix.

### Solution

- BCO, CPO and ORPO  accept a `Dataset` or a `DatasetDict` (both expose `.map`), but not a plain dict of datasets or an iterable/streaming dataset, so they are tested over `dataset`, `dataset_dict` and `none`.
- PRM additionally maps with `remove_columns=eval_dataset.features`, which a `DatasetDict` does not expose, so it is tested over `dataset` and `none` only.
- Each test asserts the tokenized output and includes a comment explaining the supported input types.

### Changes

- Add `test_init_with_eval_dataset` to the BCO, CPO, ORPO and PRM test suites.
- Parametrize over only the input types each trainer supports today, with an in-code comment documenting the limitation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or trainer implementation modifications.
> 
> **Overview**
> Adds **`test_init_with_eval_dataset`** to the experimental **BCO**, **CPO**, **ORPO**, and **PRM** test suites, aligned with similar coverage on core trainers. The tests exercise constructor behavior when `eval_dataset` is omitted, a single Hugging Face **`Dataset`**, or (where supported) a **`DatasetDict`**, and assert that init-time tokenization leaves the expected fields on `trainer.eval_dataset`.
> 
> **BCO**, **CPO**, and **ORPO** are parametrized over `dataset`, `dataset_dict`, and `none`, with comments noting that init calls `.map()` on `eval_dataset` so plain dicts and streaming datasets are out of scope. **PRM** only covers `dataset` and `none` because its init path uses `remove_columns=eval_dataset.features`, which **`DatasetDict`** does not provide. Imports add **`DatasetDict`** where those tests build multi-split eval data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62b0064883b8f9861e6662c18d6af205ea1c86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->