### PR TITLE
Update quantization tests for bitsandbytes 0.50.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,12 +212,6 @@ filterwarnings = [
     # Upstream fix (merged, unreleased as of liger-kernel 0.8.0): https://github.com/linkedin/Liger-Kernel/pull/1274
     "ignore:Error detected in IndexPutBackward0:UserWarning",
 
-    # bitsandbytes calls the deprecated torch._check_is_size in its CUDA quant ops (upstream, not actionable in TRL)
-    # Triggered indirectly by loading bitsandbytes-quantized models in the PEFT + quantization tests
-    # Tracking issue: https://github.com/huggingface/trl/issues/6447
-    # Upstream fix (merged, unreleased as of bitsandbytes 0.49.2): https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1940
-    "ignore:_check_is_size will be removed in a future PyTorch release:FutureWarning",
-
     # triton builds an ast.AnnAssign node without the required `simple` field during kernel compilation (upstream,
     # not actionable in TRL); a DeprecationWarning on Python 3.14 that becomes an error on 3.15
     # Tracking issue: https://github.com/huggingface/trl/issues/6466

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1395,17 +1395,10 @@ class TestDPOTrainer(TrlTestCase):
         # Check that the peft params have changed and the base model params have not changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # In bitsandbytes, bias parameters are automatically cast to the input dtype during the forward pass if
-            # their dtype doesn’t match. This causes the module to change unexpectedly during the first forward pass of
-            # the training. To handle this, we cast these specific bias parameters to float32 before comparison.
-            # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/45553f7392e524eacf400b132cfe01261f6477be/bitsandbytes/nn/modules.py#L518
-            # We still need to investigate why the compute dtype ends up being different than for these parameters.
-            if n in [
-                "base_model.model.model.layers.1.self_attn.k_proj.bias",
-                "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-            ]:
-                param = param.float()
+            # bitsandbytes casts 4-bit layer biases to the compute dtype during the first forward pass. As of
+            # bitsandbytes 0.50.0, this applies to all Linear4bit biases, so align dtypes before comparing values.
+            if n.endswith(".bias") and param.dtype != new_param.dtype:
+                param = param.to(new_param.dtype)
 
             if "lora" not in n:  # We expect the base model params to be the same
                 torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -1324,17 +1324,10 @@ class TestKTOTrainer(TrlTestCase):
         # Check that the peft params have changed and the base model params have not changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # In bitsandbytes, bias parameters are automatically cast to the input dtype during the forward pass if
-            # their dtype doesn’t match. This causes the module to change unexpectedly during the first forward pass of
-            # the training. To handle this, we cast these specific bias parameters to float32 before comparison.
-            # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/45553f7392e524eacf400b132cfe01261f6477be/bitsandbytes/nn/modules.py#L518
-            # We still need to investigate why the compute dtype ends up being different than for these parameters.
-            if n in [
-                "base_model.model.model.layers.1.self_attn.k_proj.bias",
-                "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-            ]:
-                param = param.float()
+            # bitsandbytes casts 4-bit layer biases to the compute dtype during the first forward pass. As of
+            # bitsandbytes 0.50.0, this applies to all Linear4bit biases, so align dtypes before comparing values.
+            if n.endswith(".bias") and param.dtype != new_param.dtype:
+                param = param.to(new_param.dtype)
 
             if "lora" not in n:  # We expect the base model params to be the same
                 torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2136,17 +2136,10 @@ class TestSFTTrainer(TrlTestCase):
         # Check that the peft params have changed and the base model params have not changed
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            # In bitsandbytes, bias parameters are automatically cast to the input dtype during the forward pass if
-            # their dtype doesn’t match. This causes the module to change unexpectedly during the first forward pass of
-            # the training. To handle this, we cast these specific bias parameters to float32 before comparison.
-            # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/45553f7392e524eacf400b132cfe01261f6477be/bitsandbytes/nn/modules.py#L518
-            # We still need to investigate why the compute dtype ends up being different than for these parameters.
-            if n in [
-                "base_model.model.model.layers.1.self_attn.k_proj.bias",
-                "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-            ]:
-                param = param.float()
+            # bitsandbytes casts 4-bit layer biases to the compute dtype during the first forward pass. As of
+            # bitsandbytes 0.50.0, this applies to all Linear4bit biases, so align dtypes before comparing values.
+            if n.endswith(".bias") and param.dtype != new_param.dtype:
+                param = param.to(new_param.dtype)
 
             if "lora" not in n:  # We expect the base model params to be the same
                 torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")


### PR DESCRIPTION
# What does this PR do?

bitsandbytes 0.50.0 includes bitsandbytes-foundation/bitsandbytes#1940, which removes the deprecated `_check_is_size` calls. This removes the temporary warning filter now that the fixed release is available.

The release also casts every `Linear4bit` bias to the compute dtype on the first forward pass. The existing DPO, KTO, and SFT quantization tests only accounted for three model-specific biases, so they fail with 0.50.0 even though the values are unchanged. The assertions now align changed bias dtypes before comparing values while leaving every non-bias parameter check unchanged.

Fixes #6447

## Tests

- bitsandbytes 0.50.0: DPO, KTO, and SFT `test_peft_with_quantization` (3 passed)
- bitsandbytes 0.49.2: same tests (3 passed; expected upstream warnings)
- `pre-commit run --all-files`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and pytest config changes; no production trainer or library behavior is modified.
> 
> **Overview**
> Updates TRL’s **bitsandbytes 0.50.0** compatibility: drops the pytest `filterwarnings` entry for the upstream `_check_is_size` `FutureWarning` (fixed in that release), and fixes **DPO**, **KTO**, and **SFT** `test_peft_with_quantization` so frozen-base checks survive the new behavior where **all** `Linear4bit` biases are cast to the compute dtype on the first forward.
> 
> Instead of hard-coding three layer-specific bias names and forcing `float32`, the tests now **match dtypes for any `.bias` parameter** before `assert_close`, without changing how LoRA vs base parameters are validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881c5bc12dfcb11cf5ece5a64bbe93ffe2205909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->