### PR TITLE
Fix inaccuracies in the release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,6 +91,8 @@ This ensures that future patch releases (`v{major}.{minor}.1`, `v{major}.{minor}
 1. Create a branch `bump-dev-version-{major}.{minor+1}` from `main` and checkout to it.
 
   ```shell
+  git checkout main
+  git pull origin main
   git checkout -b bump-dev-version-{major}.{minor+1}
   ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -158,7 +158,7 @@ git tag -a v{major}.{minor}.{patch} -m 'Adds tag v{major}.{minor}.{patch} for Py
 git push origin v{major}.{minor}.{patch}
 ```
 
-#### 7. Create a GitHub Release
+### 7. Create a GitHub Release
 
 1. Go to the repo’s [releases section](https://github.com/huggingface/trl/releases) on GitHub.
 2. Click **Draft a new release**.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ git checkout -b release-v{major}.{minor}
 ### 3. Change the version in the following files
 
 - `.github/workflows/tests_latest.yml`:
-  
+
   ```diff
   - with: { ref: v{major}.{minor-1}-release }
   + with: { ref: v{major}.{minor}-release }
@@ -90,26 +90,26 @@ This ensures that future patch releases (`v{major}.{minor}.1`, `v{major}.{minor}
 
 1. Create a branch `bump-dev-version-{major}.{minor+1}` from `main` and checkout to it.
 
-  ```shell
-  git checkout main
-  git pull origin main
-  git checkout -b bump-dev-version-{major}.{minor+1}
-  ```
+   ```shell
+   git checkout main
+   git pull origin main
+   git checkout -b bump-dev-version-{major}.{minor+1}
+   ```
 
 2. Change the version in file `VERSION`:
 
-  ```diff
-  - {major}.{minor}.0
-  + {major}.{minor+1}.0.dev0
-  ```
+   ```diff
+   - {major}.{minor}.0
+   + {major}.{minor+1}.0.dev0
+   ```
 
 3. Commit and push these changes
 
-  ```shell
-  git add VERSION
-  git commit -m '⬆️ Bump dev version'
-  git push origin bump-dev-version-{major}.{minor+1}
-  ```
+   ```shell
+   git add VERSION
+   git commit -m '⬆️ Bump dev version'
+   git push origin bump-dev-version-{major}.{minor+1}
+   ```
 
 4. Create a pull request from `bump-dev-version-{major}.{minor+1}` to `main`, named `⬆️ Bump dev version`, and request urgent review.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -162,6 +162,6 @@ git push origin v{major}.{minor}.{patch}
 
 1. Go to the repo’s [releases section](https://github.com/huggingface/trl/releases) on GitHub.
 2. Click **Draft a new release**.
-3. Select the `v{major}.{minor}.{patch}` tag you just created in step 7.
+3. Select the `v{major}.{minor}.{patch}` tag you just created in step 6.
 4. Add a title (`v{major}.{minor}.{patch}`) and a short description of what’s new.
 5. Click **Publish Release**.


### PR DESCRIPTION
This PR fixes several inaccuracies in RELEASE.md.

### Motivation

While following the release instructions, a few steps turned out to be wrong or misleading: the dev version bump branch was created from whatever branch the previous step left checked out, and the patch release section pointed to the wrong step number for the tag it tells you to select.

### Changes

- Create the dev version bump branch from an up-to-date main, instead of from the branch left over from the previous step
- Point the GitHub Release step of a patch release at the step that actually creates the tag
- Fix the heading level of the last step of the patch release section, which was nested one level too deep
- Fix the indentation of the code blocks in the dev version bump step, so they stay part of their numbered list items, and drop a trailing whitespace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to release runbooks with no runtime or dependency impact.
> 
> **Overview**
> Updates **RELEASE.md** so maintainers can follow the release flow without wrong branches or step references.
> 
> For **§10 Bump to dev version**, the bump branch instructions now explicitly **checkout `main`, pull, then create** `bump-dev-version-{major}.{minor+1}` instead of implying you branch from whatever was checked out after the prior steps. Nested list **code blocks are re-indented** so they stay under the right numbered items, and a stray blank line after the `tests_latest.yml` bullet is removed.
> 
> For **patch releases**, the final GitHub Release step is promoted from `####` to **`### 7`**, and the tag selection bullet now references **step 6** (where the tag is created) instead of step 7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4df118151e80d910ce4e70eb3e2511410f128e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->