### PR TITLE
Add a tip to the Paper Index on reading papers with the hf CLI

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -2,6 +2,9 @@
 
 <!-- Within sections, papers are sorted by publish dates -->
 
+> [!TIP]
+> Each paper below links to its Hugging Face paper page. You can also read any of them from the terminal with the `hf` CLI, e.g. `hf papers read 2402.03300` — particularly handy for coding agents.
+
 ## Group Relative Policy Optimization
 
 Papers relating to the [`GRPOTrainer`].


### PR DESCRIPTION
# What does this PR do?

Adds a short tip at the top of the Paper Index pointing out that any paper
on the page can be read from the terminal with the `hf` CLI
(`hf papers read <arxiv-id>`). Handy for humans, and gives coding agents
working with TRL a direct way to pull a cited paper into context instead
of scraping the paper page.

Example verified with `hf` 1.23.0:

```
$ hf papers read 2402.03300
Title: DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models
...
```

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Documentation change — @qgallouedec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on training code, APIs, or runtime behavior.
> 
> **Overview**
> Adds a **GitHub tip callout** at the top of **`docs/source/paper_index.md`** so readers know indexed papers can be opened from the terminal with **`hf papers read <arxiv-id>`** (example: `hf papers read 2402.03300`), in addition to the existing Hugging Face paper page links.
> 
> The note calls out that this workflow is especially useful for **coding agents** that need paper text in context without scraping the web page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1ef8d10c871f900188bb130d7c13ae8eb228b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->