### PR TITLE
Test train_dataset=None raises for core trainers

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1162,6 +1162,11 @@ class TestDPOTrainer(TrlTestCase):
         assert trainer.state.log_history[-3]["eval_data1_loss"] is not None
         assert trainer.state.log_history[-2]["eval_data2_loss"] is not None
 
+    def test_train_dataset_required(self):
+        training_args = DPOConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="`train_dataset` is required"):
+            DPOTrainer(model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args)
+
     @pytest.mark.parametrize(
         "eval_dataset_type",
         [

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -1124,6 +1124,11 @@ class TestKTOTrainer(TrlTestCase):
         assert trainer.state.log_history[-3]["eval_data1_loss"] is not None
         assert trainer.state.log_history[-2]["eval_data2_loss"] is not None
 
+    def test_train_dataset_required(self):
+        training_args = KTOConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="`train_dataset` is required"):
+            KTOTrainer(model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args)
+
     @pytest.mark.parametrize(
         "eval_dataset_type",
         [

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -746,6 +746,11 @@ class TestRewardTrainer(TrlTestCase):
         assert trainer.state.log_history[-3]["eval_data1_loss"] is not None
         assert trainer.state.log_history[-2]["eval_data2_loss"] is not None
 
+    def test_train_dataset_required(self):
+        training_args = RewardConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="`train_dataset` is required"):
+            RewardTrainer(model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args)
+
     @pytest.mark.parametrize(
         "eval_dataset_type",
         [

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -236,6 +236,15 @@ class TestRLOOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_train_dataset_required(self):
+        training_args = RLOOConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="`train_dataset` is required"):
+            RLOOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+            )
+
     @pytest.mark.parametrize(
         "eval_dataset_type",
         [

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1644,6 +1644,11 @@ class TestSFTTrainer(TrlTestCase):
         assert trainer.state.log_history[-3]["eval_data1_loss"] is not None
         assert trainer.state.log_history[-2]["eval_data2_loss"] is not None
 
+    def test_train_dataset_required(self):
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none")
+        with pytest.raises(ValueError, match="`train_dataset` is required"):
+            SFTTrainer(model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args)
+
     @pytest.mark.parametrize(
         "eval_dataset_type",
         [


### PR DESCRIPTION
This PR adds a dedicated test to DPOTrainer, KTOTrainer, RewardTrainer, RLOOTrainer and SFTTrainer asserting that constructing the trainer without a `train_dataset` raises `ValueError` with the message `` `train_dataset` is required ``.

### Motivation

We're auditing `train_dataset` handling across core trainers to bring it in line with the test coverage `eval_dataset` already has (e.g. #6336, "Test all supported eval_dataset input types in core trainer init tests"). Each of these five trainers already raises `` ValueError("`train_dataset` is required") `` when `train_dataset` is omitted, but nothing in the test suite exercised that path.

While doing this audit we noticed `GRPOTrainer` already covers this exact case, just incidentally: `test_dataset_required_without_environment` happens to hit the same `` `train_dataset` is required `` error, but its name and framing are about GRPO's environment-factory feature (a dataset is optional only when an environment owns the data), not about the plain "no dataset at all" requirement the other trainers share. A follow-up PR could rename that test (or add a same-named counterpart) so GRPO's coverage reads consistently with this one.

### Solution

Add one `test_train_dataset_required` per trainer (one commit each), each constructing the trainer with a minimal valid config and no `train_dataset`, and asserting the expected `ValueError`.

This is one PR in a small series aligning `train_dataset` handling and test coverage across core trainers with the existing `eval_dataset` work.

### Changes

- `tests/test_dpo_trainer.py`: add `test_train_dataset_required`
- `tests/test_kto_trainer.py`: add `test_train_dataset_required`
- `tests/test_reward_trainer.py`: add `test_train_dataset_required`
- `tests/test_rloo_trainer.py`: add `test_train_dataset_required`
- `tests/test_sft_trainer.py`: add `test_train_dataset_required`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production code changes; lowest risk.
> 
> **Overview**
> Adds **`test_train_dataset_required`** to the DPO, KTO, Reward, RLOO, and SFT trainer test modules so init without `train_dataset` is covered the same way as existing **`eval_dataset`** init tests.
> 
> Each test builds the trainer with a minimal config (and **`reward_funcs`** for RLOO) and expects **`ValueError`** with message `` `train_dataset` is required ``. No trainer implementation changes—only regression tests for behavior that was already present but untested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d9000a8e6cde3d54efe6beec5f507f3735a609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->