### PR TITLE
Fix extract_prompt dropping the last shared turn when one completion is a prefix

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -629,9 +629,13 @@ def extract_prompt(example: dict[str, Sequence]) -> dict[str, Sequence]:
     """
     for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
         if example["chosen"][idx] != example["rejected"][idx]:
-            if example["chosen"][idx - 1] == " ":  # remove space before the prompt
+            if idx > 0 and example["chosen"][idx - 1] == " ":  # remove space before the prompt
                 idx -= 1
             break
+    else:
+        # chosen and rejected never diverge within the shorter length (one is a prefix of the
+        # other), so the entire shared prefix is the prompt.
+        idx = min(len(example["chosen"]), len(example["rejected"]))
     return {
         "prompt": example["chosen"][:idx],
         "chosen": example["chosen"][idx:],


### PR DESCRIPTION
## Problem

`extract_prompt` splits the shared prefix of `chosen`/`rejected` into `prompt` by scanning to the first divergence:

```python
for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
    if example["chosen"][idx] != example["rejected"][idx]:
        if example["chosen"][idx - 1] == " ":  # remove space before the prompt
            idx -= 1
        break
return {
    "prompt": example["chosen"][:idx],
    "chosen": example["chosen"][idx:],
    "rejected": example["rejected"][idx:],
}
```

Two edge cases are handled wrong:

1. **One completion is a prefix of the other.** If `chosen` and `rejected` are equal up to the shorter length (e.g. `chosen = "The sky is blue"`, `rejected = "The sky is blue and vast"`, or conversational where one has an extra turn), the loop finishes **without** `break`, so `idx` is left at `min_len - 1`. The last shared turn/token is then excluded from `prompt` and leaks into `chosen`/`rejected`.

2. **First elements differ (`idx == 0`).** `example["chosen"][idx - 1]` becomes `example["chosen"][-1]` (the last element). For string data that can be a trailing space, which wrongly decrements `idx` to `-1`.

## Reproduction

```
chosen   = "The sky is blue"
rejected = "The sky is blue and vast"   # chosen is a prefix of rejected
```

| | prompt | chosen | rejected |
|---|---|---|---|
| before | `"The sky is blu"` ❌ | `"e"` | `"e and vast"` |
| after | `"The sky is blue"` ✅ | `""` | `" and vast"` |

## Fix

- Add a `for/else` so that when the completions never diverge within the shorter length, `idx = min(len(chosen), len(rejected))` — the full shared prefix becomes the prompt.
- Guard the space check with `idx > 0` so `idx == 0` doesn't index `[-1]`.

Normal cases (a genuine shared prefix followed by divergence) are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preference dataset preprocessing logic; incorrect splits would corrupt training labels, but normal diverging cases are unchanged and the fix is narrowly scoped.
> 
> **Overview**
> Fixes **`extract_prompt`** so implicit preference examples split correctly when `chosen` and `rejected` share a prefix.
> 
> When one completion is a prefix of the other (no divergence within the shorter length), a **`for`/`else`** now sets the split index to the full shared length so the entire common prefix stays in **`prompt`** instead of leaking the last shared turn into **`chosen`**/**`rejected`**.
> 
> The optional space-backtrack before the split is guarded with **`idx > 0`**, avoiding a mistaken read of **`chosen[-1]`** when the first elements already differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4bbe5a0fb672bacdeaec6b53f0275e7d6658b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->