### PR TITLE
Fix save_pretrained IndexError in PreTrainedModelWrapper (PEFT models)

### DIFF
--- a/tests/experimental/test_ppo_trainer.py
+++ b/tests/experimental/test_ppo_trainer.py
@@ -586,16 +586,22 @@ class TestPeftModel(TrlTestCase):
         assert nb_trainable_params == 905
         assert isinstance(trl_model.pretrained_model.model.model.layers[0].mlp.gate_proj, Linear8bitLt)
 
-    def test_save_pretrained_peft(self):
+    @pytest.mark.parametrize("save_pretrained_call", ["positional", "save_directory_kwarg"])
+    def test_save_pretrained_peft(self, save_pretrained_call):
         r"""
-        Check that the model can be saved and loaded properly.
+        Check that the model can be saved and loaded properly, whether the save directory is passed positionally
+        (`save_pretrained(path)`) or as the `save_directory` keyword argument (`save_pretrained(save_directory=path)`),
+        mirroring the signature of [`~transformers.PreTrainedModel.save_pretrained`].
         """
         causal_lm_model = AutoModelForCausalLM.from_pretrained(self.causal_lm_model_id)
         pretrained_model = get_peft_model(causal_lm_model, self.lora_config)
 
         model = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model)
 
-        model.save_pretrained(self.tmp_dir)
+        if save_pretrained_call == "positional":
+            model.save_pretrained(self.tmp_dir)
+        else:
+            model.save_pretrained(save_directory=self.tmp_dir)
 
         # check that the files `adapter_model.safetensors` and `adapter_config.json` are in the directory
         assert os.path.isfile(f"{self.tmp_dir}/adapter_model.safetensors"), (

--- a/trl/experimental/ppo/modeling_value_head.py
+++ b/trl/experimental/ppo/modeling_value_head.py
@@ -540,8 +540,10 @@ class PreTrainedModelWrapper(nn.Module):
         # if it is a peft model only save the `v_head` state_dict and
         # pop the `state_dict` from the kwargs to avoid silent bugs with `peft`
         if self.is_peft_model:
-            save_path = args[0]
-            save_path = os.path.join(save_path, "pytorch_model.bin")
+            # `save_directory` may be passed positionally or as a keyword, mirroring
+            # `~transformers.PreTrainedModel.save_pretrained`'s signature.
+            save_directory = args[0] if args else kwargs["save_directory"]
+            save_path = os.path.join(save_directory, "pytorch_model.bin")
             torch.save(state_dict, save_path)
             _ = kwargs.pop("state_dict", None)
 


### PR DESCRIPTION
## What does this PR do?

`PreTrainedModelWrapper.save_pretrained` (in `trl/experimental/ppo/modeling_value_head.py`) is documented as a wrapper around [`~transformers.PreTrainedModel.save_pretrained`], whose real signature takes the target directory as `save_directory` (positional-or-keyword). The wrapper's own implementation, however, always reads the path from `args[0]`:

```python
if self.is_peft_model:
    save_path = args[0]
    save_path = os.path.join(save_path, "pytorch_model.bin")
    torch.save(state_dict, save_path)
    _ = kwargs.pop("state_dict", None)
```

For a PEFT-wrapped value-head model (`self.is_peft_model = True`), calling `save_pretrained` the natural, doc-mirroring way —

```python
model.save_pretrained(save_directory=tmp_dir)
```

— raises `IndexError: tuple index out of range`, because `args` is empty (the directory arrived through `kwargs`, not `args`). Only the positional call style, `model.save_pretrained(tmp_dir)`, happens to work. Every existing call site in the test suite (`tests/experimental/test_ppo_trainer.py`) uses the positional style, which is why this had gone unnoticed.

### Fix

Resolve `save_directory` once, from either `args[0]` or `kwargs["save_directory"]`, before branching on `self.is_peft_model`:

```python
if self.is_peft_model:
    save_directory = args[0] if args else kwargs["save_directory"]
    save_path = os.path.join(save_directory, "pytorch_model.bin")
    torch.save(state_dict, save_path)
    _ = kwargs.pop("state_dict", None)
```

Note: `PreTrainedModelWrapper` / `AutoModelForCausalLMWithValueHead` live under `trl.experimental` and aren't used by the modern `PPOTrainer` path, but the class is still directly instantiable and documented, so this is a real, user-reachable bug rather than dead code.

### Tests

Parametrized `TestPeftModel.test_save_pretrained_peft` over both call styles (`save_pretrained(tmp_dir)` and `save_pretrained(save_directory=tmp_dir)`) so they're asserted to behave identically (same saved files, same reloaded weights). Confirmed the new `save_directory_kwarg` parametrization fails with the exact `IndexError` above against the pre-fix code, and passes after the fix — checked both directions by reverting/reapplying just the source change. Afterward ran the full `tests/experimental/test_ppo_trainer.py` and `tests/experimental/test_modeling_value_head.py` suites: all green (60 passed, 2 skipped unrelated `push_to_hub` tests).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? _(N/A — found via code review/testing, not previously reported.)_
- [ ] Did you make sure to update the documentation with your changes? _(N/A — the docstring already describes generic `*args`/`**kwargs`; no user-facing doc change needed.)_
- [x] Did you write any new necessary tests?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to experimental PPO value-head saving; no auth or training-path changes, covered by existing PEFT save/load tests.
> 
> **Overview**
> Fixes **`IndexError`** when saving a PEFT-wrapped **`AutoModelForCausalLMWithValueHead`** via `save_pretrained(save_directory=...)`, which matches Transformers’ API but previously failed because the PEFT branch always read the path from `args[0]`.
> 
> **`PreTrainedModelWrapper.save_pretrained`** now resolves the output directory from either the first positional argument or **`save_directory`** in kwargs before writing **`pytorch_model.bin`** for the value head; the adapter save path through the wrapped model is unchanged.
> 
> **`test_save_pretrained_peft`** is parametrized so both `save_pretrained(tmp_dir)` and `save_pretrained(save_directory=tmp_dir)` are asserted to produce the same artifacts and reload correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c692c5825cb000c4c52db497fe8e95f38f14c43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->