### PR TITLE
Use `dtype` instead of `torch_dtype` (deprecated)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1400,7 +1400,7 @@ class TestPatchChunkedLMHead:
     @pytest.mark.parametrize("model_id", _CHUNKED_LM_HEAD_MODEL_IDS)
     @pytest.mark.parametrize("temperature", [1.0, 0.7])
     def test_forward(self, model_id, temperature):
-        model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(torch_device)
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16).to(torch_device)
         model.eval()
 
         B, S, chunk_size = 2, 8, 32


### PR DESCRIPTION
See title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only API rename with no production or behavioral change.
> 
> **Overview**
> Updates **`TestPatchChunkedLMHead.test_forward`** so `AutoModelForCausalLM.from_pretrained` passes **`dtype=torch.bfloat16`** instead of the deprecated **`torch_dtype`** argument, matching current Hugging Face Transformers APIs and avoiding deprecation warnings in the chunked LM-head forward tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcebb9a2dbe9235c451030f09cd628d006706329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->