### PR TITLE
Hotfix CI: Xfail NemotronH GRPO/RLOO tests against a broken transformers dev build

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -35,7 +35,7 @@ from transformers import (
     BitsAndBytesConfig,
 )
 from transformers.testing_utils import backend_empty_cache, torch_device
-from transformers.utils import is_peft_available
+from transformers.utils import is_kernels_available, is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
 from trl.import_utils import is_liger_kernel_available
@@ -300,10 +300,20 @@ class TestGRPOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
             pytest.param(
                 "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
-                marks=pytest.mark.skipif(
-                    Version(transformers.__version__) < Version("5.7.0"),
-                    reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
-                ),
+                marks=[
+                    pytest.mark.skipif(
+                        Version(transformers.__version__) < Version("5.7.0"),
+                        reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
+                    ),
+                    pytest.mark.xfail(
+                        Version(transformers.__version__).is_devrelease and is_kernels_available(),
+                        reason=(
+                            "transformers' NemotronHMamba2Mixer.cuda_kernels_forward breaks generation when Hub kernels "
+                            "are available (see #6541)."
+                        ),
+                        strict=True,
+                    ),
+                ],
             ),
         ],
     )

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -25,7 +25,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
 )
-from transformers.utils import is_peft_available
+from transformers.utils import is_kernels_available, is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
 
@@ -62,10 +62,20 @@ class TestRLOOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
             pytest.param(
                 "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
-                marks=pytest.mark.skipif(
-                    Version(transformers.__version__) < Version("5.7.0"),
-                    reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
-                ),
+                marks=[
+                    pytest.mark.skipif(
+                        Version(transformers.__version__) < Version("5.7.0"),
+                        reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
+                    ),
+                    pytest.mark.xfail(
+                        Version(transformers.__version__).is_devrelease and is_kernels_available(),
+                        reason=(
+                            "transformers' NemotronHMamba2Mixer.cuda_kernels_forward breaks generation when Hub kernels "
+                            "are available (see #6541)."
+                        ),
+                        strict=True,
+                    ),
+                ],
             ),
         ],
     )


### PR DESCRIPTION
This PR marks the NemotronH parametrization of test_train in TestGRPOTrainer and TestRLOOTrainer as an expected failure (xfail, strict=True) when running against a transformers dev build with the kernels package available.

Hotfix:
- #6541

### Motivation

The CI job that installs dev dependencies (transformers[kernels], which pulls in the kernels pip package) started failing test_grpo_trainer.py::TestGRPOTrainer::test_train and test_rloo_trainer.py::TestRLOOTrainer::test_train for trl-internal-testing/tiny-NemotronHForCausalLM-nano:

> RuntimeError: expand(CUDABFloat16Type{[3, 1, 1, 8]}, size=[-1, -1, 4]): the number of sizes provided (3) must be greater or equal to the number of dimensions in the tensor (4)

### Solution

This is a short-term, TRL-side workaround to keep CI green while the fix lands upstream in transformers, no transformers code is changed here.

### Changes

- Add an xfail mark to the NemotronH parametrization in both test_grpo_trainer.py and test_rloo_trainer.py, alongside the existing skipif mark (kept unchanged)
- Condition the xfail on Version(transformers.__version__).is_devrelease and is_kernels_available(), so it only applies where the bug actually reproduces
- Use strict=True so that once transformers ships the real fix, the test flips to an unexpected pass and fails CI loudly, forcing removal of the marker instead of letting it go stale
- Scope is limited to these two tests: other NemotronH-parametrized tests (DPO, SFT, chat_template_utils, utils, data_utils) don't call .generate() with a KV cache, so they never hit this decode path and are left untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI workaround with no runtime or library behavior changes; scoped to two parametrized training tests.
> 
> **Overview**
> Keeps CI green while **transformers** dev builds with the Hub **kernels** package break NemotronH generation during GRPO/RLOO training (#6541).
> 
> For `trl-internal-testing/tiny-NemotronHForCausalLM-nano` in **`TestGRPOTrainer.test_train`** and **`TestRLOOTrainer.test_train`**, the existing transformers `>=5.7.0` **skip** is unchanged and a conditional **`pytest.mark.xfail(strict=True)`** is added. The xfail runs only when `Version(transformers.__version__).is_devrelease` and `is_kernels_available()` are both true, matching the failing dev-deps job. **`strict=True`** forces removal of the marker once upstream fixes the bug (unexpected pass fails CI). Both files import **`is_kernels_available`** from `transformers.utils`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed52b73844af7383601a70b3083a9e24018e1922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->