### PR TITLE
Fix negative truncation bound in experimental BCO `_process_tokens`

### DIFF
--- a/tests/experimental/test_bco_trainer.py
+++ b/tests/experimental/test_bco_trainer.py
@@ -315,6 +315,67 @@ class TestBCOTrainer(TrlTestCase):
         assert processed_dataset["completion_attention_mask"][0] == [1, 1, 1, 1, 1, 1, 1]
         assert processed_dataset["completion_labels"][0] == [-100, -100, -100, -100, 27261, 13, 151645]
 
+    @pytest.mark.parametrize(
+        ("prompt_length", "answer_length"),
+        [
+            (4, 6),  # everything fits, nothing is truncated
+            (28, 10),  # answer truncated, budget still positive
+            (31, 1),  # prompt one token short of max_length: bound goes negative by one
+            (60, 10),  # prompt alone exceeds max_length
+            (1000, 10),  # prompt exceeds max_length by a lot
+        ],
+    )
+    def test_process_tokens_truncation_respects_max_length(self, prompt_length, answer_length):
+        """`_process_tokens` must keep the sequence within `max_length` and only ever truncate prefixes.
+
+        The response budget is `max_length` minus the prompt, so a prompt longer than `max_length` used to make
+        that bound negative. `answer[:negative]` slices from the *end* of the answer, which empties it outright
+        whenever the answer is shorter than the overflow, and the resulting sequence stayed over `max_length`
+        because the prompt was never truncated.
+        """
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        max_length = 32
+        # Synthetic ids: the branch under test only looks at lengths and at the BOS/EOS ids.
+        prompt_input_ids = list(range(100, 100 + prompt_length))
+        answer_input_ids = list(range(200, 200 + answer_length))
+        example = {
+            "prompt": "prompt",
+            "completion": "completion",
+            "label": True,
+            "prompt_input_ids": prompt_input_ids,
+            "prompt_attention_mask": [1] * prompt_length,
+            "answer_input_ids": answer_input_ids,
+            "answer_attention_mask": [1] * answer_length,
+        }
+
+        processed = _process_tokens(
+            example,
+            prefix="",
+            is_encoder_decoder=False,
+            tokenizer=tokenizer,
+            max_length=max_length,
+        )
+
+        completion_input_ids = processed["completion_input_ids"]
+        assert len(completion_input_ids) <= max_length
+        assert len(processed["completion_attention_mask"]) == len(completion_input_ids)
+        assert len(processed["completion_labels"]) == len(completion_input_ids)
+
+        # Both halves must stay prefixes of what went in. A negative slice bound cuts from the end instead.
+        kept_prompt = processed["prompt_input_ids"]
+        if tokenizer.bos_token_id is not None and kept_prompt and kept_prompt[0] == tokenizer.bos_token_id:
+            kept_prompt = kept_prompt[1:]
+        assert kept_prompt == prompt_input_ids[: len(kept_prompt)]
+
+        kept_answer = completion_input_ids[len(processed["prompt_input_ids"]) :]
+        if kept_answer and kept_answer[-1] == tokenizer.eos_token_id:
+            kept_answer = kept_answer[:-1]
+        assert kept_answer == answer_input_ids[: len(kept_answer)]
+
+        # The completion must survive as long as the prompt leaves room for it.
+        if prompt_length + answer_length <= max_length - 2:
+            assert kept_answer == answer_input_ids
+
     @require_sklearn
     def test_train_without_providing_ref_model(self):
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -293,10 +293,18 @@ def _process_tokens(example: dict[str, Any], model: "PreTrainedModel" = None, **
         if eos_token_id != all_tokens["answer_input_ids"][-1]:
             max_length -= 1
 
-        # if combined sequence is too long (> max_length - 1 for BOS token - 1 for EOS), truncate the response
+        # if combined sequence is too long (> max_length - 1 for BOS token - 1 for EOS), truncate it. The prompt
+        # is truncated first, then the response gets whatever budget is left. Truncating only the response with
+        # `max_length - len(prompt_input_ids)` breaks down once the prompt alone exceeds `max_length`: the bound
+        # goes negative, `answer[:negative]` slices from the *end* of the response and empties it entirely
+        # whenever the response is shorter than the overflow, and the sequence stays over `max_length` anyway.
+        # This matches `KTOTrainer`, which truncates the concatenated sequence with `full_ids[:max_length]`.
         if len(all_tokens["prompt_input_ids"]) + len(all_tokens["answer_input_ids"]) > max_length:
+            for k in ["prompt_input_ids", "prompt_attention_mask"]:
+                all_tokens[k] = all_tokens[k][:max_length]
+            answer_budget = max_length - len(all_tokens["prompt_input_ids"])
             for k in ["answer_input_ids", "answer_attention_mask"]:
-                all_tokens[k] = all_tokens[k][: max_length - len(all_tokens["prompt_input_ids"])]
+                all_tokens[k] = all_tokens[k][:answer_budget]
 
         # all input_ids and attention mask as is. We then check if we need to add BOS/EOS tokens
         batch[f"{kwargs['prefix']}prompt_input_ids"] = all_tokens["prompt_input_ids"]


### PR DESCRIPTION
## What this fixes

`_process_tokens` gives the response a budget of `max_length - len(prompt_input_ids)`:

https://github.com/huggingface/trl/blob/8d19a361e928cc35674f7e94bb5a66e490dcafe9/trl/experimental/bco/bco_trainer.py#L296-L299

Nothing caps the prompt in `BCOTrainer`, so that bound goes negative as soon as the prompt is longer than the (BOS/EOS adjusted) `max_length`. `answer[:negative]` slices from the *end* of the response rather than the start, so it empties the response entirely whenever the response is shorter than the overflow, and the sequence stays over `max_length` anyway because the prompt is never shortened.

Calling `_process_tokens` directly with the tiny test tokenizer:

```
 prompt  answer  max_len |  seq_len  <=max?  answer_tokens
     10      10       32 |       22    True             11
     28      10       32 |       32    True              3
     60      10       32 |       62   False              1
     60      40       32 |       72   False             11
   1000      10       32 |     1002   False              1
```

`answer_tokens: 1` is the appended EOS and nothing else. Those rows carry no completion tokens at all, so they contribute no learning signal, and the 1000-token one still costs a full forward pass at 1000+ tokens under a `max_length` of 32.

## Where it came from

#4964 removed `max_prompt_length` from BCO. Before that PR the branch was two steps:

```python
# if combined sequence is too long (> max_length - 1 for BOS token - 1 for EOS), truncate the prompt
if len(all_tokens["prompt_input_ids"]) + len(all_tokens["answer_input_ids"]) > max_length:
    for k in ["prompt_input_ids", "prompt_attention_mask"]:
        ...
        all_tokens[k] = all_tokens[k][: kwargs["max_prompt_length"]]

# if that's still too long, truncate the response
if len(all_tokens["prompt_input_ids"]) + len(all_tokens["answer_input_ids"]) > max_length:
    for k in ["answer_input_ids", "answer_attention_mask"]:
        all_tokens[k] = all_tokens[k][: max_length - kwargs["max_prompt_length"]]
```

The response bound got the better `- len(prompt_input_ids)` form, but the step that kept the prompt bounded went away with `max_prompt_length` and nothing replaced it. The PR description says "only the response is truncated if the total sequence exceeds `max_length`", which can't hold when the prompt on its own is already past `max_length`.

## The change

Restore the two-step order, with `max_length` as the prompt cap instead of the removed `max_prompt_length`:

```python
if len(all_tokens["prompt_input_ids"]) + len(all_tokens["answer_input_ids"]) > max_length:
    for k in ["prompt_input_ids", "prompt_attention_mask"]:
        all_tokens[k] = all_tokens[k][:max_length]
    answer_budget = max_length - len(all_tokens["prompt_input_ids"])
    for k in ["answer_input_ids", "answer_attention_mask"]:
        all_tokens[k] = all_tokens[k][:answer_budget]
```

`answer_budget` can no longer be negative, and the sequence honours `max_length` in every case. This is the same policy `KTOTrainer` applies when it truncates the concatenated sequence with `full_ids[: self.max_length]` ([`kto_trainer.py#L179-L181`](https://github.com/huggingface/trl/blob/8d19a361e928cc35674f7e94bb5a66e490dcafe9/trl/trainer/kto_trainer.py#L179-L181)).

Same table after the change:

```
 prompt  answer  max_len |  seq_len  <=max?  answer_tokens
     10      10       32 |       22    True             11
     28      10       32 |       32    True              3
     60      10       32 |       32    True              1
     60      40       32 |       32    True              1
   1000      10       32 |       32    True              1
```

Rows 3 to 5 still end up with no completion tokens, because there is no way to honour `max_length` and keep completion tokens when the prompt alone fills the budget. That matches KTO. What changes is that the sequence is now actually within budget and the response is never cut from the end.

## Question for maintainers

`DPOTrainer` goes one step further and drops the rows where truncation leaves nothing behind:

https://github.com/huggingface/trl/blob/8d19a361e928cc35674f7e94bb5a66e490dcafe9/trl/trainer/dpo_trainer.py#L1077-L1083

Adding the same `.filter()` to BCO would be a two-line change next to the existing desirable/undesirable filters, but it changes the row count and therefore the desirable-to-undesirable ratio BCO uses, so it felt like your call rather than mine. Happy to add it here or send it separately if you want it.

## Tests

`test_process_tokens_truncation_respects_max_length` in `tests/experimental/test_bco_trainer.py`, parametrized over five prompt/answer length combinations. It asserts that the sequence stays within `max_length`, that both halves remain prefixes of what went in (a negative bound keeps a suffix instead), and that the response survives intact when it fits.

Reverting only `bco_trainer.py` (`git stash push -- trl/experimental/bco/bco_trainer.py`) fails the `[60-10]` and `[1000-10]` cases:

```
FAILED tests/experimental/test_bco_trainer.py::TestBCOTrainer::test_process_tokens_truncation_respects_max_length[60-10]
FAILED tests/experimental/test_bco_trainer.py::TestBCOTrainer::test_process_tokens_truncation_respects_max_length[1000-10]
2 failed, 3 passed
```

The three that pass either way are guards against over-truncating the cases that already worked.

```
$ pytest tests/experimental/test_bco_trainer.py -k "tokenize_and_process_tokens or truncation_respects_max_length"
6 passed
```

## Related

CPO and ORPO have a different flavour of the same problem in `tokenize_row` (they size the bound off `longer_response_length` instead of the prompt), tracked in #6548. That one is being picked up separately, this PR does not touch either file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix in experimental BCO preprocessing with new regression tests; no auth or API surface changes.
> 
> **Overview**
> Fixes **experimental BCO** token processing when prompt + completion exceed `max_length`. After `max_prompt_length` was removed, only the answer was capped with `max_length - len(prompt)`, which goes **negative** if the prompt alone is longer than the budget. That made `answer[:negative]` keep a **suffix** (often wiping the completion) while the **prompt stayed untruncated**, so sequences could still exceed `max_length` and waste compute.
> 
> **`_process_tokens`** now caps the prompt at `max_length` first, then truncates the answer with `answer_budget = max_length - len(prompt)` (always ≥ 0), aligned with **`KTOTrainer`**’s prefix-style truncation.
> 
> Adds **`test_process_tokens_truncation_respects_max_length`** with five length cases: total length ≤ `max_length`, prefix-only truncation, and intact completions when they fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c9e866f7ad7f900906d3a8aa56c69a7e4e48cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->