### PR TITLE
Align KTO with DPO: Drop `hasattr` guards on `lm_head.bias` in the Liger path

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1432,11 +1432,11 @@ class KTOTrainer(_BaseTrainer):
                 _input=outputs.last_hidden_state[:, :-1],
                 lin_weight=lm_head.weight,
                 target=target,
-                bias=lm_head.bias if hasattr(lm_head, "bias") else None,
+                bias=lm_head.bias,
                 preference_labels=torch.tensor(batch["label"], dtype=torch.bool).to(self.accelerator.device),
                 ref_input=ref_outputs.last_hidden_state[:, :-1],
                 ref_weight=ref_lm_head.weight,
-                ref_bias=ref_lm_head.bias if hasattr(lm_head, "bias") else None,
+                ref_bias=ref_lm_head.bias,
                 kl=kl,
             )
 


### PR DESCRIPTION
`KTOTrainer._compute_loss_liger` passed the Liger loss biases as:

```python
bias=lm_head.bias if hasattr(lm_head, "bias") else None,
...
ref_bias=ref_lm_head.bias if hasattr(lm_head, "bias") else None,
```

Two problems:

1. `nn.Linear` always defines `bias` (it is set to `None` when `bias=False`, not omitted), so `hasattr(lm_head, "bias")` is unconditionally `True` and the guard is dead. AGENTS.md asks to avoid `hasattr` for exactly this reason. The same method already reads `lm_head.bias` / `ref_lm_head.bias` directly two lines earlier in `maybe_gather_lm_head_ctx(...)`, so the guard was also internally inconsistent.
2. The `ref_bias` guard tests `lm_head` where it means `ref_lm_head` — a copy-paste slip. It is latent rather than live *because* of (1): since the predicate is always `True`, the wrong operand never changes the outcome. Removing the guard removes the trap before someone makes the predicate meaningful.

Aligns with `DPOTrainer._compute_loss_liger`, which reads `lm_head.bias` / `ref_lm_head.bias` directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-neutral cleanup in the Liger KTO loss path; biases are still passed the same values as before for typical linear LM heads.
> 
> **Overview**
> In **`KTOTrainer._compute_loss_liger`**, the Liger fused KTO call now passes **`bias=lm_head.bias`** and **`ref_bias=ref_lm_head.bias`** directly, instead of wrapping them in **`hasattr(lm_head, "bias")`** checks that fell back to **`None`**.
> 
> That matches **`DPOTrainer`**’s Liger path and the surrounding **`maybe_gather_lm_head_ctx`** usage in the same method. For standard **`nn.Linear`** heads, **`bias`** is always present (it is **`None`** when disabled), so the guards were redundant and did not change runtime behavior. Removing them also drops a latent **`ref_bias`** guard that tested **`lm_head`** instead of **`ref_lm_head`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d14f2ec50b4ce4768f49cd99f5a7ec3e67a5c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->