### PR TITLE
Silence transformers LOAD REPORT tables in test output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,28 @@
 # limitations under the License.
 
 import gc
+import logging
 import traceback
 from functools import wraps
 
 import pytest
 import torch
+
+
+# ============================================================================
+# Silence transformers "LOAD REPORT" tables
+# ============================================================================
+# transformers >= 5 prints a "LOAD REPORT" table whenever a checkpoint has missing/mismatched/unexpected keys
+# (transformers/utils/loading_report.py). TRL's tiny test models don't serialize the tied `lm_head.weight`, so
+# this fires on nearly every model load and floods the test output. It is emitted through `logging` at WARNING
+# level from three loggers; we drop only these records, keeping all other warnings visible.
+class _DropLoadReport(logging.Filter):
+    def filter(self, record):
+        return "LOAD REPORT" not in record.getMessage()
+
+
+for _logger_name in ("transformers.modeling_utils", "transformers.modeling_layers", "transformers.integrations.peft"):
+    logging.getLogger(_logger_name).addFilter(_DropLoadReport())
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
This PR silences the transformers "LOAD REPORT" tables from the test output.

### Motivation

transformers >= 5 prints a "LOAD REPORT" table whenever a checkpoint has missing, mismatched, or unexpected keys. TRL's tiny test models don't serialize the tied `lm_head.weight`, so this report fires on nearly every model load and floods the CI output with noise.

### Solution

The report is emitted through the `logging` module (not `warnings`) at WARNING level from three transformers loggers, so the `filterwarnings` list in `pyproject.toml` cannot catch it. Rather than lowering the transformers verbosity globally (which would hide every other warning too), a logging filter attached to the originating loggers drops only these records while keeping all other warnings visible.

### Changes

- Add a `logging.Filter` in `tests/conftest.py` that discards "LOAD REPORT" records from the `transformers.modeling_utils`, `transformers.modeling_layers`, and `transformers.integrations.peft` loggers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only logging configuration with no production or security impact.
> 
> **Overview**
> Reduces CI/test log noise from **transformers ≥ 5** by filtering **LOAD REPORT** tables that appear on almost every tiny-model `from_pretrained` load (missing tied `lm_head.weight` keys).
> 
> Because those tables are emitted via **`logging` at WARNING** (not `warnings`), `pyproject.toml` `filterwarnings` cannot suppress them. **`tests/conftest.py`** now registers a `_DropLoadReport` filter on `transformers.modeling_utils`, `transformers.modeling_layers`, and `transformers.integrations.peft` so only messages containing `LOAD REPORT` are dropped; other warnings stay visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7f9ea8776e392eb19d52bc2a5204fafe6f2ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->