### PR TITLE
Document max_steps requirement for iterable datasets in GRPO and RLOO

### DIFF
--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -212,6 +212,10 @@ class GRPOTrainer(_BaseTrainer):
             - [Standard](dataset_formats#standard): Each sample contains plain text.
             - [Conversational](dataset_formats#conversational): Each sample contains structured messages (e.g., role
               and content).
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -177,6 +177,10 @@ class RLOOTrainer(_BaseTrainer):
             - [Standard](dataset_formats#standard): Each sample contains plain text.
             - [Conversational](dataset_formats#conversational): Each sample contains structured messages (e.g., role
               and content).
+
+            When `train_dataset` is an [`~datasets.IterableDataset`] (e.g. a streaming dataset), `max_steps` must be
+            set in the training arguments, since its length cannot be inferred and the total number of training steps
+            is required to bound the training loop and configure the learning rate scheduler.
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):


### PR DESCRIPTION
This PR documents that `max_steps` must be set in the training arguments when `train_dataset` is an `IterableDataset`, for consistency with the other core trainers.

Follow-up to:
- #6351

### Changes

- Add a note to the train_dataset docstring in GRPOTrainer and RLOOTrainer, matching the wording already used in DPOTrainer, SFTTrainer, KTOTrainer, and RewardTrainer, explaining that max_steps must be set when using an IterableDataset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates with no behavioral changes to training or data loading.
> 
> **Overview**
> Aligns **GRPOTrainer** and **RLOOTrainer** API docs with the other core trainers by documenting that **`max_steps` must be set** when `train_dataset` is an [`IterableDataset`](https://huggingface.co/docs/datasets/main/en/package_reference/main_classes#datasets.IterableDataset) (e.g. streaming), because dataset length cannot be inferred and step count is needed for the training loop and LR scheduler.
> 
> Documentation-only change; no runtime or validation logic is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7aa41b48fc7d047c1cc4b57b7a4e73d061ef2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->