### PR TITLE
Remove unnecessary loss_type in KTO precompute ref log-probs test

### DIFF
--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -410,7 +410,6 @@ class TestKTOTrainer(TrlTestCase):
         eval_dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="test")
         training_args = KTOConfig(
             output_dir=self.tmp_dir,
-            loss_type="apo_zero_unpaired",
             max_steps=1,
             precompute_ref_log_probs=True,
             report_to="none",


### PR DESCRIPTION
This PR removes an unnecessary `loss_type="apo_zero_unpaired"` argument from the KTO `test_evaluate_precompute_ref_log_probs_after_training_raises` test.

### Motivation

This follows up on a review comment by @qgallouedec on #6488 (https://github.com/huggingface/trl/pull/6488#discussion_r3625147481), which noted that `loss_type="apo_zero_unpaired"` was not needed in the test added there. The same observation applies to this sibling test, where the setting is likewise unnecessary: the test verifies the reference log-probs guard, which is independent of the loss type. `apo_zero_unpaired` is the only loss type that disables the KL term, so relying on the default `"kto"` keeps the test representative and exercises the more general code path. The test passes unchanged with the default.

### Changes

- Remove the redundant `loss_type="apo_zero_unpaired"` from `test_evaluate_precompute_ref_log_probs_after_training_raises` in the KTO trainer tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code impact.
> 
> **Overview**
> Removes **`loss_type="apo_zero_unpaired"`** from `test_evaluate_precompute_ref_log_probs_after_training_raises` so the test uses the default **`kto`** loss.
> 
> The test only checks that **`evaluate()`** on a new dataset fails after training when **`precompute_ref_log_probs=True`** and no **`ref_model`** is set; that guard does not depend on loss type. Using the default keeps the scenario closer to typical KTO usage (with the KL term) without changing what the test asserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1736662c7ec3017c6f9c10df5a05a384f184a2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->