### PR TITLE
Ignore benign bitsandbytes _check_is_size FutureWarning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,4 +209,10 @@ filterwarnings = [
     # Tracking issue: https://github.com/huggingface/trl/issues/6435
     # Upstream fix (merged, unreleased as of liger-kernel 0.8.0): https://github.com/linkedin/Liger-Kernel/pull/1274
     "ignore:Error detected in IndexPutBackward0:UserWarning",
+
+    # bitsandbytes calls the deprecated torch._check_is_size in its CUDA quant ops (upstream, not actionable in TRL)
+    # Triggered indirectly by loading bitsandbytes-quantized models in the PEFT + quantization tests
+    # Tracking issue: https://github.com/huggingface/trl/issues/6447
+    # Upstream fix (merged, unreleased as of bitsandbytes 0.49.2): https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1940
+    "ignore:_check_is_size will be removed in a future PyTorch release:FutureWarning",
 ]


### PR DESCRIPTION
This PR silences a benign `FutureWarning` emitted in CI by the PEFT + quantization tests when a bitsandbytes-quantized model is loaded.

### Motivation

`test_peft_with_quantization` in the DPO, KTO, and SFT trainer tests triggers a `FutureWarning` from bitsandbytes:

```
bitsandbytes/backends/cuda/ops.py:213: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious. Use _check(i >= 0) instead.
  torch._check_is_size(blocksize)
```

The warning comes from bitsandbytes, which calls the deprecated `torch._check_is_size` in its CUDA quantization ops. TRL only triggers it indirectly by loading a quantized model; there is nothing actionable on the TRL side. The warning clutters CI.

### Solution

The issue is already fixed upstream in bitsandbytes (bitsandbytes-foundation/bitsandbytes#1940), but that fix is unreleased (latest is `0.49.2`, which predates it; it is only in the `continuous-release_main` build). Following the existing precedent in `pyproject.toml` (and the same approach as #6436), this filters the non-actionable upstream warning until a bitsandbytes release including the fix is available. Removal is tracked in #6447.

### Changes

- Add a `filterwarnings` entry in `pyproject.toml` to ignore the `_check_is_size` `FutureWarning` from bitsandbytes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/CI configuration only; no runtime or training behavior changes.
> 
> **Overview**
> Adds a **pytest `filterwarnings` ignore** in `pyproject.toml` for the bitsandbytes `FutureWarning` about deprecated `torch._check_is_size`, which shows up when PEFT + quantization tests load 4-bit models.
> 
> This matches the existing pattern for other upstream noise (Liger, PyTorch JIT, etc.): documented with tracking issue **#6447** and the upstream bitsandbytes fix PR, until a release includes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72b8f4978389866b94b7ba7187eb53798612e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->