### PR TITLE
Fix precompute_ref_log_probs=True crash under FSDP2 in DPO and KTO

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -166,6 +166,7 @@ class TestDistributed(TrlTestCase):
                     reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
                 ),
             ),
+            "fsdp2",
         ],
     )
     def test_dpo_precompute_ref_log_probs(self, config, get_config_path):

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -954,7 +954,8 @@ class DPOTrainer(_BaseTrainer):
                 )
             self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
 
-        # Reference forwards during precompute reuse a single DeepSpeed inference engine (see `_precompute_ref_logps`).
+        # Reference forwards during precompute reuse a single DeepSpeed/FSDP inference engine (see
+        # `_precompute_ref_logps`).
         self._precompute_engine = None
         if args.precompute_ref_log_probs:
             self.train_dataset = self._precompute_ref_logps(
@@ -1132,11 +1133,16 @@ class DPOTrainer(_BaseTrainer):
         data_loader = self.accelerator.prepare(dataloader)
 
         # This runs before the parent class prepares the model in `train`, so with DeepSpeed the parameters are still
-        # on CPU (ZeRO-1/2) and sharded (ZeRO-3). Wrap the model in an inference engine to place and gather them. Build
-        # it once and reuse it across precompute passes (train, eval, and later `evaluate` calls)
+        # on CPU (ZeRO-1/2) and sharded (ZeRO-3), and with FSDP they are still on the meta/CPU device. Wrap the model
+        # in an inference engine to place and gather them. Build it once and reuse it across precompute passes (train,
+        # eval, and later `evaluate` calls)
         if self.ref_model is None and self.is_deepspeed_enabled:
             if self._precompute_engine is None:
                 self._precompute_engine = prepare_deepspeed(self.model, self.accelerator)
+            model = self._precompute_engine
+        elif self.ref_model is None and self.is_fsdp_enabled:
+            if self._precompute_engine is None:
+                self._precompute_engine = prepare_fsdp(self.model, self.accelerator)
             model = self._precompute_engine
         else:
             model = self.ref_model or self.model

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -980,7 +980,8 @@ class KTOTrainer(_BaseTrainer):
             # under ZeRO-3 the parameter coordinator gathers/reduces `lm_head.weight` around the fused loss.
             self._forward_redirection = _ForwardRedirection()
 
-        # Reference forwards during precompute reuse a single DeepSpeed inference engine (see `_precompute_ref_logps`).
+        # Reference forwards during precompute reuse a single DeepSpeed/FSDP inference engine (see
+        # `_precompute_ref_logps`).
         self._precompute_engine = None
         if self.precompute_ref_logps:
             self.train_dataset = self._precompute_ref_logps(
@@ -1199,11 +1200,16 @@ class KTOTrainer(_BaseTrainer):
         data_loader = self.accelerator.prepare(dataloader)
 
         # This runs before the parent class prepares the model in `train`, so with DeepSpeed the parameters are still
-        # on CPU (ZeRO-1/2) and sharded (ZeRO-3). Wrap the model in an inference engine to place and gather them. Build
-        # it once and reuse it across precompute passes (train, eval, and later `evaluate` calls)
+        # on CPU (ZeRO-1/2) and sharded (ZeRO-3), and with FSDP they are still on the meta/CPU device. Wrap the model
+        # in an inference engine to place and gather them. Build it once and reuse it across precompute passes (train,
+        # eval, and later `evaluate` calls)
         if self.ref_model is None and self.is_deepspeed_enabled:
             if self._precompute_engine is None:
                 self._precompute_engine = prepare_deepspeed(self.model, self.accelerator)
+            model = self._precompute_engine
+        elif self.ref_model is None and self.is_fsdp_enabled:
+            if self._precompute_engine is None:
+                self._precompute_engine = prepare_fsdp(self.model, self.accelerator)
             model = self._precompute_engine
         else:
             model = self.ref_model or self.model


### PR DESCRIPTION
Fixes #6470.

### Problem

With `ref_model=None`, `_precompute_ref_logps` runs the reference forward pass in `__init__`, before `train()` prepares the model. Under FSDP2 the model's parameters are still on CPU at that point, so the forward pass hits CPU weights with CUDA inputs and crashes with a device-mismatch error.

`_precompute_ref_logps` already has a DeepSpeed branch for exactly this problem (added in #6403): it wraps `self.model` in an inference engine via `prepare_deepspeed` and reuses it across the train/eval precompute passes. There was no equivalent FSDP2 branch, so under FSDP2 it fell through to the raw, un-prepared module.

### Fix

Add an `elif ... self.is_fsdp_enabled` branch mirroring the DeepSpeed one in both `DPOTrainer._precompute_ref_logps` and `KTOTrainer._precompute_ref_logps`: wrap `self.model` with the existing `prepare_fsdp` helper (already used elsewhere in both trainers for the `ref_model is not None` case, and in RLOO/GRPO/online_dpo) and cache it on `self._precompute_engine`, reusing the same engine across precompute passes exactly like the DeepSpeed path. No new imports were needed; `prepare_fsdp` was already imported in both files.

### Testing

- Added `"fsdp2"` to the parametrization of `tests/distributed/test_distributed.py::TestDistributed::test_dpo_precompute_ref_log_probs`, mirroring the issue's own MRE (`accelerate launch` with the `fsdp2` config + `dpo.py --precompute_ref_log_probs --eval_strategy epoch`). This is a `require_torch_multi_accelerator` test (needs >=2 accelerators), so it runs in CI, not locally.
- I could not run that distributed test myself: this environment has a single GPU, and — independent of this fix — even a single-process `accelerate launch` under this environment's Windows PyTorch build fails before reaching any trainer code, with `RuntimeError: use_libuv was requested but PyTorch was build without libuv support` (a known Windows-wheel limitation in `torch.distributed`'s TCPStore, unrelated to this change).
- What I *did* verify locally, without a real multi-rank process group: constructed a real `DPOTrainer`/`KTOTrainer` (`ref_model=None`, `precompute_ref_log_probs=True`) on the tiny test model, set `is_deepspeed_enabled=False` / `is_fsdp_enabled=True` on the instance, mocked `prepare_fsdp` to return `self.model`, and called `_precompute_ref_logps` directly. This confirms the new branch is reached, `prepare_fsdp(self.model, self.accelerator)` is called exactly once, the result is cached on `_precompute_engine`, and it is reused (not re-created) on a second call simulating the eval-dataset pass — while the method still produces valid `ref_chosen_logps`/`ref_rejected_logps` (DPO) / `ref_logps` (KTO) columns.
- As a negative control, I reverted just the trainer changes and re-ran the same check: on the pre-fix code, `prepare_fsdp` is never called under `is_fsdp_enabled=True`, confirming the gap is real and that this check actually discriminates between the buggy and fixed behavior.
- This does not exercise real multi-rank FSDP2 sharding or device placement — only CI's multi-GPU run of the extended distributed test can confirm that end-to-end, the same way it did for the DeepSpeed fix in #6403.
- `ruff check` / `ruff format --check` pass on all three changed files.
- Existing non-distributed unit tests in `tests/test_dpo_trainer.py` / `tests/test_kto_trainer.py` selected with `-k precompute` pass (one VLM-specific test in each file fails locally due to a pre-existing, unrelated environment gap: `torchvision` is not installed in this environment; that test doesn't touch the FSDP/DeepSpeed branch at all).

## Before submitting

- [x] Was this discussed/agreed via a GitHub issue? Please add a link to it if that's the case: #6470 (filed by @qgallouedec, who also diagnosed the root cause and suggested the fix implemented here).
- [ ] Did you make sure to update the documentation with your changes? No doc changes needed: I checked `docs/source/dpo_trainer.md` and `docs/source/kto_trainer.md` and neither documents an FSDP-specific limitation for `precompute_ref_log_probs` that would need removing.
- [x] Did you write any new necessary tests?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed reference precompute initialization for FSDP, but follows the same cached-engine pattern already used for DeepSpeed and existing `prepare_fsdp` usage for separate ref models.
> 
> **Overview**
> Fixes crashes when **`precompute_ref_log_probs=True`** and **`ref_model=None`** under **FSDP2**: reference forwards run in `__init__` before `train()` prepares the policy, so weights were still on CPU/meta while batches were on GPU.
> 
> **`DPOTrainer`** and **`KTOTrainer`** now mirror the existing DeepSpeed path in **`_precompute_ref_logps`**: when FSDP is enabled, the policy is wrapped once via **`prepare_fsdp`**, cached on **`_precompute_engine`**, and reused across train/eval precompute passes. Comments note FSDP alongside DeepSpeed for the shared engine.
> 
> **`tests/distributed/test_distributed.py`** adds **`"fsdp2"`** to **`test_dpo_precompute_ref_log_probs`** so CI exercises DPO with precompute + eval under FSDP2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193684acfcee3af96abb673b39553cdfec0b4857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->