### PR TITLE
Fix create_reference_model deprecation warning

### DIFF
--- a/trl/experimental/a2po/a2po_trainer.py
+++ b/trl/experimental/a2po/a2po_trainer.py
@@ -31,9 +31,10 @@ from transformers import (
 )
 
 from ...data_utils import maybe_apply_chat_template
-from ...models import create_reference_model, unwrap_model_for_generation
+from ...models import unwrap_model_for_generation
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import selective_log_softmax
+from ..utils import create_reference_model
 from .a2po_config import A2POConfig
 
 


### PR DESCRIPTION
Fix `create_reference_model` FutureWarning:

> FutureWarning: The `create_reference_model` function is now located in `trl.experimental.utils`. Please update your imports to `from trl.experimental.utils import create_reference_model`. This import path will be removed in TRL 1.0.0.


This PR updates import statements in the `trl/experimental/a2po/a2po_trainer.py` file to fix a FutureWarning and improve code organization and maintainability.

The import of deprecated function was introduced by:
- #5940
 
### Changes

Import organization:

* Moved the import of `create_reference_model` from `trl.models.utils` to `trl.experimental.utils`, reflecting its new or correct location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only change with no logic or API behavior changes.
> 
> **Overview**
> Updates **`A2POTrainer`** imports so `create_reference_model` comes from `trl.experimental.utils` instead of `trl.models`, clearing the TRL deprecation **FutureWarning** ahead of the 1.0.0 removal of the old path.
> 
> `unwrap_model_for_generation` stays on `trl.models`; only the reference-model helper’s import source changes—behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a000585823fa8ec1b9187468f0f5529e0579eb18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->