### PR TITLE
Hotfix CI: Temporarily pin bitsandbytes < 0.50.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ quality = [
     "hf-doc-builder"
 ]
 quantization = [
-    "bitsandbytes"
+    "bitsandbytes<0.50.0",  # temporary hotfix for #6543
 ]
 scikit = [
     "scikit-learn"
@@ -120,7 +120,7 @@ dev = [
     "pre-commit",
     "hf-doc-builder",
     # quantization
-    "bitsandbytes",
+    "bitsandbytes<0.50.0",  # temporary hotfix for #6543
     # scikit: included in bco
     # test
     "pytest-cov",


### PR DESCRIPTION
This pull request applies a temporary hotfix to address issue #6543 by restricting the version of the `bitsandbytes` dependency to below 0.50.0 in both the `quantization` and `dev` dependency groups in `pyproject.toml`.

Temporary hotfix for:
- #6543

Dependency management:

* Restricted `bitsandbytes` to versions below 0.50.0 in the `quantization` dependencies to work around compatibility issues.
* Restricted `bitsandbytes` to versions below 0.50.0 in the `dev` dependencies for the same reason.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no runtime code paths; risk is limited to install resolution and users who need bitsandbytes 0.50+ via these extras until the pin is removed.
> 
> **Overview**
> **Temporary dependency pin** to restore CI after a `bitsandbytes` 0.50.x compatibility break tracked in **#6543**.
> 
> Both optional dependency lists that pull in quantization support now require `bitsandbytes<0.50.0` instead of an unpinned `bitsandbytes`: the `quantization` extra and the bundled `dev` extra. Inline comments mark this as a temporary hotfix until upstream or TRL can adopt 0.50+ safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd4a6196087a62a9ad0033f63c7a878d365366c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->