### PR TITLE
Stop emitting the messages-format deprecation warning in distillation tests

### DIFF
--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -221,7 +221,7 @@ class TestDistillationTrainer(TrlTestCase):
         return DistillationConfig(**args)
 
     def _make_local_trainer(self, **kwargs):
-        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
         return DistillationTrainer(
             model=self.model_id,
             teacher_model=self.model_id,
@@ -248,7 +248,7 @@ class TestDistillationTrainer(TrlTestCase):
             save_steps=2,
             per_device_eval_batch_size=2,
         )
-        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling")
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only")
         trainer = DistillationTrainer(
             model=self.model_id,
             teacher_model=self.model_id,
@@ -319,7 +319,7 @@ class TestDistillationTrainer(TrlTestCase):
 
         monkeypatch.setattr(DistillationTrainer, "_reduce_divergence_loss", staticmethod(_recording))
 
-        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
         trainer = DistillationTrainer(
             model=self.model_id,
             teacher_model=self.model_id,
@@ -419,7 +419,7 @@ class TestDistillationTrainer(TrlTestCase):
         import importlib
 
         training_args = self._make_args(use_liger_kernel=True, use_cpu=False)
-        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
 
         trainer = DistillationTrainer(
             model=self.model_id,

--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -230,10 +230,6 @@ class TestDistillationTrainer(TrlTestCase):
             processing_class=self.tokenizer,
         )
 
-    def _make_batch(self, trainer):
-        examples = [trainer.train_dataset[i] for i in range(2)]
-        return trainer.data_collator(examples)
-
     @staticmethod
     def _move_batch_to_device(batch, device):
         return {key: value.to(device) for key, value in batch.items()}
@@ -396,7 +392,12 @@ class TestDistillationTrainer(TrlTestCase):
             for p in trainer.teacher_model.parameters():
                 p.add_(0.5 * torch.randn_like(p))
 
-        batch = self._move_batch_to_device(self._make_batch(trainer), trainer.accelerator.device)
+        # A static batch standing in for what on-policy generation feeds `compute_loss`: a prompt (labels `-100`)
+        # followed by completion tokens (labels kept).
+        input_ids = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 6, 7]])
+        labels = torch.tensor([[-100, -100, -100, 4, 5], [-100, -100, -100, 6, 7]])
+        batch = {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids), "labels": labels}
+        batch = self._move_batch_to_device(batch, trainer.accelerator.device)
 
         # Number of valid (non-ignored) tokens in the local batch, sliced the same way `compute_loss` does.
         prompt_length = trainer._compute_prompt_length(batch)

--- a/tests/experimental/test_server_distillation_trainer.py
+++ b/tests/experimental/test_server_distillation_trainer.py
@@ -69,16 +69,8 @@ def _canned_teacher_logprobs(**kwargs):
 def _variable_length_dataset():
     return Dataset.from_list(
         [
-            {"messages": [{"role": "user", "content": "What's 2+2?"}, {"role": "assistant", "content": "4."}]},
-            {
-                "messages": [
-                    {"role": "user", "content": "Name three primary colors."},
-                    {
-                        "role": "assistant",
-                        "content": "Red, green, and blue are the three primary colors commonly used in additive color mixing.",
-                    },
-                ]
-            },
+            {"prompt": [{"role": "user", "content": "What's 2+2?"}]},
+            {"prompt": [{"role": "user", "content": "Name three primary colors."}]},
         ]
     )
 


### PR DESCRIPTION
This PR stops the distillation test suite from emitting the `messages`-format `FutureWarning` in CI.

Follow-up to:
- #6474

### Motivation

Since #6474 deprecated passing `messages`-format (conversational language-modeling) datasets to `DistillationTrainer`, several distillation tests kept using that format and emitted `FutureWarning` noise on every CI run.

>  FutureWarning: Passing a `messages`-format (conversational language-modeling) dataset to `DistillationTrainer` is deprecated and will be removed. Use a prompt-only dataset with a `prompt` column instead.

```python

tests/experimental/test_distillation_trainer.py::TestDistillationTrainer::test_distillation_trainer_train_runs_with_local_teacher
tests/experimental/test_distillation_trainer.py::TestDistillationTrainer::test_train_updates_params
tests/experimental/test_distillation_trainer.py::TestDistillationTrainer::test_num_items_in_batch_counts_the_tokens_trained_on
tests/experimental/test_distillation_trainer.py::TestDistillationTrainer::test_loss_normalizes_by_num_items_in_batch
tests/experimental/test_distillation_trainer.py::TestDistillationTrainer::test_distillation_trainer_with_liger
tests/experimental/test_server_distillation_trainer.py::TestServerDistillationTrainerRaggedGrad::test_reverse_kl_finite_grad_with_ragged_batch[1-2]
tests/experimental/test_server_distillation_trainer.py::TestServerDistillationTrainerRaggedGrad::test_reverse_kl_finite_grad_with_ragged_batch[2-1]
  /__w/trl/trl/trl/experimental/distillation/distillation_trainer.py:194: FutureWarning: Passing a `messages`-format (conversational language-modeling) dataset to `DistillationTrainer` is deprecated and will be removed. Use a prompt-only dataset with a `prompt` column instead.
    warnings.warn(

```

### Solution

Migrate the affected tests to the forward-looking prompt-only format. Training is always on-policy (the student generates completions at runtime regardless of dataset format), so the `messages` format was incidental to what these tests exercise. The one test that computes loss on a static batch needs completion labels, which the collator only produces from the deprecated `messages` branch, so it now builds that batch directly instead.

### Changes

- Switch the training tests and the server ragged-batch dataset to the prompt-only format (`conversational_prompt_only` / `prompt` column).
- Build the loss-normalization test's batch inline instead of collating a `messages` dataset, and remove the now-unused `_make_batch` helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production trainer or collator logic modified.
> 
> **Overview**
> Distillation-related tests no longer load **`conversational_language_modeling`** / **`messages`** examples, so CI stops spamming the **`FutureWarning`** from deprecating that dataset shape on `DistillationTrainer`.
> 
> Training and integration tests now use **`conversational_prompt_only`** (and server ragged-batch fixtures use a **`prompt`** column). That matches on-policy distillation, where completions come from generation rather than pre-filled assistant turns in the dataset.
> 
> The **`num_items_in_batch`** loss-normalization test no longer collates a deprecated **`messages`** batch via **`_make_batch`**; it builds a fixed prompt + completion **`labels`** tensor inline. The unused **`_make_batch`** helper is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f89d5003fb0a2da56d63819cfa92ebe7f2b0b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->