### PR TITLE
Add support for vLLM 0.26.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.17.0` to `0.25.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.17.0` to `0.26.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.17.0,<=0.25.1",
+    "vllm>=0.17.0,<=0.26.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -116,9 +116,9 @@ def is_vllm_available(min_version: str | None = None) -> bool:
         # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
         # above the plain release and would otherwise fail the upper-bound check.
         _vllm_base_version = Version(Version(_vllm_version).base_version)
-        if not (Version("0.17.0") <= _vllm_base_version <= Version("0.25.1")):
+        if not (Version("0.17.0") <= _vllm_base_version <= Version("0.26.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.17.0 to 0.25.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.17.0 to 0.26.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
# What does this PR do?

Adds support for vLLM 0.26.0 by:

- extending the optional dependency upper bound to `0.26.0`;
- updating the supported-version check and warning in `is_vllm_available`;
- updating the vLLM integration documentation.

I reviewed the vLLM 0.26.0 release notes and the vLLM interfaces used by TRL (`sleep`, `collective_rpc`, `load_weights`, `update_named_param`, `reload_weights`, and `external_launcher`). No additional TRL code changes appeared necessary for this version bump. `update_named_param` remains a TRL worker extension invoked through `collective_rpc`.

Fixes #6561

## Validation

Local validation:

- `python -m compileall -q trl/import_utils.py`
- parsed `pyproject.toml` with Python's `tomllib` and verified the vLLM requirement
- `git diff --check`

Linux/CUDA validation was also attempted on Ubuntu 22.04 with 2 x RTX 4090 GPUs using Python 3.10.8, PyTorch 2.11.0+cu130, vLLM 0.26.0, FlashInfer 0.6.14, Triton 3.6.0, and Transformers 5.13.0.

- `pytest --collect-only -q tests/test_vllm_client_server.py`: 51 tests collected successfully.
- `pytest -q tests/test_vllm_client_server.py`: 3 failed, 9 passed, 18 skipped, 1 xfailed, and 21 errors. The errors occurred because the vLLM server never became healthy.
- After pre-downloading `Qwen/Qwen2.5-1.5B`, manual server startup was blocked before the health endpoint became available by `AttributeError: 'NoneType' object has no attribute 'start'` in `triton/runtime/jit.py` while vLLM imported the new MiniMax-M3 Triton kernels on Python 3.10. The first occurrence was in `index_topk.py`; a temporary diagnostic bypass exposed the same failure in `sparse_attn.py`.

The Python 3.10 GPU suite is therefore **not reported as passing**. The temporary diagnostic change was limited to the installed vLLM package and is not part of this PR. The observed startup failure appears to be upstream of the three TRL version-bound/documentation changes in this PR; the subsequent Python 3.11 follow-up is reported below.

The upstream startup failure is tracked in [vllm-project/vllm#49920](https://github.com/vllm-project/vllm/issues/49920).

### Python 3.11 follow-up

A follow-up run used the same Ubuntu 22.04 / 2 x RTX 4090 host with Python 3.11.15, PyTorch 2.11.0+cu130, vLLM 0.26.0, Triton 3.6.0, and Transformers 5.14.1.

- Without modifying the installed vLLM package, a manual `Qwen/Qwen2.5-1.5B` server reached the health endpoint successfully.
- The focused suite initially reported 30 passed, 18 skipped, 1 xfailed, and 2 errors. The two errors were limited to the VLM tests because the first cold start of `Qwen/Qwen2.5-VL-3B-Instruct` exceeded the fixed 240-second connection timeout.
- After prewarming the VLM server (which reached readiness in about 160 seconds), a targeted rerun of both VLM tests passed: `2 passed in 216.31s`.
- The Python 3.10 `AttributeError: 'NoneType' object has no attribute 'start'` did not recur.

The initial full-suite invocation is not reported as a clean pass because of the two cold-start timeout errors; the targeted rerun verifies those two test cases after model/cache warmup.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6561.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? No new tests were added for this version-bound update; the existing focused test was exercised as described above.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in this PR.
