### PR TITLE
[DistillationTrainer refactor] Deprecate messages-style datasets

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -112,6 +112,8 @@ When using the teacher server:
 
 ### Expected dataset type
 
+<!-- TODO: Add a prompt-only dataset preview/format section here (as GRPO has) and point the `messages`-deprecation warning in `_DistillationCollator` at it, instead of linking to the GRPO quick-start. -->
+
 The dataset should be formatted as a [conversational](dataset_formats#conversational) [language modeling](dataset_formats#language-modeling) dataset:
 
 ```python

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -14,6 +14,7 @@
 
 import random
 import textwrap
+import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -188,6 +189,12 @@ class _DistillationCollator:
                 prompt_messages = example["prompt"]
                 has_completion = False
             else:
+                warnings.warn(
+                    "Passing a `messages`-style (conversational language-modeling) dataset to `DistillationTrainer` "
+                    "is deprecated and will be removed in a future release. Use the prompt-only format instead: "
+                    "https://huggingface.co/docs/trl/v1.8.0/en/grpo_trainer#quick-start",
+                    FutureWarning,
+                )
                 messages = example[self.messages_key]
                 # Split: prompt = everything before the last assistant turn, completion = last assistant turn
                 has_completion = len(messages) > 1 and messages[-1].get("role") == "assistant"


### PR DESCRIPTION
*Plan step 3.2 — stacked on PR #6461. Second PR of Phase 3 (dataset contract → prompt-only). Part of #6449.*

PR #6461 additively taught the collator the forward-looking **prompt-only** format (a `prompt` column of conversational messages, the same column GRPO consumes), so both formats now work. This PR **deprecates** the old `messages` (conversational language-modeling) format, steering users toward prompt-only. Nothing is removed — the `messages` path is byte-for-byte unchanged and still trains. This is the "announce" step in the roadmap's add → announce → switch → delete cadence.

### Trainer
- `_DistillationCollator` now emits a `FutureWarning` when it receives a `messages`-style example (the `else` branch — any dataset using the `messages` column, whether or not it carries a trailing assistant completion), pointing users to the prompt-only format. The rest of the `messages` path is unchanged, and the prompt-only (`prompt` column) branch added in #6461 stays silent.

### Docs
- Added a `TODO` in `distillation_trainer.md` (*Expected dataset type*) to add a prompt-only dataset preview/format section — as GRPO has — and re-point the warning at it. The warning links to the GRPO quick-start for now because distillation has no equivalent prompt-only section yet.

### Scope
Announce-only. Nothing is removed: the `messages` code path is fully functional. Removing `messages` support (and `max_length` / `max_prompt_length`) lands at plan step 3.5. The repo's own tests, docs and example move to prompt-only at plan step 3.3.

### Verification (pytest)

Full `test_distillation_trainer.py`: **37 passed, 2 xfailed** (the pre-existing `num_items_in_batch` xfails). The existing `messages`-based tests all pass and surface the new `FutureWarning` in the pytest warnings summary, confirming it fires on the `messages` path and stays silent on prompt-only. `make precommit` clean.

### Risk

Low. Purely a warning — no behaviour or loss-value change. The only new runtime surface is a `warnings.warn` at the top of the collator's existing `messages` branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a FutureWarning on an existing code path with no loss or collator logic changes.
> 
> **Overview**
> Announces deprecation of **`messages`** conversational LM datasets for `DistillationTrainer`, steering users toward the **`prompt`** column format (aligned with GRPO). Training behavior is unchanged.
> 
> `_DistillationCollator` now raises a **`FutureWarning`** on the legacy `messages` path (any example without a `prompt` key), linking to the GRPO quick-start until distillation docs get a dedicated prompt-only section. The **`prompt`** path stays silent.
> 
> Docs add a **TODO** under *Expected dataset type* to document prompt-only format and repoint the warning away from GRPO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620787de766c359a492a06f2aef0c9da0eadaca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->