### PR TITLE
Reject unsupported `f_divergence_type` / loss type combinations in DPO

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -586,6 +586,25 @@ class TestDPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.parametrize("loss_type", ["apo_zero", "apo_down", "aot", "aot_unpaired", "nca_pair", "sppo_hard"])
+    def test_init_fails_with_f_divergence_and_unsupported_loss(self, loss_type):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        # These losses are not built on the chosen-rejected reward difference, so a non-default value is rejected.
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type=loss_type,
+            f_divergence_type="js_divergence",
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="is only supported for the following loss types"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     def test_train_with_explicit_ref_model(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
 

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -990,6 +990,25 @@ class TestDPOTrainer(TrlTestCase):
             )
 
     @require_liger_kernel
+    def test_init_fails_with_f_divergence_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        # The Liger fused loss always uses the reverse-KL parameterization; it can't honor another f-divergence.
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            f_divergence_type="js_divergence",
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="incompatible with a non-default `f_divergence_type`"):
+            DPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+    @require_liger_kernel
     def test_init_fails_with_compute_metrics_and_liger(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
 

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -92,7 +92,10 @@ class DPOConfig(_BaseConfig):
             tokens beyond shared lengths.
         f_divergence_type (`str`, *optional*, defaults to `"reverse_kl"`):
             f-divergence regularizer between policy and reference (f-DPO paper). Possible values are: `reverse_kl`
-            (default), `forward_kl`, `js_divergence`, `alpha_divergence`.
+            (default), `forward_kl`, `js_divergence`, `alpha_divergence`. Only the loss types built on the
+            chosen-rejected reward difference support a non-default value: `'sigmoid'`, `'sigmoid_norm'`, `'hinge'`,
+            `'ipo'`, `'exo_pair'`, `'robust'`, `'discopop'`, `'sft'`. The other loss types have no valid f-divergence
+            generalization and are rejected with a non-default value.
         f_alpha_divergence_coef (`float`, *optional*, defaults to `0.5`):
             α coefficient for the α-divergence u^-α regularizer, used only when `f_divergence_type='alpha_divergence'`.
         label_smoothing (`float`, *optional*, defaults to `0.0`):
@@ -261,7 +264,10 @@ class DPOConfig(_BaseConfig):
         default="reverse_kl",
         metadata={
             "help": "f-divergence regularizer between policy and reference (f-DPO paper). Possible values are: "
-            "`reverse_kl` (default), `forward_kl`, `js_divergence`, `alpha_divergence`.",
+            "`reverse_kl` (default), `forward_kl`, `js_divergence`, `alpha_divergence`. Only the loss types built on "
+            "the chosen-rejected reward difference support a non-default value: `'sigmoid'`, `'sigmoid_norm'`, "
+            "`'hinge'`, `'ipo'`, `'exo_pair'`, `'robust'`, `'discopop'`, `'sft'`. The other loss types have no valid "
+            "f-divergence generalization and are rejected with a non-default value.",
         },
     )
     f_alpha_divergence_coef: float = field(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import json
+import math
 import os
 import textwrap
 from collections import defaultdict
@@ -1418,13 +1419,13 @@ class DPOTrainer(_BaseTrainer):
             chosen_scores = chosen_logratios
             rejected_scores = rejected_logratios
         elif self.f_divergence_type == "forward_kl":
-            # f'(t) = 1 - 1/t  -> drop constant -> -exp(-logratio)
-            chosen_scores = -torch.exp(-chosen_logratios)
-            rejected_scores = -torch.exp(-rejected_logratios)
+            # f'(t) = 1 - 1/t
+            chosen_scores = 1 - torch.exp(-chosen_logratios)
+            rejected_scores = 1 - torch.exp(-rejected_logratios)
         elif self.f_divergence_type == "js_divergence":
-            # f'(t) = log(2t/(t+1)) -> drop log 2
-            chosen_scores = F.logsigmoid(chosen_logratios)
-            rejected_scores = F.logsigmoid(rejected_logratios)
+            # f'(t) = log(2t/(t+1)) = log 2 + logsigmoid(log t)
+            chosen_scores = math.log(2) + F.logsigmoid(chosen_logratios)
+            rejected_scores = math.log(2) + F.logsigmoid(rejected_logratios)
         elif self.f_divergence_type == "alpha_divergence":
             # alpha-divergence: f'(t) = (t^(α-1) - 1)/(α-1)
             if abs(self.f_alpha_divergence_coef - 1.0) < 1e-6:  # limit case f'(t) -> log(t), fall back to reverse_kl
@@ -1439,8 +1440,8 @@ class DPOTrainer(_BaseTrainer):
                 clamp_max = {torch.float16: 11.0, torch.bfloat16: 80.0, torch.float32: 80.0}[dtype]
                 t_chosen_float = torch.clamp(t_chosen.float(), max=clamp_max)
                 t_rejected_float = torch.clamp(t_rejected.float(), max=clamp_max)
-                chosen_scores = torch.exp(t_chosen_float).to(dtype) * coef
-                rejected_scores = torch.exp(t_rejected_float).to(dtype) * coef
+                chosen_scores = (torch.exp(t_chosen_float) - 1.0).to(dtype) * coef
+                rejected_scores = (torch.exp(t_rejected_float) - 1.0).to(dtype) * coef
         else:
             raise ValueError(f"Unknown f_divergence_type: {self.f_divergence_type}")
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -768,6 +768,15 @@ class DPOTrainer(_BaseTrainer):
         self.ld_alpha = args.ld_alpha
         self.f_divergence_type = args.f_divergence_type
         self.f_alpha_divergence_coef = args.f_alpha_divergence_coef
+        # The f-DPO reparameterization leaves a β·log Z(x) term that only cancels in the chosen-rejected reward
+        # difference, so the other losses have no valid f-divergence generalization.
+        f_divergence_loss_types = {"sigmoid", "sigmoid_norm", "hinge", "ipo", "exo_pair", "robust", "discopop", "sft"}
+        if self.f_divergence_type != "reverse_kl" and not set(self.loss_types) <= f_divergence_loss_types:
+            raise ValueError(
+                f"`f_divergence_type='{self.f_divergence_type}'` is only supported for the following loss types: "
+                f"{sorted(f_divergence_loss_types)}. You provided {self.loss_types}. Use the default "
+                "`f_divergence_type='reverse_kl'` with these losses."
+            )
         self.label_smoothing = args.label_smoothing
         self.use_weighting = args.use_weighting
         if self.use_weighting and any(loss_type in {"aot", "aot_unpaired"} for loss_type in self.loss_types):
@@ -1472,8 +1481,8 @@ class DPOTrainer(_BaseTrainer):
                 per_sequence_loss = qw * (log_qw - log_pw) + ql * (log_ql - log_pl)
 
             elif loss_type == "nca_pair":
-                chosen_rewards = self.beta * chosen_scores
-                rejected_rewards = self.beta * rejected_scores
+                chosen_rewards = self.beta * chosen_logratios
+                rejected_rewards = self.beta * rejected_logratios
                 per_sequence_loss = (
                     -F.logsigmoid(chosen_rewards)
                     - 0.5 * F.logsigmoid(-chosen_rewards)
@@ -1486,8 +1495,8 @@ class DPOTrainer(_BaseTrainer):
                 per_sequence_loss = (clean_loss_term - flipped_loss_term) / (1 - 2 * self.label_smoothing)
 
             elif loss_type == "bco_pair":
-                chosen_rewards = self.beta * chosen_scores
-                rejected_rewards = self.beta * rejected_scores
+                chosen_rewards = self.beta * chosen_logratios
+                rejected_rewards = self.beta * rejected_logratios
                 per_sequence_loss = -F.logsigmoid(chosen_rewards) - F.logsigmoid(-rejected_rewards)
 
             elif loss_type == "sppo_hard":
@@ -1495,8 +1504,8 @@ class DPOTrainer(_BaseTrainer):
                 # estimated using the PairRM score. The probability calculation is conducted outside of the trainer
                 # class. The version described here is the hard probability version, where P in Equation (4.7) of
                 # Algorithm 1 is set to 1 for the winner and 0 for the loser.
-                winner_margin_error = (chosen_scores - 0.5 / self.beta) ** 2
-                loser_margin_error = (rejected_scores + 0.5 / self.beta) ** 2
+                winner_margin_error = (chosen_logratios - 0.5 / self.beta) ** 2
+                loser_margin_error = (rejected_logratios + 0.5 / self.beta) ** 2
                 per_sequence_loss = winner_margin_error + loser_margin_error
 
             elif loss_type == "aot":
@@ -1532,7 +1541,7 @@ class DPOTrainer(_BaseTrainer):
                 # Use this loss when you believe the chosen outputs are worse than your model's default output.
                 # Decrease chosen likelihood and decrease rejected likelihood more
                 losses_chosen = torch.sigmoid(self.beta * chosen_logratios)
-                losses_rejected = 1 - torch.sigmoid(self.beta * delta_score)
+                losses_rejected = 1 - torch.sigmoid(self.beta * (chosen_logratios - rejected_logratios))
                 per_sequence_loss = losses_chosen + losses_rejected
 
             elif loss_type == "discopop":

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -809,6 +809,12 @@ class DPOTrainer(_BaseTrainer):
                     "Multiple loss types are not yet supported when using Liger kernel. If you need this feature, "
                     "please open a feature request at https://github.com/huggingface/trl/issues."
                 )
+            if self.f_divergence_type != "reverse_kl":
+                raise ValueError(
+                    "`use_liger_kernel=True` is incompatible with a non-default `f_divergence_type`. The Liger fused "
+                    "DPO loss always uses the standard reverse-KL parameterization, so the requested divergence would "
+                    "be silently ignored. Either set `f_divergence_type='reverse_kl'`, or set `use_liger_kernel=False`."
+                )
             if compute_metrics is not None:
                 raise ValueError(
                     "compute_metrics is not supported with the Liger kernel. compute_metrics requires to be able to "


### PR DESCRIPTION
Fixes #6441. Closes #6475, which patched `apo_down` alone.

The f-DPO reparameterization leaves a `β·log Z(x)` term that only cancels in the chosen-rejected reward difference, so `f_divergence_type` is only meaningful for difference-based losses. Today the others either silently ignore it or, worse, are half-wired to it.

- Raise at init when `f_divergence_type != "reverse_kl"` and any loss type is outside `{sigmoid, sigmoid_norm, hinge, ipo, exo_pair, robust, discopop, sft}`.
- Use raw log-ratios in `nca_pair`, `bco_pair`, `sppo_hard` and `apo_down`, so the loss chain reads the same boundary as the validator.

## History

Before #3906, `f_divergence_type` reached only the pairwise `logits`; losses that recomputed their own quantities never saw it. That refactor introduced `chosen_scores` / `rejected_scores` / `delta_score` and widened the reach; deliberately for some losses, accidentally for others.

| loss | before #3906 | after #3906 | this PR |
|---|---|---|---|
| `sigmoid`, `hinge`, `ipo`, `exo_pair`, `robust` | f-div | f-div | unchanged |
| `discopop` | raw (recomputed `logits` locally) | f-div | unchanged, keeps f-div |
| `sigmoid_norm` | did not exist | f-div | unchanged |
| `nca_pair`, `bco_pair`, `sppo_hard` | raw | f-div | back to raw |
| `apo_down` | raw | **mixed: raw chosen, f-div rejected** | back to raw |
| `apo_zero`, `aot`, `aot_unpaired` | raw | raw | unchanged |
| `sft` | n/a | n/a | unchanged |

All edits are identity under the default `reverse_kl`! Breaking only for `nca_pair` / `bco_pair` / `sppo_hard` / `apo_*` / `aot*` with a non-default divergence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DPO loss computation and can alter training when using non-default f_divergence with nca_pair, bco_pair, sppo_hard, or apo_* losses; default reverse_kl paths are unchanged.
> 
> **Overview**
> Tightens **f-DPO** (`f_divergence_type`) support in `DPOTrainer` so unsupported combinations fail at init instead of being ignored or half-applied.
> 
> **Validation:** Non-default `f_divergence_type` is allowed only with difference-based losses (`sigmoid`, `sigmoid_norm`, `hinge`, `ipo`, `exo_pair`, `robust`, `discopop`, `sft`). Other losses (`apo_*`, `aot*`, `nca_pair`, `sppo_hard`, etc.) must use `reverse_kl`. **`use_liger_kernel=True`** with a non-default divergence now raises, since Liger only implements reverse-KL.
> 
> **Loss math:** `forward_kl`, `js_divergence`, and `alpha_divergence` scoring no longer drop terms that belong in the f′ transform. **`nca_pair`**, **`bco_pair`**, **`sppo_hard`**, and **`apo_down`** again use raw log-ratios (fixing accidental f-div wiring and the **`apo_down`** bug where the rejected term used f-div scores). Default `reverse_kl` behavior is unchanged for standard DPO setups.
> 
> **Docs/tests:** `DPOConfig` help text documents the loss whitelist; new tests cover init failures for bad loss/divergence pairs and Liger + non-default divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426d0bea36dfdfafc9847b2a3d0ec7cf16e95f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->