### PR TITLE
Fix GeometricMixtureWrapper.generate() crash after transformers' MoE decode optimization change

### DIFF
--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -102,6 +102,12 @@ class GeometricMixtureWrapper(GenerationMixin):
     def _validate_model_kwargs(self, model_kwargs):
         return self.model._validate_model_kwargs(model_kwargs)
 
+    def get_experts_implementation(self):
+        return self.model.get_experts_implementation()
+
+    def set_experts_implementation(self, experts_implementation):
+        self.model.set_experts_implementation(experts_implementation)
+
 
 class NashMDTrainer(OnlineDPOTrainer):
     """


### PR DESCRIPTION
This PR fixes a crash in NashMDTrainer (experimental) caused by a recent transformers change to GenerationMixin._optimize_model_for_decode.

Fix #6412.

### Motivation

transformers PR huggingface/transformers#47107 (https://github.com/huggingface/transformers/pull/47107) changed _optimize_model_for_decode to unconditionally call self.get_experts_implementation() during every decode step of .generate(), instead of only reading self.config._experts_implementation and conditionally calling self.set_experts_implementation(...).

get_experts_implementation/set_experts_implementation are defined on PreTrainedModel, not on GenerationMixin. GeometricMixtureWrapper intentionally subclasses only GenerationMixin (it wraps two real models rather than being one itself), so it now hits AttributeError: 'GeometricMixtureWrapper' object has no attribute 'get_experts_implementation' as soon as .generate() is called, breaking all NashMDTrainer training tests.

### Solution

Add thin delegating stubs for get_experts_implementation/set_experts_implementation on GeometricMixtureWrapper, following the same pattern already used for _validate_model_class/_validate_model_kwargs to satisfy the GenerationMixin contract expected by .generate().

### Changes

- Add get_experts_implementation and set_experts_implementation methods to GeometricMixtureWrapper, delegating to the wrapped self.model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small compatibility shim with no change to Nash-MD loss or mixture logic; behavior only affects generation-time MoE hooks on the wrapper.
> 
> **Overview**
> **Fixes Nash-MD training crashes** when `GeometricMixtureWrapper.generate()` runs against newer `transformers`, where decode optimization now calls `get_experts_implementation()` / `set_experts_implementation()` on the generation object every step.
> 
> Adds **thin delegators** on `GeometricMixtureWrapper` that forward those calls to the wrapped policy `self.model`, matching the existing pattern used for `_validate_model_class` and `_validate_model_kwargs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfade6b8c8a930f0d4800b9e264045eabda12f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->