### PR TITLE
Point the opencode example at huggingface/OpenEnv

### DIFF
--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -17,7 +17,7 @@
 #     "trl",
 #     "trackio",
 #     "datasets",
-#     "openenv-opencode @ git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/opencode_env",
+#     "openenv-opencode @ git+https://github.com/huggingface/OpenEnv.git#subdirectory=envs/opencode_env",
 # ]
 # ///
 
@@ -37,7 +37,7 @@ rollout worker can pickle the factory + verifier into its spawned child process.
 Requirements:
   - An OpenAI-compatible vLLM server (see below) reachable at `--vllm-url`.
   - Internet on this node the first time: `warmup()` installs the `opencode` CLI into a template dir once.
-  - `pip install git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/opencode_env`
+  - `pip install git+https://github.com/huggingface/OpenEnv.git#subdirectory=envs/opencode_env`
 
 Run (2 GPUs: vLLM on one, trainer on the other):
 

--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -17,7 +17,7 @@
 #     "trl",
 #     "trackio",
 #     "datasets",
-#     "openenv-opencode @ git+https://github.com/huggingface/OpenEnv.git#subdirectory=envs/opencode_env",
+#     "openenv-opencode-env @ git+https://github.com/huggingface/OpenEnv.git#subdirectory=envs/opencode_env",
 # ]
 # ///
 


### PR DESCRIPTION
# What does this PR do?

The `opencode` example's uv-script header and install hint still point at `github.com/meta-pytorch/OpenEnv`, which is outdated: OpenEnv lives at `github.com/huggingface/OpenEnv`. This updates both references (the only `meta-pytorch/OpenEnv` occurrences in the repo).

```diff
-#     "openenv-opencode @ git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/opencode_env",
+#     "openenv-opencode @ git+https://github.com/huggingface/OpenEnv.git#subdirectory=envs/opencode_env",
```

`envs/opencode_env` exists under `huggingface/OpenEnv`, so the install resolves. No behavior change beyond the source URL.

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

@AmineDiro


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dependency URL/name only; no application or training behavior changes.
> 
> **Overview**
> The **opencode** AsyncGRPO example still referenced the old **`meta-pytorch/OpenEnv`** Git URL in its uv-script dependency block and in the Requirements install line. Both now use **`github.com/huggingface/OpenEnv`** with `#subdirectory=envs/opencode_env`.
> 
> The uv dependency name was also updated from **`openenv-opencode`** to **`openenv-opencode-env`** to match the current package naming. No training or runtime logic changes—only where users install the OpenEnv opencode env from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e975a13af6ff3b469f418ca2902b0058bf6bd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->