### PR TITLE
Fix numerical overflow in native GRPO KL estimator

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1709,7 +1709,7 @@ class TestGRPOTrainer(TrlTestCase):
         assert GRPOConfig(output_dir=self.tmp_dir, report_to="none").kl_log_ratio_clip == 20.0
         assert GRPOConfig(output_dir=self.tmp_dir, report_to="none", kl_log_ratio_clip=None).kl_log_ratio_clip is None
 
-    def _get_kl_test_case(
+    def _make_kl_test_case(
         self,
         log_ratios,
         *,
@@ -1778,7 +1778,7 @@ class TestGRPOTrainer(TrlTestCase):
             (torch.float16, 20.0, False, 100.0, 0.0),
             (torch.bfloat16, 20.0, False, 100.0, 0.0),
             (torch.float32, 20.0, False, 100.0, 0.0),
-            (torch.float32, 20.0, True, 100.0, 0.0),
+            (torch.float32, 2.0, True, 3.0, 0.0),
             (torch.float32, 20.0, False, 1.0, 0.1 * (1.0 - np.exp(1.0))),
             (torch.float32, 20.0, True, 1.0, -0.1),
             (torch.float32, 20.0, False, -100.0, 0.1 * (1.0 - np.exp(-100.0))),
@@ -1793,7 +1793,7 @@ class TestGRPOTrainer(TrlTestCase):
         log_ratio,
         expected_grad,
     ):
-        trainer, per_token_logps, inputs = self._get_kl_test_case(
+        trainer, per_token_logps, inputs = self._make_kl_test_case(
             [log_ratio],
             dtype=dtype,
             kl_log_ratio_clip=kl_log_ratio_clip,
@@ -1831,7 +1831,7 @@ class TestGRPOTrainer(TrlTestCase):
     def test_kl_log_ratio_clip_interactions(
         self, importance_sampling_level, log_ratios, completion_mask, tool_mask, advantage, expected_grad
     ):
-        trainer, per_token_logps, inputs = self._get_kl_test_case(
+        trainer, per_token_logps, inputs = self._make_kl_test_case(
             log_ratios,
             use_bias_correction_kl=True,
             importance_sampling_level=importance_sampling_level,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -15,6 +15,7 @@
 import gc
 import os
 import warnings
+from collections import defaultdict
 from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1703,6 +1704,155 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_kl_log_ratio_clip_config(self):
+        assert GRPOConfig(output_dir=self.tmp_dir, report_to="none").kl_log_ratio_clip == 20.0
+        assert GRPOConfig(output_dir=self.tmp_dir, report_to="none", kl_log_ratio_clip=None).kl_log_ratio_clip is None
+
+    def _get_kl_test_case(
+        self,
+        log_ratios,
+        *,
+        dtype=torch.float32,
+        kl_log_ratio_clip=20.0,
+        use_bias_correction_kl=False,
+        importance_sampling_level="token",
+        completion_mask=None,
+        tool_mask=None,
+        advantage=0.0,
+    ):
+        trainer = object.__new__(GRPOTrainer)
+        trainer.beta = 0.1
+        trainer.kl_log_ratio_clip = kl_log_ratio_clip
+        trainer.top_entropy_quantile = 1.0
+        trainer.off_policy_mask_threshold = None
+        trainer.importance_sampling_level = importance_sampling_level
+        trainer.loss_type = "grpo"
+        trainer.epsilon_low = 0.2
+        trainer.epsilon_high = 0.2
+        trainer.use_vllm = False
+        trainer.vllm_importance_sampling_correction = False
+        trainer.current_gradient_accumulation_steps = 1
+        trainer._entropy_bonus_enabled = False
+        trainer.aux_loss_enabled = False
+        trainer.args = SimpleNamespace(use_bias_correction_kl=use_bias_correction_kl, delta=None)
+        trainer.accelerator = SimpleNamespace(reduce=lambda tensor, reduction: tensor, gather=lambda tensor: tensor)
+        trainer._metrics = {"train": defaultdict(list)}
+
+        log_ratios = torch.tensor(log_ratios, dtype=dtype)
+        if log_ratios.ndim == 1:
+            log_ratios = log_ratios.unsqueeze(0)
+        batch_size, num_tokens = log_ratios.shape
+        per_token_logps = torch.full_like(log_ratios, -100.0, requires_grad=True)
+        trainer._get_per_token_logps_and_entropies = MagicMock(
+            return_value=(per_token_logps, torch.zeros_like(per_token_logps), None)
+        )
+        trainer.model = torch.nn.Identity()
+        if completion_mask is None:
+            completion_mask = torch.ones_like(log_ratios, dtype=torch.long)
+        else:
+            completion_mask = torch.tensor(completion_mask).reshape(batch_size, num_tokens)
+        advantages = torch.tensor(advantage, dtype=dtype).reshape(-1).expand(batch_size)
+        inputs = {
+            "prompt_ids": torch.zeros((batch_size, 1), dtype=torch.long),
+            "prompt_mask": torch.ones((batch_size, 1), dtype=torch.long),
+            "completion_ids": torch.arange(1, num_tokens + 1).expand(batch_size, -1),
+            "completion_mask": completion_mask,
+            "advantages": advantages,
+            "ref_per_token_logps": per_token_logps.detach() + log_ratios,
+        }
+        if tool_mask is not None:
+            inputs["tool_mask"] = torch.tensor(tool_mask).reshape(batch_size, num_tokens)
+
+        return trainer, per_token_logps, inputs
+
+    @pytest.mark.parametrize(
+        (
+            "dtype",
+            "kl_log_ratio_clip",
+            "use_bias_correction_kl",
+            "log_ratio",
+            "expected_grad",
+        ),
+        [
+            (torch.float16, 20.0, False, 100.0, 0.0),
+            (torch.bfloat16, 20.0, False, 100.0, 0.0),
+            (torch.float32, 20.0, False, 100.0, 0.0),
+            (torch.float32, 20.0, True, 100.0, 0.0),
+            (torch.float32, 20.0, False, 1.0, 0.1 * (1.0 - np.exp(1.0))),
+            (torch.float32, 20.0, True, 1.0, -0.1),
+            (torch.float32, 20.0, False, -100.0, 0.1 * (1.0 - np.exp(-100.0))),
+            (torch.float32, None, False, 25.0, 0.1 * (1.0 - np.exp(25.0))),
+        ],
+    )
+    def test_kl_log_ratio_clip(
+        self,
+        dtype,
+        kl_log_ratio_clip,
+        use_bias_correction_kl,
+        log_ratio,
+        expected_grad,
+    ):
+        trainer, per_token_logps, inputs = self._get_kl_test_case(
+            [log_ratio],
+            dtype=dtype,
+            kl_log_ratio_clip=kl_log_ratio_clip,
+            use_bias_correction_kl=use_bias_correction_kl,
+        )
+
+        loss = trainer._compute_loss(trainer.model, inputs)
+
+        assert torch.isfinite(loss)
+        expected_log_ratio = min(log_ratio, kl_log_ratio_clip) if kl_log_ratio_clip is not None else log_ratio
+        expected_kl = np.exp(expected_log_ratio) - expected_log_ratio - 1
+        assert trainer._metrics["train"]["kl"][-1] == pytest.approx(expected_kl)
+        loss.backward()
+        assert torch.isfinite(per_token_logps.grad).all()
+        assert per_token_logps.grad.item() == pytest.approx(expected_grad, rel=1e-4, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        ("importance_sampling_level", "log_ratios", "completion_mask", "tool_mask", "advantage", "expected_grad"),
+        [
+            (
+                "sequence",
+                [[100.0, 1.0], [1.0, 1.0]],
+                None,
+                None,
+                [0.0, 0.0],
+                [[0.0, 0.025 * (1.0 - np.exp(1.0))], [-0.025, -0.025]],
+            ),
+            ("sequence", [1.0, 100.0], [1, 0], None, 0.0, [-0.1, 0.0]),
+            ("sequence", [1.0, 100.0], [1, 1], [1, 0], 0.0, [-0.1, 0.0]),
+            ("sequence", [1.0, 100.0], [0, 0], None, 0.0, [0.0, 0.0]),
+            ("sequence", [1.0, 100.0], [1, 1], [0, 0], 0.0, [0.0, 0.0]),
+            ("token", [100.0], None, None, 1.0, [-1.0]),
+        ],
+    )
+    def test_kl_log_ratio_clip_interactions(
+        self, importance_sampling_level, log_ratios, completion_mask, tool_mask, advantage, expected_grad
+    ):
+        trainer, per_token_logps, inputs = self._get_kl_test_case(
+            log_ratios,
+            use_bias_correction_kl=True,
+            importance_sampling_level=importance_sampling_level,
+            completion_mask=completion_mask,
+            tool_mask=tool_mask,
+            advantage=advantage,
+        )
+
+        loss = trainer._compute_loss(trainer.model, inputs)
+
+        assert torch.isfinite(loss)
+        loss.backward()
+
+        assert torch.isfinite(per_token_logps.grad).all()
+        expected_grad = torch.tensor(expected_grad, dtype=per_token_logps.dtype).reshape_as(per_token_logps)
+        torch.testing.assert_close(
+            per_token_logps.grad,
+            expected_grad,
+            rtol=1e-4,
+            atol=1e-6,
+        )
 
     def test_reward_func_wrong_number_of_rewards(self):
         # A reward function that returns the wrong number of rewards should raise a clear error instead of silently

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -108,9 +108,10 @@ class GMPOTrainer(GRPOTrainer):
         # objective). Disabled by default (beta == 0)
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            ref_log_ratio = ref_per_token_logps.float() - per_token_logps.float()
+            if self.kl_log_ratio_clip is not None:
+                ref_log_ratio = ref_log_ratio.clamp(max=self.kl_log_ratio_clip)
+            per_token_kl = torch.exp(ref_log_ratio) - ref_log_ratio - 1
             seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
             per_sequence_loss = per_sequence_loss + self.beta * seq_kl
 

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -51,9 +51,10 @@ class GRPOTrainer(_GRPOTrainer):
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            ref_log_ratio = ref_per_token_logps.float() - per_token_logps.float()
+            if self.kl_log_ratio_clip is not None:
+                ref_log_ratio = ref_log_ratio.clamp(max=self.kl_log_ratio_clip)
+            per_token_kl = torch.exp(ref_log_ratio) - ref_log_ratio - 1
 
         # Compute the loss
         advantages = inputs["advantages"]

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -180,6 +180,10 @@ class GRPOConfig(_BaseConfig):
             KL coefficient. If `0.0` (default), the reference model is not loaded, reducing memory usage and improving
             training speed. [DeepSeek-R1 incentivizes reasoning in LLMs through reinforcement
             learning](https://huggingface.co/papers/2501.12948) use a value of `0.001`.
+        kl_log_ratio_clip (`float` or `None`, *optional*, defaults to `20.0`):
+            Maximum reference-to-model log-ratio used by the native GRPO KL estimator. Values above the limit
+            contribute no gradient through the KL term. Set to `None` to disable clipping. Ignored when
+            `use_liger_kernel=True`.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
         epsilon (`float`, *optional*, defaults to `0.2`):
@@ -674,6 +678,14 @@ class GRPOConfig(_BaseConfig):
             "help": "KL coefficient. If `0.0` (default), the reference model is not loaded, reducing memory usage and "
             "improving training speed. [DeepSeek-R1 incentivizes reasoning in LLMs through reinforcement "
             "learning](https://huggingface.co/papers/2501.12948) use a value of `0.001`."
+        },
+    )
+    kl_log_ratio_clip: float | None = field(
+        default=20.0,
+        metadata={
+            "help": "Maximum reference-to-model log-ratio used by the native GRPO KL estimator. Values above the "
+            "limit contribute no gradient through the KL term. Set to `None` to disable clipping. Ignored when "
+            "`use_liger_kernel=True`."
         },
     )
     num_iterations: int = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -181,8 +181,8 @@ class GRPOConfig(_BaseConfig):
             training speed. [DeepSeek-R1 incentivizes reasoning in LLMs through reinforcement
             learning](https://huggingface.co/papers/2501.12948) use a value of `0.001`.
         kl_log_ratio_clip (`float` or `None`, *optional*, defaults to `20.0`):
-            Maximum reference-to-model log-ratio used by the native GRPO KL estimator. Values above the limit
-            contribute no gradient through the KL term. Set to `None` to disable clipping. Ignored when
+            Maximum reference-to-model log-ratio used by the native PyTorch KL estimator. Values above the limit are
+            capped and contribute no gradient through the KL term. Set to `None` to disable clipping. Ignored when
             `use_liger_kernel=True`.
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
@@ -683,9 +683,9 @@ class GRPOConfig(_BaseConfig):
     kl_log_ratio_clip: float | None = field(
         default=20.0,
         metadata={
-            "help": "Maximum reference-to-model log-ratio used by the native GRPO KL estimator. Values above the "
-            "limit contribute no gradient through the KL term. Set to `None` to disable clipping. Ignored when "
-            "`use_liger_kernel=True`."
+            "help": "Maximum reference-to-model log-ratio used by the native PyTorch KL estimator. Values above the "
+            "limit are capped and contribute no gradient through the KL term. Set to `None` to disable clipping. "
+            "Ignored when `use_liger_kernel=True`."
         },
     )
     num_iterations: int = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -956,6 +956,7 @@ class GRPOTrainer(_BaseTrainer):
 
         # Reference model
         self.beta = args.beta
+        self.kl_log_ratio_clip = args.kl_log_ratio_clip
         if self.beta == 0.0:
             # If beta is 0.0, the reference model is not needed
             self.ref_model = None
@@ -3084,12 +3085,25 @@ class GRPOTrainer(_BaseTrainer):
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
             ref_per_token_logps = inputs["ref_per_token_logps"]
-            per_token_kl = (
-                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-            )
+            ref_log_ratio = ref_per_token_logps.float() - per_token_logps.float()
+            if self.kl_log_ratio_clip is not None:
+                is_kl_log_ratio_clipped = ref_log_ratio > self.kl_log_ratio_clip
+                ref_log_ratio = ref_log_ratio.clamp(max=self.kl_log_ratio_clip)
+            else:
+                is_kl_log_ratio_clipped = None
+            per_token_kl = torch.exp(ref_log_ratio) - ref_log_ratio - 1
             # Importance sampling correction for the KL divergence
             if self.args.use_bias_correction_kl:
-                per_token_kl = per_token_kl * coef_1
+                kl_coef = coef_1
+                if is_kl_log_ratio_clipped is not None:
+                    detach_kl_coef = is_kl_log_ratio_clipped & mask.bool()
+                    if self.importance_sampling_level == "sequence":
+                        # The sequence-level KL coefficient is shared across all active tokens.
+                        # Detach it if any active token is clipped to prevent capped KL values from
+                        # contributing to other tokens' gradients through the shared coefficient.
+                        detach_kl_coef = detach_kl_coef.any(dim=-1, keepdim=True)
+                    kl_coef = torch.where(detach_kl_coef, coef_1.detach(), coef_1)
+                per_token_kl = per_token_kl * kl_coef
 
         # From here, log_importance_weights (and all subsequent tensors, coef_1, coef_2, etc.) shape depends on
         # importance_sampling_level: "token" level: (B, T); "sequence" level: (B, 1)


### PR DESCRIPTION
# What does this PR do?

The native K3 KL estimator directly computes `exp(log(pi_ref) - log(pi_theta))`. When the model and reference log-probabilities diverge, this exponential can overflow and produce non-finite losses.

This PR:

- computes the reference-to-model log-ratio in FP32 before exponentiation;
- adds `GRPOConfig.kl_log_ratio_clip`, with a default of `20.0` and `None` to disable clipping;
- applies the same upper-bound protection to the native GRPO, GMPO, and GSPO-token paths;
- detaches the KL bias-correction coefficient at clipped token positions and, for sequence-level importance sampling, detaches the shared coefficient when any active token in the sequence is clipped;
- adds regression tests covering different dtypes, a non-default clipping threshold, disabled clipping, KL bias correction, token- and sequence-level importance sampling with batch isolation, completion and tool masks, and the policy-gradient path.

Tokens whose reference-to-model log-ratio exceeds the configured limit use the capped log-ratio to compute the KL value and contribute no gradient through the KL term. They may still receive gradients from the policy objective.

This change applies only to the native PyTorch KL paths. The Liger fused loss and the computation of the policy-to-old-policy importance coefficient are unchanged.

Fixes #3015

## Tests

- `python -m pytest tests/test_grpo_trainer.py -k kl_log_ratio_clip -q`
- `python -m pytest "tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_with_bias_correction_kl[False]" -q`
- `python -m pytest tests/experimental/test_gmpo_trainer.py::TestGMPOTrainer::test_train_with_kl -q`
- Manual finite-loss and gradient smoke checks for the native GSPO-token and GMPO override paths
- Ruff formatting and lint checks for all modified files

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. Reported in #3015.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GRPO training loss numerics and default KL behavior (clip at 20) on critical RL paths; scope is limited to native PyTorch KL, not Liger or policy IS.
> 
> **Overview**
> Fixes **non-finite GRPO losses** when the native K3 KL term evaluates `exp(ref_logp - model_logp)` on extreme log-probability gaps.
> 
> Training adds **`GRPOConfig.kl_log_ratio_clip`** (default `20.0`, `None` to turn off). Native PyTorch KL paths in **GRPO**, **GMPO**, and **GSPO-token** now compute the ref-to-model log-ratio in **FP32**, **cap** it at that limit, then apply the K3 estimator. Ratios above the cap still affect the KL **value** at the cap but **stop gradients** through the KL term; the policy loss is unchanged.
> 
> With **`use_bias_correction_kl`**, the importance-sampling coefficient is **detached** for clipped tokens, and for **sequence-level** IS it is detached for the whole sequence if any active token is clipped. **Liger** fused KL and policy importance weights are untouched.
> 
> Regression tests cover dtypes, custom/disabled clip, bias correction, sequence vs token IS, and masks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518ed6cfec956ec2af9ec9d3696d7d85a5d37bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->