### PR TITLE
Remove redundant torch.tensor re-wrapping of batch labels in KTO

### DIFF
--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1344,7 +1344,7 @@ class KTOTrainer(_BaseTrainer):
         mode = "train" if self.model.training else "eval"
         batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
 
-        labels = torch.tensor(batch["label"])
+        labels = batch["label"]
         num_chosen = labels.sum().to(self.accelerator.device)
         num_rejected = (len(labels) - num_chosen).to(self.accelerator.device)
 
@@ -1433,7 +1433,7 @@ class KTOTrainer(_BaseTrainer):
                 lin_weight=lm_head.weight,
                 target=target,
                 bias=lm_head.bias,
-                preference_labels=torch.tensor(batch["label"], dtype=torch.bool).to(self.accelerator.device),
+                preference_labels=batch["label"],
                 ref_input=ref_outputs.last_hidden_state[:, :-1],
                 ref_weight=ref_lm_head.weight,
                 ref_bias=ref_lm_head.bias,
@@ -1485,7 +1485,7 @@ class KTOTrainer(_BaseTrainer):
         mode = "train" if self.model.training else "eval"
         batch = {k: (v.to(self.accelerator.device) if isinstance(v, torch.Tensor) else v) for k, v in inputs.items()}
 
-        labels = torch.tensor(batch["label"])
+        labels = batch["label"]
         num_chosen = labels.sum().to(self.accelerator.device)
         num_rejected = (len(labels) - num_chosen).to(self.accelerator.device)
 


### PR DESCRIPTION
This PR removes a redundant tensor re-wrap in KTOTrainer `_compute_loss` and `_compute_loss_liger`, which was left over from before the KTO data collator returned `batch["label"]` as a tensor.

### Motivation

The KTO data collator builds `batch["label"]` as a `torch.tensor(...)` directly instead of a plain Python list since:
- #6325 
 
The three call sites that wrapped `batch["label"]` in `torch.tensor(...)` again predate that change and are now calling `torch.tensor()` on an already-existing tensor, which does a needless copy and triggers a warning in CI:
> UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.detach().clone()...

### Solution

Use `batch["label"]` directly at each of the three sites, since it is already a `torch.bool` tensor moved to `self.accelerator.device` by the preceding dict comprehension. This matches the existing `torch.as_tensor(batch["label"], ...)` pattern already used elsewhere in the same file, which is a no-op when the input is already a tensor.

### Changes

- _compute_loss: use `batch["label"]` directly instead of `torch.tensor(batch["label"])`
- _compute_loss_liger: use `batch["label"]` directly instead of `torch.tensor(batch["label"])` and `torch.tensor(batch["label"], dtype=torch.bool).to(self.accelerator.device)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup in KTO loss code; labels were already tensors from the collator and device placement is unchanged.
> 
> **Overview**
> Removes redundant `torch.tensor(...)` wrapping of `batch["label"]` in **KTOTrainer** loss paths now that the KTO data collators already emit `label` as a tensor.
> 
> In `_compute_loss` and `_compute_loss_liger`, labels are taken directly from the batch (already on device after the existing tensor move). The Liger path also passes `batch["label"]` straight through as `preference_labels` instead of re-casting and copying. This avoids unnecessary tensor copies and silences CI warnings about constructing tensors from existing tensors, without changing KTO math or metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97dd43ea73dbc2b7155c81db3597c474e22f333c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->