### PR TITLE
Fix test: don't call `add_response_schema` when the model already ships a response template

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen3_moe_for_causal_lm_response_template.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen3_moe_for_causal_lm_response_template.py
@@ -1,0 +1,52 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unlike its siblings, this script does not build a model: it re-publishes an existing tiny model with a
+# `response_template` baked into `tokenizer_config.json`, as if the checkpoint shipped one natively.
+#
+# Most models on the Hub do not (yet) ship a response template, so `add_response_schema` has to supply one
+# from its table of known chat templates. This fixture covers the other case — a model that already carries
+# its own — which callers must detect and leave alone rather than trying to add a second one.
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
+
+from trl import add_response_schema
+
+from .._common import check_transformers_version, push_to_hub, smoke_test
+
+
+# The new-style `response_template` attribute (as opposed to the legacy `response_schema`) is only set, and
+# only serialized to `tokenizer_config.json`, from this release on.
+check_transformers_version("5.13.0")
+
+MODEL_ID = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+
+# Take the response template `add_response_schema` would have supplied, so the fixture parses exactly like
+# its source model.
+tokenizer = add_response_schema(tokenizer)
+
+# Then make the chat template unrecognizable to `add_response_schema`, which matches templates by exact
+# string equality. Without this the fixture would prove nothing: `add_response_schema` would still find a
+# match and quietly re-set the same template. The marker is a Jinja comment, so rendering is byte-for-byte unchanged.
+tokenizer.chat_template = "{# trl-internal-testing fixture: ships its own response template #}" + (
+    tokenizer.chat_template
+)
+
+smoke_test(model, tokenizer)
+push_to_hub(model, tokenizer, generation_config, "tiny", suffix="ResponseTemplate")

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -1072,13 +1072,17 @@ class TestParseResponse:
         if "ForCausalLM" in model_name:
             self.is_vlm = False
             processing_class = AutoTokenizer.from_pretrained(model_name)
-            response_schema = getattr(processing_class, "response_schema", None)
+            tokenizer = processing_class
         elif "ForConditionalGeneration" in model_name:
             self.is_vlm = True
             processing_class = AutoProcessor.from_pretrained(model_name)
-            response_schema = getattr(processing_class.tokenizer, "response_schema", None)
+            tokenizer = processing_class.tokenizer
 
-        if response_schema is None:
+        # Nothing to add for models that already ship a new-style `response_template` or a legacy
+        # `response_schema`; `add_response_schema` only knows a fixed set of chat templates and raises otherwise.
+        has_template = getattr(tokenizer, "response_template", None) is not None
+        has_schema = getattr(tokenizer, "response_schema", None) is not None
+        if not has_template and not has_schema:
             processing_class = add_response_schema(processing_class)
 
         return processing_class

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -1046,6 +1046,16 @@ class TestGetTrainingChatTemplate:
         ),
         pytest.param("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", id="qwen2.5"),
         pytest.param("trl-internal-testing/tiny-Qwen3MoeForCausalLM", id="qwen3"),
+        pytest.param(
+            # Same model as `qwen3`, but shipping the response template itself instead of relying on
+            # `add_response_schema` to supply it — so `_load` must leave it alone.
+            "trl-internal-testing/tiny-Qwen3MoeForCausalLM-ResponseTemplate",
+            id="qwen3-response-template",
+            marks=pytest.mark.skipif(
+                not _SUPPORTS_RESPONSE_TEMPLATE,
+                reason="Fixture ships a new-style response template, which requires transformers>=5.13",
+            ),
+        ),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
         pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
         pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink", id="qwen35-nothink"),

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -1080,7 +1080,7 @@ class TestParseResponse:
 
         # Nothing to add for models that already ship a new-style `response_template` or a legacy
         # `response_schema`; `add_response_schema` only knows a fixed set of chat templates and raises otherwise.
-        has_template = getattr(tokenizer, "response_template", None) is not None
+        has_template = _SUPPORTS_RESPONSE_TEMPLATE and tokenizer.response_template is not None
         has_schema = getattr(tokenizer, "response_schema", None) is not None
         if not has_template and not has_schema:
             processing_class = add_response_schema(processing_class)

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -1090,7 +1090,7 @@ class TestParseResponse:
 
         # Nothing to add for models that already ship a new-style `response_template` or a legacy
         # `response_schema`; `add_response_schema` only knows a fixed set of chat templates and raises otherwise.
-        has_template = _SUPPORTS_RESPONSE_TEMPLATE and tokenizer.response_template is not None
+        has_template = getattr(tokenizer, "response_template", None) is not None
         has_schema = getattr(tokenizer, "response_schema", None) is not None
         if not has_template and not has_schema:
             processing_class = add_response_schema(processing_class)


### PR DESCRIPTION
`TestParseResponse._load` only looked for the legacy `response_schema`, so for a model that ships the new-style `response_template` it fell through to `add_response_schema`, which only knows a fixed set of chat templates and raises otherwise:

```
ValueError: Unrecognized chat template, failed to add response schema.
```

Found while adding a new model to the test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and tiny-model fixture changes only; no production chat-template or parsing logic is modified.
> 
> **Overview**
> **`TestParseResponse._load`** now treats both new-style **`response_template`** and legacy **`response_schema`** as “already configured,” and only calls **`add_response_schema`** when neither is present. That stops **`ValueError: Unrecognized chat template`** for checkpoints that ship their own template but use a chat template string **`add_response_schema`** does not recognize.
> 
> A new tiny-model publish script repackages **`tiny-Qwen3MoeForCausalLM`** with **`response_template`** baked into **`tokenizer_config.json`** and a Jinja comment prefix so **`add_response_schema`** cannot match the chat template by exact string. **`TestParseResponse`** gains the **`qwen3-response-template`** case (transformers **≥ 5.13**) to assert **`_load`** leaves that fixture alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a2ae12b3a2854621df860693938d8443e73077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->