### PR TITLE
Add Gemma4 training chat template

### DIFF
--- a/docs/source/chat_templates.md
+++ b/docs/source/chat_templates.md
@@ -55,6 +55,17 @@ Split the unified assistant output so that the `<start_of_turn>model\n` header (
 
 Patched Gemma 3 template. Same diff as `gemma_training.jinja` (split the unified output line into role-specific branches so the `<start_of_turn>model\n` prompt cue sits outside the generation block, and wrap the assistant content with `&#123;% generation %&#125;` / `&#123;% endgeneration %&#125;`), applied to the Gemma 3 base template that supports system messages and multimodal content blocks.
 
+### `gemma4_training.jinja`
+
+Patched Gemma 4 template. Diff vs `gemma4.jinja`:
+
+Gemma 4 renders an assistant turn as a `<|turn>model\n` header, an optional `<|channel>thought ... <channel|>` block, tool calls, tool responses, the message content, and a `<turn|>\n` terminator. Only some of that is produced by the model, so the generation markers are placed in two spans rather than one:
+
+- The `<|turn>model\n` header is a prompt cue and stays outside the generation block.
+- The thinking channel and the assistant's tool calls are wrapped in the first generation block.
+- Tool responses are rendered inside the assistant turn by this template but are environment output, so they sit between the two blocks and are excluded from the loss.
+- The message content and the `<turn|>\n` terminator are wrapped in the second generation block, so the model is trained to end its own turn. Because Jinja block tags cannot be opened conditionally, this tail is duplicated for non-assistant roles without the markers.
+
 ### `glm4moe_training.jinja`
 
 Patched GLM-4-MoE template. Diff vs `glm4moe.jinja`:

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -617,6 +617,17 @@ class TestIsChatTemplateStopTokenTrained:
         pytest.param("trl-internal-testing/tiny-Gemma2ForCausalLM", id="gemma2"),
         pytest.param("trl-internal-testing/tiny-Gemma3ForConditionalGeneration", id="gemma3", marks=require_vision),
         pytest.param(
+            "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+            id="gemma4",
+            marks=[
+                require_vision,
+                pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ],
+        ),
+        pytest.param(
             "trl-internal-testing/tiny-Glm4MoeForCausalLM",
             id="glm4moe",
             marks=pytest.mark.skipif(

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -927,6 +927,8 @@ gemma_training_chat_template = (_CHAT_TEMPLATES_DIR / "gemma_training.jinja").re
 
 gemma3_training_chat_template = (_CHAT_TEMPLATES_DIR / "gemma3_training.jinja").read_text(encoding="utf-8")
 
+gemma4_training_chat_template = (_CHAT_TEMPLATES_DIR / "gemma4_training.jinja").read_text(encoding="utf-8")
+
 glm4moe_training_chat_template = (_CHAT_TEMPLATES_DIR / "glm4moe_training.jinja").read_text(encoding="utf-8")
 
 gptoss_training_chat_template = (_CHAT_TEMPLATES_DIR / "gptoss_training.jinja").read_text(encoding="utf-8")
@@ -987,9 +989,9 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LFM2, LLaMA 3,
-    Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and
-    Qwen3.6 are supported.
+    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, Gemma 4, GLM-4-MoE, GPT-OSS, Idefics3, LFM2,
+    LLaMA 3, Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL,
+    Qwen3.5, and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -1072,6 +1074,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == gemma3_chat_template:
         return gemma3_training_chat_template
+
+    if processing_class.chat_template == gemma4_chat_template:
+        return gemma4_training_chat_template
 
     if processing_class.chat_template == glm4moe_chat_template:
         return glm4moe_training_chat_template

--- a/trl/chat_templates/gemma4_training.jinja
+++ b/trl/chat_templates/gemma4_training.jinja
@@ -1,0 +1,380 @@
+{#-
+  Training variant of the Gemma 4 chat template (see gemma4.jinja for the original).
+  Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around the parts of an assistant turn that the
+      model actually produces, to support assistant-only loss masking in SFT training.
+    - The '<|turn>model\n' turn header is a prompt cue rather than model output, so it stays
+      outside the generation block.
+    - Tool responses are rendered inside the assistant turn by this template but are environment
+      output, not model output, so they are excluded from the generation block as well.
+    - The '<turn|>\n' turn terminator is kept inside the generation block so the model is trained
+      to end its own turn.
+ #}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Assistant-generated span 1/2: thinking channel and tool calls. -#}
+    {%- generation -%}
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+    {%- endgeneration -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Assistant-generated span 2/2: message content and the turn terminator. The same
+            emission is duplicated for non-assistant roles without the generation markers,
+            because Jinja block tags cannot be opened conditionally. -#}
+        {%- if role == 'model' -%}
+            {%- generation -%}
+            {{- captured_content -}}
+            {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+                {{- '<|tool_response>' -}}
+            {%- elif not (ns_tr_out.flag and not has_content) -%}
+                {{- '<turn|>\n' -}}
+            {%- endif -%}
+            {%- endgeneration -%}
+        {%- else -%}
+            {{- captured_content -}}
+            {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+                {{- '<|tool_response>' -}}
+            {%- elif not (ns_tr_out.flag and not has_content) -%}
+                {{- '<turn|>\n' -}}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- endif -%}
+{%- endif -%}


### PR DESCRIPTION
## What this does

Adds a training chat template for Gemma 4 so `assistant_only_loss=True` works for the family. This is one of the open entries in #5471.

## Why

TRL already recognizes Gemma 4: `trl/chat_templates/gemma4.jinja` is stored and used by `add_response_schema`. There is no `gemma4_training.jinja` though, so `get_training_chat_template()` falls through to the final `raise ValueError(...)` for every Gemma 4 model.

It needs one because the stock template has no `{% generation %}` markers, so `return_assistant_tokens_mask=True` comes back all zeros. On `google/gemma-4-26B-A4B-it`, `google/gemma-4-12B-it` and `google/gemma-4-31B-it`, which all ship an identical template:

```python
tok.apply_chat_template(msgs, tokenize=True, return_dict=True,
                        return_assistant_tokens_mask=True)["assistant_masks"]
# sums to 0 out of 44 tokens
```

Before and after on `trl-internal-testing/tiny-Gemma4ForConditionalGeneration`:

| check | `gemma4.jinja` | `gemma4_training.jinja` |
|---|---|---|
| `has_generation_markers` | `False` | `True` |
| `is_chat_template_stop_token_trained` | `False` | `True` |
| `is_chat_template_prefix_preserving` | `True` | `True` |
| `get_training_chat_template()` | raises `ValueError` | returns the template |

## How the markers are placed

Gemma 4 renders an assistant turn as a `<|turn>model\n` header, then an optional `<|channel>thought ... <channel|>` block, then tool calls, then tool responses, then the content, then a `<turn|>\n` terminator. Only some of that is model output, so the template uses two generation spans instead of one.

The `<|turn>model\n` header is a prompt cue, so it sits outside the blocks, which is what `gemma3_training.jinja` already does. The thinking channel and the assistant's tool calls go in the first span. Tool responses are rendered inside the assistant turn by this template, but they come from the environment rather than the model, so they fall between the two spans and stay out of the loss. Content and the `<turn|>\n` terminator go in the second span, which is what trains the model to end its own turn.

Jinja block tags cannot be opened conditionally, so the content and terminator tail is duplicated for non-assistant roles without the markers. `gemma3_training.jinja` splits on role the same way.

Decoded masks on the tiny fixture:

```
single turn          -> '12<turn|>\n'
multi turn           -> 'Hello!<turn|>\nGoodbye!<turn|>\n'
tool call + response -> '<|tool_call>call:multiply{a:3,b:4}<tool_call|>It is 12.<turn|>\n'
reasoning content    -> '<|channel>thought\n3 times 4.\n<channel|><|tool_call>call:multiply{a:3,b:4}<tool_call|>It is 12.<turn|>\n'
```

The tool call is trained. The tool response is not.

## Tests

Added `gemma4` to the `TestGetTrainingChatTemplate` parametrization, guarded by `require_vision` and `transformers>=5.5.0` to match the existing Gemma 4 entries elsewhere in the suite. That class already checks rendering against the original template across plain turns, system messages, generation prompts, `enable_thinking=False`, reasoning content, existing think tags, tool calls, and tools with and without a system message, plus the assistant-mask and stop-token cases.

```
pytest tests/test_chat_template_utils.py -k "TestGetTrainingChatTemplate and gemma"
46 passed, 19 skipped
```

## Something else I ran into, separate from this PR

`trl/chat_templates/gemma4.jinja` has drifted from the Hub. The pinned copy matches `trl-internal-testing/tiny-Gemma4ForConditionalGeneration`, but the released Gemma 4 repos now ship a newer revision:

| source | chars | sha256[:12] |
|---|---|---|
| `trl/chat_templates/gemma4.jinja` | 16804 | `33204f1acb5b` |
| `trl-internal-testing/tiny-Gemma4ForConditionalGeneration` | 16804 | `33204f1acb5b` |
| `google/gemma-4-{12B,26B-A4B,31B}-it` (current) | 18681 | `ae53464bf3be` |

The Hub revision is headed `Template: Google Gemma 4 Canonical Chat Template ... Published: 2026-07-09`. Since dispatch is exact string equality, `add_response_schema()` raises `Unrecognized chat template` on a real Gemma 4 model today, and the `get_training_chat_template()` entry in this PR will only fire for the pinned revision. Refreshing the pinned copy means updating the test fixture too, which I can't do from outside. I can send a second PR once the fixture moves, or add the newer revision as a separate file if you'd rather have both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to chat-template selection and Jinja markup for SFT masking; no auth, data, or training-loop logic is modified.
> 
> **Overview**
> Adds **`gemma4_training.jinja`** and wires it into **`get_training_chat_template()`** so Gemma 4 can use **`assistant_only_loss=True`** in SFT. Stock Gemma 4 templates lack `{% generation %}` markers, which made assistant masks all zeros and caused `get_training_chat_template()` to error.
> 
> The training template keeps rendered text aligned with **`gemma4.jinja`** while splitting assistant loss into **two generation spans**: thinking channel + tool calls in the first block; plain content + `<turn|>\n` in the second. The `<|turn>model\n` header and inlined tool responses stay **outside** the loss. Non-assistant roles duplicate the content/terminator tail without generation tags because Jinja cannot open those blocks conditionally.
> 
> **Docs** describe the marker layout; **`TestGetTrainingChatTemplate`** gains a `gemma4` case (vision + transformers ≥ 5.5.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d807edfa09a54f1911c24c003fa148d62ab1cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->