### PR TITLE
Align KTO with DPO: Fix `logits/chosen` and `logits/rejected` metrics

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1526,8 +1526,6 @@ class KTOTrainer(_BaseTrainer):
 
         chosen_logps = completion_logps.index_select(0, chosen_idx)
         rejected_logps = completion_logps.index_select(0, rejected_idx)
-        chosen_logits = outputs.logits.index_select(0, chosen_idx)
-        rejected_logits = outputs.logits.index_select(0, rejected_idx)
 
         if self.precompute_ref_logps:
             ref_chosen_logps = batch["ref_logps"].index_select(0, chosen_idx)
@@ -1618,6 +1616,25 @@ class KTOTrainer(_BaseTrainer):
             self._total_train_tokens += num_tokens_in_batch
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
+        # Average logits for chosen and rejected completions
+        shift_completion_mask = batch["completion_mask"][:, 1:]
+        chosen_logits = shift_logits.detach().index_select(0, chosen_idx)
+        rejected_logits = shift_logits.detach().index_select(0, rejected_idx)
+        chosen_mask = shift_completion_mask.index_select(0, chosen_idx)
+        rejected_mask = shift_completion_mask.index_select(0, rejected_idx)
+        total_chosen_logits = chosen_logits[chosen_mask.bool()].mean(-1).sum()
+        total_chosen_tokens = chosen_mask.sum()
+        total_rejected_logits = rejected_logits[rejected_mask.bool()].mean(-1).sum()
+        total_rejected_tokens = rejected_mask.sum()
+        total_chosen_logits = self.accelerator.gather_for_metrics(total_chosen_logits).sum().item()
+        total_chosen_tokens = self.accelerator.gather_for_metrics(total_chosen_tokens).sum().item()
+        total_rejected_logits = self.accelerator.gather_for_metrics(total_rejected_logits).sum().item()
+        total_rejected_tokens = self.accelerator.gather_for_metrics(total_rejected_tokens).sum().item()
+        avg_chosen_logits = total_chosen_logits / total_chosen_tokens if total_chosen_tokens > 0 else 0.0
+        avg_rejected_logits = total_rejected_logits / total_rejected_tokens if total_rejected_tokens > 0 else 0.0
+        self._metrics[mode]["logits/chosen"].append(avg_chosen_logits)
+        self._metrics[mode]["logits/rejected"].append(avg_rejected_logits)
+
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()
 
@@ -1628,9 +1645,6 @@ class KTOTrainer(_BaseTrainer):
             self._metrics[mode]["logps/chosen"].append(
                 self.accelerator.gather_for_metrics(chosen_logps.nansum()).nansum().item() / all_num_chosen
             )
-            self._metrics[mode]["logits/chosen"].append(
-                self.accelerator.gather_for_metrics(chosen_logits.nansum()).nansum().item() / all_num_chosen
-            )
 
         if all_num_rejected > 0:
             self._metrics[mode]["rewards/rejected"].append(
@@ -1638,9 +1652,6 @@ class KTOTrainer(_BaseTrainer):
             )
             self._metrics[mode]["logps/rejected"].append(
                 self.accelerator.gather_for_metrics(rejected_logps.nansum()).nansum().item() / all_num_rejected
-            )
-            self._metrics[mode]["logits/rejected"].append(
-                self.accelerator.gather_for_metrics(rejected_logits.nansum()).nansum().item() / all_num_rejected
             )
 
         if all_num_chosen > 0 and all_num_rejected > 0:

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1630,10 +1630,10 @@ class KTOTrainer(_BaseTrainer):
         total_chosen_tokens = self.accelerator.gather_for_metrics(total_chosen_tokens).sum().item()
         total_rejected_logits = self.accelerator.gather_for_metrics(total_rejected_logits).sum().item()
         total_rejected_tokens = self.accelerator.gather_for_metrics(total_rejected_tokens).sum().item()
-        avg_chosen_logits = total_chosen_logits / total_chosen_tokens if total_chosen_tokens > 0 else 0.0
-        avg_rejected_logits = total_rejected_logits / total_rejected_tokens if total_rejected_tokens > 0 else 0.0
-        self._metrics[mode]["logits/chosen"].append(avg_chosen_logits)
-        self._metrics[mode]["logits/rejected"].append(avg_rejected_logits)
+        if total_chosen_tokens > 0:
+            self._metrics[mode]["logits/chosen"].append(total_chosen_logits / total_chosen_tokens)
+        if total_rejected_tokens > 0:
+            self._metrics[mode]["logits/rejected"].append(total_rejected_logits / total_rejected_tokens)
 
         all_num_chosen = self.accelerator.gather_for_metrics(num_chosen).sum().item()
         all_num_rejected = self.accelerator.gather_for_metrics(num_rejected).sum().item()


### PR DESCRIPTION
`KTOTrainer._compute_loss` selected the chosen/rejected logits as

```python
chosen_logits = outputs.logits.index_select(0, chosen_idx)
```

i.e. the **full** `[n_chosen, seq_len, vocab_size]` tensor, and then logged

```python
self.accelerator.gather_for_metrics(chosen_logits.nansum()).nansum().item() / all_num_chosen
```

`.nansum()` reduces over *every* element, so the logged value was the sum of all logits across the whole vocabulary, every sequence position, and the prompt and padding tokens, divided only by the number of sequences. The result scaled with `seq_len × vocab_size` and did not measure a mean logit.

This aligns the computation with `DPOTrainer._compute_loss`: mean over the vocabulary dimension, restricted to completion tokens, token-weighted across ranks. Only `chunk(2, dim=0)` is replaced by `index_select(0, chosen_idx)`, since KTO is unpaired.

## Why not the previous aggregation

The surrounding `nansum() / all_num_*` aggregation is correct for `rewards/*` and `logps/*` and is left untouched: those are per-sequence quantities and KTO ranks hold unequal numbers of chosen/rejected examples, so a plain `gather().mean()` would be biased. `logits/*` is a per-token quantity, so DPO's token-weighted form is both correct and already rank-safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change in KTOTrainer._compute_loss; training loss and gradients are unaffected.
> 
> **Overview**
> **KTO** `logits/chosen` and `logits/rejected` were wrong: they summed every element of the full `[batch, seq, vocab]` logits tensor (prompt, padding, and all vocab dims) and divided only by the number of chosen/rejected **sequences**, so logged values scaled with `seq_len × vocab_size` instead of a meaningful mean logit.
> 
> This PR recomputes those metrics like **DPO**: use shifted logits (`shift_logits`), split chosen/rejected with `index_select` on unpaired labels, mask to **completion** tokens only, take **mean over vocab** per token, then **token-weight** sums across ranks via `gather_for_metrics`. `rewards/*` and `logps/*` aggregation is unchanged (still per-sequence `nansum / all_num_*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3188bc71b94b71bf6c9e58d680d35f39bc3cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->