### PR TITLE
Fix uncaptured cross-architecture VLM warning in GOLD trainer CI tests

### DIFF
--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -2620,14 +2620,15 @@ def test_cross_architecture_vlm_without_uld_raises_error(monkeypatch):
     student, teacher = _make_dummy_vlm_models("smolvlm", "qwen2_5_vl")
     args = _make_vlm_trainer_args()  # use_uld_loss=False by default
 
-    with pytest.raises(ValueError, match="Cross-architecture VLM distillation.*use_uld_loss=True"):
-        GOLDTrainer(
-            model=student,
-            teacher_model=teacher,
-            args=args,
-            train_dataset=vision_dataset,
-            processing_class=processor,
-        )
+    with pytest.warns(UserWarning, match="Cross-architecture VLM distillation"):
+        with pytest.raises(ValueError, match="Cross-architecture VLM distillation.*use_uld_loss=True"):
+            GOLDTrainer(
+                model=student,
+                teacher_model=teacher,
+                args=args,
+                train_dataset=vision_dataset,
+                processing_class=processor,
+            )
 
 
 def test_cross_architecture_vlm_with_uld_sets_teacher_processor(monkeypatch):
@@ -3553,13 +3554,14 @@ def test_vlm_uld_cross_arch_train_step_smoke(tmp_path, vlm_dataset):
         dataloader_drop_last=True,
     )
 
-    trainer = GOLDTrainer(
-        model=student,
-        teacher_model=teacher,
-        args=args,
-        train_dataset=vlm_dataset,
-        processing_class=processor,
-    )
+    with pytest.warns(UserWarning, match="Cross-architecture VLM distillation"):
+        trainer = GOLDTrainer(
+            model=student,
+            teacher_model=teacher,
+            args=args,
+            train_dataset=vlm_dataset,
+            processing_class=processor,
+        )
     train_output = trainer.train()
     assert torch.isfinite(torch.tensor(train_output.training_loss))
 


### PR DESCRIPTION

This PR fixes two GOLD trainer tests that were leaking an unhandled UserWarning into the pytest warnings summary.

### Motivation

GOLDTrainer.__init__ always emits a UserWarning when student and teacher VLMs have different model_types, regardless of whether use_uld_loss is set. Two tests exercised this cross-architecture path without capturing the warning, so it showed up as noise in CI's warnings summary instead of being asserted as expected behavior.

### Solution

Wrap the trainer construction in pytest.warns(UserWarning, match=...) so the warning is captured and explicitly asserted, matching the pattern already used by sibling tests in the same file (test_cross_architecture_vlm_with_uld_sets_teacher_processor, test_same_architecture_vlm_no_teacher_processor).

### Changes

- test_cross_architecture_vlm_without_uld_raises_error: nest pytest.raises inside pytest.warns, since both the warning and the ValueError fire during construction.
- test_vlm_uld_cross_arch_train_step_smoke: wrap the GOLDTrainer construction in pytest.warns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no trainer or runtime behavior is modified.
> 
> **Overview**
> Two GOLD trainer tests that construct **cross-architecture** VLM student/teacher pairs now **expect** the `UserWarning` emitted during `GOLDTrainer.__init__`, instead of letting it leak into CI’s pytest warnings summary.
> 
> In `test_cross_architecture_vlm_without_uld_raises_error`, `pytest.warns` wraps the existing `pytest.raises(ValueError, …)` block so both the warning and the error are asserted during construction. In `test_vlm_uld_cross_arch_train_step_smoke`, trainer creation is wrapped the same way before `train()` runs.
> 
> This matches how sibling tests in the file already handle the cross-architecture VLM warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6e00e7396981107cdd3c58959225eaf6a224ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->