### PR TITLE
Hotfix CI: Temporarily pin liger-kernel < 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dev = [
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
     # liger
-    "liger-kernel>=0.8.0",
+    "liger-kernel>=0.8.0,<0.8.1",  # temporary hotfix for #6516
     # openreward (requires Python 3.11+)
     "openreward>=0.1.109; python_version >= '3.11'",
     # peft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.
     "transformers[hub-kernels]",  # transformers < 5.1.0
 ]
 liger = [
-    "liger-kernel>=0.8.0"
+    "liger-kernel>=0.8.0,<0.8.1"  # temporary hotfix for #6516
 ]
 peft = [
     "peft>=0.8.0"


### PR DESCRIPTION
Hotfix CI: Temporarily pin liger-kernel < 0.8.1.

Hotfix for:
- #6516


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change that limits an optional dev dependency version; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> **Temporary dependency pin** for `liger-kernel` in `pyproject.toml` so installs stay on `>=0.8.0,<0.8.1` instead of allowing 0.8.1+.
> 
> The same constraint is applied in both the **`liger`** optional extra and the **`dev`** extra, with a comment pointing at issue **#6516**. No application code changes—only packaging metadata to unblock CI until the upstream liger-kernel issue is resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e701a09f0cb4d8d3b7722f392575f9f59a9bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->