### PR TITLE
Fix stale `self._is_vision_dataset` reference in `_reject_skip_prepare_without_labels`

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1743,7 +1743,7 @@ class SFTTrainer(_BaseTrainer):
         # `evaluate`, since a dataset passed directly to `evaluate` also skips preparation.
         if not (
             self._skip_prepare_dataset
-            and not self._is_vision_dataset
+            and not self._is_multimodal_dataset
             and isinstance(data_collator, DataCollatorForLanguageModeling)
         ):
             return


### PR DESCRIPTION
### What

While testing the new audio SFT support on this branch, `SFTTrainer.__init__` crashes for **any** multimodal dataset (audio *or* vision):

```
File "trl/trainer/sft_trainer.py", line 1746, in _reject_skip_prepare_without_labels
    and not self._is_vision_dataset
AttributeError: 'SFTTrainer' object has no attribute '_is_vision_dataset'
```

This branch renamed `_is_vision_dataset` → `_is_multimodal_dataset` everywhere except this one spot. `_reject_skip_prepare_without_labels` is called unconditionally from `__init__`, and for multimodal models `_skip_prepare_dataset` is `True`, so the `and` chain doesn't short-circuit and hits the missing attribute.

### Fix

One line in `_reject_skip_prepare_without_labels`:

```diff
-            and not self._is_vision_dataset
+            and not self._is_multimodal_dataset
```

### Testing

Fine-tuned `trl-internal-testing/tiny-Qwen2AudioForConditionalGeneration` on `trl-internal-testing/zen-audio` with `SFTTrainer` on an A10G (via `hf jobs`); with the fix, training runs to completion and logs loss (it errors on `AttributeError` without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-attribute rename in an init guard; behavior aligns with the already-migrated multimodal SFT path and only fixes a regression.
> 
> **Overview**
> Fixes a **startup crash** for multimodal `SFTTrainer` runs (vision or audio) where `__init__` called `_reject_skip_prepare_without_labels` with a stale attribute name.
> 
> After the broader rename from `_is_vision_dataset` to `_is_multimodal_dataset`, this guard still referenced the old flag. For multimodal data, `_skip_prepare_dataset` is true and the condition does not short-circuit, so construction raised `AttributeError` before training could start. The check now uses `self._is_multimodal_dataset`, matching the rest of the trainer and preserving the intended behavior: **skip** the text-only “masks without labels” validation for multimodal datasets that use on-the-fly collator labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb45cf846cd4de89030ed58b224f1539a5a5227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->