### PR TITLE
Refactor evaluate [1/N]: Fully fix DPOTrainer/KTOTrainer crash on dict eval_dataset with precompute_ref_log_probs

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1622,43 +1622,15 @@ class DPOTrainer(_BaseTrainer):
 
         return (loss, outputs) if return_outputs else loss
 
-    def evaluate(
-        self,
-        eval_dataset: Dataset
-        | IterableDataset
-        | DatasetDict
-        | IterableDatasetDict
-        | dict[str, Dataset | IterableDataset]
-        | None = None,
-        ignore_keys: list[str] | None = None,
-        metric_key_prefix: str = "eval",
-    ) -> dict[str, float]:
-        # When a dataset is passed directly to `evaluate` (e.g. a held-out test set), preprocess it the same way
-        # `__init__` does, so that `evaluate` accepts the same dataset types as the trainer. `_prepare_dataset` is
-        # idempotent: it skips datasets that are already tokenized. A `str` selects a dataset that was already prepared
-        # at init time, so it's left untouched.
+    def get_eval_dataloader(self, eval_dataset: str | Dataset | IterableDataset | None = None) -> DataLoader:
+        # `Trainer.evaluate` already resolves a dict `eval_dataset` into individual splits before calling this, once
+        # per split, so `eval_dataset` here is never a dict. `_prepare_dataset` is idempotent.
         if not self._is_vision_dataset and eval_dataset is not None and not isinstance(eval_dataset, str):
-            if isinstance(eval_dataset, dict):
-                eval_dataset = {
-                    key: self._prepare_dataset(dataset, self.processing_class, self.args, key)
-                    for key, dataset in eval_dataset.items()
-                }
-            else:
-                eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
-            # With `precompute_ref_log_probs`, `_compute_loss` reads the reference log-probs from the batch, so they
-            # must be precomputed here as well, mirroring `__init__`.
+            eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
             if self.precompute_ref_logps:
                 batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
-                if isinstance(eval_dataset, dict):
-                    eval_dataset = {
-                        name: self._precompute_ref_logps(dataset, name, batch_size)
-                        for name, dataset in eval_dataset.items()
-                    }
-                else:
-                    eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
-        return super().evaluate(
-            eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
-        )
+                eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
+        return super().get_eval_dataloader(eval_dataset)
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         try:

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1089,9 +1089,6 @@ class DPOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
-        # Idempotent skip: dataset already has ref log-probs precomputed.
-        if "ref_chosen_logps" in dataset.column_names and "ref_rejected_logps" in dataset.column_names:
-            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1089,6 +1089,9 @@ class DPOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
+        # Idempotent skip: dataset already has ref log-probs precomputed.
+        if "ref_chosen_logps" in dataset.column_names and "ref_rejected_logps" in dataset.column_names:
+            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1157,6 +1157,9 @@ class KTOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
+        # Idempotent skip: dataset already has ref log-probs precomputed.
+        if "ref_logps" in dataset.column_names:
+            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash, self.calculate_KL))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1637,43 +1637,15 @@ class KTOTrainer(_BaseTrainer):
 
         return (loss, outputs) if return_outputs else loss
 
-    def evaluate(
-        self,
-        eval_dataset: Dataset
-        | IterableDataset
-        | DatasetDict
-        | IterableDatasetDict
-        | dict[str, Dataset | IterableDataset]
-        | None = None,
-        ignore_keys: list[str] | None = None,
-        metric_key_prefix: str = "eval",
-    ) -> dict[str, float]:
-        # When a dataset is passed directly to `evaluate` (e.g. a held-out test set), preprocess it the same way
-        # `__init__` does, so that `evaluate` accepts the same dataset types as the trainer. `_prepare_dataset` is
-        # idempotent: it skips datasets that are already tokenized. A `str` selects a dataset that was already prepared
-        # at init time, so it's left untouched.
+    def get_eval_dataloader(self, eval_dataset: str | Dataset | IterableDataset | None = None) -> DataLoader:
+        # `Trainer.evaluate` already resolves a dict `eval_dataset` into individual splits before calling this, once
+        # per split, so `eval_dataset` here is never a dict. `_prepare_dataset` is idempotent.
         if not self._is_vision_dataset and eval_dataset is not None and not isinstance(eval_dataset, str):
-            if isinstance(eval_dataset, dict):
-                eval_dataset = {
-                    key: self._prepare_dataset(dataset, self.processing_class, self.args, key)
-                    for key, dataset in eval_dataset.items()
-                }
-            else:
-                eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
-            # With `precompute_ref_log_probs`, `_compute_loss` reads the reference log-probs from the batch, so they
-            # must be precomputed here as well, mirroring `__init__`.
+            eval_dataset = self._prepare_dataset(eval_dataset, self.processing_class, self.args, "eval")
             if self.precompute_ref_logps:
                 batch_size = self.args.precompute_ref_batch_size or self.args.per_device_eval_batch_size
-                if isinstance(eval_dataset, dict):
-                    eval_dataset = {
-                        name: self._precompute_ref_logps(dataset, name, batch_size)
-                        for name, dataset in eval_dataset.items()
-                    }
-                else:
-                    eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
-        return super().evaluate(
-            eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
-        )
+                eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
+        return super().get_eval_dataloader(eval_dataset)
 
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         try:

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1157,9 +1157,6 @@ class KTOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
-        # Idempotent skip: dataset already has ref log-probs precomputed.
-        if "ref_logps" in dataset.column_names:
-            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash, self.calculate_KL))
         cache_file = dataset._get_cache_file_path(fingerprint)


### PR DESCRIPTION
This PR is a follow-up to #6370, which applied a narrow fix (an idempotent guard in `_precompute_ref_logps`) for a crash when `evaluate(eval_dataset=<dict-like>)` was combined with `precompute_ref_log_probs=True`. This PR replaces that guard with a structural fix that addresses the root cause.

Follow-up to:
- #6370

### Motivation

`transformers.Trainer.evaluate()` handles a dict `eval_dataset` by recursing into `self.evaluate(...)` once per split. Since `self.evaluate` resolves polymorphically, this re-enters the trainer's own `evaluate()` override a second time on an already-processed dataset. The narrow fix in #6370 papered over this for `precompute_ref_log_probs`, but the underlying double-dispatch was still there, latent, waiting for the next stateful preprocessing step to trip over it.

### Solution

Move dataset preparation and ref-logps precomputation out of the `evaluate()` override and into `get_eval_dataloader()`, which is the extension point transformers documents for this purpose:
> Subclass and override this method if you want to inject some custom behavior

Unlike `evaluate()`, `get_eval_dataloader()` is called exactly once per split, so it's structurally immune to the double-dispatch: `Trainer.evaluate()` already resolves a dict eval_dataset into individual splits before `get_eval_dataloader()` is ever called. This also removes the now-unnecessary idempotent guard from #6370, since the scenario it protected against can no longer occur.

### Changes

- trl/trainer/dpo_trainer.py: replace the `evaluate()` override with a `get_eval_dataloader()` override; remove the idempotent guard in `_precompute_ref_logps`
- trl/trainer/kto_trainer.py: same change, mirroring DPO per the repo's duplicated-code convention


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the eval dataloader path for DPO/KTO when passing ad-hoc eval data or using precomputed reference log-probs; behavior should improve but eval preprocessing timing shifts relative to the old override.
> 
> **Overview**
> **DPOTrainer** and **KTOTrainer** no longer override `evaluate()` for eval-time dataset handling. That logic now lives in **`get_eval_dataloader()`**, which tokenizes/prepares a raw eval set and optionally runs **`_precompute_ref_logps`** when `precompute_ref_log_probs=True`, then delegates to the base `Trainer`.
> 
> This fixes crashes and redundant work when **`eval_dataset` is a dict of splits**: Hugging Face `Trainer.evaluate()` already iterates splits and calls `get_eval_dataloader()` once per split, whereas the old `evaluate()` override re-entered on already-processed data (double preprocessing). Dict branching in the override is removed because `eval_dataset` is never a dict at this hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb6ac52b47ea54c47b29cd8246949e98f1868c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->