### PR TITLE
feat: add activation_offloading support to GRPOTrainer

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -361,6 +361,9 @@ class GRPOConfig(_BaseConfig):
             KL divergence estimate by multiplying it with the importance sampling ratio. This is described in the
             [DeepSeek-V3.2 paper](https://huggingface.co/papers/2512.02556).
 
+        activation_offloading (`bool`, *optional*, defaults to `False`):
+            Whether to offload the activations to the CPU.
+
         > Parameters that control the logging
 
         log_completions (`bool`, *optional*, defaults to `False`):
@@ -966,6 +969,10 @@ class GRPOConfig(_BaseConfig):
             "corrects the KL divergence estimate by multiplying it with the importance sampling ratio. "
             "This is described in the [DeepSeek-V3.2 paper](https://huggingface.co/papers/2512.02556)."
         },
+    )
+    activation_offloading: bool = field(
+        default=False,
+        metadata={"help": "Whether to offload the activations to the CPU."},
     )
 
     # Parameters that control the logging

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -26,6 +26,7 @@ import time
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Callable
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -70,7 +71,7 @@ from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
 from ..import_utils import is_jmespath_available, is_liger_kernel_available
-from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
+from ..models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import _ForwardRedirection, disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer
 from .callbacks import SyncRefModelCallback
@@ -1048,6 +1049,10 @@ class GRPOTrainer(_BaseTrainer):
             )
 
         # Initialize the metrics
+        if self.args.activation_offloading:
+            self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
+        else:
+            self.maybe_activation_offload_context = nullcontext()
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
         self._current_train_step_time = 0.0
@@ -1546,7 +1551,8 @@ class GRPOTrainer(_BaseTrainer):
 
     def training_step(self, model, inputs, num_items_in_batch):
         time_before = time.perf_counter()
-        output = super().training_step(model, inputs, num_items_in_batch)
+        with self.maybe_activation_offload_context:
+            output = super().training_step(model, inputs, num_items_in_batch)
         self._step += 1
         time_after = time.perf_counter()
         self._current_train_step_time += time_after - time_before


### PR DESCRIPTION
## What does this PR do?

Ports the activation offloading feature from `DPOTrainer` to `GRPOTrainer`, as requested in #3717.

When `activation_offloading=True`, activations are offloaded to CPU during each `training_step`, reducing peak GPU memory usage during RLHF training — useful when training large models with long completions.

## Changes

- `trl/trainer/grpo_config.py` — adds `activation_offloading: bool = field(default=False, ...)` and its docstring entry
- `trl/trainer/grpo_trainer.py` — imports `get_act_offloading_ctx_manager` from `..models`, sets up `self.maybe_activation_offload_context` in `__init__`, and wraps `super().training_step()` with the context manager

## Usage

```python
from trl import GRPOConfig, GRPOTrainer

training_args = GRPOConfig(
    activation_offloading=True,
    ...
)
```

## Notes

- Mirrors the implementation in `DPOTrainer` exactly — same `get_act_offloading_ctx_manager` utility, same pattern
- When `activation_offloading=False` (default), falls back to `nullcontext()` — zero overhead on the default path
- Compatible with all existing GRPO loss types and vLLM/non-vLLM generation modes

Fixes #3717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in training memory optimization that reuses an established utility; default behavior is unchanged.
> 
> **Overview**
> Adds optional **activation offloading** to GRPO training so activations can be moved to CPU during the policy update step, lowering peak GPU memory when training with long completions.
> 
> `GRPOConfig` gains `activation_offloading` (default `False`) with matching docs. `GRPOTrainer` wires the existing `get_act_offloading_ctx_manager` into `__init__` and wraps `super().training_step()` in that context when enabled; otherwise it uses `nullcontext()` so the default path is unchanged.
> 
> This follows the same pattern already used in `DPOTrainer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7728462aac88e553325ecc26c81683b2aff6b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->