### PR TITLE
Silence experimental environment_factory warning in GRPO tests

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3012,6 +3012,7 @@ class TestGRPOTrainer(TrlTestCase):
         strict=True,
     )
     @require_jmespath
+    @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
     def test_train_with_environment_owned_reward(self):
         # Same setup as `test_train_with_environment_factory`, but the environment owns the reward via a `get_reward`
         # method and no `reward_funcs` is passed. The reward equals the final counter, so the 3 generations
@@ -3112,6 +3113,7 @@ class TestGRPOTrainer(TrlTestCase):
         strict=True,
     )
     @require_jmespath
+    @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
     def test_environment_owned_reward_coexists_with_reward_funcs(self):
         # When both `reward_funcs` and an environment-owned `get_reward` are present, `get_reward` is appended as an
         # extra reward source (weight 1) after the trainer-owned reward functions.
@@ -3170,6 +3172,7 @@ class TestGRPOTrainer(TrlTestCase):
         strict=True,
     )
     @require_jmespath
+    @patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})
     def test_environment_owned_reward_mixed_environments(self):
         # With a dict `environment_factory`, only some environments may own their reward via `get_reward`. Each such
         # env *class* contributes one reward column (named after its class); a rollout is scored only when its


### PR DESCRIPTION
This PR silences the experimental `environment_factory` `UserWarning` emitted during three GRPO trainer tests, so the CI test log stays clean.

### Motivation

`GRPOTrainer` warns when `environment_factory` is used, since it is an experimental API. Three environment-owned-reward tests instantiate the trainer with `environment_factory` but do not silence this warning, unlike the sibling `environment_factory` tests (e.g. `test_train_with_environment_factory`) which already set `TRL_EXPERIMENTAL_SILENCE=1`. This produced three `UserWarning`s in the CI test report.

### Solution

Add the `@patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})` decorator to the affected tests, matching the existing convention used by the other `environment_factory` tests.

### Changes

- Silence the experimental `environment_factory` warning in `test_train_with_environment_owned_reward`, `test_environment_owned_reward_coexists_with_reward_funcs`, and `test_environment_owned_reward_mixed_environments`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or training logic is modified.
> 
> **Overview**
> Adds `@patch.dict(os.environ, {"TRL_EXPERIMENTAL_SILENCE": "1"})` to three GRPO trainer tests that use `environment_factory` but did not silence the experimental API `UserWarning`, so CI logs stay clean.
> 
> The decorator is applied to `test_train_with_environment_owned_reward`, `test_environment_owned_reward_coexists_with_reward_funcs`, and `test_environment_owned_reward_mixed_environments`, matching the existing pattern on sibling tests such as `test_train_with_environment_factory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e059d7d1cb5bb319b1ed756f1fa11d7f6efd8bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->