### PR TITLE
Support image sources in vLLM generation

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -15,14 +15,16 @@
 import os
 import subprocess
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
+from transformers.image_processing_utils import BaseImageProcessor
 from transformers.testing_utils import torch_device
 
 from trl.generation.vllm_client import VLLMClient
-from trl.generation.vllm_generation import extract_logprobs
+from trl.generation.vllm_generation import VLLMGeneration, extract_logprobs
 from trl.import_utils import is_vllm_available
 from trl.scripts.vllm_serve import chunk_list
 
@@ -122,6 +124,46 @@ class TestExtractLogprobs(TrlTestCase):
 
         assert all_logprobs is None
         assert all_token_ids is None
+
+
+class TestVLLMGeneration(TrlTestCase):
+    @require_vision
+    def test_generate_loads_image_paths(self, tmp_path):
+        from PIL import Image
+
+        image_path = tmp_path / "image.png"
+        Image.new("RGB", (8, 8), color="red").save(image_path)
+        generation = object.__new__(VLLMGeneration)
+        generation.mode = "server"
+        generation.processing_class = SimpleNamespace(image_processor=BaseImageProcessor())
+        generation.accelerator = SimpleNamespace(is_main_process=True, process_index=0)
+        generation.temperature = 1.0
+        generation.top_p = 1.0
+        generation.top_k = 0
+        generation.min_p = 0.0
+        generation.repetition_penalty = 1.0
+        generation.max_completion_length = 16
+        generation.logprobs = 0
+        generation.structured_outputs_regex = None
+        generation.generation_kwargs = {}
+        generation.vllm_client = MagicMock()
+        generation.vllm_client.generate.return_value = {
+            "prompt_ids": [[1], [2]],
+            "completion_ids": [[3], [4]],
+            "logprobs": [[[-0.1]], [[-0.2]]],
+            "logprob_token_ids": [[[3]], [[4]]],
+        }
+
+        with (
+            patch("trl.generation.vllm_generation.gather_object", side_effect=lambda value: value),
+            patch("trl.generation.vllm_generation.broadcast_object_list"),
+        ):
+            generation.generate(prompts=[[1], [2]], images=[[str(image_path)], None], num_generations=1)
+
+        images = generation.vllm_client.generate.call_args.kwargs["images"]
+        assert isinstance(images[0][0], Image.Image)
+        assert images[0][0].getpixel((0, 0)) == (255, 0, 0)
+        assert images[1] is None
 
 
 @pytest.mark.slow

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -511,8 +511,8 @@ class VLLMGeneration:
 
         Args:
             prompts: List of token ID lists, one per prompt (already tokenized).
-            images: Optional list of image lists for VLM support. Each element is a list of PIL images for the
-                corresponding prompt, or `None` if no images for that prompt. `None` if no images at all.
+            images: Optional list of image-source lists for VLM support. Each element is a list of images, paths, or
+                URLs for the corresponding prompt, or `None` if no images for that prompt. `None` if no images at all.
             num_generations: Number of generations per prompt.
             profiler: Optional profiler for performance tracking.
 
@@ -535,6 +535,12 @@ class VLLMGeneration:
         min_p = self.min_p
         repetition_penalty = self.repetition_penalty
         max_completion_length = self.max_completion_length
+
+        if images is not None:
+            images = [
+                self.processing_class.image_processor.fetch_images(image_list) if image_list is not None else None
+                for image_list in images
+            ]
 
         # Wake up colocated vLLM weights if needed (idempotent if already awake from sync_weights)
         if self.mode == "colocate" and self.enable_sleep_mode:


### PR DESCRIPTION
# What does this PR do?

`GRPOTrainer` and `RLOOTrainer` can extract image paths or URLs from multimodal prompts, but their shared vLLM generation backend previously forwarded those values unchanged. Server mode then attempted to serialize each string as a PIL image, while colocated mode passed the string directly as vLLM multimodal data.

This change normalizes each per-prompt image list through the configured Transformers image processor at the shared `VLLMGeneration` boundary. Existing PIL inputs remain unchanged, while local paths and URLs are loaded before either vLLM mode consumes them. The regression test covers a local path, a mixed image/`None` batch, and the server boundary.

Fixes #6519

Validation:

- `pytest -q tests/test_vllm_client_server.py -m 'not slow'` — 10 passed, 42 deselected
- `make precommit` — all hooks passed
- AMD GPU smoke (SLURM 1547921): one Qwen2.5-VL GRPO training step with colocated vLLM and a raw local image path completed successfully

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? See #6519; maintainer discussion is pending while this PR remains a draft.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.