### PR TITLE
Ignore benign IndexPutBackward0 warning from Liger SAPO loss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,4 +202,11 @@ filterwarnings = [
     # Upstream issue: https://github.com/pytorch/pytorch/issues/174546
     "ignore:The argument 'device' of Tensor.pin_memory:DeprecationWarning",
     "ignore:The argument 'device' of Tensor.is_pinned:DeprecationWarning",
+
+    # Liger SAPO loss torch.compile anomaly-mode warning (upstream, not actionable in TRL)
+    # Liger's SAPO branch assigns per-token loss with boolean-mask indexing, which graph-breaks under
+    # torch.compile and is traced by AOTAutograd under anomaly mode
+    # Tracking issue: https://github.com/huggingface/trl/issues/6435
+    # Upstream fix (merged, unreleased as of liger-kernel 0.8.0): https://github.com/linkedin/Liger-Kernel/pull/1274
+    "ignore:Error detected in IndexPutBackward0:UserWarning",
 ]


### PR DESCRIPTION
This PR silences a benign `UserWarning` emitted in CI by the SAPO loss test when `use_liger_kernel=True`.

### Motivation

`test_train_loss_types[sapo-True]` triggers a `torch.autograd` anomaly-mode `UserWarning` about `IndexPutBackward0`. The warning comes from liger-kernel's SAPO branch, which assigns the per-token loss with boolean-mask indexing; that lowers to `aten.nonzero`, graph-breaks under `torch.compile`, and gets traced by AOTAutograd under anomaly mode. Training is unaffected (the test passes and parameters update), but the warning clutters CI.

> UserWarning: Error detected in IndexPutBackward0.

```python
  tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_loss_types[sapo-True]
  tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_loss_types[sapo-True]
    /__w/trl/trl/.venv/lib/python3.10/site-packages/torch/autograd/graph.py:979: UserWarning: Error detected in IndexPutBackward0. Traceback of forward call that caused the error:
      File "/__w/trl/trl/.venv/lib/python3.10/site-packages/liger_kernel/chunked_loss/grpo_loss.py", line 171, in torch_dynamo_resume_in_ppo_loss_fn_at_172
        per_token_loss[positive_advantages_mask] = sapo_loss_fn(
     (Triggered internally at /__w/pytorch/pytorch/torch/csrc/autograd/python_anomaly_mode.cpp:122.)
      return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
```

### Solution

The issue is already fixed upstream in liger-kernel (linkedin/Liger-Kernel#1274), but that fix is unreleased (latest is 0.8.0, which predates it). Following the existing precedent in `pyproject.toml`, this filters the non-actionable upstream warning until a liger-kernel release including the fix is available. Removal is tracked in #6435.

### Changes

- Add a `filterwarnings` entry in `pyproject.toml` to ignore the `IndexPutBackward0` `UserWarning` from liger-kernel's SAPO loss

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-configuration-only change; no production code paths or dependency versions modified.
> 
> **Overview**
> Adds a **pytest `filterwarnings` ignore** in `pyproject.toml` for the upstream `UserWarning` matching `Error detected in IndexPutBackward0`, which shows up in CI during SAPO + `use_liger_kernel` tests (e.g. `test_train_loss_types[sapo-True]`).
> 
> The entry follows the same pattern as existing upstream noise filters (DeepSpeed JIT, DataLoader `pin_memory`), with comments pointing to TRL **#6435** for removal once **liger-kernel** ships the fix from linkedin/Liger-Kernel#1274. **No training or library runtime behavior changes**—only test output filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c029bb0c031d98421734c635b967f9f54583e229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->