### PR TITLE
Force use_cpu in tests when no CUDA device is available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,15 +122,17 @@ def apply_model_revisions(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def force_use_cpu_without_accelerator(monkeypatch):
-    """Force `use_cpu=True` on all TRL configs when no CUDA device is available.
+    """Force `use_cpu=True` on all TRL configs when no accelerator is available.
 
     TRL configs default `bf16` to `True` (see `_BaseConfig.__post_init__`), which makes
     `transformers.TrainingArguments.__post_init__` raise `ValueError: Your setup doesn't support bf16/gpu. You need to
     assign use_cpu ...` on machines without a GPU. Setting `use_cpu=True` before that validation runs lets the whole
-    suite run on CPU without editing every individual config in the tests. On a machine with a CUDA device this fixture
-    is a no-op.
+    suite run on CPU without editing every individual config in the tests. On a machine with an accelerator (CUDA, XPU,
+    NPU, ...) this fixture is a no-op, so on-device tests and explicit `use_cpu=False` are left untouched.
     """
-    if torch.cuda.is_available():
+    from transformers.testing_utils import torch_device
+
+    if torch_device is not None and torch_device != "cpu":
         return
 
     from trl.trainer.base_config import _BaseConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,30 @@ def apply_model_revisions(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def force_use_cpu_without_accelerator(monkeypatch):
+    """Force `use_cpu=True` on all TRL configs when no CUDA device is available.
+
+    TRL configs default `bf16` to `True` (see `_BaseConfig.__post_init__`), which makes
+    `transformers.TrainingArguments.__post_init__` raise `ValueError: Your setup doesn't support bf16/gpu. You need to
+    assign use_cpu ...` on machines without a GPU. Setting `use_cpu=True` before that validation runs lets the whole
+    suite run on CPU without editing every individual config in the tests. On a machine with a CUDA device this fixture
+    is a no-op.
+    """
+    if torch.cuda.is_available():
+        return
+
+    from trl.trainer.base_config import _BaseConfig
+
+    original_post_init = _BaseConfig.__post_init__
+
+    def patched_post_init(self):
+        self.use_cpu = True
+        original_post_init(self)
+
+    monkeypatch.setattr(_BaseConfig, "__post_init__", patched_post_init)
+
+
+@pytest.fixture(autouse=True)
 def cleanup_gpu():
     """
     Automatically cleanup GPU memory after each test.


### PR DESCRIPTION
This PR allows the test suite to run on machines without a GPU.

### Motivation

TRL configs default `bf16` to `True` in `_BaseConfig.__post_init__`. On a machine without a CUDA device, `transformers.TrainingArguments.__post_init__` then raises `ValueError: Your setup doesn't support bf16/gpu. You need to assign use_cpu if you want to train the model on CPU.`, causing the core trainer tests to fail during config construction even though none of them mention bf16.

### Solution

An autouse pytest fixture forces `use_cpu=True` on all TRL configs when no CUDA device is available, setting it before the transformers validation runs. This covers every config transparently since they all inherit `_BaseConfig`, so individual tests do not need to be edited. On a machine with a CUDA device the fixture is a no-op.

### Changes

- Add the `force_use_cpu_without_accelerator` autouse fixture to `tests/conftest.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conftest change with a narrow guard on accelerator presence; no runtime training or library behavior changes.
> 
> **Overview**
> **CPU-only CI and local runs** can now construct TRL trainer configs without hitting Transformers’ bf16/GPU validation error.
> 
> An **autouse fixture** in `tests/conftest.py` (`force_use_cpu_without_accelerator`) monkeypatches `_BaseConfig.__post_init__` so `use_cpu=True` is applied **before** the original post-init (and thus before `TrainingArguments` validation). When `transformers.testing_utils.torch_device` is a real accelerator (CUDA, XPU, NPU, etc.), the fixture returns immediately and does nothing.
> 
> No production code or per-test config edits are required because every TRL config inherits `_BaseConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33cd6b356132f8c9496b96987e79ff6e98f4c7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->