### PR TITLE
[OpenReward] Return None for unrewarded rollouts to prevent default-0.0 advantage poisoning

### DIFF
--- a/tests/experimental/test_openreward.py
+++ b/tests/experimental/test_openreward.py
@@ -168,7 +168,25 @@ class TestOpenRewardSpec(TrlTestCase):
         out = env.echo(text="goodbye")
         assert "no match" in out
         assert env.reward == 0.0
+        assert env.has_reward is True  # wrong answer → server returned 0.0 (a real score)
         assert env.finished is False
+        env._close()
+
+    def test_unrewarded_rollout_returns_none_not_zero(self, echo_env_url):
+        """A rollout that never triggers a rewarding tool must return None, not 0.0.
+
+        Without this, the default ``self.reward = 0.0`` would be treated as a real reward in GRPO's
+        advantage computation: a sibling that does nothing gets ``reward=0.0``, a spurious positive
+        advantage over siblings that tried and got negative rewards. Returning None lets the trainer's
+        unscorable_mask zero the advantage, carrying no gradient.
+        """
+        spec = OpenRewardSpec(echo_env_url, env_name="echoenvironment", num_tasks=1)
+        env = spec.environment_factory()
+        env.reset(**spec.train_dataset[0])
+        # Don't call echo at all — simulate a rollout where the model never submitted
+        assert env.has_reward is False
+        rewards = spec.reward_funcs(environments=[env])
+        assert rewards == [None]  # unrewarded → None, not 0.0
         env._close()
 
     def test_reward_func_reads_last_non_null_per_environment(self, echo_env_url):

--- a/tests/experimental/test_sdpo_trainer.py
+++ b/tests/experimental/test_sdpo_trainer.py
@@ -502,6 +502,78 @@ class TestSDPOTrainer(TrlTestCase):
         assert "Observed flat SDPO rewards across all sampled generations" in caplog.text
         assert "SDPO self-distillation is inactive because no reprompted samples were constructed" in caplog.text
 
+    def test_unscorable_completions_get_zero_advantage(self, caplog):
+        """A completion for which all reward functions return None must not receive a spurious advantage.
+
+        Without the unscorable_mask defense, `nansum` collapses the row to a reward of 0, which can produce a
+        positive advantage when siblings in the generation group have negative rewards. That would reinforce the
+        model for producing unscorable output — a reward-hacking gradient.
+        """
+        dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
+
+        training_args = SDPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=1,
+            generation_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            max_steps=1,
+            report_to="none",
+        )
+
+        # Return None for the first completion (unscorable) and valid negative rewards for the others.
+        call_count = [0]
+
+        def partially_none_reward(**kwargs):
+            n = len(kwargs["prompts"])
+            rewards = []
+            for _ in range(n):
+                if call_count[0] % 3 == 0:
+                    rewards.append(None)  # unscorable
+                else:
+                    rewards.append(-1.0)  # valid negative reward
+                call_count[0] += 1
+            return rewards
+
+        trainer = SDPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=partially_none_reward,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # Capture the advantages computed during _prepare_training_batch
+        original_compute = trainer._compute_policy_loss
+
+        captured_advantages = []
+
+        def capture_loss(model, inputs, **kwargs):
+            if "advantages" in inputs:
+                captured_advantages.append(inputs["advantages"].clone())
+            return original_compute(model, inputs, **kwargs)
+
+        trainer._compute_policy_loss = capture_loss
+
+        with caplog.at_level(logging.WARNING):
+            trainer.train()
+
+        assert len(captured_advantages) > 0, "No training step was executed"
+        advantages = captured_advantages[0]
+
+        # No NaN should leak into advantages (the unscorable rows are zeroed).
+        assert not torch.isnan(advantages).any(), "NaN found in advantages — unscorable defense failed"
+
+        # The unscorable advantage should be exactly 0, not a spurious positive value.
+        # With 3 generations: one None (unscorable → 0), two -1.0. Before the fix, the unscorable
+        # row would get reward 0 via nansum, producing a positive advantage over its -1.0 siblings.
+        # After the fix, it gets advantage 0.
+        zero_advantages = (advantages.abs() < 1e-6)
+        assert zero_advantages.any(), f"Expected at least one zeroed (unscorable) advantage, got: {advantages}"
+
+        # Verify the warning was emitted
+        assert "unscorable" in caplog.text.lower(), "Expected unscorable warning in logs"
+
     def test_train_preserves_teacher_completion_attention_mask(self):
         dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
 

--- a/trl/experimental/openreward/_spec.py
+++ b/trl/experimental/openreward/_spec.py
@@ -71,8 +71,15 @@ def _outcome_only_reward_func(environments, **_):
 
     Suitable for sparse-outcome envs (e.g. SETA, where only `submit_solution` returns a non-null reward). Override by
     passing a different callable to ``reward_funcs=``.
+
+    Returns ``None`` for rollouts that never received a reward signal (no tool returned a non-null
+    ``out.reward``). This prevents the default ``self.reward = 0.0`` from being treated as a real
+    reward: in a GRPO group, a sibling that does nothing would otherwise get ``reward=0.0`` — a
+    spurious positive advantage over siblings that tried and got negative rewards. The trainer's
+    ``unscorable_mask`` (GRPO) or ``nan_to_num`` (SDPO) then zeroes the advantage, ensuring
+    unrewarded rollouts carry no gradient.
     """
-    return [env.reward for env in environments]
+    return [env.reward if env.has_reward else None for env in environments]
 
 
 class OpenRewardSpec:

--- a/trl/experimental/openreward/environment.py
+++ b/trl/experimental/openreward/environment.py
@@ -131,7 +131,13 @@ class _RolloutEnvironment:
 
     Attributes:
         reward (`float`):
-            Last non-null reward in the trajectory (outcome-only convention).
+            Last non-null reward in the trajectory (outcome-only convention). Only meaningful when
+            ``has_reward`` is ``True``; otherwise the default ``0.0`` is a placeholder, not a real score.
+        has_reward (`bool`):
+            ``True`` once any tool call returned a non-null ``out.reward``. The default reward func
+            (``_outcome_only_reward_func``) returns ``None`` when this is ``False`` so that unrewarded
+            rollouts are treated as unscorable rather than scored ``0.0`` (which would produce a spurious
+            positive advantage over siblings that tried and got negative rewards).
         rewards (`list[float | None]`):
             Per-step reward sequence in tool-call order.
         metadata (`list[dict | None]`):
@@ -190,6 +196,7 @@ class _RolloutEnvironment:
 
         # Episode state — read by the trainer's reward_func.
         self.reward: float = 0.0
+        self.has_reward: bool = False  # True once any tool returned a non-null reward
         self.rewards: list[float | None] = []
         self.metadata: list[dict[str, Any] | None] = []
         self.finished: bool = False
@@ -217,6 +224,7 @@ class _RolloutEnvironment:
         """
         self._teardown_session()
         self.reward = 0.0
+        self.has_reward = False
         self.rewards = []
         self.metadata = []
         self.finished = False
@@ -289,6 +297,7 @@ class _RolloutEnvironment:
         self.rewards.append(step_reward)
         if step_reward is not None:
             self.reward = step_reward  # last-non-null wins (outcome-only convention)
+            self.has_reward = True
 
         self.metadata.append(out.metadata if isinstance(out.metadata, dict) else None)
         self.finished = bool(out.finished)

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -54,6 +54,7 @@ from ...trainer.utils import (
     get_callable_name,
     get_config_model_id,
     identity,
+    nanstd,
     pad,
     selective_log_softmax,
     split_tensor_dict,
@@ -863,29 +864,55 @@ class SDPOTrainer(_BaseTrainer):
 
         # Compute rewards over the globally gathered rollout batch
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
+        num_generations = self.num_generations if mode == "train" else self.num_generations_eval
         if rewards_per_func.numel() == 0:
             rewards = torch.zeros(self.accelerator.num_processes * len(prompts), device=device)
+            unscorable_mask = torch.zeros(rewards.shape[0], dtype=torch.bool, device=device)
         else:
+            # A completion for which every reward function returned None is unscorable. nansum would collapse it to 0,
+            # which both biases the per-group baseline and hands the completion a spurious advantage. Mark these rows
+            # NaN so they're excluded from the (nan-aware) baseline below; their advantage is forced to 0 afterwards.
+            # This mirrors the defense in `GRPOTrainer._prepare_training_batch`.
+            unscorable_mask = torch.isnan(rewards_per_func).all(dim=1)
             rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards[unscorable_mask] = torch.nan
 
         # Normalize rewards within generation groups to produce local policy advantages
-        num_generations = self.num_generations if mode == "train" else self.num_generations_eval
-        mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1).repeat_interleave(num_generations, dim=0)
+        mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1).repeat_interleave(
+            num_generations, dim=0
+        )
         if self.scale_rewards == "batch":
-            std_rewards = rewards.std().expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
-            group_std_rewards = rewards.view(-1, num_generations).std(dim=1)
+            std_rewards = nanstd(rewards).expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
+            group_std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
         elif self.scale_rewards == "none":
             std_rewards = torch.ones_like(rewards)
             group_std_rewards = torch.ones(rewards.numel() // num_generations, device=device, dtype=rewards.dtype)
         else:
-            group_std_rewards = rewards.view(-1, num_generations).std(dim=1)
+            group_std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
             std_rewards = group_std_rewards.repeat_interleave(num_generations, dim=0)
         advantages = (rewards - mean_grouped_rewards) / (std_rewards + 1e-4)
+
+        # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
+        # so zero their advantage to keep them from moving the policy.
+        advantages = torch.nan_to_num(advantages, nan=0.0)
         local_batch_size = batch["completion_ids"].size(0)
         process_start = self.accelerator.process_index * local_batch_size
         process_slice = slice(process_start, process_start + local_batch_size)
         local_rewards = rewards[process_slice]
         local_advantages = advantages[process_slice]
+
+        # Warn if any completion was unscorable (every reward function returned None for it). This is a silent
+        # reward-hacking vector: without the unscorable_mask above, nansum collapses the row to a reward of 0,
+        # which can produce a spurious positive advantage that reinforces the completion. Mirrors GRPO's warning.
+        if rewards_per_func.numel() > 0 and unscorable_mask.any():
+            unscorable_frac = unscorable_mask.float().mean().item()
+            logger.warning(
+                "%d/%d completions (%.1f%%) were unscorable (all reward functions returned None). "
+                "Their advantages have been zeroed; check that reward functions cover all completion types.",
+                int(unscorable_mask.sum()),
+                unscorable_mask.numel(),
+                unscorable_frac * 100,
+            )
 
         self._record_reward_diagnostics(mode, rewards, rewards_per_func, group_std_rewards)
         self._record_completion_metrics(mode, batch)
@@ -1696,10 +1723,14 @@ class SDPOTrainer(_BaseTrainer):
     ) -> None:
         tolerance = self.args.diagnostics_flat_tolerance
 
-        reward_mean = rewards.mean() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_std = rewards.std() if rewards.numel() > 1 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_min = rewards.min() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_max = rewards.max() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_mean = torch.nanmean(rewards) if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_std = nanstd(rewards) if rewards.numel() > 1 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_min = torch.where(
+            torch.isnan(rewards), torch.tensor(float("inf"), device=rewards.device), rewards
+        ).min() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_max = torch.where(
+            torch.isnan(rewards), torch.tensor(float("-inf"), device=rewards.device), rewards
+        ).max() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
         flat_group_fraction = (
             (group_std_rewards <= tolerance).float().mean()
             if group_std_rewards.numel() > 0


### PR DESCRIPTION
## Problem

The `_RolloutEnvironment` initializes `self.reward = 0.0`. The default reward function (`_outcome_only_reward_func`) returns `env.reward` unconditionally. When a rollout never triggers a rewarding tool call (the model explores but never submits), the default `0.0` is returned as a **real reward**.

In a GRPO generation group, a sibling that does nothing gets `reward=0.0` — a spurious positive advantage over siblings that tried and got negative rewards (e.g. `-1.0` for a wrong submission). That advantage becomes a positive policy gradient, **reinforcing the model for inaction**. The model is trained toward "do nothing" rather than "try and fail."

### Concrete example (4 siblings, same prompt)

| Sibling | Action | Reward before fix | Advantage before fix | Reward after fix |
|---|---|---|---|---|
| 0 | does nothing | `0.0` (default) | **+1.0** (reinforced!) | `None` → 0.0 (zeroed by unscorable_mask) |
| 1 | tried, failed | `-1.0` | `-1.0` (penalized) | `-1.0` |
| 2 | tried, failed | `-1.0` | `-1.0` (penalized) | `-1.0` |
| 3 | does nothing | `0.0` (default) | **+1.0** (reinforced!) | `None` → 0.0 (zeroed by unscorable_mask) |

The do-nothing siblings (0, 3) get positive gradients. The try-and-fail siblings (1, 2) get penalized. The model learns to avoid submitting.

## Fix

Track whether any tool call returned a non-null reward via a `has_reward` flag:
- Set to `True` in `_call_ors_tool` when `out.reward is not None`
- Reset to `False` in `reset()`
- The default reward function returns `None` when `has_reward is False`

This lets the trainer's existing `unscorable_mask` defense (GRPO) or `nan_to_num` (SDPO) zero the advantage, so unrewarded rollouts carry no gradient.

### Important: server-returned 0.0 is still a real reward

A wrong answer that gets `reward=0.0` from the server (e.g. the echo env on a mismatch) still sets `has_reward=True`. The `0.0` is a genuine score from the environment, not the default placeholder. Only rollouts where **no tool ever returned a reward** are affected.

## Test

- Updated `test_wrong_echo_returns_no_match_with_zero_reward` to assert `has_reward is True` (wrong answer → real 0.0)
- Added `test_unrewarded_rollout_returns_none_not_zero` — verifies that a rollout with no rewarding tool call returns `None`, not `0.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes advantage/reward aggregation in SDPO and default OpenReward reward semantics; incorrect `has_reward` handling could mis-score rollouts, but scope is RL training paths with targeted tests.
> 
> **Overview**
> Fixes **reward-hacking from placeholder `0.0` scores**: OpenReward rollouts that never get a tool reward used to surface `env.reward == 0.0`, which GRPO/SDPO treated like a real score and could give **positive advantage** over siblings with negative rewards (reinforcing “do nothing”).
> 
> **OpenReward** adds `has_reward` (set on any non-null tool reward, cleared on `reset`). `_outcome_only_reward_func` returns **`None`** when `has_reward` is false; server-returned **`0.0` still counts** as a real reward (`has_reward=True`).
> 
> **SDPO** aligns with GRPO: rows where every reward func is `None` are marked unscorable (`NaN` reward), group stats use **`nanmean` / `nanstd`**, advantages are **`nan_to_num` → 0**, plus an **unscorable warning** and NaN-safe reward diagnostics.
> 
> Tests cover unrewarded echo rollouts → `[None]`, wrong echo still `0.0` with `has_reward`, and SDPO zero advantage for `None` rewards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189730178c5240a23c06a2572343e035b09a8df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->