### PR TITLE
Fix DistillationTrainer use_liger_kernel under DeepSpeed ZeRO-3 during evaluation

### DIFF
--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -413,6 +413,53 @@ class TestDistillationTrainer(TrlTestCase):
         finally:
             importlib.reload(importlib.import_module(trainer.model.__module__))
 
+    def test_prediction_step_gathers_liger_zero3_lm_head_like_training_step(self, monkeypatch):
+        """`training_step` wraps `super().training_step(...)` in `_get_liger_zero3_lm_head_gather_ctx` because the
+        fused Liger JSD loss (the `use_liger_loss` branch of `compute_loss`) reads `student_head.weight` /
+        `teacher_head.weight` directly, bypassing the module forward that would otherwise gather them under
+        DeepSpeed ZeRO-3 (see `_get_liger_zero3_lm_head_gather_ctx`'s own docstring). `DistillationTrainer` has no
+        `prediction_step` override, so `evaluate()` ran the base `transformers.Trainer.prediction_step`, which
+        computes the same loss via `compute_loss` but never entered the same gather context.
+
+        This doesn't require `use_liger_kernel` or DeepSpeed to be installed/enabled: the helper is a no-op in that
+        case, but it must still be *called* on every `compute_loss` path, exactly like `training_step` calls it.
+        Same technique used for the sibling SDPO/SDFT (#6384) and GOLD (#6391) fixes.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling")
+        training_args = self._make_args(
+            eval_strategy="no",
+            per_device_eval_batch_size=2,
+        )
+        trainer = DistillationTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+            processing_class=self.tokenizer,
+        )
+
+        # Count calls instead of inspecting `model.training`: `training_step` enters the gather context *before*
+        # `super().training_step(...)` flips the model into train mode, so the flag isn't a reliable phase marker at
+        # the point this helper is called. Splitting the count across separate `train()` / `evaluate()` invocations
+        # is unambiguous instead.
+        call_count = 0
+        original_gather_ctx = trainer._get_liger_zero3_lm_head_gather_ctx
+
+        def counting_gather_ctx(model):
+            nonlocal call_count
+            call_count += 1
+            return original_gather_ctx(model)
+
+        monkeypatch.setattr(trainer, "_get_liger_zero3_lm_head_gather_ctx", counting_gather_ctx)
+
+        trainer.train()
+        assert call_count > 0  # sanity check: training_step already does this today
+
+        call_count = 0
+        trainer.evaluate()
+        assert call_count > 0, "prediction_step must gather lm_head weights just like training_step does"
+
     def test_teacher_vocab_size_mismatch_raises(self):
         # The local-teacher loss compares full next-token distributions, so student and teacher must share a
         # vocabulary. A teacher with a different vocab_size is rejected (use GOLD for cross-tokenizer distillation).

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1147,6 +1147,17 @@ class DistillationTrainer(_BaseTrainer):
 
         return loss
 
+    def prediction_step(
+        self,
+        model: nn.Module,
+        inputs: dict[str, torch.Tensor | Any],
+        prediction_loss_only: bool,
+        ignore_keys: list[str] | None = None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        # Gather spans the forward only: evaluation never calls backward.
+        with self._get_liger_zero3_lm_head_gather_ctx(model):
+            return super().prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
+
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model.training else "eval"
         metrics = {key: sum(val) / len(val) for key, val in self._metrics[mode].items()}


### PR DESCRIPTION
## What this fixes

`training_step` already gathers the sharded `lm_head` weights for the fused Liger JSD loss under DeepSpeed ZeRO-3:

```python
with self._get_liger_zero3_lm_head_gather_ctx(model):
    loss = super().training_step(model, inputs, num_items_in_batch)
```

`DistillationTrainer` has no `prediction_step` override, so `trainer.evaluate()` runs the base `transformers.Trainer.prediction_step`, which calls `compute_loss(model, inputs, return_outputs=True, ...)` directly, with no such wrapping. `compute_loss`'s liger branch (`_compute_liger_loss`) reads `student_head.weight` / `teacher_head.weight` directly — the whole point of the fused kernel is to bypass the module forward that would otherwise trigger ZeRO-3's gather hook (see `_get_liger_zero3_lm_head_gather_ctx`'s own docstring). So `use_liger_kernel=True` + DeepSpeed ZeRO-3 + any `eval_dataset`/`eval_strategy` matmuls against an ungathered, sharded weight during evaluation, even though training under the exact same config gathers it correctly.

This is the same bug, in the same shape, as #6384 (SDPO/SDFT) and #6391 (GOLDTrainer). #6384's own description explicitly flagged `DistillationTrainer` as having "the same gap" and left it out to keep that PR focused, inviting a follow-up — this is that follow-up.

#6393 (open in parallel) fixes a different bug in this same file's Liger path: `_compute_liger_loss` returning a bare `None` for `outputs`, crashing `evaluate()`'s `compute_loss(..., return_outputs=True)` call with `TypeError: 'NoneType' object is not subscriptable`. That fix does not add a `prediction_step` override or touch the gather context, so the gap this PR closes is still fully open regardless of #6393's state.

## Fix

Add a `prediction_step` override to `DistillationTrainer` that wraps `super().prediction_step(...)` in the same `_get_liger_zero3_lm_head_gather_ctx(model)` that `training_step` already uses, scoped to the forward only (evaluation never calls backward) — mirrors #6391's fix for `GOLDTrainer` exactly.

Unlike `GOLDTrainer`/`SDPOTrainer`/`SDFTTrainer`, `DistillationTrainer` didn't already have its own `prediction_step` to modify in place — it relied entirely on the base `Trainer` implementation. So instead of reimplementing that method's label/logits/`ignore_keys` handling inline, this wraps the whole `super().prediction_step(...)` call, which keeps the diff to a single small, self-contained override.

## Verification

Neither `liger_kernel` nor DeepSpeed is installed in my environment, so — same as #6384/#6391 — I exercise trl's real control flow with only the fused kernel itself out of the picture. The added test never sets `use_liger_kernel=True`: the helper is a documented no-op unless both Liger and ZeRO-3 are active, but it must still be *called* on every `compute_loss` path, exactly like `training_step` already calls it.

Built a real `DistillationTrainer` and instrumented `_get_liger_zero3_lm_head_gather_ctx` to count calls:
- On current `main`: `trainer.train()` enters it once per step; `trainer.evaluate()` enters it zero times.
- With this fix: `trainer.evaluate()` also enters it.

Added `test_prediction_step_gathers_liger_zero3_lm_head_like_training_step` to `tests/experimental/test_distillation_trainer.py`, matching the tests already added for SDPO/SDFT/GOLD. Verified fail-before/pass-after by reverting just the `distillation_trainer.py` hunk with the new test held in place — confirmed it reproduces the same failure (`AssertionError: prediction_step must gather lm_head weights just like training_step does`) — then reapplied.

Full `tests/experimental/test_distillation_trainer.py` run: 36 passed, 1 skipped (the pre-existing `use_liger_kernel=True` GPU/liger-kernel test, skipped for the same environment reason noted above), with this fix applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, symmetric change to the eval forward path with a targeted test; behavior is unchanged when Liger or ZeRO-3 is not active.
> 
> **Overview**
> **Evaluation now matches training** for fused Liger JSD loss under DeepSpeed ZeRO-3: `DistillationTrainer` adds a `prediction_step` override that wraps `super().prediction_step(...)` in `_get_liger_zero3_lm_head_gather_ctx(model)`, the same context `training_step` already uses. Without it, `evaluate()` hit `compute_loss` / `_compute_liger_loss` with sharded `lm_head` weights because the fused path reads weights directly instead of going through a forward that ZeRO-3 would gather.
> 
> A regression test instruments that helper and asserts `trainer.evaluate()` invokes it (mirroring SDPO/SDFT and GOLD fixes); the helper remains a no-op when Liger or ZeRO-3 is inactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c649de71d19135447ba155eb22ab475687b596f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->