### PR TITLE
Fix SFTTrainer chunked-CE patch crash when forward is not a bound method

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -23,6 +23,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 import transformers
+from accelerate.hooks import AlignDevicesHook, add_hook_to_module
 from accelerate.utils.memory import release_memory
 from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
@@ -2965,3 +2966,34 @@ class TestPatchChunkedCELMHead:
         assert out.num_valid_tokens.item() == unpadded + B
         # Accuracy denominator from the patched output keeps numerator/denominator aligned, so accuracy ≤ 1.
         assert out.num_correct_tokens.item() <= out.num_valid_tokens.item()
+
+
+class TestPatchChunkedCELMHeadWithAccelerateHook:
+    """Regression test for #6483: `original_forward` is not always a plain bound method. `device_map="auto"`
+    (and other accelerate dispatch/offload configurations) replace `model.forward` with a `functools.partial`
+    via `accelerate.hooks.add_hook_to_module`, which has no `__func__` and used to make
+    `_patch_chunked_ce_lm_head` crash with `AttributeError: 'functools.partial' object has no attribute
+    '__func__'`. Runs on CPU: the crash is in signature introspection, not model computation."""
+
+    def test_patch_succeeds_when_forward_is_wrapped_by_accelerate_hook(self):
+        model_id = "trl-internal-testing/tiny-CohereForCausalLM"
+        ref_model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.float32)
+        chunked_model = copy.deepcopy(ref_model)
+
+        # Simulates what `device_map="auto"` does when accelerate needs to dispatch/offload the model.
+        add_hook_to_module(chunked_model, AlignDevicesHook())
+        assert not hasattr(chunked_model.forward, "__func__")
+
+        _patch_chunked_ce_lm_head(chunked_model, chunk_size=5)
+
+        B, S = 2, 16
+        input_ids = torch.randint(0, ref_model.config.vocab_size, (B, S))
+        labels = input_ids.clone()
+        labels[:, :4] = -100
+        num_items = int((labels[..., 1:] != -100).sum())
+
+        with torch.no_grad():
+            ref_out = ref_model(input_ids=input_ids, labels=labels, num_items_in_batch=num_items)
+            out = chunked_model(input_ids=input_ids, labels=labels, num_items_in_batch=num_items)
+
+        torch.testing.assert_close(out.loss, ref_out.loss, atol=1e-5, rtol=1e-5)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -372,9 +372,16 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         )
 
     # Keep the original forward signature so `generate`'s `_validate_model_kwargs` still sees the
-    # model's real inputs (e.g. VLM `pixel_values`, `spatial_shapes`) and doesn't reject them. The
-    # unbound `__func__` signature makes `MethodType`'s `self`-stripping land correctly.
-    _chunked_ce_forward.__signature__ = inspect.signature(original_forward.__func__)
+    # model's real inputs (e.g. VLM `pixel_values`, `spatial_shapes`) and doesn't reject them. We need
+    # the unbound signature (with `self` as the first parameter) since `_chunked_ce_forward` declares
+    # `self` explicitly and gets bound via `MethodType` below.
+    # `original_forward` is not always a plain bound method: `device_map="auto"` (and other accelerate
+    # dispatch/offload hooks) replace it with a `functools.partial` built via `functools.update_wrapper`,
+    # and `transformers` decorators (e.g. `can_return_tuple`) wrap the real forward with `functools.wraps`
+    # too. Both set `__wrapped__`, and both make the bound method's implicit `self`-stripping not apply
+    # (a `functools.partial`/`@wraps`-wrapped function has no `__func__`). `inspect.unwrap` follows the
+    # full `__wrapped__` chain in either case, landing on the innermost unbound function with `self` intact.
+    _chunked_ce_forward.__signature__ = inspect.signature(inspect.unwrap(original_forward))
     model.forward = types.MethodType(_chunked_ce_forward, model)
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes the crash in `_patch_chunked_ce_lm_head` reported in #6483. The issue title says it's a Qwen3.5 problem, but it's actually broader: the patch assumes `model.forward` is always a bound method and reads `original_forward.__func__` to build the patched forward's signature. That breaks for *any* model whose forward has been wrapped by accelerate's device-dispatch hooks — which is exactly what `device_map="auto"` does when accelerate decides to dispatch/offload the model.

`accelerate.hooks.add_hook_to_module` replaces `model.forward` with:

```python
module.forward = functools.update_wrapper(functools.partial(new_forward, module), old_forward)
```

A `functools.partial` has no `__func__`, hence the `AttributeError` in the issue.

**Fix:** use `inspect.unwrap(original_forward)` instead of `original_forward.__func__`. `functools.update_wrapper` always sets `__wrapped__` on the wrapper, pointing back at `old_forward`, so `inspect.unwrap` recovers the original callable regardless of whether it went through an accelerate hook. It also happens to correctly handle another layer of wrapping that's unrelated to this bug: some `transformers` forwards are themselves decorated with `@functools.wraps` (e.g. via `can_return_tuple`), which also sets `__wrapped__`. I checked that `inspect.unwrap` produces a byte-identical signature to the old `.__func__` access on a plain (non-hooked) model, so this isn't a behavior change for the common case — it just also works for the hooked one.

I reproduced the crash locally against a small model wrapped with `accelerate.hooks.add_hook_to_module` (no GPU or the actual Qwen3.5 checkpoint needed — the bug is in signature introspection, not model computation), confirmed the fix resolves it, and confirmed a real forward/backward pass through the patched model still produces correct results afterward.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

This wasn't pre-discussed with a maintainer — it's a small, self-contained bug fix (no public API or checkpoint format change) with a repro and regression test, so I went ahead and opened the PR directly rather than waiting on a design discussion. Happy to adjust if there's a reason to handle it differently.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

To be upfront about this: the investigation, fix, and test were done by Claude Code under my direction — I reviewed the reasoning and the diff, ran the tests myself, and I'm able to discuss/defend the change, but I want to flag the AI involvement honestly rather than undersell it.

## Who can review?

@qgallouedec — you commented on the original issue and might have context on why the patch does the `.__func__` dance in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to signature copying during SFT chunked-CE patching, with a targeted regression test and no training API changes.
> 
> **Overview**
> Fixes **`AttributeError`** when **`_patch_chunked_ce_lm_head`** runs on models whose **`forward`** is not a plain bound method (e.g. **`device_map="auto"`** via Accelerate **`functools.partial`**, or Transformers **`@wraps`** layers).
> 
> **Signature introspection** now uses **`inspect.signature(inspect.unwrap(original_forward))`** instead of **`original_forward.__func__`**, so the patched forward keeps the real parameter list for **`generate`** / VLMs without changing behavior on unwrapped models.
> 
> Adds a **CPU regression test** that wraps **`forward`** with **`AlignDevicesHook`**, asserts patching succeeds, and checks loss matches the reference model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571c9cbb57b85d76b7392891427be2c000803391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->