### PR TITLE
fix(sft): support functools.partial model.forward in chunked CE patch

### DIFF
--- a/tests/test_chunked_ce_partial_forward.py
+++ b/tests/test_chunked_ce_partial_forward.py
@@ -1,0 +1,47 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0
+
+import functools
+import inspect
+import types
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+from trl.trainer.sft_trainer import _patch_chunked_ce_lm_head
+
+
+class _TinyLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = MagicMock()
+        self.config.text_config = None
+        # top-level config attrs used when is_vlm=False
+        self.config.final_logit_softcapping = None
+        self.config.logit_scale = 1.0
+        self.config.output_router_logits = False
+        self.lm_head = nn.Linear(4, 8, bias=False)
+        self.base_model = MagicMock()
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def forward(self, input_ids=None, attention_mask=None, labels=None, **kwargs):
+        return MagicMock(loss=torch.tensor(0.0), logits=None)
+
+
+def test_patch_chunked_ce_accepts_partial_forward():
+    """Qwen3.5-style models expose forward as functools.partial (#6483)."""
+    model = _TinyLM()
+    real = model.forward
+    model.forward = functools.partial(real)  # no __func__
+
+    # Should not raise AttributeError: 'partial' object has no attribute '__func__'
+    _patch_chunked_ce_lm_head(model, chunk_size=2, is_vlm=False)
+
+    assert isinstance(model.forward, types.MethodType)
+    sig = inspect.signature(model.forward)
+    # Bound method signature should include original kwargs surface
+    assert "input_ids" in sig.parameters or len(sig.parameters) >= 1

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import functools
 import inspect
 import json
 import os
@@ -373,8 +374,16 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
 
     # Keep the original forward signature so `generate`'s `_validate_model_kwargs` still sees the
     # model's real inputs (e.g. VLM `pixel_values`, `spatial_shapes`) and doesn't reject them. The
-    # unbound `__func__` signature makes `MethodType`'s `self`-stripping land correctly.
-    _chunked_ce_forward.__signature__ = inspect.signature(original_forward.__func__)
+    # unbound function signature makes `MethodType`'s `self`-stripping land correctly.
+    #
+    # Some multimodal models (e.g. Qwen3.5) expose `forward` as a `functools.partial` rather than a
+    # bound method, so `original_forward.__func__` is unavailable — unwrap partials / fall back to
+    # the callable itself (see #6483).
+    forward_for_sig = original_forward
+    while isinstance(forward_for_sig, functools.partial):
+        forward_for_sig = forward_for_sig.func
+    unbound = getattr(forward_for_sig, "__func__", forward_for_sig)
+    _chunked_ce_forward.__signature__ = inspect.signature(unbound)
     model.forward = types.MethodType(_chunked_ce_forward, model)
 
 


### PR DESCRIPTION
# What does this PR do?

`_patch_chunked_ce_lm_head` clones the original `model.forward` signature via `original_forward.__func__`. That assumes a bound method. Multimodal checkpoints such as `Qwen3_5ForConditionalGeneration` can expose `forward` as a `functools.partial`, which has no `__func__`, so `SFTTrainer` crashes during init when applying the chunked CE LM-head patch (even for text-only training with the vision tower frozen).

This PR unwraps nested `functools.partial` objects and falls back to the callable itself when `__func__` is missing, then keeps the existing `MethodType` rebinding.

Fixes #6483

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to signature extraction during chunked CE patching; behavior for normal bound `forward` methods is unchanged.
> 
> **Overview**
> Fixes **`SFTTrainer` init crashes** when `loss_type='chunked_nll'` is used with models whose **`forward` is a `functools.partial`** (e.g. Qwen3.5-style VLMs), where reading `original_forward.__func__` raised `AttributeError`.
> 
> **`_patch_chunked_ce_lm_head`** now **unwraps nested partials**, then uses **`__func__` when present** or the **underlying callable** for `inspect.signature`, so the patched forward still exposes the original kwargs for `generate` validation.
> 
> Adds **`test_patch_chunked_ce_accepts_partial_forward`** to lock in the behavior (#6483).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1a551568e0847cbfdd2be0f15c08daeb3d9775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->