### PR TITLE
Fix `extract_prompt` when one completion is a prefix of the other

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1173,6 +1173,42 @@ class TestExtractPrompt(TrlTestCase):
         example_extracted_prompt = maybe_extract_prompt(self.example_explicit_prompt_standard)
         assert example_extracted_prompt == self.example_explicit_prompt_standard, "The prompt should remain unchanged."
 
+    def test_extract_prompt_one_completion_is_prefix_of_the_other_conversational(self):
+        # When one completion is a prefix of the other, the completions never diverge within the shared
+        # range, so the whole shared part is the prompt (not the shared part minus its last turn).
+        example = {
+            "chosen": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "rejected": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+                {"role": "assistant", "content": "Actually, it is green."},
+            ],
+        }
+        expected = {
+            "prompt": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "chosen": [],
+            "rejected": [{"role": "assistant", "content": "Actually, it is green."}],
+        }
+        assert extract_prompt(example) == expected
+
+    def test_extract_prompt_one_completion_is_prefix_of_the_other_standard(self):
+        example = {"chosen": "The sky", "rejected": "The sky is blue"}
+        expected = {"prompt": "The sky", "chosen": "", "rejected": " is blue"}
+        assert extract_prompt(example) == expected
+
+    def test_extract_prompt_completions_differ_at_first_token_standard(self):
+        # The completions differ at index 0, so the prompt is empty; the leading-space adjustment must
+        # not wrap around to the last character of the chosen completion.
+        example = {"chosen": "a b ", "rejected": "x"}
+        expected = {"prompt": "", "chosen": "a b ", "rejected": "x"}
+        assert extract_prompt(example) == expected
+
 
 class TestPackDatasetWrapped(TrlTestCase):
     def test_with_dataset(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -629,11 +629,16 @@ def extract_prompt(example: dict[str, Sequence]) -> dict[str, Sequence]:
      'rejected': [{'role': 'assistant', 'content': 'It is green.'}]}
     ```
     """
-    for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
+    min_len = min(len(example["chosen"]), len(example["rejected"]))
+    for idx in range(min_len):
         if example["chosen"][idx] != example["rejected"][idx]:
-            if example["chosen"][idx - 1] == " ":  # remove space before the prompt
+            if idx > 0 and example["chosen"][idx - 1] == " ":  # remove space before the prompt
                 idx -= 1
             break
+    else:
+        # One completion is a prefix of the other, so they never diverge within the shared range:
+        # the whole shared part is the prompt.
+        idx = min_len
     return {
         "prompt": example["chosen"][:idx],
         "chosen": example["chosen"][idx:],


### PR DESCRIPTION
## What does this PR do?

`extract_prompt` (used by `maybe_extract_prompt` for implicit-prompt preference datasets) splits an example into the shared `prompt` and the diverging `chosen`/`rejected` completions by walking their longest common prefix. Two edge cases were handled incorrectly:

1. **One completion is a prefix of the other.** The loop never breaks, so `idx` is left at `min_len - 1` (Python leaves the loop variable at its last value). The last shared element is then dropped from the prompt and duplicated into both completions. For example, with

   ```python
   {"chosen": "The sky", "rejected": "The sky is blue"}
   ```

   the current code returns `prompt="The sk"`, `chosen="y"`, `rejected="y is blue"` (splitting mid-word), and the conversational analogue leaves the last shared turn out of the prompt and in both completions.

2. **Completions differ at the first element.** When `chosen[0] != rejected[0]`, `idx` is `0` and the leading-space check reads `chosen[idx - 1]` == `chosen[-1]`, wrapping around to the last element. With `{"chosen": "a b ", "rejected": "x"}` this returns `prompt="a b"`, `chosen=" "` instead of `prompt=""`, `chosen="a b "`.

The fix tracks the shared length explicitly, uses a `for/else` so the whole shared prefix becomes the prompt when the completions never diverge, and guards the leading-space adjustment with `idx > 0`. Normal preference examples (which share a real prompt prefix and then diverge) are unaffected, and the existing string leading-space handling is preserved.

Fixes the incorrect prompt/completion split for these cases.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

Added three tests in `TestExtractPrompt`: a conversational prefix case, a standard (string) prefix case, and a differ-at-first-token case. All three fail on the current code and pass with the fix; the existing `extract_prompt` tests are unchanged.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to preference dataset preprocessing with targeted tests; typical diverging-prefix behavior is unchanged.
> 
> **Overview**
> Fixes **`extract_prompt`** (and **`maybe_extract_prompt`** on implicit-prompt preference rows) so prompt/completion splits match the full shared prefix between `chosen` and `rejected`.
> 
> When one completion is a **prefix** of the other, the loop no longer leaves `idx` at `min_len - 1`; a **`for`/`else`** sets **`idx = min_len`** so the entire shared segment becomes the prompt instead of dropping the last shared turn or splitting strings mid-word.
> 
> When completions **diverge at index 0**, the leading-space backstep only runs when **`idx > 0`**, so it no longer reads **`chosen[-1]`** and corrupts the split (e.g. empty prompt with truncated `chosen`).
> 
> Three regression tests cover conversational prefix, string prefix, and first-token mismatch cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a68a774ac9cb70289799aa842fc0abf5d5d192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->