### PR TITLE
[GRPO] Treat explicit max_tool_calling_iterations=0 as zero, not unlimited 

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -726,7 +726,10 @@ class GRPOTrainer(_BaseTrainer):
         # Training arguments
         self.max_completion_length = args.max_completion_length  # = |o_i| in the GRPO paper
         self.num_generations = args.num_generations  # = G in the GRPO paper
-        self.max_tool_calling_iterations = args.max_tool_calling_iterations or sys.maxsize
+        # `is not None`: an explicit 0 means "parse tool calls but never execute them", not "unlimited"
+        self.max_tool_calling_iterations = (
+            args.max_tool_calling_iterations if args.max_tool_calling_iterations is not None else sys.maxsize
+        )
         self.num_generations_eval = args.num_generations_eval or self.num_generations
         self.chat_template_kwargs = args.chat_template_kwargs or {}
         self.temperature = args.temperature

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -726,7 +726,6 @@ class GRPOTrainer(_BaseTrainer):
         # Training arguments
         self.max_completion_length = args.max_completion_length  # = |o_i| in the GRPO paper
         self.num_generations = args.num_generations  # = G in the GRPO paper
-        # `is not None`: an explicit 0 means "parse tool calls but never execute them", not "unlimited"
         self.max_tool_calling_iterations = (
             args.max_tool_calling_iterations if args.max_tool_calling_iterations is not None else sys.maxsize
         )


### PR DESCRIPTION
# What does this PR do?

`self.max_tool_calling_iterations = args.max_tool_calling_iterations or sys.maxsize` normalizes with truthiness, so an explicit max_tool_calling_iterations=0 (parse tool calls but never execute a follow-up turn) is silently treated as unset and the tool loop runs up to `sys.maxsize` iterations -- the opposite of what was configured. This replaces the truthiness check with an explicit `is not None` so 0 is honored.

Another approach that can be used -- raising an Error  in `GRPOConfig.__post_init__` if `args.max_tool_calling_iterations < 1`. If you would prefer it -- let me know.

Affecting only GRPO; once merged will be added to GOLD as part of https://github.com/huggingface/trl/pull/6328
## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [X] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in GRPO trainer init; only affects tool-calling rollout length when users set the cap to 0.
> 
> **Overview**
> Fixes **GRPO** initialization so `max_tool_calling_iterations=0` is respected instead of being collapsed to unlimited tool-calling turns.
> 
> `GRPOTrainer` now sets `self.max_tool_calling_iterations` with an explicit `is not None` check (`None` → `sys.maxsize`, any integer including **0** kept as-is). The previous `value or sys.maxsize` pattern treated **0** as unset, so the tool loop in `_tool_call_loop` could run up to `sys.maxsize` iterations despite a zero cap—opposite of the intended “parse tool calls but don’t run follow-up turns” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8e42ee6d86b31211e22786994bb66988f6f2fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->