### PR TITLE
Fix DPO/KTO double-preprocessing eval_dataset dict passed to evaluate()

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1675,6 +1675,17 @@ class DPOTrainer(_BaseTrainer):
                     }
                 else:
                     eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
+            # Call `super().evaluate()` once per split ourselves instead of handing the whole dict to it: `Trainer.evaluate`
+            # would otherwise recurse into `self.evaluate` per split, re-entering this override on an already-prepared dataset.
+            if isinstance(eval_dataset, dict):
+                metrics = {}
+                for name, dataset in eval_dataset.items():
+                    metrics.update(
+                        super().evaluate(
+                            eval_dataset=dataset, ignore_keys=ignore_keys, metric_key_prefix=f"{metric_key_prefix}_{name}"
+                        )
+                    )
+                return metrics
         return super().evaluate(
             eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
         )

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1108,9 +1108,6 @@ class DPOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
-        # Idempotent skip: dataset already has ref log-probs precomputed.
-        if "ref_chosen_logps" in dataset.column_names and "ref_rejected_logps" in dataset.column_names:
-            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1679,7 +1679,9 @@ class DPOTrainer(_BaseTrainer):
                 for name, dataset in eval_dataset.items():
                     metrics.update(
                         super().evaluate(
-                            eval_dataset=dataset, ignore_keys=ignore_keys, metric_key_prefix=f"{metric_key_prefix}_{name}"
+                            eval_dataset=dataset,
+                            ignore_keys=ignore_keys,
+                            metric_key_prefix=f"{metric_key_prefix}_{name}",
                         )
                     )
                 return metrics

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1701,6 +1701,17 @@ class KTOTrainer(_BaseTrainer):
                     }
                 else:
                     eval_dataset = self._precompute_ref_logps(eval_dataset, "eval", batch_size)
+            # Call `super().evaluate()` once per split ourselves instead of handing the whole dict to it: `Trainer.evaluate`
+            # would otherwise recurse into `self.evaluate` per split, re-entering this override on an already-prepared dataset.
+            if isinstance(eval_dataset, dict):
+                metrics = {}
+                for name, dataset in eval_dataset.items():
+                    metrics.update(
+                        super().evaluate(
+                            eval_dataset=dataset, ignore_keys=ignore_keys, metric_key_prefix=f"{metric_key_prefix}_{name}"
+                        )
+                    )
+                return metrics
         return super().evaluate(
             eval_dataset=eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
         )

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1176,9 +1176,6 @@ class KTOTrainer(_BaseTrainer):
                 "`precompute_ref_log_probs=True` is not supported with IterableDataset. Please use a map-style "
                 "Dataset or set `precompute_ref_log_probs=False`."
             )
-        # Idempotent skip: dataset already has ref log-probs precomputed.
-        if "ref_logps" in dataset.column_names:
-            return dataset
         model_hash = hash_module(self.ref_model or self.model)
         fingerprint = Hasher.hash((dataset._fingerprint, model_hash, self.calculate_KL))
         cache_file = dataset._get_cache_file_path(fingerprint)

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -1705,7 +1705,9 @@ class KTOTrainer(_BaseTrainer):
                 for name, dataset in eval_dataset.items():
                     metrics.update(
                         super().evaluate(
-                            eval_dataset=dataset, ignore_keys=ignore_keys, metric_key_prefix=f"{metric_key_prefix}_{name}"
+                            eval_dataset=dataset,
+                            ignore_keys=ignore_keys,
+                            metric_key_prefix=f"{metric_key_prefix}_{name}",
                         )
                     )
                 return metrics


### PR DESCRIPTION
This PR is a follow-up to #6370, which applied a narrow fix (an idempotent guard in _precompute_ref_logps) for a crash when a dict eval_dataset was passed to evaluate() combined with precompute_ref_log_probs=True. This PR fixes the underlying redundant preprocessing that guard was papering over.

### Motivation

transformers.Trainer.evaluate() handles a dict eval_dataset by recursing into self.evaluate(...) once per split. Since self.evaluate resolves polymorphically, this re-enters the trainer's own evaluate() override a second time on an already-processed dataset, when a dict is passed directly as an override argument to evaluate(). _prepare_dataset has no protection against this, so each split gets tokenized twice. #6370's guard only prevented the resulting crash in _precompute_ref_logps; it didn't address the redundant _prepare_dataset work, which was still there for that call pattern.

(A separate attempt at a structural fix, #6400, moved this logic into get_eval_dataloader() instead, but that introduced two regressions found in review: it made every scheduled evaluation during train() re-run _prepare_dataset/_precompute_ref_logps on the whole eval set, a bug that never existed on main. That PR was closed in favor of this one.)

### Solution

Instead of handing the whole prepared dict to super().evaluate() (which triggers the recursion), evaluate() now iterates the splits itself and calls super().evaluate() once per already-prepared split. Since each of those calls passes a single Dataset, not a dict, Trainer.evaluate()'s recursive branch never fires, so the double-dispatch is structurally impossible rather than something each processing step has to individually guard against. As a result, the idempotent guard in _precompute_ref_logps is no longer needed and has been removed.

### Changes

- trl/trainer/dpo_trainer.py: evaluate() iterates eval_dataset splits and calls super().evaluate() once per split instead of delegating the whole dict; removed the now-unnecessary idempotent guard in _precompute_ref_logps
- trl/trainer/kto_trainer.py: same change, mirroring DPO per the repo's duplicated-code convention

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the evaluation code path for dict `eval_dataset` and `precompute_ref_log_probs`; behavior should match intent with less redundant work, but eval metrics naming/prefixing for multi-split calls should be sanity-checked.
> 
> **Overview**
> Fixes redundant dataset preparation when **DPO** and **KTO** trainers evaluate a **dict** of eval splits (e.g. after passing a multi-split set into `evaluate()` with `precompute_ref_log_probs=True`).
> 
> Previously, calling `super().evaluate()` with the full dict made Hugging Face `Trainer.evaluate` recurse into the trainer’s `evaluate` override once per split, so each split was **tokenized and ref-log-prob precomputed twice**; an idempotent skip in `_precompute_ref_logps` only avoided a crash.
> 
> The override now **iterates splits** and calls `super().evaluate()` with a **single `Dataset` per split** (with per-split `metric_key_prefix`), so the recursive dict path never runs. The **column-name early-return guards** in `_precompute_ref_logps` are removed as unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9ac4f3d34577af967b3f96e116b8912fe12bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->