### PR TITLE
Suppress deprecated torch.get_autocast_gpu_dtype() warning from mamba-ssm kernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,4 +223,10 @@ filterwarnings = [
     # Tracking issue: https://github.com/huggingface/trl/issues/6466
     # Upstream issue: https://github.com/triton-lang/triton/issues/10981
     "ignore:AnnAssign.__init__ missing 1 required positional argument:DeprecationWarning",
+
+    # kernels-community/mamba-ssm (a Hub-hosted build of state-spaces/mamba) calls the deprecated
+    # torch.get_autocast_gpu_dtype() in its Triton ssd_combined.py kernel (upstream, not actionable in TRL)
+    # Triggered by the NemotronH (Nemotron 3) Mamba2 mixer fast path during training under CUDA autocast
+    # Tracking issue: https://github.com/huggingface/trl/issues/6555
+    "ignore:torch.get_autocast_gpu_dtype\\(\\) is deprecated:DeprecationWarning",
 ]


### PR DESCRIPTION
This PR adds a `filterwarnings` entry in `pyproject.toml` to suppress a `DeprecationWarning` raised by the Hub-hosted `kernels-community/mamba-ssm` kernel.

### Motivation

`tests_dev` (the CI job installing `accelerate`/`transformers`/`datasets`/`peft` from git main) emits repeated `DeprecationWarning`s from the NemotronH (Nemotron 3) parametrized test cases in `test_dpo_trainer.py` and `test_sft_trainer.py`. The warning comes from `kernels-community/mamba-ssm`'s Triton `ssd_combined.py` kernel, which still calls the deprecated `torch.get_autocast_gpu_dtype()` instead of `torch.get_autocast_dtype('cuda')`. This is triggered by the NemotronH Mamba2 mixer fast path during training under CUDA autocast. It is upstream kernel code fetched from the Hub, not actionable in TRL.

See #6555 for full root-cause details and follow-up action items (reporting upstream, bisecting the dependency that changed autocast behavior, and removing this filter once a release with the fix is available).

### Changes

- Add an `ignore` entry for `torch.get_autocast_gpu_dtype() is deprecated` to the `filterwarnings` list in `pyproject.toml`, following the same documented pattern used for other upstream, non-actionable warnings in that section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest configuration with no runtime or training logic changes.
> 
> **Overview**
> Adds a pytest **`filterwarnings`** ignore in **`pyproject.toml`** for **`DeprecationWarning`** messages about **`torch.get_autocast_gpu_dtype()`**, with comments pointing to upstream **`kernels-community/mamba-ssm`** and tracking issue **#6555**.
> 
> This quiets noisy CI output from NemotronH (Nemotron 3) DPO/SFT tests when the Hub Mamba2 kernel runs under CUDA autocast; TRL behavior is unchanged and the filter is meant to be removed after an upstream fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e7a6eab3947c6f593fea358cd0ea3860a10b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->