### PR TITLE
Revert xfail for NemotronH GRPO/RLOO tests now that transformers#47569 fixed the kernels bug

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -35,7 +35,7 @@ from transformers import (
     BitsAndBytesConfig,
 )
 from transformers.testing_utils import backend_empty_cache, torch_device
-from transformers.utils import is_kernels_available, is_peft_available
+from transformers.utils import is_peft_available
 
 from trl import GRPOConfig, GRPOTrainer
 from trl.import_utils import is_liger_kernel_available
@@ -300,20 +300,10 @@ class TestGRPOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
             pytest.param(
                 "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
-                marks=[
-                    pytest.mark.skipif(
-                        Version(transformers.__version__) < Version("5.7.0"),
-                        reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
-                    ),
-                    pytest.mark.xfail(
-                        Version(transformers.__version__).is_devrelease and is_kernels_available(),
-                        reason=(
-                            "transformers' NemotronHMamba2Mixer.cuda_kernels_forward breaks generation when Hub kernels "
-                            "are available (see #6541)."
-                        ),
-                        strict=True,
-                    ),
-                ],
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.7.0"),
+                    reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
+                ),
             ),
         ],
     )

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -25,7 +25,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
 )
-from transformers.utils import is_kernels_available, is_peft_available
+from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
 
@@ -62,20 +62,10 @@ class TestRLOOTrainer(TrlTestCase):
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
             pytest.param(
                 "trl-internal-testing/tiny-NemotronHForCausalLM-nano",
-                marks=[
-                    pytest.mark.skipif(
-                        Version(transformers.__version__) < Version("5.7.0"),
-                        reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
-                    ),
-                    pytest.mark.xfail(
-                        Version(transformers.__version__).is_devrelease and is_kernels_available(),
-                        reason=(
-                            "transformers' NemotronHMamba2Mixer.cuda_kernels_forward breaks generation when Hub kernels "
-                            "are available (see #6541)."
-                        ),
-                        strict=True,
-                    ),
-                ],
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.7.0"),
+                    reason="Nemotron 3 gradient checkpointing requires transformers>=5.7.0 (see transformers#45625)",
+                ),
             ),
         ],
     )


### PR DESCRIPTION
This PR reverts the temporary xfail marker added for NemotronH GRPO/RLOO tests, now that the underlying bug has been fixed upstream:
- huggingface/transformers#47569

Fix #6541.

### Motivation

NemotronHMamba2Mixer.cuda_kernels_forward was breaking generation when Hub kernels were available, so the NemotronH GRPO/RLOO tests were marked xfail as a temporary hotfix (#6542) to keep CI green. The bug has since been fixed upstream in transformers#47569.

### Solution

Revert the hotfix commit that added the xfail marker, restoring the tests to their normal (non-xfail) state.

### Changes

- Remove the xfail marker (and the now-unused is_kernels_available import) from the NemotronH parametrization in tests/test_grpo_trainer.py
- Remove the xfail marker (and the now-unused is_kernels_available import) from the NemotronH parametrization in tests/test_rloo_trainer.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only marker cleanup with no production code changes; CI may fail if the upstream fix is not present in the pinned transformers version.
> 
> **Overview**
> Removes the temporary **xfail** on `tiny-NemotronHForCausalLM-nano` in `test_grpo_trainer.py` and `test_rloo_trainer.py`, now that **transformers#47569** fixes the Hub-kernels generation bug that motivated the hotfix (#6542).
> 
> Each file drops the unused `is_kernels_available` import and leaves only the existing **skipif** for `transformers>=5.7.0` on that parametrized `test_train` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6bf29a177ac203d4f70ef14ac7a3652ed683de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->