### PR TITLE
Fix CI quality: Fix copyright year in trl/experimental/async_grpo/openenv_harness.py

### DIFF
--- a/trl/experimental/async_grpo/openenv_harness.py
+++ b/trl/experimental/async_grpo/openenv_harness.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The HuggingFace Team. All rights reserved.
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trl/experimental/async_grpo/openenv_harness.py
+++ b/trl/experimental/async_grpo/openenv_harness.py
@@ -1,17 +1,3 @@
-# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Copyright 2020-2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trl/experimental/async_grpo/openenv_harness.py
+++ b/trl/experimental/async_grpo/openenv_harness.py
@@ -1,3 +1,17 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Copyright 2020-2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This pull request updates copyright notice for 2020-2026 and the Apache License header to the top of the `trl/experimental/async_grpo/openenv_harness.py` file. This ensures proper attribution and legal compliance.

Folllow-up to: CC: @AmineDiro 
- #6420

- Licensing and attribution:
  * Updated the Apache License, Version 2.0 header and updated the copyright year to 2026 in `trl/experimental/async_grpo/openenv_harness.py`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only copyright year change with no functional impact.
> 
> **Overview**
> Updates the file header in `trl/experimental/async_grpo/openenv_harness.py` so the Hugging Face copyright line reads **2020-2026** instead of **2020-2025**. No runtime or API behavior changes—only the license/copyright notice for CI compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88df40b7e2318666682b82a0d57893d9e3770df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->