### PR TITLE
[SDPO] Port unscorable-mask reward defense from GRPO

### DIFF
--- a/tests/experimental/test_sdpo_trainer.py
+++ b/tests/experimental/test_sdpo_trainer.py
@@ -502,6 +502,78 @@ class TestSDPOTrainer(TrlTestCase):
         assert "Observed flat SDPO rewards across all sampled generations" in caplog.text
         assert "SDPO self-distillation is inactive because no reprompted samples were constructed" in caplog.text
 
+    def test_unscorable_completions_get_zero_advantage(self, caplog):
+        """A completion for which all reward functions return None must not receive a spurious advantage.
+
+        Without the unscorable_mask defense, `nansum` collapses the row to a reward of 0, which can produce a
+        positive advantage when siblings in the generation group have negative rewards. That would reinforce the
+        model for producing unscorable output — a reward-hacking gradient.
+        """
+        dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
+
+        training_args = SDPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=1,
+            generation_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            max_steps=1,
+            report_to="none",
+        )
+
+        # Return None for the first completion (unscorable) and valid negative rewards for the others.
+        call_count = [0]
+
+        def partially_none_reward(**kwargs):
+            n = len(kwargs["prompts"])
+            rewards = []
+            for _ in range(n):
+                if call_count[0] % 3 == 0:
+                    rewards.append(None)  # unscorable
+                else:
+                    rewards.append(-1.0)  # valid negative reward
+                call_count[0] += 1
+            return rewards
+
+        trainer = SDPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=partially_none_reward,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # Capture the advantages computed during _prepare_training_batch
+        original_compute = trainer._compute_policy_loss
+
+        captured_advantages = []
+
+        def capture_loss(model, inputs, **kwargs):
+            if "advantages" in inputs:
+                captured_advantages.append(inputs["advantages"].clone())
+            return original_compute(model, inputs, **kwargs)
+
+        trainer._compute_policy_loss = capture_loss
+
+        with caplog.at_level(logging.WARNING):
+            trainer.train()
+
+        assert len(captured_advantages) > 0, "No training step was executed"
+        advantages = captured_advantages[0]
+
+        # No NaN should leak into advantages (the unscorable rows are zeroed).
+        assert not torch.isnan(advantages).any(), "NaN found in advantages — unscorable defense failed"
+
+        # The unscorable advantage should be exactly 0, not a spurious positive value.
+        # With 3 generations: one None (unscorable → 0), two -1.0. Before the fix, the unscorable
+        # row would get reward 0 via nansum, producing a positive advantage over its -1.0 siblings.
+        # After the fix, it gets advantage 0.
+        zero_advantages = (advantages.abs() < 1e-6)
+        assert zero_advantages.any(), f"Expected at least one zeroed (unscorable) advantage, got: {advantages}"
+
+        # Verify the warning was emitted
+        assert "unscorable" in caplog.text.lower(), "Expected unscorable warning in logs"
+
     def test_train_preserves_teacher_completion_attention_mask(self):
         dataset = Dataset.from_dict({"prompt": ["Solve 2+2."]})
 

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -54,6 +54,7 @@ from ...trainer.utils import (
     get_callable_name,
     get_config_model_id,
     identity,
+    nanstd,
     pad,
     selective_log_softmax,
     split_tensor_dict,
@@ -863,29 +864,55 @@ class SDPOTrainer(_BaseTrainer):
 
         # Compute rewards over the globally gathered rollout batch
         rewards_per_func = self._calculate_rewards(inputs, prompts, completions, completion_ids_list)
+        num_generations = self.num_generations if mode == "train" else self.num_generations_eval
         if rewards_per_func.numel() == 0:
             rewards = torch.zeros(self.accelerator.num_processes * len(prompts), device=device)
+            unscorable_mask = torch.zeros(rewards.shape[0], dtype=torch.bool, device=device)
         else:
+            # A completion for which every reward function returned None is unscorable. nansum would collapse it to 0,
+            # which both biases the per-group baseline and hands the completion a spurious advantage. Mark these rows
+            # NaN so they're excluded from the (nan-aware) baseline below; their advantage is forced to 0 afterwards.
+            # This mirrors the defense in `GRPOTrainer._prepare_training_batch`.
+            unscorable_mask = torch.isnan(rewards_per_func).all(dim=1)
             rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
+            rewards[unscorable_mask] = torch.nan
 
         # Normalize rewards within generation groups to produce local policy advantages
-        num_generations = self.num_generations if mode == "train" else self.num_generations_eval
-        mean_grouped_rewards = rewards.view(-1, num_generations).mean(dim=1).repeat_interleave(num_generations, dim=0)
+        mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1).repeat_interleave(
+            num_generations, dim=0
+        )
         if self.scale_rewards == "batch":
-            std_rewards = rewards.std().expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
-            group_std_rewards = rewards.view(-1, num_generations).std(dim=1)
+            std_rewards = nanstd(rewards).expand_as(rewards) if rewards.numel() > 1 else torch.zeros_like(rewards)
+            group_std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
         elif self.scale_rewards == "none":
             std_rewards = torch.ones_like(rewards)
             group_std_rewards = torch.ones(rewards.numel() // num_generations, device=device, dtype=rewards.dtype)
         else:
-            group_std_rewards = rewards.view(-1, num_generations).std(dim=1)
+            group_std_rewards = nanstd(rewards.view(-1, num_generations), dim=1)
             std_rewards = group_std_rewards.repeat_interleave(num_generations, dim=0)
         advantages = (rewards - mean_grouped_rewards) / (std_rewards + 1e-4)
+
+        # Unscorable completions (every reward func returned None) carry no learning signal: their reward is NaN here,
+        # so zero their advantage to keep them from moving the policy.
+        advantages = torch.nan_to_num(advantages, nan=0.0)
         local_batch_size = batch["completion_ids"].size(0)
         process_start = self.accelerator.process_index * local_batch_size
         process_slice = slice(process_start, process_start + local_batch_size)
         local_rewards = rewards[process_slice]
         local_advantages = advantages[process_slice]
+
+        # Warn if any completion was unscorable (every reward function returned None for it). This is a silent
+        # reward-hacking vector: without the unscorable_mask above, nansum collapses the row to a reward of 0,
+        # which can produce a spurious positive advantage that reinforces the completion. Mirrors GRPO's warning.
+        if rewards_per_func.numel() > 0 and unscorable_mask.any():
+            unscorable_frac = unscorable_mask.float().mean().item()
+            logger.warning(
+                "%d/%d completions (%.1f%%) were unscorable (all reward functions returned None). "
+                "Their advantages have been zeroed; check that reward functions cover all completion types.",
+                int(unscorable_mask.sum()),
+                unscorable_mask.numel(),
+                unscorable_frac * 100,
+            )
 
         self._record_reward_diagnostics(mode, rewards, rewards_per_func, group_std_rewards)
         self._record_completion_metrics(mode, batch)
@@ -1696,10 +1723,14 @@ class SDPOTrainer(_BaseTrainer):
     ) -> None:
         tolerance = self.args.diagnostics_flat_tolerance
 
-        reward_mean = rewards.mean() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_std = rewards.std() if rewards.numel() > 1 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_min = rewards.min() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
-        reward_max = rewards.max() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_mean = torch.nanmean(rewards) if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_std = nanstd(rewards) if rewards.numel() > 1 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_min = torch.where(
+            torch.isnan(rewards), torch.tensor(float("inf"), device=rewards.device), rewards
+        ).min() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
+        reward_max = torch.where(
+            torch.isnan(rewards), torch.tensor(float("-inf"), device=rewards.device), rewards
+        ).max() if rewards.numel() > 0 else torch.tensor(0.0, device=self.accelerator.device)
         flat_group_fraction = (
             (group_std_rewards <= tolerance).float().mean()
             if group_std_rewards.numel() > 0


### PR DESCRIPTION
# What does this PR do?

The SDPO trainer inherits from `_BaseTrainer` (not `GRPOTrainer`), so the `unscorable_mask` defense added to GRPO was never carried over. When every reward function returns `None` for a completion, `nansum` collapses the row to a reward of `0`. If siblings in the generation group have negative rewards, the unscorable completion receives a **spurious positive advantage** — which becomes a positive policy gradient that reinforces the model for producing output that defeats the reward function.

This is a reward-hacking gradient: the model is trained *toward* unscorable completions.

### Concrete example (8 generations, 1 unscorable)

| Completion | Reward func output | After `nansum` (vulnerable) | Advantage (vulnerable) | After fix |
|---|---|---|---|---|
| 0–6 | `0.5 … -0.8` | `0.5 … -0.8` | normal | normal |
| 7 (unscorable) | `None` → `NaN` | `0.0` | **+0.264** | `NaN` → **0.0** |

The unscorable completion (idx 7) gets a **+0.264 advantage** without the defense — a positive policy gradient despite carrying no learning signal.

### Fix

Port GRPO's `unscorable_mask` defense to `SDPOTrainer._prepare_training_batch`:

1. Detect unscorable rows: `torch.isnan(rewards_per_func).all(dim=1)`
2. Set their reward to `NaN` (not `0`) after `nansum`
3. Use `torch.nanmean` / `nanstd` for the group baseline so unscorable rows are excluded
4. Zero their advantage: `torch.nan_to_num(advantages, nan=0.0)`
5. Make `_record_reward_diagnostics` NaN-aware (`nanmean`, `nanstd`, NaN-masked `min`/`max`)
6. Emit a warning when unscorable rows are present

This mirrors the defense already shipped in `GRPOTrainer._prepare_training_batch` (same comment, same logic).

### Scope

The same pattern (`nansum` without `unscorable_mask`) exists in several experimental trainers that do not inherit the defense:
- `SDPOTrainer` (this PR — inherits `_BaseTrainer`)
- `OnlineDPOTrainer` (inherits `_BaseTrainer`)
- `DPPOTrainer` (overrides `_generate_and_score_completions`, drops the parent's defense)
- `GRPOWithReplayBufferTrainer` (overrides the reward path)

This PR fixes SDPO as the first/most impactful case (it is the newest trainer with the most direct self-play reward-hacking surface). The remaining trainers can follow the same pattern.

Fixes # N/A

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that is the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

@vwxyzjn @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SDPO policy-gradient advantage computation during training; incorrect handling could affect learning, but the change aligns with proven GRPO logic and is covered by a targeted test.
> 
> **Overview**
> **SDPO** now treats completions where every reward function returns `None` as **unscorable**, matching the existing **GRPO** behavior.
> 
> In `_prepare_training_batch`, those rows are marked with `NaN` rewards (instead of `0` from `nansum`), group baselines use `nanmean` / `nanstd`, advantages are zeroed with `nan_to_num`, and a warning is logged when unscorable completions appear. Reward diagnostics were updated to stay correct when `NaN` rewards are present.
> 
> A regression test asserts unscorable samples get **zero advantage** (no spurious positive gradient) and that the warning is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6faeb16a3422ba69d1636978cd81451a7cbb92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->