### PR TITLE
Record rollout traces to trackio 

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -16,6 +16,7 @@
 import math
 import queue
 import textwrap
+import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator
@@ -199,6 +200,15 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
         self.report_to = report_to
         self._trace_buf: list = []
         self._trace_log_interval = 8
+        # Log traces off the training path: __iter__ enqueues, a daemon thread drains. Bounded + drop-on-full so a
+        # slow trackio backend never blocks sample delivery.
+        self._trace_queue: queue.Queue = queue.Queue(maxsize=4)
+        threading.Thread(target=self._drain_traces, name="rollout-trace-logger", daemon=True).start()
+
+    def _drain_traces(self):
+        while True:
+            samples, step = self._trace_queue.get()
+            log_rollout_traces(samples, step=step, report_to=self.report_to)
 
     def __iter__(self):
         while True:
@@ -222,7 +232,10 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
 
             self._trace_buf.append(sample)
             if len(self._trace_buf) >= self._trace_log_interval:
-                log_rollout_traces(self._trace_buf, step=self.model_version_fn(), report_to=self.report_to)
+                try:
+                    self._trace_queue.put_nowait((self._trace_buf, self.model_version_fn()))
+                except queue.Full:
+                    pass
                 self._trace_buf = []
 
             yield {

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -33,7 +33,7 @@ from transformers.data.data_collator import DataCollatorMixin
 from ...trainer.base_trainer import _BaseTrainer
 from ...trainer.utils import get_config_model_id, nanmax, nanmin, pad, patch_chunked_lm_head
 from .async_grpo_config import AsyncGRPOConfig
-from .async_rollout_worker import AsyncRolloutWorker
+from .async_rollout_worker import AsyncRolloutWorker, log_rollout_traces
 from .vllm_client import VLLMClient
 from .weight_transfer import WeightTransferClient
 
@@ -188,6 +188,7 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
         stale_after_s,
         max_staleness=3,
         poll_interval_s=5.0,
+        report_to=(),
     ):
         self.queue = rollout_queue
         self.model_version_fn = model_version_fn
@@ -195,6 +196,9 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
         self.stale_after_s = stale_after_s
         self.max_staleness = max_staleness
         self.poll_interval_s = poll_interval_s
+        self.report_to = report_to
+        self._trace_buf: list = []
+        self._trace_log_interval = 8
 
     def __iter__(self):
         while True:
@@ -215,6 +219,11 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
             if staleness > self.max_staleness:
                 logger.info(f"dropping stale sample (staleness={staleness}, max={self.max_staleness})")
                 continue  # drop stale, pull next
+
+            self._trace_buf.append(sample)
+            if len(self._trace_buf) >= self._trace_log_interval:
+                log_rollout_traces(self._trace_buf, step=self.model_version_fn(), report_to=self.report_to)
+                self._trace_buf = []
 
             yield {
                 "input_ids": sample.input_ids,
@@ -779,6 +788,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
                 check_health_fn=self.rollout_worker.check_health,
                 stale_after_s=self.args.heartbeat_stale_after_s,
                 max_staleness=self.args.max_staleness,
+                report_to=self.args.report_to,
             )
             # Default the token budget to the vLLM server's max_model_len (the cap on prompt + completion), so no
             # rollout sample can exceed it. Wait for the server like weight sync does, so a still-loading vLLM doesn't

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -208,10 +208,11 @@ def log_rollout_traces(samples: list[RolloutSample], step: int, report_to: list[
             trackio.Trace(
                 messages=list(sample.completion) or list(sample.prompt),
                 metadata={
-                    "reward": float(sample.metrics.get("reward", float("nan"))),
-                    "reward_std": float(sample.metrics.get("reward_std", float("nan"))),
+                    **sample.metrics,  # reward, reward_std, rewards/<func>, tools/call_frequency, tools/failure_frequency
                     "advantage": float(sample.advantage),
+                    "group_id": int(sample.group_id),
                     "model_version": int(sample.model_version),
+                    "prompt_tokens": len(sample.input_ids) - int(sum(sample.completion_mask)),
                     "completion_tokens": int(sum(sample.completion_mask)),
                 },
             )

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -32,14 +32,17 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenize
 from transformers.data.data_collator import DataCollatorMixin
 
 from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import get_config_model_id, nanmax, nanmin, pad, patch_chunked_lm_head
+from ...trainer.utils import get_config_model_id, is_trackio_available, nanmax, nanmin, pad, patch_chunked_lm_head
 from .async_grpo_config import AsyncGRPOConfig
-from .async_rollout_worker import AsyncRolloutWorker, log_rollout_traces
+from .async_rollout_worker import AsyncRolloutWorker, RolloutSample
 from .vllm_client import VLLMClient
 from .weight_transfer import WeightTransferClient
 
 
 logger = get_logger(__name__)
+
+if is_trackio_available():
+    import trackio
 
 # A reward function is a callable that returns a list of floats (the rewards). The callable receives prompts,
 # completions, and additional arguments from the trainer (refer to the trainer's source for details). To ensure forward
@@ -178,6 +181,45 @@ class _EpochStopCallback(TrainerCallback):
         reached = torch.tensor(int(len(self._trainer._trained_groups) >= self._target), device=acc.device)
         if int(acc.reduce(reached, reduction="sum").item()) >= 1:
             control.should_training_stop = True
+
+
+def log_rollout_traces(samples: list[RolloutSample], step: int, report_to: list[str], max_traces: int = 16) -> None:
+    """Log rollout samples to trackio as inspectable traces (prompt + completion + reward/advantage per sample).
+
+    Call from rank 0 during training, where the HF trackio callback has already initialised the run; the traces then
+    show up under the run's Traces tab so rollouts can be read directly instead of grepping logs. No-op unless trackio
+    is the active logging backend (installed and listed in `report_to`). Best-effort: a trackio hiccup must never break
+    training.
+
+    Args:
+        samples (`list[RolloutSample]`):
+            Consumed rollout samples to log; the first `max_traces` are recorded.
+        step (`int`):
+            Step value the traces are logged under (e.g. the policy version, so the UI groups by policy).
+        report_to (`list[str]`):
+            The training args' `report_to`; logging happens only when it contains `"trackio"`.
+        max_traces (`int`, *optional*, defaults to `16`):
+            Maximum number of traces to log per call.
+    """
+    if not samples or "trackio" not in report_to or not is_trackio_available():
+        return
+    try:
+        traces = [
+            trackio.Trace(
+                messages=list(sample.completion) or list(sample.prompt),
+                metadata={
+                    "reward": float(sample.metrics.get("reward", float("nan"))),
+                    "reward_std": float(sample.metrics.get("reward_std", float("nan"))),
+                    "advantage": float(sample.advantage),
+                    "model_version": int(sample.model_version),
+                    "completion_tokens": int(sum(sample.completion_mask)),
+                },
+            )
+            for sample in samples[:max_traces]
+        ]
+        trackio.log({"rollouts": traces}, step=step)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"rollout trace logging skipped: {type(e).__name__}: {e}")
 
 
 class RolloutQueueDataset(torch.utils.data.IterableDataset):

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -232,7 +232,7 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
         stale_after_s,
         max_staleness=3,
         poll_interval_s=5.0,
-        report_to=(),
+        report_to=None,
     ):
         self.queue = rollout_queue
         self.model_version_fn = model_version_fn
@@ -240,7 +240,7 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
         self.stale_after_s = stale_after_s
         self.max_staleness = max_staleness
         self.poll_interval_s = poll_interval_s
-        self.report_to = report_to
+        self.report_to = report_to or []
         self._trace_buf: list = []
         self._trace_log_interval = 8
         # Log traces off the training path: __iter__ enqueues, a daemon thread drains. Bounded + drop-on-full so a

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import contextvars
 import math
 import queue
 import textwrap
@@ -250,8 +251,10 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
 
     def _drain_traces(self):
         while True:
-            samples, step = self._trace_queue.get()
-            log_rollout_traces(samples, step=step, report_to=self.report_to)
+            samples, step, ctx = self._trace_queue.get()
+            # Replay the main-thread context captured at enqueue: trackio's run lives in a ContextVar this daemon
+            # thread wouldn't otherwise inherit, so trackio.log() would raise "call init() first".
+            ctx.run(log_rollout_traces, samples, step=step, report_to=self.report_to)
 
     def __iter__(self):
         while True:
@@ -276,7 +279,10 @@ class RolloutQueueDataset(torch.utils.data.IterableDataset):
             self._trace_buf.append(sample)
             if len(self._trace_buf) >= self._trace_log_interval:
                 try:
-                    self._trace_queue.put_nowait((self._trace_buf, self.model_version_fn()))
+                    # Capture the main-thread context (holds trackio's run) so the drain thread can replay it.
+                    self._trace_queue.put_nowait(
+                        (self._trace_buf, self.model_version_fn(), contextvars.copy_context())
+                    )
                 except queue.Full:
                     pass
                 self._trace_buf = []

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -206,7 +206,7 @@ def log_rollout_traces(samples: list[RolloutSample], step: int, report_to: list[
     try:
         traces = [
             trackio.Trace(
-                messages=list(sample.completion) or list(sample.prompt),
+                messages=list(sample.prompt) + list(sample.completion),
                 metadata={
                     **sample.metrics,  # reward, reward_std, rewards/<func>, tools/call_frequency, tools/failure_frequency
                     "advantage": float(sample.advantage),

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -45,13 +45,10 @@ from ...chat_template_utils import (
     parse_response,
 )
 from ...import_utils import is_vllm_available
-from ...trainer.utils import get_callable_name, is_trackio_available, print_prompt_completions_sample
+from ...trainer.utils import get_callable_name, print_prompt_completions_sample
 
 
 logger = get_logger(__name__)
-
-if is_trackio_available():
-    import trackio
 
 Messages: TypeAlias = list[dict[str, str]]
 RolloutId: TypeAlias = str
@@ -197,45 +194,6 @@ class RolloutSample:
     model_version: int
     group_id: int
     metrics: dict[str, float]
-
-
-def log_rollout_traces(samples: list[RolloutSample], step: int, report_to: list[str], max_traces: int = 16) -> None:
-    """Log rollout samples to trackio as inspectable traces (prompt + completion + reward/advantage per sample).
-
-    Call from rank 0 during training, where the HF trackio callback has already initialised the run; the traces then
-    show up under the run's Traces tab so rollouts can be read directly instead of grepping logs. No-op unless trackio
-    is the active logging backend (installed and listed in `report_to`). Best-effort: a trackio hiccup must never break
-    training.
-
-    Args:
-        samples (`list[RolloutSample]`):
-            Consumed rollout samples to log; the first `max_traces` are recorded.
-        step (`int`):
-            Step value the traces are logged under (e.g. the policy version, so the UI groups by policy).
-        report_to (`list[str]`):
-            The training args' `report_to`; logging happens only when it contains `"trackio"`.
-        max_traces (`int`, *optional*, defaults to `16`):
-            Maximum number of traces to log per call.
-    """
-    if not samples or "trackio" not in report_to or not is_trackio_available():
-        return
-    try:
-        traces = [
-            trackio.Trace(
-                messages=list(sample.completion) or list(sample.prompt),
-                metadata={
-                    "reward": float(sample.metrics.get("reward", float("nan"))),
-                    "reward_std": float(sample.metrics.get("reward_std", float("nan"))),
-                    "advantage": float(sample.advantage),
-                    "model_version": int(sample.model_version),
-                    "completion_tokens": int(sum(sample.completion_mask)),
-                },
-            )
-            for sample in samples[:max_traces]
-        ]
-        trackio.log({"rollouts": traces}, step=step)
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"rollout trace logging skipped: {type(e).__name__}: {e}")
 
 
 # Env vars the child must drop so accelerate's `PartialState()` initialises in

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -45,10 +45,13 @@ from ...chat_template_utils import (
     parse_response,
 )
 from ...import_utils import is_vllm_available
-from ...trainer.utils import get_callable_name, print_prompt_completions_sample
+from ...trainer.utils import get_callable_name, is_trackio_available, print_prompt_completions_sample
 
 
 logger = get_logger(__name__)
+
+if is_trackio_available():
+    import trackio
 
 Messages: TypeAlias = list[dict[str, str]]
 RolloutId: TypeAlias = str
@@ -194,6 +197,45 @@ class RolloutSample:
     model_version: int
     group_id: int
     metrics: dict[str, float]
+
+
+def log_rollout_traces(samples: list[RolloutSample], step: int, report_to: list[str], max_traces: int = 16) -> None:
+    """Log rollout samples to trackio as inspectable traces (prompt + completion + reward/advantage per sample).
+
+    Call from rank 0 during training, where the HF trackio callback has already initialised the run; the traces then
+    show up under the run's Traces tab so rollouts can be read directly instead of grepping logs. No-op unless trackio
+    is the active logging backend (installed and listed in `report_to`). Best-effort: a trackio hiccup must never break
+    training.
+
+    Args:
+        samples (`list[RolloutSample]`):
+            Consumed rollout samples to log; the first `max_traces` are recorded.
+        step (`int`):
+            Step value the traces are logged under (e.g. the policy version, so the UI groups by policy).
+        report_to (`list[str]`):
+            The training args' `report_to`; logging happens only when it contains `"trackio"`.
+        max_traces (`int`, *optional*, defaults to `16`):
+            Maximum number of traces to log per call.
+    """
+    if not samples or "trackio" not in report_to or not is_trackio_available():
+        return
+    try:
+        traces = [
+            trackio.Trace(
+                messages=list(sample.completion) or list(sample.prompt),
+                metadata={
+                    "reward": float(sample.metrics.get("reward", float("nan"))),
+                    "reward_std": float(sample.metrics.get("reward_std", float("nan"))),
+                    "advantage": float(sample.advantage),
+                    "model_version": int(sample.model_version),
+                    "completion_tokens": int(sum(sample.completion_mask)),
+                },
+            )
+            for sample in samples[:max_traces]
+        ]
+        trackio.log({"rollouts": traces}, step=step)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"rollout trace logging skipped: {type(e).__name__}: {e}")
 
 
 # Env vars the child must drop so accelerate's `PartialState()` initialises in


### PR DESCRIPTION
# What does this PR do?


- Adds log_rollout_traces: logs rollout samples (full prompt/completion transcript + reward, reward_std, advantage, model_version, completion_tokens) to trackio's Traces
- Wired into `RolloutQueueDataset`: buffers consumed samples and flushes a batch (up to 16) every 8, stepped by policy version so the UI groups by policy.
- Best-effort: any trackio error is caught and logged, never breaks training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only path gated on trackio; failures are caught and trace drops are intentional to avoid blocking training.
> 
> **Overview**
> Adds **inspectable rollout traces** in trackio when `"trackio"` is in `report_to`: consumed `RolloutSample`s are logged as prompt+completion messages with reward metrics, advantage, group/model version, and token counts, grouped by **policy version** (`step`).
> 
> **`RolloutQueueDataset`** buffers samples and flushes every 8 to a **daemon drain thread** via a small bounded queue; **`contextvars.copy_context()`** replays the main-thread trackio run on that thread. Full queues drop trace batches so logging never blocks training. **`log_rollout_traces`** is best-effort (warnings only on failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b446da97c265b8078c44e6228a5db67dc9f884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->