### PR TITLE
Fix opencode example uv package name to openenv-opencode-env

### DIFF
--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -17,7 +17,7 @@
 #     "trl",
 #     "trackio",
 #     "datasets",
-#     "openenv-opencode @ git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/opencode_env",
+#     "openenv-opencode-env @ git+https://github.com/meta-pytorch/OpenEnv.git#subdirectory=envs/opencode_env",
 # ]
 # ///
 


### PR DESCRIPTION
The opencode example's uv-script header pins `openenv-opencode`, but the package's real name is `openenv-opencode-env`, so `uv run examples/scripts/openenv/opencode.py` fails at install with a name mismatch. One-line fix.

## AI writing disclosure

- [x] AI-assisted

cc @AmineDiro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only dependency metadata change with no runtime or training logic touched.
> 
> **Overview**
> The **opencode** example’s PEP 723 `uv` script header listed the wrong PyPI-style package name (`openenv-opencode`), so `uv run examples/scripts/openenv/opencode.py` failed when resolving dependencies. It now pins **`openenv-opencode-env`**, matching the OpenEnv `opencode_env` package name, with the same git URL and subdirectory unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769e1e432cd3e6e46e90df3cfe8b2f481e9435e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->