### PR TITLE
Point the opencode example at openenv.core.sandbox

### DIFF
--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -78,7 +78,7 @@ from datasets import Dataset, load_dataset
 from opencode_env import harness as oc_harness
 from opencode_env.config import OpenCodeConfig
 from opencode_env.harness import OpenCodeSessionFactory
-from opencode_env.sandbox.base import ExecResult, SandboxHandle
+from openenv.core.sandbox import ExecResult, SandboxHandle
 from opencode_env.task import OpenCodeTask
 from openenv.core.harness import ResourceSession, ResourceSessionFactory, VerifyResult
 from transformers import AutoTokenizer


### PR DESCRIPTION
# What does this PR do?

The shared sandbox layer (`SandboxBackend` / `SandboxHandle` / `ExecResult`, the E2B and Hugging Face backends, the interception proxy) is moving from `opencode_env.sandbox` to `openenv.core.sandbox` in huggingface/OpenEnv#1022 (it closes the `pi_env` → `opencode_env` peer dependency). This updates the `opencode` example's one sandbox import so it keeps working once that lands:

```diff
-from opencode_env.sandbox.base import ExecResult, SandboxHandle
+from openenv.core.sandbox import ExecResult, SandboxHandle
```

> [!WARNING]
> **Draft, do not merge until huggingface/OpenEnv#1022 lands.** `openenv.core.sandbox` does not exist until that PR merges, so this import would break against the current OpenEnv.

Depends on: huggingface/OpenEnv#1022

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@AmineDiro

