### PR TITLE
Fix patch release instructions: Pull release branch instead of main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -120,8 +120,9 @@ This ensures that future patch releases (`v{major}.{minor}.1`, `v{major}.{minor}
 ### 1. Ensure your local repository is up to date with the upstream repository
 
 ```bash
+git fetch origin
 git checkout v{major}.{minor}-release
-git pull origin main
+git pull origin v{major}.{minor}-release
 ```
 
 ### 2. Cherry-pick the changes you want to include in the patch release


### PR DESCRIPTION
This PR fixes the update step of the patch release instructions in `RELEASE.md`.

### Motivation

The patch release instructions told the maintainer to run `git pull origin main` while on the `v{major}.{minor}-release` branch. That merges every unreleased commit from `main` into the release branch, which defeats the purpose of the cherry-pick step that follows and would ship untested changes in a patch release.

### Solution

The release branch is now updated from its own remote branch, and `main` is only fetched so that the commits to cherry-pick are available locally.

### Changes

- Pull the release branch instead of `main` when updating the local repository for a patch release
- Fetch the remote beforehand, so the commits to cherry-pick are available without merging them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to maintainer git workflow; no runtime or release automation code is modified.
> 
> **Overview**
> **Patch release setup** in `RELEASE.md` no longer tells maintainers to run `git pull origin main` while checked out on `v{major}.{minor}-release`.
> 
> The step now runs `git fetch origin`, checks out the release branch, and **pulls that branch** (`git pull origin v{major}.{minor}-release`) so the local release line matches the remote without merging all of `main`. Fetching still makes cherry-pick targets from `main` available locally without folding unreleased `main` commits into the patch branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad9f057560a5e0422c481854676f2f97ecab5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->