### PR TITLE
Fix GRPO truncated-completion loss normalization

### DIFF
--- a/tests/experimental/test_grpo_with_replay_buffer_trainer.py
+++ b/tests/experimental/test_grpo_with_replay_buffer_trainer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -93,48 +91,6 @@ class TestReplayBuffer:
         assert len(sampled) == 3
         for item in sampled:
             assert item in [entry[1] for entry in self.replay_buffer.heap]
-
-
-@pytest.mark.low_priority
-def test_update_with_replay_buffer_preserves_tool_mask():
-    trainer = object.__new__(GRPOWithReplayBufferTrainer)
-    trainer.replay_buffer = ReplayBuffer(max_size=5)
-    trainer.num_generations = 2
-    trainer._tokenizer = SimpleNamespace(pad_token_id=0)
-    trainer.use_vllm = False
-    trainer.vllm_importance_sampling_correction = False
-
-    buffered_group = {
-        "prompt_ids": torch.tensor([[100, 101], [102, 103]]),
-        "prompt_mask": torch.ones(2, 2, dtype=torch.long),
-        "completion_ids": torch.tensor([[10, 11, 12], [13, 14, 0]]),
-        "completion_mask": torch.tensor([[1, 1, 1], [1, 1, 0]]),
-        "tool_mask": torch.tensor([[1, 0, 1], [0, 1, 1]]),
-        "advantages": torch.tensor([0.5, 0.6]),
-    }
-    trainer.replay_buffer.add([1.0], [buffered_group])
-    trainer.replay_buffer.sample = lambda num_samples: [buffered_group]
-
-    outputs = trainer.update_with_replay_buffer(
-        group_advantages=torch.tensor([[0.5, 0.5], [0.2, 0.8]]),
-        group_std_rewards=torch.tensor([[0.0, 1.0], [0.0, 1.0]]),
-        prompt_ids=torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]]),
-        prompt_mask=torch.ones(4, 2, dtype=torch.long),
-        completion_ids=torch.tensor([[20, 21], [22, 23], [24, 25], [26, 27]]),
-        completion_mask=torch.ones(4, 2, dtype=torch.long),
-        forward_kwargs={},
-        num_items_in_batch=8,
-        tool_mask=torch.tensor([[0, 0], [0, 0], [1, 0], [0, 1]]),
-    )
-
-    expected_tool_mask = torch.tensor([[1, 0, 1], [0, 1, 1], [1, 0, 1], [0, 1, 1]])
-    torch.testing.assert_close(outputs["tool_mask"], expected_tool_mask)
-    assert (outputs["completion_mask"] * outputs["tool_mask"]).sum().item() == 5
-
-    stored_group = next(
-        data for _, data in trainer.replay_buffer.heap if data["prompt_ids"].tolist() == [[5, 6], [7, 8]]
-    )
-    torch.testing.assert_close(stored_group["tool_mask"], torch.tensor([[1, 0], [0, 1]]))
 
 
 @pytest.mark.low_priority

--- a/tests/experimental/test_grpo_with_replay_buffer_trainer.py
+++ b/tests/experimental/test_grpo_with_replay_buffer_trainer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -91,6 +93,48 @@ class TestReplayBuffer:
         assert len(sampled) == 3
         for item in sampled:
             assert item in [entry[1] for entry in self.replay_buffer.heap]
+
+
+@pytest.mark.low_priority
+def test_update_with_replay_buffer_preserves_tool_mask():
+    trainer = object.__new__(GRPOWithReplayBufferTrainer)
+    trainer.replay_buffer = ReplayBuffer(max_size=5)
+    trainer.num_generations = 2
+    trainer._tokenizer = SimpleNamespace(pad_token_id=0)
+    trainer.use_vllm = False
+    trainer.vllm_importance_sampling_correction = False
+
+    buffered_group = {
+        "prompt_ids": torch.tensor([[100, 101], [102, 103]]),
+        "prompt_mask": torch.ones(2, 2, dtype=torch.long),
+        "completion_ids": torch.tensor([[10, 11, 12], [13, 14, 0]]),
+        "completion_mask": torch.tensor([[1, 1, 1], [1, 1, 0]]),
+        "tool_mask": torch.tensor([[1, 0, 1], [0, 1, 1]]),
+        "advantages": torch.tensor([0.5, 0.6]),
+    }
+    trainer.replay_buffer.add([1.0], [buffered_group])
+    trainer.replay_buffer.sample = lambda num_samples: [buffered_group]
+
+    outputs = trainer.update_with_replay_buffer(
+        group_advantages=torch.tensor([[0.5, 0.5], [0.2, 0.8]]),
+        group_std_rewards=torch.tensor([[0.0, 1.0], [0.0, 1.0]]),
+        prompt_ids=torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]]),
+        prompt_mask=torch.ones(4, 2, dtype=torch.long),
+        completion_ids=torch.tensor([[20, 21], [22, 23], [24, 25], [26, 27]]),
+        completion_mask=torch.ones(4, 2, dtype=torch.long),
+        forward_kwargs={},
+        num_items_in_batch=8,
+        tool_mask=torch.tensor([[0, 0], [0, 0], [1, 0], [0, 1]]),
+    )
+
+    expected_tool_mask = torch.tensor([[1, 0, 1], [0, 1, 1], [1, 0, 1], [0, 1, 1]])
+    torch.testing.assert_close(outputs["tool_mask"], expected_tool_mask)
+    assert (outputs["completion_mask"] * outputs["tool_mask"]).sum().item() == 5
+
+    stored_group = next(
+        data for _, data in trainer.replay_buffer.heap if data["prompt_ids"].tolist() == [[5, 6], [7, 8]]
+    )
+    torch.testing.assert_close(stored_group["tool_mask"], torch.tensor([[1, 0], [0, 1]]))
 
 
 @pytest.mark.low_priority

--- a/tests/experimental/test_gspo_token_trainer.py
+++ b/tests/experimental/test_gspo_token_trainer.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from collections import defaultdict
+from types import SimpleNamespace
+
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -24,6 +27,54 @@ from ..testing_utils import TrlTestCase
 
 
 class TestGSPOTokenTrainer(TrlTestCase):
+    @pytest.mark.parametrize(
+        ("tool_mask", "num_items_in_batch", "expected_loss", "expected_entropy"),
+        [
+            ([1, 0, 1], 2, 1.0, 2.0),
+            ([0, 0, 0], 0, 0.0, 0.0),
+        ],
+    )
+    def test_dapo_uses_tool_mask_for_loss_and_metrics(
+        self, tool_mask, num_items_in_batch, expected_loss, expected_entropy
+    ):
+        trainer = object.__new__(GSPOTokenTrainer)
+        trainer.accelerator = SimpleNamespace(num_processes=1, gather=lambda tensor: tensor)
+        trainer.top_entropy_quantile = 1.0
+        trainer.beta = 0.0
+        trainer.importance_sampling_level = "sequence_token"
+        trainer.epsilon_low = 0.2
+        trainer.epsilon_high = 0.2
+        trainer.args = SimpleNamespace(delta=None)
+        trainer.use_vllm = False
+        trainer.loss_type = "dapo"
+        trainer.model = SimpleNamespace(training=True)
+        trainer._metrics = {"train": defaultdict(list)}
+
+        per_token_logps = torch.zeros((1, 3))
+        entropies = torch.tensor([[1.0, 100.0, 3.0]])
+        trainer._get_per_token_logps_and_entropies = lambda *args, **kwargs: (
+            per_token_logps,
+            entropies,
+            None,
+        )
+        inputs = {
+            "prompt_ids": torch.tensor([[1]]),
+            "prompt_mask": torch.tensor([[1]]),
+            "completion_ids": torch.tensor([[2, 3, 4]]),
+            "completion_mask": torch.tensor([[1, 1, 1]]),
+            "tool_mask": torch.tensor([tool_mask]),
+            "advantages": torch.tensor([-1.0]),
+            # A large policy ratio on the masked tool-result token must not affect GSPO's sequence weight.
+            "old_per_token_logps": torch.tensor([[0.0, -6.0, 0.0]]),
+            "num_items_in_batch": torch.tensor(num_items_in_batch),
+        }
+
+        loss = trainer._compute_loss(trainer.model, inputs)
+
+        assert loss.item() == pytest.approx(expected_loss)
+        assert torch.isfinite(loss)
+        assert trainer._metrics["train"]["entropy"][-1] == pytest.approx(expected_entropy)
+
     def test_train(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/tests/experimental/test_gspo_token_trainer.py
+++ b/tests/experimental/test_gspo_token_trainer.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from collections import defaultdict
-from types import SimpleNamespace
-
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -27,54 +23,6 @@ from ..testing_utils import TrlTestCase
 
 
 class TestGSPOTokenTrainer(TrlTestCase):
-    @pytest.mark.parametrize(
-        ("tool_mask", "num_items_in_batch", "expected_loss", "expected_entropy"),
-        [
-            ([1, 0, 1], 2, 1.0, 2.0),
-            ([0, 0, 0], 0, 0.0, 0.0),
-        ],
-    )
-    def test_dapo_uses_tool_mask_for_loss_and_metrics(
-        self, tool_mask, num_items_in_batch, expected_loss, expected_entropy
-    ):
-        trainer = object.__new__(GSPOTokenTrainer)
-        trainer.accelerator = SimpleNamespace(num_processes=1, gather=lambda tensor: tensor)
-        trainer.top_entropy_quantile = 1.0
-        trainer.beta = 0.0
-        trainer.importance_sampling_level = "sequence_token"
-        trainer.epsilon_low = 0.2
-        trainer.epsilon_high = 0.2
-        trainer.args = SimpleNamespace(delta=None)
-        trainer.use_vllm = False
-        trainer.loss_type = "dapo"
-        trainer.model = SimpleNamespace(training=True)
-        trainer._metrics = {"train": defaultdict(list)}
-
-        per_token_logps = torch.zeros((1, 3))
-        entropies = torch.tensor([[1.0, 100.0, 3.0]])
-        trainer._get_per_token_logps_and_entropies = lambda *args, **kwargs: (
-            per_token_logps,
-            entropies,
-            None,
-        )
-        inputs = {
-            "prompt_ids": torch.tensor([[1]]),
-            "prompt_mask": torch.tensor([[1]]),
-            "completion_ids": torch.tensor([[2, 3, 4]]),
-            "completion_mask": torch.tensor([[1, 1, 1]]),
-            "tool_mask": torch.tensor([tool_mask]),
-            "advantages": torch.tensor([-1.0]),
-            # A large policy ratio on the masked tool-result token must not affect GSPO's sequence weight.
-            "old_per_token_logps": torch.tensor([[0.0, -6.0, 0.0]]),
-            "num_items_in_batch": torch.tensor(num_items_in_batch),
-        }
-
-        loss = trainer._compute_loss(trainer.model, inputs)
-
-        assert loss.item() == pytest.approx(expected_loss)
-        assert torch.isfinite(loss)
-        assert trainer._metrics["train"]["entropy"][-1] == pytest.approx(expected_entropy)
-
     def test_train(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2200,7 +2200,7 @@ class TestGRPOTrainer(TrlTestCase):
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             mask_truncated_completions=True,  # Enable masking of truncated completions
-            loss_type="dapo",
+            loss_type="dapo",  # we test specifically dapo because it normalizes by num_items_in_batch
             report_to="none",
         )
         trainer = GRPOTrainer(
@@ -2212,18 +2212,8 @@ class TestGRPOTrainer(TrlTestCase):
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
-        captured = {}
-        original_compute_loss = trainer._compute_loss
+        trainer.train()
 
-        def capture_compute_loss(model, inputs):
-            captured["completion_tokens"] = inputs["completion_mask"].sum().item()
-            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
-            return original_compute_loss(model, inputs)
-
-        with patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss):
-            trainer.train()
-
-        assert captured["num_items_in_batch"] == captured["completion_tokens"]
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
         # Check that the params have changed
@@ -2249,7 +2239,7 @@ class TestGRPOTrainer(TrlTestCase):
             num_generations=3,  # reduce the number of generations to reduce memory usage
             max_completion_length=8,  # reduce the completion length to reduce memory usage
             mask_truncated_completions=True,  # Enable masking of truncated completions
-            loss_type="dapo",
+            loss_type="dapo",  # we test specifically dapo because it normalizes by num_items_in_batch
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2170,93 +2170,178 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @patch("transformers.generation.utils.GenerationMixin.generate")
-    def test_train_with_mask_truncated_completions(self, mock_generate):
-        """Test that training works with mask_truncated_completions=True parameter."""
+    @pytest.mark.parametrize("loss_type", ["dapo", "cispo", "vespo"])
+    def test_train_with_mask_truncated_completions(self, loss_type):
+        """Test that token-normalized losses use the final completion mask for normalization."""
 
-        # We mock the generate method because the model's random weights make it extremely unlikely to produce a
-        # sequence containing the EOS token within the allowed max_completion_length. As a result, all tokens are
-        # masked in the loss, the model doesn't update, and the final check (which verifies the update) fails.
+        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
+
+        def reward_func(completions, **kwargs):
+            return list(range(len(completions)))
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            mask_truncated_completions=True,
+            loss_type=loss_type,
+            max_steps=1,
+            bf16=False,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        eos_token_id = trainer._tokenizer.eos_token_id
+        pad_token_id = trainer._tokenizer.pad_token_id
+
         def fake_generate(input_ids, **kwargs):
-            # pad_token_id = 151643; eos_token_id = 151645
             completion_ids = torch.tensor(
                 [
-                    [1, 2, 3, 4, 5, 6, 7, 8],  # this one is truncated
-                    [9, 10, 11, 151645, 151643, 151643, 151643, 151643],  # this one contains eos
-                    [12, 13, 14, 15, 16, 17, 18, 151645],  # particular case, eos is generated just within the limit
+                    [1, 2, 3, 4, 5, 6, 7, 8],  # truncated: excluded from the loss
+                    [9, 10, 11, eos_token_id, pad_token_id, pad_token_id, pad_token_id, pad_token_id],
+                    [12, 13, 14, 15, 16, 17, 18, eos_token_id],
                 ],
                 device=input_ids.device,
             )
             return torch.cat([input_ids, completion_ids], dim=1)
 
-        mock_generate.side_effect = fake_generate
+        captured = {}
+        original_compute_loss = trainer._compute_loss
 
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        def capture_compute_loss(model, inputs):
+            captured["completion_tokens"] = inputs["completion_mask"].sum().item()
+            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
+            return original_compute_loss(model, inputs)
 
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=8,  # reduce the completion length to reduce memory usage
-            mask_truncated_completions=True,  # Enable masking of truncated completions
-            report_to="none",
-        )
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=training_args,
-            train_dataset=dataset,
-        )
+        with (
+            patch.object(trainer.model, "generate", side_effect=fake_generate),
+            patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss),
+        ):
+            trainer.train()
 
-        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        # The raw generated total is 20 tokens, but the truncated 8-token completion is excluded from the loss.
+        assert captured["completion_tokens"] == 12
+        assert captured["num_items_in_batch"] == 12
+        assert np.isfinite(trainer.state.log_history[-1]["train_loss"])
 
-        trainer.train()
-
-        assert trainer.state.log_history[-1]["train_loss"] is not None
-
-        # Check that the params have changed
-        for n, param in previous_trainable_params.items():
-            new_param = trainer.model.get_parameter(n)
-            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
-
-    def test_train_with_mask_truncated_completions_all_masked(self):
+    @pytest.mark.parametrize("loss_type", ["dapo", "cispo", "vespo"])
+    def test_train_with_mask_truncated_completions_all_masked(self, loss_type):
         """
         Test that when all generated completions are truncated (i.e., none contain an EOS token), and
         mask_truncated_completions=True, the model receives no effective learning signal and therefore does not update
         its parameters.
-
-        Here, we don't mock the generate method, be we rely on the fact that the model the probability of generating
-        the EOS token is extremely low, so all generated completions are truncated.
         """
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
+
+        def reward_func(completions, **kwargs):
+            return list(range(len(completions)))
 
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
-            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=8,  # reduce the completion length to reduce memory usage
-            mask_truncated_completions=True,  # Enable masking of truncated completions
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            mask_truncated_completions=True,
+            loss_type=loss_type,
+            max_steps=1,
+            bf16=False,
             report_to="none",
         )
         trainer = GRPOTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            reward_funcs=reward_func,
             args=training_args,
             train_dataset=dataset,
         )
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
-        trainer.train()
+        def fake_generate(input_ids, **kwargs):
+            completion_ids = torch.arange(1, 25, device=input_ids.device).view(3, 8)
+            return torch.cat([input_ids, completion_ids], dim=1)
 
-        assert trainer.state.log_history[-1]["train_loss"] is not None
+        captured = {}
+        original_compute_loss = trainer._compute_loss
 
-        # Check that the params have changed
+        def capture_compute_loss(model, inputs):
+            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
+            loss = original_compute_loss(model, inputs)
+            captured["loss"] = loss.detach().item()
+            return loss
+
+        with (
+            patch.object(trainer.model, "generate", side_effect=fake_generate),
+            patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss),
+        ):
+            trainer.train()
+
+        assert captured["num_items_in_batch"] == 0
+        assert captured["loss"] == pytest.approx(0.0)
+        assert trainer.state.log_history[-1]["train_loss"] == pytest.approx(0.0)
+
+        # Check that the params have not changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert torch.equal(param, new_param), f"Parameter {n} has changed."
+
+    def test_train_with_tool_mask_and_truncated_completions(self):
+        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
+
+        def reward_func(completions, **kwargs):
+            return list(range(len(completions)))
+
+        def rollout_func(prompts, trainer):
+            assert len(prompts) == 3
+            eos_token_id = trainer._tokenizer.eos_token_id
+            return {
+                "prompt_ids": [[1], [1], [1]],
+                "completion_ids": [[10, 11, 12], [13, eos_token_id], [14, 15, eos_token_id]],
+                "logprobs": None,
+                "env_mask": [[1, 0, 1], [0, 0], [1, 0, 1]],
+            }
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=3,
+            mask_truncated_completions=True,
+            loss_type="dapo",
+            max_steps=1,
+            bf16=False,
+            report_to="none",
+        )
+        with patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"}):
+            trainer = GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=reward_func,
+                args=training_args,
+                train_dataset=dataset,
+                rollout_func=rollout_func,
+            )
+
+        captured = {}
+        original_compute_loss = trainer._compute_loss
+
+        def capture_compute_loss(model, inputs):
+            loss_mask = inputs["completion_mask"] * inputs["tool_mask"]
+            captured["completion_tokens"] = loss_mask.sum().item()
+            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
+            return original_compute_loss(model, inputs)
+
+        with patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss):
+            trainer.train()
+
+        assert captured["completion_tokens"] == 2
+        assert captured["num_items_in_batch"] == 2
+        # Throughput still counts all four model-generated tokens, including two from the truncated completion.
+        assert trainer.state.num_input_tokens_seen == 7
 
     def test_warning_raised_all_rewards_none(self, caplog):
         """Test that a proper warning is raised when all rewards are None."""

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -329,7 +329,7 @@ class TestGRPOTrainer(TrlTestCase):
 
         trainer.train()
 
-        assert trainer.state.log_history[-1]["train_loss"] is not None
+        assert trainer.state.log_history[-1]["train_loss"] == pytest.approx(0.0)
 
         # MoE models log the load-balancing auxiliary loss (on by default)
         if trainer.aux_loss_enabled:
@@ -2170,46 +2170,47 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.parametrize("loss_type", ["dapo", "cispo", "vespo"])
-    def test_train_with_mask_truncated_completions(self, loss_type):
-        """Test that token-normalized losses use the final completion mask for normalization."""
+    @patch("transformers.generation.utils.GenerationMixin.generate")
+    def test_train_with_mask_truncated_completions(self, mock_generate):
+        """Test that training works with mask_truncated_completions=True parameter."""
 
-        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
-
-        def reward_func(completions, **kwargs):
-            return list(range(len(completions)))
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=3,
-            num_generations=3,
-            max_completion_length=8,
-            mask_truncated_completions=True,
-            loss_type=loss_type,
-            max_steps=1,
-            bf16=False,
-            report_to="none",
-        )
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs=reward_func,
-            args=training_args,
-            train_dataset=dataset,
-        )
-
-        eos_token_id = trainer._tokenizer.eos_token_id
-        pad_token_id = trainer._tokenizer.pad_token_id
-
+        # We mock the generate method because the model's random weights make it extremely unlikely to produce a
+        # sequence containing the EOS token within the allowed max_completion_length. As a result, all tokens are
+        # masked in the loss, the model doesn't update, and the final check (which verifies the update) fails.
         def fake_generate(input_ids, **kwargs):
+            # pad_token_id = 151643; eos_token_id = 151645
             completion_ids = torch.tensor(
                 [
-                    [1, 2, 3, 4, 5, 6, 7, 8],  # truncated: excluded from the loss
-                    [9, 10, 11, eos_token_id, pad_token_id, pad_token_id, pad_token_id, pad_token_id],
-                    [12, 13, 14, 15, 16, 17, 18, eos_token_id],
+                    [1, 2, 3, 4, 5, 6, 7, 8],  # this one is truncated
+                    [9, 10, 11, 151645, 151643, 151643, 151643, 151643],  # this one contains eos
+                    [12, 13, 14, 15, 16, 17, 18, 151645],  # particular case, eos is generated just within the limit
                 ],
                 device=input_ids.device,
             )
             return torch.cat([input_ids, completion_ids], dim=1)
+
+        mock_generate.side_effect = fake_generate
+
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            mask_truncated_completions=True,  # Enable masking of truncated completions
+            loss_type="dapo",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
         captured = {}
         original_compute_loss = trainer._compute_loss
@@ -2219,129 +2220,55 @@ class TestGRPOTrainer(TrlTestCase):
             captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
             return original_compute_loss(model, inputs)
 
-        with (
-            patch.object(trainer.model, "generate", side_effect=fake_generate),
-            patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss),
-        ):
+        with patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss):
             trainer.train()
 
-        # The raw generated total is 20 tokens, but the truncated 8-token completion is excluded from the loss.
-        assert captured["completion_tokens"] == 12
-        assert captured["num_items_in_batch"] == 12
-        assert np.isfinite(trainer.state.log_history[-1]["train_loss"])
+        assert captured["num_items_in_batch"] == captured["completion_tokens"]
+        assert trainer.state.log_history[-1]["train_loss"] is not None
 
-    @pytest.mark.parametrize("loss_type", ["dapo", "cispo", "vespo"])
-    def test_train_with_mask_truncated_completions_all_masked(self, loss_type):
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_with_mask_truncated_completions_all_masked(self):
         """
         Test that when all generated completions are truncated (i.e., none contain an EOS token), and
         mask_truncated_completions=True, the model receives no effective learning signal and therefore does not update
         its parameters.
-        """
-        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
 
-        def reward_func(completions, **kwargs):
-            return list(range(len(completions)))
+        Here, we don't mock the generate method, be we rely on the fact that the model the probability of generating
+        the EOS token is extremely low, so all generated completions are truncated.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
-            per_device_train_batch_size=3,
-            num_generations=3,
-            max_completion_length=8,
-            mask_truncated_completions=True,
-            loss_type=loss_type,
-            max_steps=1,
-            bf16=False,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            mask_truncated_completions=True,  # Enable masking of truncated completions
+            loss_type="dapo",
             report_to="none",
         )
         trainer = GRPOTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs=reward_func,
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
             args=training_args,
             train_dataset=dataset,
         )
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
-        def fake_generate(input_ids, **kwargs):
-            completion_ids = torch.arange(1, 25, device=input_ids.device).view(3, 8)
-            return torch.cat([input_ids, completion_ids], dim=1)
+        trainer.train()
 
-        captured = {}
-        original_compute_loss = trainer._compute_loss
-
-        def capture_compute_loss(model, inputs):
-            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
-            loss = original_compute_loss(model, inputs)
-            captured["loss"] = loss.detach().item()
-            return loss
-
-        with (
-            patch.object(trainer.model, "generate", side_effect=fake_generate),
-            patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss),
-        ):
-            trainer.train()
-
-        assert captured["num_items_in_batch"] == 0
-        assert captured["loss"] == pytest.approx(0.0)
         assert trainer.state.log_history[-1]["train_loss"] == pytest.approx(0.0)
 
-        # Check that the params have not changed
+        # Check that the params have changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert torch.equal(param, new_param), f"Parameter {n} has changed."
-
-    def test_train_with_tool_mask_and_truncated_completions(self):
-        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
-
-        def reward_func(completions, **kwargs):
-            return list(range(len(completions)))
-
-        def rollout_func(prompts, trainer):
-            assert len(prompts) == 3
-            eos_token_id = trainer._tokenizer.eos_token_id
-            return {
-                "prompt_ids": [[1], [1], [1]],
-                "completion_ids": [[10, 11, 12], [13, eos_token_id], [14, 15, eos_token_id]],
-                "logprobs": None,
-                "env_mask": [[1, 0, 1], [0, 0], [1, 0, 1]],
-            }
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            per_device_train_batch_size=3,
-            num_generations=3,
-            max_completion_length=3,
-            mask_truncated_completions=True,
-            loss_type="dapo",
-            max_steps=1,
-            bf16=False,
-            report_to="none",
-        )
-        with patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"}):
-            trainer = GRPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                reward_funcs=reward_func,
-                args=training_args,
-                train_dataset=dataset,
-                rollout_func=rollout_func,
-            )
-
-        captured = {}
-        original_compute_loss = trainer._compute_loss
-
-        def capture_compute_loss(model, inputs):
-            loss_mask = inputs["completion_mask"] * inputs["tool_mask"]
-            captured["completion_tokens"] = loss_mask.sum().item()
-            captured["num_items_in_batch"] = inputs["num_items_in_batch"].item()
-            return original_compute_loss(model, inputs)
-
-        with patch.object(trainer, "_compute_loss", side_effect=capture_compute_loss):
-            trainer.train()
-
-        assert captured["completion_tokens"] == 2
-        assert captured["num_items_in_batch"] == 2
-        # Throughput still counts all four model-generated tokens, including two from the truncated completion.
-        assert trainer.state.num_input_tokens_seen == 7
 
     def test_warning_raised_all_rewards_none(self, caplog):
         """Test that a proper warning is raised when all rewards are None."""

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -329,7 +329,7 @@ class TestGRPOTrainer(TrlTestCase):
 
         trainer.train()
 
-        assert trainer.state.log_history[-1]["train_loss"] == pytest.approx(0.0)
+        assert trainer.state.log_history[-1]["train_loss"] is not None
 
         # MoE models log the load-balancing auxiliary loss (on by default)
         if trainer.aux_loss_enabled:

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -946,7 +946,7 @@ class DPPOTrainer(GRPOTrainer):
             completion_ids_list,
             tool_mask_list,
             completions,
-            num_items_in_batch,
+            _total_completion_tokens,
             sampling_per_token_logps_list,
             topk_logprobs_list,
             topk_token_ids_list,
@@ -1018,6 +1018,10 @@ class DPPOTrainer(GRPOTrainer):
             # Also mask tool_mask for consistency in multi-turn training
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
+
+        # Keep loss normalization separate from `_generate`'s raw completion count, which feeds throughput metrics.
+        loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+        num_items_in_batch = self.accelerator.gather(loss_mask.sum()).sum()
 
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
@@ -1401,7 +1405,7 @@ class DPPOTrainer(GRPOTrainer):
             per_token_loss = per_token_loss + self.beta * per_token_kl
 
         mode = "train" if self.model.training else "eval"
-        normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
+        normalizer = inputs["num_items_in_batch"].clamp(min=1.0) / self.accelerator.num_processes
         loss = (per_token_loss * mask).sum() / normalizer
 
         # Log metrics

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -715,10 +715,10 @@ class DPPOTrainer(GRPOTrainer):
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
-        total_completion_tokens = agg_completion_lengths.sum()
 
+        # Log the metrics
         if mode == "train":
-            self.state.num_input_tokens_seen += (total_prompt_tokens + total_completion_tokens).item()
+            self.state.num_input_tokens_seen += (total_prompt_tokens + agg_completion_lengths.sum()).item()
         self._metrics[mode]["num_tokens"] = [self.state.num_input_tokens_seen]
 
         self._metrics[mode]["completions/mean_length"].append(agg_completion_lengths.float().mean().item())

--- a/trl/experimental/dppo/dppo_trainer.py
+++ b/trl/experimental/dppo/dppo_trainer.py
@@ -629,8 +629,8 @@ class DPPOTrainer(GRPOTrainer):
         """Generate completions, handling tool calls, and thread top-K logprob data through the full pipeline.
 
         Returns:
-            9-tuple of (prompt_ids, completion_ids, tool_mask, completions, total_completion_tokens, logprobs,
-            topk_logprobs, topk_token_ids, extra_fields).
+            8-tuple of (prompt_ids, completion_ids, tool_mask, completions, logprobs, topk_logprobs, topk_token_ids,
+            extra_fields).
         """
         device = self.accelerator.device
         mode = "train" if self.model.training else "eval"
@@ -751,7 +751,6 @@ class DPPOTrainer(GRPOTrainer):
             completion_ids,
             tool_mask,
             completions,
-            total_completion_tokens,
             logprobs,
             topk_logprobs,
             topk_token_ids,
@@ -946,7 +945,6 @@ class DPPOTrainer(GRPOTrainer):
             completion_ids_list,
             tool_mask_list,
             completions,
-            _total_completion_tokens,
             sampling_per_token_logps_list,
             topk_logprobs_list,
             topk_token_ids_list,
@@ -1019,7 +1017,6 @@ class DPPOTrainer(GRPOTrainer):
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
 
-        # Keep loss normalization separate from `_generate`'s raw completion count, which feeds throughput metrics.
         loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
         num_items_in_batch = self.accelerator.gather(loss_mask.sum()).sum()
 

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -195,7 +195,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             ).to(device=device)
         else:
             sampling_per_token_logps = None
-        if self.tools:
+        if tool_mask_list is not None:
             tool_mask = [torch.tensor(mask) for mask in tool_mask_list]
             tool_mask = pad(
                 tool_mask,
@@ -203,12 +203,18 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 padding_side="right",
                 pad_to_multiple_of=self.pad_to_multiple_of,
             ).to(device=device)  # 0 for tool result tokens, 1 elsewhere
+        else:
+            tool_mask = None
 
-        # If mask_truncated_completions is enabled, zero out truncated completions in completion_mask
+        # If mask_truncated_completions is enabled, zero out truncated completions for attention and loss masking
         if self.mask_truncated_completions:
             eos_and_pad = [self._tokenizer.eos_token_id, self._tokenizer.pad_token_id]
             is_truncated = torch.tensor([ids[-1] not in eos_and_pad for ids in completion_ids_list], device=device)
+            # Mask completion_mask for attention masking
             completion_mask = completion_mask * (~is_truncated).unsqueeze(1).int()
+            # Also mask tool_mask for consistency in multi-turn training
+            if tool_mask is not None:
+                tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
 
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
@@ -401,7 +407,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
         if self.use_vllm and self.vllm_importance_sampling_correction:
             delta = torch.abs(old_per_token_logps - sampling_per_token_logps)
-            mask = completion_mask.bool() if not self.tools else (completion_mask * tool_mask).bool()
+            mask = completion_mask.bool() if tool_mask is None else (completion_mask * tool_mask).bool()
             delta = delta[mask]
             mean_delta = torch.mean(delta) if delta.numel() > 0 else torch.tensor(0.0, device=device)
             max_delta = torch.max(delta) if delta.numel() > 0 else torch.tensor(0.0, device=device)
@@ -443,6 +449,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps,
             ref_per_token_logps,
             importance_sampling_ratio if self.use_vllm and self.vllm_importance_sampling_correction else None,
+            tool_mask=tool_mask,
         )
         if outputs_after_sampling_buffer is None:
             output = {
@@ -471,7 +478,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 output["token_type_ids"] = forward_kwargs["token_type_ids"]
             if images is not None:
                 output["num_images"] = num_images
-            if self.tools:
+            if tool_mask is not None:
                 output["tool_mask"] = tool_mask
         else:
             output = outputs_after_sampling_buffer
@@ -519,6 +526,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         old_per_token_logps: torch.Tensor | None = None,
         ref_per_token_logps: torch.Tensor | None = None,
         importance_sampling_ratio: float | None = None,
+        tool_mask: torch.Tensor | None = None,
     ) -> None:
         """
         Update the replay buffer with groups that have reward variance (std > 0).
@@ -536,6 +544,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps: Optional tensor of old per-token log probabilities
             ref_per_token_logps: Optional tensor of reference per-token log probabilities
             importance_sampling_ratio: Optional importance sampling correction ratio
+            tool_mask: Optional tensor marking model-generated tokens
         """
         # Prepare buffered outputs for groups with variance
         buffered_outputs = []
@@ -556,6 +565,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
             # Add optional fields if they exist
             optional_fields = {
+                "tool_mask": tool_mask,
                 "old_per_token_logps": old_per_token_logps if old_per_token_logps is not None else None,
                 "ref_per_token_logps": ref_per_token_logps if ref_per_token_logps is not None else None,
             }
@@ -643,6 +653,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         old_per_token_logps: torch.Tensor | None = None,
         ref_per_token_logps: torch.Tensor | None = None,
         importance_sampling_ratio: float | None = None,
+        tool_mask: torch.Tensor | None = None,
     ) -> None:
         """
         Update current batch data with samples from replay buffer.
@@ -662,6 +673,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps: Optional tensor of old per-token log probabilities
             ref_per_token_logps: Optional tensor of reference per-token log probabilities
             importance_sampling_ratio: Optional importance sampling correction ratio
+            tool_mask: Optional tensor marking model-generated tokens
         """
         if self.replay_buffer.max_size <= 0:
             return
@@ -673,6 +685,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
         # Track which optional fields are present in sampled data
         optional_tensor_fields = ["old_per_token_logps", "ref_per_token_logps"]
+        buffer_tensor_fields = optional_tensor_fields + (["tool_mask"] if tool_mask is not None else [])
         vision_fields = ["pixel_values", "image_grid_thw", "pixel_attention_mask", "image_sizes"]
 
         self.update_replay_buffer(
@@ -688,6 +701,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps,
             ref_per_token_logps,
             importance_sampling_ratio,
+            tool_mask=tool_mask,
         )
 
         # Sample from replay buffer to replace groups with variance
@@ -698,7 +712,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         sampled_data = self.sample_from_replay_buffer(
             num_samples=num_groups_to_replace,
             optional_vision_fields=vision_fields,
-            optional_tensor_fields=optional_tensor_fields,
+            optional_tensor_fields=buffer_tensor_fields,
         )
 
         # Pad sampled data if they are shorter than the current batch sequences
@@ -739,6 +753,13 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 pad_to_multiple_of=target_completion_len,
                 padding_side="right",
             )
+            if tool_mask is not None:
+                tool_mask = pad(
+                    list(tool_mask.unbind(0)),
+                    padding_value=1,
+                    pad_to_multiple_of=target_completion_len,
+                    padding_side="right",
+                )
             if old_per_token_logps is not None:
                 old_per_token_logps = pad(
                     list(old_per_token_logps.unbind(0)),
@@ -789,6 +810,13 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                     pad_to_multiple_of=target_completion_len,
                     padding_side="right",
                 )
+                if "tool_mask" in sampled_data:
+                    sampled_data["tool_mask"][i] = pad(
+                        sampled_data["tool_mask"][i],
+                        padding_value=1,
+                        pad_to_multiple_of=target_completion_len,
+                        padding_side="right",
+                    )
                 if "old_per_token_logps" in sampled_data:
                     sampled_data["old_per_token_logps"][i] = pad(
                         sampled_data["old_per_token_logps"][i],
@@ -811,6 +839,8 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             completion_mask[idx_range] = sampled_data["completion_mask"][i]
             group_advantages[group_idx] = sampled_data["advantages"][i]
 
+            if "tool_mask" in sampled_data:
+                tool_mask[idx_range] = sampled_data["tool_mask"][i]
             if "old_per_token_logps" in sampled_data:
                 old_per_token_logps[idx_range] = sampled_data["old_per_token_logps"][i]
             if "ref_per_token_logps" in sampled_data:
@@ -828,6 +858,8 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             "completion_mask": completion_mask,
             "advantages": group_advantages,
         }
+        if tool_mask is not None:
+            outputs_after_sampling_buffer["tool_mask"] = tool_mask
 
         # Replace optional tensor fields if they exist
         for field in optional_tensor_fields:

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -444,9 +444,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             ref_per_token_logps,
             importance_sampling_ratio if self.use_vllm and self.vllm_importance_sampling_correction else None,
         )
-        if outputs_after_sampling_buffer is not None:
-            return outputs_after_sampling_buffer
-        else:
+        if outputs_after_sampling_buffer is None:
             output = {
                 "prompt_ids": prompt_ids,
                 "prompt_mask": prompt_mask,
@@ -475,7 +473,15 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 output["num_images"] = num_images
             if self.tools:
                 output["tool_mask"] = tool_mask
-            return output
+        else:
+            output = outputs_after_sampling_buffer
+
+        # Recompute the loss denominator after replay-buffer replacement from the final masks used by the loss.
+        loss_mask = (
+            output["completion_mask"] if "tool_mask" not in output else output["completion_mask"] * output["tool_mask"]
+        )
+        output["num_items_in_batch"] = self.accelerator.gather(loss_mask.sum()).sum()
+        return output
 
     def slice_group_data(
         self, data: torch.Tensor, mask: torch.Tensor, group_idx: int

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -451,7 +451,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps,
             ref_per_token_logps,
             importance_sampling_ratio if self.use_vllm and self.vllm_importance_sampling_correction else None,
-            tool_mask=tool_mask,
         )
         if outputs_after_sampling_buffer is None:
             output = {
@@ -528,7 +527,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         old_per_token_logps: torch.Tensor | None = None,
         ref_per_token_logps: torch.Tensor | None = None,
         importance_sampling_ratio: float | None = None,
-        tool_mask: torch.Tensor | None = None,
     ) -> None:
         """
         Update the replay buffer with groups that have reward variance (std > 0).
@@ -546,7 +544,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps: Optional tensor of old per-token log probabilities
             ref_per_token_logps: Optional tensor of reference per-token log probabilities
             importance_sampling_ratio: Optional importance sampling correction ratio
-            tool_mask: Optional tensor marking model-generated tokens
         """
         # Prepare buffered outputs for groups with variance
         buffered_outputs = []
@@ -567,7 +564,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
             # Add optional fields if they exist
             optional_fields = {
-                "tool_mask": tool_mask,
                 "old_per_token_logps": old_per_token_logps if old_per_token_logps is not None else None,
                 "ref_per_token_logps": ref_per_token_logps if ref_per_token_logps is not None else None,
             }
@@ -655,7 +651,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         old_per_token_logps: torch.Tensor | None = None,
         ref_per_token_logps: torch.Tensor | None = None,
         importance_sampling_ratio: float | None = None,
-        tool_mask: torch.Tensor | None = None,
     ) -> None:
         """
         Update current batch data with samples from replay buffer.
@@ -675,7 +670,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps: Optional tensor of old per-token log probabilities
             ref_per_token_logps: Optional tensor of reference per-token log probabilities
             importance_sampling_ratio: Optional importance sampling correction ratio
-            tool_mask: Optional tensor marking model-generated tokens
         """
         if self.replay_buffer.max_size <= 0:
             return
@@ -687,7 +681,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
 
         # Track which optional fields are present in sampled data
         optional_tensor_fields = ["old_per_token_logps", "ref_per_token_logps"]
-        buffer_tensor_fields = optional_tensor_fields + (["tool_mask"] if tool_mask is not None else [])
         vision_fields = ["pixel_values", "image_grid_thw", "pixel_attention_mask", "image_sizes"]
 
         self.update_replay_buffer(
@@ -703,7 +696,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             old_per_token_logps,
             ref_per_token_logps,
             importance_sampling_ratio,
-            tool_mask=tool_mask,
         )
 
         # Sample from replay buffer to replace groups with variance
@@ -714,7 +706,7 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
         sampled_data = self.sample_from_replay_buffer(
             num_samples=num_groups_to_replace,
             optional_vision_fields=vision_fields,
-            optional_tensor_fields=buffer_tensor_fields,
+            optional_tensor_fields=optional_tensor_fields,
         )
 
         # Pad sampled data if they are shorter than the current batch sequences
@@ -755,13 +747,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                 pad_to_multiple_of=target_completion_len,
                 padding_side="right",
             )
-            if tool_mask is not None:
-                tool_mask = pad(
-                    list(tool_mask.unbind(0)),
-                    padding_value=1,
-                    pad_to_multiple_of=target_completion_len,
-                    padding_side="right",
-                )
             if old_per_token_logps is not None:
                 old_per_token_logps = pad(
                     list(old_per_token_logps.unbind(0)),
@@ -812,13 +797,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
                     pad_to_multiple_of=target_completion_len,
                     padding_side="right",
                 )
-                if "tool_mask" in sampled_data:
-                    sampled_data["tool_mask"][i] = pad(
-                        sampled_data["tool_mask"][i],
-                        padding_value=1,
-                        pad_to_multiple_of=target_completion_len,
-                        padding_side="right",
-                    )
                 if "old_per_token_logps" in sampled_data:
                     sampled_data["old_per_token_logps"][i] = pad(
                         sampled_data["old_per_token_logps"][i],
@@ -841,8 +819,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             completion_mask[idx_range] = sampled_data["completion_mask"][i]
             group_advantages[group_idx] = sampled_data["advantages"][i]
 
-            if "tool_mask" in sampled_data:
-                tool_mask[idx_range] = sampled_data["tool_mask"][i]
             if "old_per_token_logps" in sampled_data:
                 old_per_token_logps[idx_range] = sampled_data["old_per_token_logps"][i]
             if "ref_per_token_logps" in sampled_data:
@@ -860,8 +836,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             "completion_mask": completion_mask,
             "advantages": group_advantages,
         }
-        if tool_mask is not None:
-            outputs_after_sampling_buffer["tool_mask"] = tool_mask
 
         # Replace optional tensor fields if they exist
         for field in optional_tensor_fields:

--- a/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
+++ b/trl/experimental/grpo_with_replay_buffer/grpo_with_replay_buffer_trainer.py
@@ -147,7 +147,6 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             completion_ids_list,
             tool_mask_list,
             completions,
-            num_items_in_batch,
             sampling_per_token_logps_list,
             extra_fields,
             images,
@@ -215,6 +214,9 @@ class GRPOWithReplayBufferTrainer(GRPOTrainer):
             # Also mask tool_mask for consistency in multi-turn training
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
+
+        loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+        num_items_in_batch = self.accelerator.gather(loss_mask.sum()).sum()
 
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -26,6 +26,7 @@ class GRPOTrainer(_GRPOTrainer):
         input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
+        mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
 
         # Compute the per_token_logps and the entropy at each position in the completion
         per_token_logps, entropies, _ = self._get_per_token_logps_and_entropies(
@@ -43,7 +44,7 @@ class GRPOTrainer(_GRPOTrainer):
         )
 
         if self.top_entropy_quantile < 1.0:
-            entropy_mask = self.get_high_entropy_mask(entropies, completion_mask, 1 - self.top_entropy_quantile)
+            entropy_mask = self.get_high_entropy_mask(entropies, mask, 1 - self.top_entropy_quantile)
         else:
             entropy_mask = None
 
@@ -72,11 +73,11 @@ class GRPOTrainer(_GRPOTrainer):
         if self.importance_sampling_level == "token":
             log_importance_weights = log_ratio
         elif self.importance_sampling_level == "sequence":
-            log_importance_weights = (log_ratio * completion_mask).sum(-1) / completion_mask.sum(-1).clamp(min=1.0)
+            log_importance_weights = (log_ratio * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)
             log_importance_weights = log_importance_weights.unsqueeze(-1)
         elif self.importance_sampling_level == "sequence_token":
             # GSPO-token: sg[si(θ)] * πθ(yi,t)/sg[πθ(yi,t)]
-            seq_level_log_weight = (log_ratio * completion_mask).sum(-1) / completion_mask.sum(-1).clamp(min=1.0)
+            seq_level_log_weight = (log_ratio * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)
             seq_level_log_weight = seq_level_log_weight.detach().unsqueeze(-1)  # Stop gradient
             log_importance_weights = per_token_logps - per_token_logps.detach() + seq_level_log_weight
         else:
@@ -108,31 +109,31 @@ class GRPOTrainer(_GRPOTrainer):
 
         mode = "train" if self.model.training else "eval"
         if self.loss_type == "grpo":
-            loss = ((per_token_loss * completion_mask).sum(-1) / completion_mask.sum(-1).clamp(min=1.0)).mean()
+            loss = ((per_token_loss * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
         elif self.loss_type == "bnpo":
-            loss = (per_token_loss * completion_mask).sum() / completion_mask.sum().clamp(min=1.0)
+            loss = (per_token_loss * mask).sum() / mask.sum().clamp(min=1.0)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
         elif self.loss_type == "dr_grpo":
-            loss = (per_token_loss * completion_mask).sum() / (per_token_loss.size(0) * self.max_completion_length)
+            loss = (per_token_loss * mask).sum() / (per_token_loss.size(0) * self.max_completion_length)
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
             loss = loss / normalizer
         elif self.loss_type == "dapo":
-            normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
-            loss = (per_token_loss * completion_mask).sum() / normalizer
+            normalizer = inputs["num_items_in_batch"].clamp(min=1.0) / self.accelerator.num_processes
+            loss = (per_token_loss * mask).sum() / normalizer
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}")
 
         # Log the metrics
-        completion_token_count = completion_mask.sum().clamp(min=1.0)
+        completion_token_count = mask.sum().clamp(min=1.0)
 
         def masked_batch_mean(x):
             if x.shape[1] == 1:  # when importance_sampling_level == "sequence"
                 return x.mean()
             else:
-                return (x * completion_mask).sum() / completion_token_count
+                return (x * mask).sum() / completion_token_count
 
         if self.beta != 0.0:
             mean_kl = masked_batch_mean(per_token_kl)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2200,7 +2200,7 @@ class GRPOTrainer(_BaseTrainer):
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
-        total_completion_tokens = agg_completion_lengths.sum()
+        total_completion_tokens = agg_completion_lengths.sum()  # used for throughput metrics
 
         # Log the metrics
         if mode == "train":
@@ -2239,7 +2239,6 @@ class GRPOTrainer(_BaseTrainer):
             completion_ids,
             tool_mask,
             completions,
-            total_completion_tokens,
             logprobs,
             extra_fields,
             images,
@@ -2345,7 +2344,6 @@ class GRPOTrainer(_BaseTrainer):
             completion_ids_list,
             tool_mask_list,
             completions,
-            _total_completion_tokens,
             sampling_per_token_logps_list,
             extra_fields,
             images,
@@ -2405,7 +2403,6 @@ class GRPOTrainer(_BaseTrainer):
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
 
-        # Keep loss normalization separate from `_generate`'s raw completion count, which feeds throughput metrics.
         loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
         num_items_in_batch = self.accelerator.gather(loss_mask.sum()).sum()
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2200,11 +2200,10 @@ class GRPOTrainer(_BaseTrainer):
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
-        total_completion_tokens = agg_completion_lengths.sum()  # used for throughput metrics
 
         # Log the metrics
         if mode == "train":
-            self.state.num_input_tokens_seen += (total_prompt_tokens + total_completion_tokens).item()
+            self.state.num_input_tokens_seen += (total_prompt_tokens + agg_completion_lengths.sum()).item()
         self._metrics[mode]["num_tokens"] = [self.state.num_input_tokens_seen]
 
         # Log completion lengths, mean, min, max
@@ -2234,16 +2233,7 @@ class GRPOTrainer(_BaseTrainer):
             )
             self._metrics[mode]["tools/failure_frequency"].append(failure_frequency)
 
-        return (
-            prompt_ids,
-            completion_ids,
-            tool_mask,
-            completions,
-            logprobs,
-            extra_fields,
-            images,
-            tool_images,
-        )
+        return prompt_ids, completion_ids, tool_mask, completions, logprobs, extra_fields, images, tool_images
 
     def _generate_and_score_completions(
         self, inputs: list[dict[str, torch.Tensor | Any]]

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2196,7 +2196,7 @@ class GRPOTrainer(_BaseTrainer):
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
-        total_completion_tokens = agg_completion_lengths.sum()  # = num_items_in_batch, required for the DAPO loss
+        total_completion_tokens = agg_completion_lengths.sum()
 
         # Log the metrics
         if mode == "train":
@@ -2341,7 +2341,7 @@ class GRPOTrainer(_BaseTrainer):
             completion_ids_list,
             tool_mask_list,
             completions,
-            num_items_in_batch,
+            _total_completion_tokens,
             sampling_per_token_logps_list,
             extra_fields,
             images,
@@ -2400,6 +2400,10 @@ class GRPOTrainer(_BaseTrainer):
             # Also mask tool_mask for consistency in multi-turn training
             if tool_mask is not None:
                 tool_mask = tool_mask * (~is_truncated).unsqueeze(1).int()
+
+        # Keep loss normalization separate from `_generate`'s raw completion count, which feeds throughput metrics.
+        loss_mask = completion_mask if tool_mask is None else completion_mask * tool_mask
+        num_items_in_batch = self.accelerator.gather(loss_mask.sum()).sum()
 
         # Concatenate prompt_mask with completion_mask for logit computation
         prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
@@ -3112,7 +3116,7 @@ class GRPOTrainer(_BaseTrainer):
             policy_loss = loss.detach()
             loss = loss / normalizer
         elif self.loss_type in ["cispo", "dapo", "vespo"]:
-            normalizer = inputs["num_items_in_batch"] / self.accelerator.num_processes
+            normalizer = inputs["num_items_in_batch"].clamp(min=1.0) / self.accelerator.num_processes
             loss = (per_token_loss * mask).sum() / normalizer
             policy_loss = loss.detach()
         elif self.loss_type == "luspo":

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1298,11 +1298,10 @@ class RLOOTrainer(_BaseTrainer):
         agg_prompt_lengths = self.accelerator.gather(prompt_lengths)
         agg_completion_lengths = self.accelerator.gather(completion_lengths)
         total_prompt_tokens = agg_prompt_lengths.sum()
-        total_completion_tokens = agg_completion_lengths.sum()  # = num_items_in_batch, required for the DAPO loss
 
         # Log the metrics
         if mode == "train":
-            self.state.num_input_tokens_seen += (total_prompt_tokens + total_completion_tokens).item()
+            self.state.num_input_tokens_seen += (total_prompt_tokens + agg_completion_lengths.sum()).item()
         self._metrics[mode]["num_tokens"] = [self.state.num_input_tokens_seen]
 
         # Log completion lengths, mean, min, max


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes #6369 

This PR ensures that token-normalized GRPO losses use the same effective token mask for both the numerator and denominator.

  Previously, when `mask_truncated_completions=True`, truncated tokens were excluded from the loss numerator but were still counted in
  `num_items_in_batch`. This diluted DAPO, CISPO, and VESPO losses.

  The loss denominator is now computed after applying truncation and tool masks, while the raw generated-token count remains unchanged
  for throughput metrics. Fully masked batches are also handled without division by zero.

  The corresponding duplicated logic is updated consistently in GRPO, DPPO, replay-buffer GRPO, and GSPO-token.
## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RL loss scaling across GRPO, DPPO, replay-buffer, and GSPO-token trainers; incorrect masking would directly skew gradients, though behavior is narrowed to truncation/tool masking and guarded with clamp(min=1.0).
> 
> **Overview**
> Fixes **token-normalized GRPO-family losses** so the denominator matches the tokens actually included in the loss when `mask_truncated_completions` and/or tool masking apply.
> 
> **`num_items_in_batch`** is no longer taken from raw completion token counts in `_generate`. It is computed after truncation and tool masks as the global sum of `loss_mask` (`completion_mask`, or `completion_mask * tool_mask`), and passed into DAPO/CISPO/VESPO-style losses. Denominators use **`clamp(min=1.0)`** to avoid division by zero when every token is masked.
> 
> The same masking and denominator logic is applied in **DPPO**, **GRPO with replay buffer** (including a **recompute** of `num_items_in_batch` after replay-buffer replacement), and **GSPO-token** (loss, entropy, and sequence-level importance weights all use the unified mask).
> 
> **`_generate` return tuples** drop the completion-token count used for loss; throughput/token logging still uses gathered completion lengths. Tool handling keys off **`tool_mask_list`** rather than `self.tools` where relevant.
> 
> Tests for masked truncated completions now use **`loss_type="dapo"`** and assert **`train_loss == 0.0`** when all completions are truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ddc3e158910dda76e658c41b2890672f63f688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->