### PR TITLE
docs: complete GRPOConfig loss_type help

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -791,8 +791,8 @@ class GRPOConfig(_BaseConfig):
     loss_type: str = field(
         default="dapo",
         metadata={
-            "help": "Specifies the loss formulation to use. Supported values are 'grpo', 'dapo', 'bnpo', and "
-            "'dr_grpo'. "
+            "help": "Specifies the loss formulation to use. Supported values are 'grpo', 'dr_grpo', 'dapo', "
+            "'bnpo', 'cispo', 'sapo', 'luspo', and 'vespo'. "
             "'grpo': Aggregates token-level losses by normalizing over sequence length. Not recommended due to length "
             "bias—this approach tends to prefer shorter completions with positive advantages and longer ones with "
             "negative advantages. "
@@ -804,7 +804,7 @@ class GRPOConfig(_BaseConfig):
             "'bnpo': Aggregates token-level losses by normalizing with the number of active token in the local batch. "
             "Note that normalization is performed over the local batch only, so results may slightly vary depending "
             "on the local batch size, despite a constant effective batch size. When using "
-            "`per_device_train_batch_size==1`, the loss is equivalent to the GRPO loss."
+            "`per_device_train_batch_size==1`, the loss is equivalent to the GRPO loss. "
             "'cispo': Clips the importance sampling weights instead of the advantage scaled importance weights. "
             "The clipped weights are then multiplied with the advantages and policy model's log probs. "
             "Individual token losses are aggregated by normalizing with the number of active tokens in "
@@ -813,11 +813,11 @@ class GRPOConfig(_BaseConfig):
             "'sapo': Soft Adaptive Policy Optimization loss, as introduced in the "
             "[Soft Adaptive Policy Optimization paper](https://huggingface.co/papers/2511.20347). "
             "Replaces hard clipping with a smooth, temperature-controlled gate that adaptively attenuates "
-            "off-policy updates while preserving useful learning signals."
+            "off-policy updates while preserving useful learning signals. "
             "'luspo': Length-Unbiased Sequence Policy Optimization loss. A sequence-level loss that scales each "
             "sequence's loss by its length. This is a modification of GSPO and requires "
             "`importance_sampling_level='sequence'`. Introduced in the [LUSPO "
-            "paper](https://huggingface.co/papers/2602.05261)."
+            "paper](https://huggingface.co/papers/2602.05261). "
             "'vespo': Variational Sequence-Level Soft Policy Optimization. Replaces hard clipping with a smooth, "
             "asymmetric Gamma weighting function applied directly to sequence-level importance weights. Introduced in "
             "the [VESPO paper](https://huggingface.co/papers/2602.10693)."


### PR DESCRIPTION
# What does this PR do?

`GRPOConfig.loss_type`'s `help` string only lists `grpo`, `dapo`, `bnpo`, and `dr_grpo` in its summary line, but the trainer also supports `cispo`, `sapo`, `luspo`, and `vespo`. All eight are already described in the class docstring, so the field help had just fallen behind — this updates the summary line to list all of them.

While I was there I also added three missing spaces where the per-loss description strings are concatenated without a separator, so the help no longer renders as `...GRPO loss.'cispo'` (same at the `sapo`/`luspo` and `luspo`/`vespo` boundaries).

Docs only, no behavior change.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a config help string; no training or runtime behavior is affected.
> 
> **Overview**
> Updates **`GRPOConfig.loss_type`** field metadata so CLI/`--help` matches what the trainer already supports.
> 
> The opening **supported values** line now lists all eight options (`cispo`, `sapo`, `luspo`, `vespo` were missing). Trailing spaces were added where per-loss description strings are concatenated, so help text no longer runs together (e.g. `...GRPO loss.'cispo'`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896ae8766a70f225ee2b8eff25bf8c221b81a0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->