### PR TITLE
Raise a clear error for QLoRA + `vllm_mode="server"` instead of a cryptic vLLM crash

### DIFF
--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,14 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+import torch
 from datasets import Dataset, DatasetDict, features, load_dataset
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, BitsAndBytesConfig
 from transformers.utils import is_peft_available, is_vision_available
 
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
 
-from ..testing_utils import TrlTestCase, require_peft, require_torch_accelerator, require_vision, require_vllm
+from ..testing_utils import (
+    TrlTestCase,
+    require_bitsandbytes,
+    require_peft,
+    require_torch_accelerator,
+    require_torch_gpu_if_bnb_not_multi_backend_enabled,
+    require_vision,
+    require_vllm,
+)
 
 
 if is_peft_available():
@@ -346,6 +357,55 @@ class TestOnlineDPOTrainer(TrlTestCase):
         trainer.train()
 
         assert "train_loss" in trainer.state.log_history[-1]
+
+    @require_bitsandbytes
+    @require_peft
+    @require_torch_gpu_if_bnb_not_multi_backend_enabled
+    def test_server_mode_rejects_bnb_4bit_peft_model(self):
+        quantization_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.float16)
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_id, dtype="float32", quantization_config=quantization_config
+        )
+        args = OnlineDPOConfig(output_dir=self.tmp_dir, use_vllm=True, vllm_mode="server", report_to="none")
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        with (
+            patch("trl.experimental.online_dpo.online_dpo_trainer.is_vllm_available", return_value=True),
+            pytest.raises(ValueError, match="QLoRA is not supported"),
+        ):
+            OnlineDPOTrainer(
+                model=model,
+                reward_funcs=self.reward_model,
+                args=args,
+                train_dataset=dataset,
+                processing_class=self.tokenizer,
+                reward_processing_classes=self.reward_tokenizer,
+                peft_config=LoraConfig(),
+            )
+
+    @require_peft
+    def test_server_mode_allows_non_quantized_peft_model(self):
+        args = OnlineDPOConfig(output_dir=self.tmp_dir, use_vllm=True, vllm_mode="server", report_to="none")
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        with (
+            patch("trl.experimental.online_dpo.online_dpo_trainer.is_vllm_available", return_value=True),
+            patch("trl.experimental.online_dpo.online_dpo_trainer.VLLMClient", return_value=MagicMock()),
+            patch("trl.experimental.online_dpo.online_dpo_trainer.SamplingParams", MagicMock(), create=True),
+            patch("torch.accelerator.current_accelerator", return_value=MagicMock(type="cuda")),
+            patch("torch.cuda.current_device", return_value=0),
+        ):
+            trainer = OnlineDPOTrainer(
+                model=self.model,
+                reward_funcs=self.reward_model,
+                args=args,
+                train_dataset=dataset,
+                processing_class=self.tokenizer,
+                reward_processing_classes=self.reward_tokenizer,
+                peft_config=LoraConfig(),
+            )
+
+        assert trainer.vllm_client is not None
 
     def test_vllm_config_validation(self):
         """Test vLLM configuration validation"""

--- a/tests/test_vllm_generation.py
+++ b/tests/test_vllm_generation.py
@@ -1,0 +1,76 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from trl.generation.vllm_generation import VLLMGeneration
+
+
+class FakeLinear4bit:
+    pass
+
+
+def make_server_generation(model):
+    generation = VLLMGeneration.__new__(VLLMGeneration)
+    generation.model = model
+    generation.accelerator = MagicMock(is_main_process=True, device="cuda")
+    generation.mode = "server"
+    generation.server_base_url = "http://localhost:1"
+    generation.group_port = 51216
+    generation.server_timeout = 1
+    return generation
+
+
+def test_server_mode_rejects_bnb_4bit_peft_model():
+    model = MagicMock()
+    model.named_modules.return_value = [("", FakeLinear4bit())]
+    generation = make_server_generation(model)
+
+    with (
+        patch("trl.generation.vllm_generation.is_vllm_available", return_value=True),
+        patch("trl.generation.vllm_generation.is_peft_model", return_value=True),
+        patch("trl.generation.vllm_generation.is_bitsandbytes_available", return_value=True),
+        patch(
+            "trl.generation.vllm_generation.bnb",
+            SimpleNamespace(nn=SimpleNamespace(Linear4bit=FakeLinear4bit)),
+            create=True,
+        ),
+        pytest.raises(ValueError, match="QLoRA is not supported"),
+    ):
+        generation._init_vllm()
+
+
+def test_server_mode_allows_non_quantized_peft_model():
+    model = MagicMock()
+    model.named_modules.return_value = []
+    generation = make_server_generation(model)
+    client = MagicMock()
+
+    with (
+        patch("trl.generation.vllm_generation.is_vllm_available", return_value=True),
+        patch("trl.generation.vllm_generation.is_peft_model", return_value=True),
+        patch("trl.generation.vllm_generation.is_bitsandbytes_available", return_value=True),
+        patch(
+            "trl.generation.vllm_generation.bnb",
+            SimpleNamespace(nn=SimpleNamespace(Linear4bit=FakeLinear4bit)),
+            create=True,
+        ),
+        patch("trl.generation.vllm_generation.VLLMClient", return_value=client),
+    ):
+        generation._init_vllm()
+
+    client.init_communicator.assert_called_once_with(device="cuda")

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -426,6 +426,13 @@ class OnlineDPOTrainer(_BaseTrainer):
                 )
 
             if self.vllm_mode == "server":
+                if is_peft_model(model) and is_bitsandbytes_available():
+                    if any(isinstance(module, bnb.nn.Linear4bit) for _, module in model.named_modules()):
+                        raise ValueError(
+                            "QLoRA is not supported with `vllm_mode='server'` because adapter merging dequantizes the "
+                            "4-bit weights before synchronization. Use an unquantized server or `vllm_mode='colocate'`."
+                        )
+
                 if self.accelerator.is_main_process:
                     if args.vllm_server_base_url is not None:
                         base_url = args.vllm_server_base_url

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -302,6 +302,13 @@ class VLLMGeneration:
             )
 
         if self.mode == "server":
+            if is_peft_model(model) and is_bitsandbytes_available():
+                if any(isinstance(module, bnb.nn.Linear4bit) for _, module in model.named_modules()):
+                    raise ValueError(
+                        "QLoRA is not supported with `vllm_mode='server'` because adapter merging dequantizes the "
+                        "4-bit weights before synchronization. Use an unquantized server or `vllm_mode='colocate'`."
+                    )
+
             if accelerator.is_main_process:
                 if self.server_base_url is not None:
                     base_url = self.server_base_url


### PR DESCRIPTION
## What does this PR do?

Rejects QLoRA with `vllm_mode="server"` before weight synchronization. Merging a 4-bit PEFT adapter dequantizes its weights, which cannot be loaded by a server expecting packed 4-bit tensors.

The same guard is applied to `VLLMGeneration` and the self-contained `OnlineDPOTrainer`. The error directs users to an unquantized server or colocate mode. This is a fail-fast fix for #4973, not full quantized-server support.

## Tests

- server-mode guard tests for both implementations (3 passed, 1 skipped without local 4-bit support)
- Ruff check and format check on the changed files

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.