### PR TITLE
[GOLD] Support iterable datasets and collate each generation batch once per accumulation window

### DIFF
--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -114,6 +114,10 @@ GOLD requires a [conversational](dataset_formats#conversational) [language model
 `GOLDTrainer` keeps the raw messages so the ChatML collator can construct prompts and completions with the correct
 boundaries.
 
+When `train_dataset` is an `IterableDataset` (e.g. a streaming dataset), `max_steps` must be set in the training
+arguments, since its length cannot be inferred and the total number of training steps is required to bound the
+training loop and configure the learning rate scheduler.
+
 ## How Token Merging Works
 
 When student and teacher use different tokenizers, the same text may be split differently:

--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -3683,3 +3683,130 @@ class TestGOLDTrainerLoss(TrlTestCase):
             assert "input_ids" in next(iter(trainer.eval_dataset["data2"]))
         else:
             assert "input_ids" in next(iter(trainer.eval_dataset))
+
+
+class TestGOLDTrainerIterableDataset(TrlTestCase):
+    def setup_method(self):
+        self.model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    @pytest.mark.parametrize("lmbda", [0.0, 1.0])
+    def test_train_with_iterable_dataset(self, lmbda):
+        # Iterable (streaming) datasets have no length, so `max_steps` is required. Both GOLD paths consume the same
+        # repeated stream: off-policy (lmbda=0.0, loss on the dataset's ground-truth completions) and on-policy
+        # (lmbda=1.0, loss on student-generated completions).
+        dataset = load_dataset(
+            "trl-internal-testing/zen", "conversational_prompt_completion", split="train", streaming=True
+        )
+
+        training_args = GOLDConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=2,  # reduce the batch size to reduce memory usage
+            gradient_accumulation_steps=2,  # >1 so the stream must repeat each generation batch across the window
+            num_generations=2,  # >1 so the stream must group prompt repeats like the sampler
+            lmbda=lmbda,
+            max_length=64,
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            max_steps=3,
+            use_cpu=True,
+            bf16=False,
+            report_to="none",
+        )
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+
+        # Iterable datasets force `dispatch_batches=False` so the stream can be sharded per process.
+        assert trainer.args.accelerator_config.dispatch_batches is False
+
+        # Diverge the teacher from the student so JSD is well above fp noise (else the loss is identically 0 and
+        # parameters never move).
+        torch.manual_seed(0)
+        with torch.no_grad():
+            for p in trainer.teacher_model.parameters():
+                p.add_(0.5 * torch.randn_like(p))
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_iterable_dataset_requires_dispatch_batches_false(self):
+        # `dispatch_batches=True` is incompatible with iterable datasets (see get_train_dataloader).
+        dataset = load_dataset(
+            "trl-internal-testing/zen", "conversational_prompt_completion", split="train", streaming=True
+        )
+
+        training_args = GOLDConfig(
+            output_dir=self.tmp_dir, accelerator_config={"dispatch_batches": True}, report_to="none"
+        )
+        with pytest.raises(ValueError, match="Iterable datasets require `dispatch_batches=False`"):
+            GOLDTrainer(
+                model=self.model_id,
+                teacher_model=self.model_id,
+                args=training_args,
+                train_dataset=dataset,
+                processing_class=self.tokenizer,
+            )
+
+    def test_iterable_dataset_forces_num_workers_zero(self):
+        # Multiple workers would shard and interleave the repeated stream, splitting num_generations groups, so
+        # `dataloader_num_workers` is forced to 0 for iterable datasets.
+        dataset = load_dataset(
+            "trl-internal-testing/zen", "conversational_prompt_completion", split="train", streaming=True
+        )
+
+        training_args = GOLDConfig(output_dir=self.tmp_dir, dataloader_num_workers=4, max_steps=1, report_to="none")
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+
+        assert trainer.args.dataloader_num_workers == 0
+
+    def test_evaluate_with_iterable_dataset(self):
+        # GOLD evaluation is off-policy (a plain forward over the ground truth, no generation), so an iterable eval
+        # set flows through the base `Trainer` eval path; only the accelerator dispatch config needs the
+        # iterable-aware setup at init.
+        train_dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+        eval_dataset = load_dataset(
+            "trl-internal-testing/zen", "conversational_prompt_completion", split="test", streaming=True
+        )
+
+        training_args = GOLDConfig(
+            output_dir=self.tmp_dir,
+            per_device_eval_batch_size=2,  # reduce the batch size to reduce memory usage
+            max_length=64,
+            max_completion_length=8,  # must stay below max_length (unused in eval, which never generates)
+            use_cpu=True,
+            bf16=False,
+            report_to="none",
+        )
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            processing_class=self.tokenizer,
+        )
+
+        assert trainer.args.accelerator_config.dispatch_batches is False
+
+        metrics = trainer.evaluate()
+        assert metrics["eval_loss"] is not None

--- a/tests/experimental/test_gold_trainer.py
+++ b/tests/experimental/test_gold_trainer.py
@@ -3810,3 +3810,74 @@ class TestGOLDTrainerIterableDataset(TrlTestCase):
 
         metrics = trainer.evaluate()
         assert metrics["eval_loss"] is not None
+
+
+class TestGOLDTrainerRepeatBatchDataLoader(TrlTestCase):
+    def setup_method(self):
+        self.model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_generation_batch_is_collated_once_per_window(self, streaming):
+        # The training dataloader must collate (tokenize) each generation batch exactly once and then replay the cached
+        # batch across the gradient-accumulation window, instead of re-collating the same examples on every micro-step.
+        # `_RepeatBatchDataLoader` applies this window replay uniformly to map-style datasets (sampler `repeat_count=1`)
+        # and iterable datasets (`repeat_iterable_dataset(repeat_count=1)`), so the collator runs exactly once per
+        # window on both paths -- in particular the iterable path must not repeat the window a second time.
+        grad_accum = 3
+        per_device = 2
+        num_windows = 2  # dataset holds `per_device * grad_accum * num_windows` unique examples
+        messages = [
+            [{"role": "user", "content": f"Question {i}?"}, {"role": "assistant", "content": f"Answer {i}."}]
+            for i in range(per_device * grad_accum * num_windows)
+        ]
+        dataset = Dataset.from_dict({"messages": messages})
+        if streaming:
+            dataset = dataset.to_iterable_dataset()
+
+        trainer = GOLDTrainer(
+            model=self.model_id,
+            teacher_model=self.model_id,
+            args=GOLDConfig(
+                output_dir=self.tmp_dir,
+                report_to="none",
+                per_device_train_batch_size=per_device,
+                gradient_accumulation_steps=grad_accum,
+                num_generations=1,
+                max_length=64,
+                max_completion_length=16,
+                # Required for the streaming case: the Trainer rejects a length-less dataset at construction without
+                # it. Harmless for the map-style case since this test only builds the dataloader, never trains.
+                max_steps=num_windows * grad_accum,
+                use_cpu=True,
+                bf16=False,
+            ),
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+
+        # Wrap the collator to count how many times examples are actually collated (tokenized).
+        class _CountingCollator:
+            def __init__(self, inner):
+                self.inner = inner
+                self.n_calls = 0
+
+            def __call__(self, examples):
+                self.n_calls += 1
+                return self.inner(examples)
+
+        counting_collator = _CountingCollator(trainer.data_collator)
+        trainer.data_collator = counting_collator
+
+        batches = list(trainer.get_train_dataloader())
+
+        # Collated exactly once per window (not once per micro-step, and not twice for iterable datasets), then
+        # replayed `grad_accum` times across the window.
+        assert counting_collator.n_calls == num_windows
+        assert len(batches) == num_windows * grad_accum
+
+        # The `grad_accum` micro-step batches within a window are the same cached object (proof of no re-collation).
+        for window_start in range(0, len(batches), grad_accum):
+            window = batches[window_start : window_start + grad_accum]
+            assert all(batch is window[0] for batch in window)

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -73,6 +73,7 @@ from ...trainer.utils import (
     get_config_model_id,
     identity,
     pad,
+    repeat_iterable_dataset,
     split_tensor_dict,
 )
 from ..utils import (
@@ -805,6 +806,36 @@ class GOLDTrainer(SFTTrainer):
         self.model_name_or_path = model if isinstance(model, str) else model.config._name_or_path
         self.model_revision = (args.model_init_kwargs or {}).get("revision")
         dataset_sample = next(iter(train_dataset)) if train_dataset is not None else {}
+
+        # Iterable datasets can't be indexed, so the RepeatSampler can't be attached to them. Instead, the sampler's
+        # ordering is reproduced by streaming (see `get_train_dataloader` and `repeat_iterable_dataset`; evaluation is
+        # off-policy and needs no repeats, so it keeps the base `Trainer` eval path). This requires
+        # `dispatch_batches=False`: with the default dispatch path, batches are collated on the main process and
+        # Accelerate tries to concatenate non-tensor columns (e.g. the conversational `messages`), which fails;
+        # `dispatch_batches=False` also lets each process shard the stream into contiguous slices, as the sampler does.
+        # See https://github.com/huggingface/trl/issues/3213
+        uses_iterable_dataset = (
+            isinstance(train_dataset, IterableDataset)
+            or isinstance(eval_dataset, IterableDataset)
+            or (
+                isinstance(eval_dataset, dict) and any(isinstance(ds, IterableDataset) for ds in eval_dataset.values())
+            )
+        )
+        if uses_iterable_dataset:
+            if args.accelerator_config.dispatch_batches:
+                raise ValueError(
+                    "Iterable datasets require `dispatch_batches=False`, but it is set to `True` in "
+                    "`accelerator_config`. Please set it to `False`."
+                )
+            args.accelerator_config.dispatch_batches = False
+        # An iterable train set bakes prompt repeats into the stream, so it must be read by a single worker: multiple
+        # workers would shard and interleave it, splitting the num_generations groups. Map-style train keeps its workers.
+        if isinstance(train_dataset, IterableDataset) and args.dataloader_num_workers != 0:
+            warnings.warn(
+                f"Iterable datasets require `dataloader_num_workers=0` to preserve prompt grouping; overriding the "
+                f"provided value ({args.dataloader_num_workers})."
+            )
+            args.dataloader_num_workers = 0
         if processing_class is None:
             model_id = model if isinstance(model, str) else get_config_model_id(model.config)
             processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
@@ -1162,12 +1193,24 @@ class GOLDTrainer(SFTTrainer):
         The dataloader yields local batches of size `per_device_train_batch_size * gradient_accumulation_steps`. The
         `RepeatSampler` (with `repeat_count=gradient_accumulation_steps`) ensures each generation batch is sampled
         `gradient_accumulation_steps` times so Trainer's loop iterates the correct number of times. Only the first
-        batch in each window triggers `_fill_buffer`; the rest are ignored by `_prepare_inputs`.
+        batch in each window triggers `_fill_buffer`; the rest are ignored by `_prepare_inputs`. Iterable datasets
+        can't carry a sampler, so the same ordering is baked into the stream (see `repeat_iterable_dataset`).
         """
         if self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
 
         train_dataset = self.train_dataset
+        if isinstance(train_dataset, IterableDataset):
+            # Iterable datasets can't be indexed, so RepeatSampler can't be attached. Reproduce its ordering by
+            # transforming the stream instead (see `repeat_iterable_dataset`). The full permutation done by
+            # RepeatSampler (which always shuffles here) becomes a buffered shuffle.
+            train_dataset = train_dataset.shuffle(seed=self.args.seed)
+            train_dataset = repeat_iterable_dataset(
+                train_dataset,
+                mini_repeat_count=self.num_generations,
+                batch_size=self.args.generation_batch_size * self.accelerator.num_processes,
+                repeat_count=self.args.gradient_accumulation_steps,
+            )
         data_collator = self.data_collator
         if is_datasets_available() and isinstance(train_dataset, Dataset):
             train_dataset = self._remove_unused_columns(train_dataset, description="training")

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -766,6 +766,34 @@ class ULDLoss(nn.Module):
         return answers_index, answers_size
 
 
+class _RepeatBatchDataLoader:
+    """Repeats each collated batch ``repeat_count`` times without re-collation.
+
+    ``RepeatSampler`` with ``repeat_count > 1`` causes the DataLoader to re-collate (re-tokenize) the same examples on
+    every repeat, which is wasteful. This wrapper instead keeps ``repeat_count=1`` in the sampler and repeats the
+    already-collated tensor dict, avoiding redundant tokenization.
+    """
+
+    def __init__(self, dataloader, repeat_count: int):
+        self.dataloader = dataloader
+        self.repeat_count = repeat_count
+
+    def __iter__(self):
+        for batch in self.dataloader:
+            for _ in range(self.repeat_count):
+                yield batch
+
+    def __len__(self):
+        return len(self.dataloader) * self.repeat_count
+
+    def set_epoch(self, epoch: int):
+        if hasattr(self.dataloader, "set_epoch"):
+            self.dataloader.set_epoch(epoch)
+
+    def __getattr__(self, attr):
+        return getattr(self.dataloader, attr)
+
+
 class GOLDTrainer(SFTTrainer):
     _tag_names = ["trl", "gold"]
     _name = "GOLD"
@@ -1177,11 +1205,14 @@ class GOLDTrainer(SFTTrainer):
     def _get_train_sampler(self, dataset=None):
         if dataset is None:
             dataset = self.train_dataset
+        # The gradient-accumulation-window repeat is applied by `_RepeatBatchDataLoader` (see `get_train_dataloader`)
+        # rather than baked into the sampler with `repeat_count`, so each generation batch is collated (tokenized)
+        # once and the cached batch is replayed across the window instead of being re-collated every micro-step.
         return RepeatSampler(
             data_source=dataset,
             mini_repeat_count=self.num_generations,
             batch_size=self.args.generation_batch_size * self.accelerator.num_processes,
-            repeat_count=self.args.gradient_accumulation_steps,
+            repeat_count=1,
             shuffle=True,
             seed=self.args.seed,
         )
@@ -1190,26 +1221,30 @@ class GOLDTrainer(SFTTrainer):
         """
         Override Trainer.get_train_dataloader to load one generation batch per optimizer window.
 
-        The dataloader yields local batches of size `per_device_train_batch_size * gradient_accumulation_steps`. The
-        `RepeatSampler` (with `repeat_count=gradient_accumulation_steps`) ensures each generation batch is sampled
-        `gradient_accumulation_steps` times so Trainer's loop iterates the correct number of times. Only the first
-        batch in each window triggers `_fill_buffer`; the rest are ignored by `_prepare_inputs`. Iterable datasets
-        can't carry a sampler, so the same ordering is baked into the stream (see `repeat_iterable_dataset`).
+        The dataloader yields local batches of size `per_device_train_batch_size * gradient_accumulation_steps`. Each
+        generation batch is collated once and then replayed `gradient_accumulation_steps` times by
+        `_RepeatBatchDataLoader`, so Trainer's loop iterates the correct number of times without re-tokenizing the same
+        examples every micro-step. Only the first batch in each window triggers `_fill_buffer`; the rest are ignored by
+        `_prepare_inputs`. This window replay is applied uniformly to both map-style datasets (indexed via
+        `RepeatSampler`) and iterable datasets (streamed via `repeat_iterable_dataset`); neither carries the window
+        repeat itself (both use `repeat_count=1`), so it is never applied twice.
         """
         if self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
 
         train_dataset = self.train_dataset
         if isinstance(train_dataset, IterableDataset):
-            # Iterable datasets can't be indexed, so RepeatSampler can't be attached. Reproduce its ordering by
-            # transforming the stream instead (see `repeat_iterable_dataset`). The full permutation done by
-            # RepeatSampler (which always shuffles here) becomes a buffered shuffle.
+            # Iterable datasets can't be indexed, so RepeatSampler can't be attached. Reproduce its `num_generations`
+            # grouping by transforming the stream instead (see `repeat_iterable_dataset`); the full permutation done by
+            # RepeatSampler (which always shuffles here) becomes a buffered shuffle. `repeat_count=1`: the
+            # gradient-accumulation-window repeat is applied afterwards by `_RepeatBatchDataLoader`, the same as for
+            # map-style datasets, so it is not baked into the stream here.
             train_dataset = train_dataset.shuffle(seed=self.args.seed)
             train_dataset = repeat_iterable_dataset(
                 train_dataset,
                 mini_repeat_count=self.num_generations,
                 batch_size=self.args.generation_batch_size * self.accelerator.num_processes,
-                repeat_count=self.args.gradient_accumulation_steps,
+                repeat_count=1,
             )
         data_collator = self.data_collator
         if is_datasets_available() and isinstance(train_dataset, Dataset):
@@ -1236,7 +1271,9 @@ class GOLDTrainer(SFTTrainer):
             if self.args.dataloader_num_workers > 0:
                 dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
-        return self.accelerator.prepare(DataLoader(train_dataset, **dataloader_params))
+        dataloader = self.accelerator.prepare(DataLoader(train_dataset, **dataloader_params))
+        # Replay each collated generation batch across the accumulation window (see `_get_train_sampler`).
+        return _RepeatBatchDataLoader(dataloader, repeat_count=self.args.gradient_accumulation_steps)
 
     @profiling_decorator
     def _prepare_inputs(self, generation_batch: dict[str, torch.Tensor | Any]) -> dict[str, torch.Tensor | Any]:


### PR DESCRIPTION
# What does this PR do?

This PR makes two related changes to `GOLDTrainer`'s training dataloader.

## 1. Support iterable (streaming) datasets

Extends [#6351](https://github.com/huggingface/trl/pull/6351) to `GOLDTrainer`, which has the same blocker: its `get_train_dataloader` loads one generation batch per optimizer window via a `RepeatSampler`, and a sampler can't be attached to an iterable dataset.

Unlike GRPO before #6351, GOLD currently doesn't reject iterable datasets -- it silently breaks: the copied `Trainer.get_train_dataloader` boilerplate just skips the sampler, so each accumulation step draws fresh records while `_prepare_inputs` only consumes the first batch per window. `(grad_accum − 1)/grad_accum` of the stream is silently discarded, and the `num_generations` prompt grouping the buffer logic relies on never happens.

Changes, mirroring the PR above:

- `get_train_dataloader` wraps an iterable train set with `shuffle(seed)` + `repeat_iterable_dataset(...)` so the stream reproduces the sampler's `num_generations` grouping and ordering.
- Same `__init__` guards as GRPO: reject explicit `dispatch_batches=True`, force it to `False` otherwise, and warn + override `dataloader_num_workers=0` for an iterable train set.

One deliberate divergence from GRPO: no `get_eval_dataloader` override. GOLD evaluation is off-policy (a plain forward over the ground truth, no generation and no repeat sampler), so an iterable eval set flows through the base `Trainer` eval path unchanged.

## 2. Collate each generation batch once per accumulation window

Independently of streaming, GOLD baked the accumulation-window repeat into `RepeatSampler(repeat_count=gradient_accumulation_steps)`, so within each window the plain `DataLoader` drew the *same* generation batch `grad_accum` times and **re-ran the collator every time** -- for GOLD's text path that means re-running `apply_chat_template` + tokenization + byte-offset encoding on the whole batch. `_prepare_inputs` then keeps only the first window's collation (via the buffer) and discards the other `grad_accum − 1`.

This PR moves the window-repeat out of the sampler and into a small `_RepeatBatchDataLoader` wrapper (borrowed from `DistillationTrainer`), so each generation batch is collated **once** and the cached batch is replayed across the window. This eliminates `(grad_accum − 1)/grad_accum` of the collation/tokenization work; it is purely a data-pipeline change and does not touch the loss, sampling order, or numerics.

The window-repeat is now handled uniformly in exactly one place for both dataset types: `RepeatSampler` uses `repeat_count=1` (map-style) and `repeat_iterable_dataset` uses `repeat_count=1` (iterable), while `_RepeatBatchDataLoader` applies the `grad_accum` replay to both -- so it is never applied twice.

## Tests

- Streaming training through both GOLD paths (off-policy `lmbda=0.0` and on-policy `lmbda=1.0`), the `dispatch_batches` rejection, the `num_workers` override, and `evaluate()` with a streaming eval set (adapted from #6351).
- A collate-once test (parametrized over map-style and iterable) asserting the collator runs exactly once per window and the window's micro-step batches are the same cached object -- which also guards against the iterable path double-repeating.

## Who can review?

@albertvillanova @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GOLD training dataloader ordering, streaming constraints, and gradient-accumulation batch replay; behavior is well covered by tests but affects all GOLD train runs with grad_accum > 1.
> 
> **Overview**
> **GOLDTrainer** now supports **streaming (`IterableDataset`) training** and **collates each generation batch once per gradient-accumulation window**, cutting redundant ChatML tokenization.
> 
> For iterable train (or eval) data, init enforces **`accelerator_config.dispatch_batches=False`** (raises if explicitly `True`), sets **`dataloader_num_workers=0`** on iterable train sets with a warning, and **`get_train_dataloader`** shuffles and wraps the stream with **`repeat_iterable_dataset`** so `num_generations` grouping matches the map-style `RepeatSampler` path. Docs note that **`max_steps` is required** when the train set has no length.
> 
> Gradient accumulation no longer uses **`RepeatSampler(repeat_count=grad_accum)`**. Both dataset types use **`repeat_count=1`** in the sampler/stream helper; a new **`_RepeatBatchDataLoader`** replays the **same collated batch** across micro-steps. Tests cover streaming train (off/on-policy), eval with streaming eval, dispatch/worker guards, and collate-once for map and iterable loaders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c42f6659f78287d94e54eea18628ab33d836b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

