### PR TITLE
Allow packing and padding-free on VLMs with text-only data

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2062,6 +2062,77 @@ class TestSFTTrainer(TrlTestCase):
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
+    @pytest.mark.parametrize(
+        "config_kwargs",
+        [
+            {"packing": True, "max_length": 32},
+            {"packing": True, "packing_strategy": "wrapped", "max_length": 32},
+            {"padding_free": True, "max_length": None},
+            {"assistant_only_loss": True},
+            {"truncation_mode": "keep_end", "max_length": 32},
+        ],
+    )
+    @ignore_warnings(message="You are using packing, but the attention implementation is not.*", category=UserWarning)
+    @ignore_warnings(message="Padding-free training is enabled, but the attention.*", category=UserWarning)
+    @ignore_warnings(message="The `'keep_end'` truncation mode is deprecated.*", category=FutureWarning)
+    @require_vision
+    def test_train_vlm_text_only_data_uses_text_pipeline(self, config_kwargs):
+        # These options are incompatible with on-the-fly image processing, not with VLMs. A text-only dataset goes
+        # through the regular text pipeline, so they must be available on a VLM checkpoint too. Regression test
+        # for #6545.
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            report_to="none",
+            **config_kwargs,
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n.startswith("model.visual"):
+                torch.testing.assert_close(param, new_param, rtol=1e-12, atol=1e-12, msg=f"Param {n} is updated")
+            else:
+                assert not torch.equal(param, new_param), f"Param {n} is not updated"
+
+    @pytest.mark.parametrize(
+        ("config_kwargs", "error_match"),
+        [
+            ({"packing": True}, "Packing is not supported for vision datasets"),
+            ({"padding_free": True}, "Padding-free training is yet not supported for vision datasets"),
+            ({"assistant_only_loss": True}, "Assistant-only loss is not yet supported for vision datasets"),
+            (
+                {"truncation_mode": "keep_end", "max_length": 32},
+                "truncation_mode='keep_end' is not supported for vision datasets",
+            ),
+        ],
+    )
+    @ignore_warnings(message="The `'keep_end'` truncation mode is deprecated.*", category=FutureWarning)
+    @require_vision
+    def test_vision_dataset_unsupported_options_raise(self, config_kwargs, error_match):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")
+
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none", **config_kwargs)
+        with pytest.raises(ValueError, match=error_match):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_vision
     def test_vision_dataset_with_text_model_raises(self):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2073,7 +2073,6 @@ class TestSFTTrainer(TrlTestCase):
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             packing=True,
-            max_length=32,
             report_to="none",
         )
         trainer = SFTTrainer(

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2062,31 +2062,19 @@ class TestSFTTrainer(TrlTestCase):
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
 
-    @pytest.mark.parametrize(
-        "config_kwargs",
-        [
-            {"packing": True, "max_length": 32},
-            {"packing": True, "packing_strategy": "wrapped", "max_length": 32},
-            {"padding_free": True, "max_length": None},
-            {"assistant_only_loss": True},
-            {"truncation_mode": "keep_end", "max_length": 32},
-        ],
-    )
     @ignore_warnings(message="You are using packing, but the attention implementation is not.*", category=UserWarning)
-    @ignore_warnings(message="Padding-free training is enabled, but the attention.*", category=UserWarning)
-    @ignore_warnings(message="The `'keep_end'` truncation mode is deprecated.*", category=FutureWarning)
     @require_vision
-    def test_train_vlm_text_only_data_uses_text_pipeline(self, config_kwargs):
-        # These options are incompatible with on-the-fly image processing, not with VLMs. A text-only dataset goes
-        # through the regular text pipeline, so they must be available on a VLM checkpoint too. Regression test
-        # for #6545.
+    def test_train_vlm_text_only_data_packing(self):
+        # Packing is incompatible with on-the-fly image processing, not with VLMs. A text-only dataset goes through
+        # the regular text pipeline, so packing must be available on a VLM checkpoint too. Regression test for #6545.
         dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
 
         training_args = SFTConfig(
             output_dir=self.tmp_dir,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            packing=True,
+            max_length=32,
             report_to="none",
-            **config_kwargs,
         )
         trainer = SFTTrainer(
             model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
@@ -2107,31 +2095,6 @@ class TestSFTTrainer(TrlTestCase):
                 torch.testing.assert_close(param, new_param, rtol=1e-12, atol=1e-12, msg=f"Param {n} is updated")
             else:
                 assert not torch.equal(param, new_param), f"Param {n} is not updated"
-
-    @pytest.mark.parametrize(
-        ("config_kwargs", "error_match"),
-        [
-            ({"packing": True}, "Packing is not supported for vision datasets"),
-            ({"padding_free": True}, "Padding-free training is yet not supported for vision datasets"),
-            ({"assistant_only_loss": True}, "Assistant-only loss is not yet supported for vision datasets"),
-            (
-                {"truncation_mode": "keep_end", "max_length": 32},
-                "truncation_mode='keep_end' is not supported for vision datasets",
-            ),
-        ],
-    )
-    @ignore_warnings(message="The `'keep_end'` truncation mode is deprecated.*", category=FutureWarning)
-    @require_vision
-    def test_vision_dataset_unsupported_options_raise(self, config_kwargs, error_match):
-        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_language_modeling", split="train")
-
-        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none", **config_kwargs)
-        with pytest.raises(ValueError, match=error_match):
-            SFTTrainer(
-                model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-                args=training_args,
-                train_dataset=dataset,
-            )
 
     @require_vision
     def test_vision_dataset_with_text_model_raises(self):

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -59,8 +59,8 @@ class SFTConfig(_BaseConfig):
             Name of the column that contains text data in the dataset.
         dataset_kwargs (`dict[str, Any]`, *optional*):
             Dictionary of optional keyword arguments for the dataset preparation. The only supported key is
-            `skip_prepare_dataset`. When the model is a VLM, `skip_prepare_dataset` is automatically treated as `True`
-            regardless of the provided value, since preprocessing is done on the fly.
+            `skip_prepare_dataset`. When the dataset contains images, `skip_prepare_dataset` is automatically treated
+            as `True` regardless of the provided value, since preprocessing is done on the fly.
         dataset_num_proc (`int`, *optional*):
             Number of processes to use for processing the dataset.
         eos_token (`str`, *optional*):
@@ -187,9 +187,8 @@ class SFTConfig(_BaseConfig):
         default=None,
         metadata={
             "help": "Dictionary of optional keyword arguments for the dataset preparation. The only supported key is "
-            "`skip_prepare_dataset`. If the model is a VLM, `skip_prepare_dataset` value is ignored. When the model "
-            "is a VLM, `skip_prepare_dataset` is automatically treated as `True` regardless of the provided value, "
-            "since preprocessing is done on the fly."
+            "`skip_prepare_dataset`. When the dataset contains images, `skip_prepare_dataset` is automatically "
+            "treated as `True` regardless of the provided value, since preprocessing is done on the fly."
         },
     )
     dataset_num_proc: int | None = field(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -826,8 +826,8 @@ class SFTTrainer(_BaseTrainer):
             Configuration for this trainer. If `None`, a default configuration is used.
         data_collator ([`~transformers.DataCollator`], *optional*):
             Function to use to form a batch from a list of elements of the processed `train_dataset` or `eval_dataset`.
-            Will default to [`~trainer.sft_trainer.DataCollatorForLanguageModeling`] if the model is a language model
-            and [`~trainer.sft_trainer.DataCollatorForVisionLanguageModeling`] if the model is a vision-language model.
+            Will default to [`~trainer.sft_trainer.DataCollatorForLanguageModeling`], or to
+            [`~trainer.sft_trainer.DataCollatorForVisionLanguageModeling`] if the dataset contains images.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`]):
             Dataset to use for training. This trainer supports both [language modeling](#language-modeling) type and
             [prompt-completion](#prompt-completion) type. The format of the samples can be either:
@@ -1016,24 +1016,32 @@ class SFTTrainer(_BaseTrainer):
         else:
             added_tokens = []
 
-        # Catch some wrong configurations related to VLMs
-        if self._is_vlm and args.packing:
+        # Vision dataset detection
+        dataset_sample = next(iter(train_dataset))
+        self._is_vision_dataset = "image" in dataset_sample or "images" in dataset_sample
+        if self._is_vision_dataset and not self._is_vlm:
             raise ValueError(
-                "Packing is not supported for vision-language models. Please set `packing=False` in the SFTConfig."
+                "The dataset appears to be vision-related (contains 'image' or 'images' keys), but the provided "
+                "model does not seem to be a vision-language model. Please check your model and dataset."
             )
-        if self._is_vlm and args.padding_free:
+
+        if self._is_vision_dataset and args.packing:
             raise ValueError(
-                "Padding-free training is yet not supported for vision-language models. Please set "
-                "`padding_free=False` in the `SFTConfig`."
+                "Packing is not supported for vision datasets. Please set `packing=False` in the SFTConfig."
             )
-        if self._is_vlm and args.assistant_only_loss:
+        if self._is_vision_dataset and args.padding_free:
             raise ValueError(
-                "Assistant-only loss is not yet supported for vision-language models. Please set "
+                "Padding-free training is yet not supported for vision datasets. Please set `padding_free=False` in "
+                "the `SFTConfig`."
+            )
+        if self._is_vision_dataset and args.assistant_only_loss:
+            raise ValueError(
+                "Assistant-only loss is not yet supported for vision datasets. Please set "
                 "`assistant_only_loss=False` in the `SFTConfig`."
             )
-        if self._is_vlm and args.max_length is not None and args.truncation_mode == "keep_end":
+        if self._is_vision_dataset and args.max_length is not None and args.truncation_mode == "keep_end":
             raise ValueError(
-                "truncation_mode='keep_end' is not supported for vision-language models. Image tokens reside "
+                "truncation_mode='keep_end' is not supported for vision datasets. Image tokens reside "
                 "inside the prompt portion of the sequence; depending on the example, keep_end may silently "
                 "drop them, causing pixel_values to be forwarded to the model with no corresponding visual "
                 "tokens in input_ids. Use truncation_mode='keep_start' (the default) or set max_length=None."
@@ -1174,18 +1182,10 @@ class SFTTrainer(_BaseTrainer):
 
         # Decide whether to use completion-only loss: if not specified, then it is set to True if the dataset format
         # is prompt-completion, and False if the dataset format is language modeling.
-        dataset_sample = next(iter(train_dataset))
         if args.completion_only_loss is None:
             self.completion_only_loss = "prompt" in dataset_sample and "completion" in dataset_sample
         else:
             self.completion_only_loss = args.completion_only_loss
-
-        self._is_vision_dataset = "image" in dataset_sample or "images" in dataset_sample
-        if self._is_vision_dataset and not self._is_vlm:
-            raise ValueError(
-                "The dataset appears to be vision-related (contains 'image' or 'images' keys), but the provided "
-                "model does not seem to be a vision-language model. Please check your model and dataset."
-            )
 
         if data_collator is None and not self._is_vision_dataset:
             # Get the pad token: if not provided, use the one from the processing class or the eos token


### PR DESCRIPTION
# What does this PR do?

`SFTTrainer` refuses `packing`, `padding_free`, `assistant_only_loss` and `truncation_mode="keep_end"` when the
*model* is a VLM, even if the *dataset* has no images:

```python
ds = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")

SFTTrainer(
    model="trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
    train_dataset=ds,
    args=SFTConfig(packing=True),
)
# ValueError: Packing is not supported for vision-language models. Please set `packing=False` in the SFTConfig.
```

That dataset's only column is `messages`. Nothing image-related happens, the text pipeline handles it fine, and TRL
already tests that path (`test_train_vlm_text_only_data`). Losing packing here is not free either: it is the main
throughput lever on short-sequence SFT.

This PR gates the four options on `_is_vision_dataset` instead of `_is_vlm`.

Fixes #6545

### Why the dataset is the right condition

The four options are incompatible with on-the-fly processing, and on-the-fly processing is chosen by the data. The
rest of the trainer already knows this: the collator choice (`sft_trainer.py:1190`), `_skip_prepare_dataset` (`1256`),
the padding-free `max_length` guard (`1248`), `_set_signature_columns_if_needed` (`1637`) and
`_reject_skip_prepare_without_labels` (`1651`) all read `_is_vision_dataset`. Only the four gates read `_is_vlm`.

Those gates are simply older than the flag. #3862 added them when `_is_vlm` was the only signal. #4080 introduced
`_is_vision_dataset` and moved the collator and `skip_prepare_dataset` onto it, but left the gates behind. This
finishes #4080.

DPO and KTO already have the shape proposed here: probe the dataset, run the vision-dataset-on-a-text-model check,
then gate the options on `_is_vision_dataset` (`dpo_trainer.py:718-738`, `kto_trainer.py:758-777`). `AGENTS.md`
requires that duplicated trainer logic stays consistent, and SFT is the one core trainer still gating on the model.

### What changed

`_is_vision_dataset` was computed 160 lines below the gates, so the probe and the mismatch check that depends on it
move up to just above them. `completion_only_loss` reads the same `dataset_sample`, so the dataset is still read once.
The four messages now say "vision datasets", the wording DPO and KTO already use.
`_patch_chunked_ce_lm_head(..., is_vlm=self._is_vlm)` is a question about model structure and keeps the model flag.
Two docstrings in `sft_trainer.py` and `sft_config.py` described the same model-versus-data confusion and are
corrected.

Image datasets still refuse all four options, same exception, same point in `__init__`. No API, config or default
changes.

### Tests

`test_train_vlm_text_only_data_uses_text_pipeline` trains on the five configurations that used to raise, then asserts
every `model.visual` parameter is bit-identical afterwards. That assertion is what shows the text path ran: a
text-only batch gives the vision tower no gradient.

`test_vision_dataset_unsupported_options_raise` covers the four gates on `zen-image`. On `main`,
`grep -rn "Packing is not supported" tests/` returns nothing, so the refusal had no coverage at all.

Nine parametrised cases in total. All nine fail on `main` and pass with the change, and the existing
`test_train_vlm_text_only_data` cases still pass alongside them. The wider sweep,
`-k "packing or padding_free or assistant_only or vlm or vision or completion_only"`, gives 54 passed, 20 skipped, 0
failed. The skips are `@require_kernels` and GPU-only cases, since I ran on CPU. `pre-commit run --all-files` is
clean.

### Open questions

1. `keep_end` is deprecated and goes in v2.0.0. Tell me if you would rather that gate stay on `_is_vlm`, and I drop it
   from the change and from the tests.
2. Rewording that message makes it diverge from `dpo_trainer.py:727`, which gates on `_is_vision_dataset` but still
   says "vision-language models". Two lines, no behaviour change. Here or in its own PR?
3. `gold_trainer.py:886` has the same bug. I left it out because the experimental tree runs on a separate workflow.
   Happy to fold it in if you want it.

One pre-existing hole worth naming: `_is_vision_dataset` is read from the first training example only, and the eval
dataset is never probed. This PR widens the second by one option. Probing every dataset is a bigger change and looked
like its own issue.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. -> #6545
- [x] Did you make sure to update the documentation with your changes? (two docstrings corrected)
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec (issue author), @sergiopaniego (reviewed #4080, which introduced `_is_vision_dataset`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral fix in trainer init and docs with a focused regression test; image datasets keep the same restrictions, with no auth or data-path changes.
> 
> **Overview**
> **`SFTTrainer` no longer blocks packing, padding-free, assistant-only loss, or `truncation_mode='keep_end'` solely because the checkpoint is a VLM.** Those checks now key off whether the train set actually contains `image` / `images`, matching DPO/KTO and the rest of SFT (collator, `skip_prepare_dataset`, etc.).
> 
> Vision **datasets** still raise the same errors; only text-only data on a VLM processor is affected. Dataset probing and the text-vs-VLM mismatch check move up in `__init__` so gates run on `_is_vision_dataset`. Docstrings in `SFTConfig` / `SFTTrainer` describe dataset-based behavior instead of model-based.
> 
> Adds **`test_train_vlm_text_only_data_packing`** (regression for #6545): trains a tiny Qwen2.5-VL on conversational text with `packing=True` and asserts non-visual weights update while `model.visual` stays frozen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c7128cc543fe5dd8500f9220fc3cebc57f1864a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->