### PR TITLE
Add `GMPOTrainer` to the telemetry allowlist

### DIFF
--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -46,6 +46,7 @@ _TELEMETRY_TRAINERS = {
     "DistillationTrainer",
     "DPPOTrainer",
     "GKDTrainer",
+    "GMPOTrainer",
     "GOLDTrainer",
     "GRPOWithReplayBufferTrainer",
     "MiniLLMTrainer",


### PR DESCRIPTION
Adds `"GMPOTrainer"` to `_TELEMETRY_TRAINERS` in `trl/trainer/base_trainer.py`.

`GMPOTrainer` subclasses `GRPOTrainer`, so it inherits `_send_telemetry` and pings on init, but it was the only shipped trainer missing from the allowlist, its usage was being bucketed into `trl/other` instead of `trl/GMPOTrainer`.

It's a real exported trainer (`trl/experimental/gmpo/__init__.py`), not an internal helper, so it belongs in the list. Every other `*Trainer` class in the package is already accounted for.

Missed in https://github.com/huggingface/trl/pull/6078

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string allowlist entry with no runtime behavior change beyond telemetry topic naming.
> 
> **Overview**
> **Adds `GMPOTrainer` to the `_TELEMETRY_TRAINERS` allowlist** in `base_trainer.py` so init telemetry is reported under `trl/GMPOTrainer` instead of the generic `trl/other` bucket.
> 
> `GMPOTrainer` is an exported experimental trainer (subclasses `GRPOTrainer`) and already runs `_send_telemetry` on init; the change only fixes trainer-name bucketing to match the other shipped `*Trainer` classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a96d783eeba4c7e0ce22dad077ff461b419739e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->