### PR TITLE
Silence PEFT ensure_weight_tying warning on newer PEFT in GRPO tests

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -762,10 +762,14 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
-        # ensure_weight_tying suppresses the PEFT weight-tying warning, which fires for target_modules since PEFT 0.19.0
+        # `ensure_weight_tying=True` silences PEFT's weight-tying warning fired when lm_head is in the adapter on a
+        # model with untied embeddings; once tying respects `tie_word_embeddings`, the flag itself warns that no tied
+        # modules were found, so it must only be set on the affected range.
+        # - Introduced in PEFT 0.19.0 (peft#2879); fixed on main, unreleased as of 0.19.2.dev0 (peft#3171)
+        needs_ensure_weight_tying = Version("0.19.0") <= Version(peft.__version__) < Version("0.19.2.dev0")
         lora_config = LoraConfig(
             target_modules=["q_proj", "v_proj", "lm_head"],
-            **({"ensure_weight_tying": True} if Version(peft.__version__) >= Version("0.19.0") else {}),
+            **({"ensure_weight_tying": True} if needs_ensure_weight_tying else {}),
         )
         with pytest.raises(ValueError, match="lm_head"):
             GRPOTrainer(
@@ -807,11 +811,15 @@ class TestGRPOTrainer(TrlTestCase):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none")
-        # ensure_weight_tying suppresses the PEFT weight-tying warning, which fires for modules_to_save since PEFT 0.19.0
+        # `ensure_weight_tying=True` silences PEFT's weight-tying warning fired when lm_head is in the adapter on a
+        # model with untied embeddings; once tying respects `tie_word_embeddings`, the flag itself warns that no tied
+        # modules were found, so it must only be set on the affected range.
+        # - Introduced in PEFT 0.19.0 (peft#2879); fixed on main, unreleased as of 0.19.2.dev0 (peft#3171)
+        needs_ensure_weight_tying = Version("0.19.0") <= Version(peft.__version__) < Version("0.19.2.dev0")
         peft_config = LoraConfig(
             target_modules=["q_proj", "v_proj"],
             modules_to_save=["lm_head"],
-            **({"ensure_weight_tying": True} if Version(peft.__version__) >= Version("0.19.0") else {}),
+            **({"ensure_weight_tying": True} if needs_ensure_weight_tying else {}),
         )
         kwargs = {
             "model": model,


### PR DESCRIPTION
This PR restricts the `ensure_weight_tying=True` flag in the liger + PEFT GRPO tests to the PEFT versions that actually need it, so no PEFT `UserWarning` is emitted in the `tests_dev` CI lane (which installs PEFT from `main`).

### Motivation

`test_liger_kernel_with_peft_lm_head_raises` and `test_liger_kernel_with_peft_modules_to_save_lm_head_allowed` use the model `trl-internal-testing/tiny-Qwen2ForCausalLM-2.5`, which sets `tie_word_embeddings=false`.

- PEFT 0.19.0 (peft#2879) started warning when `lm_head` is part of the adapter unless `ensure_weight_tying=True` is set, so #6188 added the flag for `peft>=0.19.0`.
- PEFT #3171 (on `main`, unreleased as of `0.19.2.dev0`) makes weight tying respect the model's `tie_word_embeddings=False`. With that change, no tied modules exist, so passing `ensure_weight_tying=True` now emits a different warning: `You have requested 'ensure_weight_tying', but no tied modules were found in the model`.

Because the flag was still passed for all `peft>=0.19.0`, the `tests_dev` lane (PEFT from `main`) now emits this warning:
> UserWarning: You have requested `ensure_weight_tying`, but no tied modules were found in the model

```python
    tests/test_grpo_trainer.py::TestGRPOTrainer::test_liger_kernel_with_peft_lm_head_raises                                                                                                                
    tests/test_grpo_trainer.py::TestGRPOTrainer::test_liger_kernel_with_peft_modules_to_save_lm_head_allowed                                                                                               
      /__w/trl/trl/.venv/lib/python3.12/site-packages/peft/tuners/tuners_utils.py:1366: UserWarning: You have requested `ensure_weight_tying`, but no tied modules were found in the model                 
        warnings.warn("You have requested `ensure_weight_tying`, but no tied modules were found in the model")
```

### Solution

Pass `ensure_weight_tying=True` only on the affected PEFT range: `0.19.0 <= peft < 0.19.2.dev0`. The upper bound is `0.19.2.dev0` (not `0.19.2`) because `main` reports `0.19.2.dev0` and, per PEP 440, `0.19.2.dev0 < 0.19.2`, so a `< 0.19.2` bound would fail to exclude the `main` build. Released 0.19.0/0.19.1 keep the flag (avoiding the old warning); `main` and future releases with the fix drop it.

### Changes

- Gate `ensure_weight_tying=True` behind `0.19.0 <= Version(peft.__version__) < 0.19.2.dev0` in both liger + PEFT tests, via a `needs_ensure_weight_tying` boolean.
- Update the accompanying comments to document both the introducing and fixing PEFT versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only version gating for a PEFT LoRA flag; no production trainer or library behavior changes.
> 
> **Overview**
> Limits when **`ensure_weight_tying=True`** is passed in the two Liger + PEFT GRPO tests (`test_liger_kernel_with_peft_lm_head_raises` and `test_liger_kernel_with_peft_modules_to_save_lm_head_allowed`). Instead of enabling it for all PEFT **≥ 0.19.0**, it now uses **`needs_ensure_weight_tying`** with **`0.19.0 <= Version(peft.__version__) < Version("0.19.2.dev0")`**.
> 
> This avoids a **UserWarning** on PEFT from `main` (reporting `0.19.2.dev0`), where the weight-tying fix makes the flag warn that no tied modules were found, while still silencing the original warning on released **0.19.0/0.19.1**. Comments document the introducing (**peft#2879**) and fixing (**peft#3171**) PEFT versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4615a9036f0febe31e0eff9fe94eaec171fc741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->