### PR TITLE
Add UP (Unbounded Positive Asymmetric Optimization) to `trl.experimental`

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -139,6 +139,8 @@
     title: SSD
   - local: tpo_trainer
     title: TPO
+  - local: up
+    title: UP
   - local: xpo_trainer
     title: XPO
   title: Experimental

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -684,6 +684,35 @@ training_args = GRPOConfig(
 )
 ```
 
+### UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma
+
+**📜 Paper**: https://huggingface.co/papers/2607.06987
+
+Unbounded Positive Asymmetric Optimization (UP) addresses the exploration-stability dilemma of clipped surrogate objectives: clipping stabilizes training but prematurely truncates the update budget of correct but low-confidence tokens. UP routes tokens asymmetrically based on the sign of the advantage. For positive advantages, the importance sampling ratio is replaced by a self-anchored ratio whose denominator is the current policy under a stop-gradient. Its value is exactly 1 and its gradient is the unclipped REINFORCE gradient, independent of the old policy. For non-positive advantages, the standard clipped surrogate is kept as a safeguard.
+
+$$
+\mathcal{L}_{\text{UP}}(\theta) = -\frac{1}{\sum_{i=1}^G |o_i|} \sum_{i=1}^G \sum_{t=1}^{|o_i|}
+\begin{cases}
+\hat{A}_{i,t} \, \dfrac{\pi_\theta(o_{i,t} \mid q, o_{i,<t})}{\operatorname{sg}\!\left[\pi_\theta(o_{i,t} \mid q, o_{i,<t})\right]} & \text{if } \hat{A}_{i,t} > 0 \\
+\min \left( r_{i,t}(\theta) \hat{A}_{i,t},\ \operatorname{clip}\!\left(r_{i,t}(\theta), 1 - \epsilon_{\text{low}}, 1 + \epsilon_{\text{high}}\right) \hat{A}_{i,t} \right) & \text{if } \hat{A}_{i,t} \le 0
+\end{cases}
+$$
+
+TRL provides an experimental implementation, see [Experimental - UP](up). To reproduce the paper's token-level UP-DAPO setup:
+
+```python
+from trl.experimental.up import UPConfig, UPTrainer
+
+training_args = UPConfig(
+    epsilon=0.2,  # lower clip bound; only applies to the non-positive-advantage branch
+    beta=0.0,  # the paper's UP-DAPO setup, reported at 14B
+)
+```
+
+The upper clip bound (`epsilon_high`) has no effect with the default `delta=None`, and more generally whenever `delta >= 1 + epsilon_high`: positive advantages bypass clipping entirely, and for non-positive advantages the upper bound is dominated (Table A1 of the paper accordingly reports no `ϵ_high` for UP-DAPO). The lower bound `epsilon` and the optional two-sided cap `delta` both still apply to the non-positive branch.
+
+The paper's UP-DAPO results are at 14B with `beta=0.0`. At smaller scale, consider keeping a KL term (`beta > 0`), as the paper's UP-GRPO variant does.
+
 ## Optimal Advantage Regression
 
 Papers relating to the [`experimental.a2po.A2POTrainer`].

--- a/docs/source/up.md
+++ b/docs/source/up.md
@@ -1,0 +1,42 @@
+# UP
+
+In the paper [UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma](https://huggingface.co/papers/2607.06987), the authors propose a GRPO variant that routes tokens asymmetrically on the sign of the advantage. Clipping stabilizes training but truncates the update budget of correct yet low-confidence tokens. UP removes the clip only where it hurts exploration: for positive advantages the importance sampling ratio is replaced by the self-anchored ratio `πθ / sg(πθ)`, whose value is exactly 1 and whose gradient is the unclipped REINFORCE gradient, independent of the old policy. Non-positive advantages keep the standard clipped surrogate as a safeguard.
+
+To use UP, you can use the [`UPTrainer`] class in `trl.experimental.up`.
+
+## Usage
+
+```python
+from trl.experimental.up import UPConfig, UPTrainer
+
+training_args = UPConfig(
+    epsilon=0.2,  # lower clip bound; only applies to the non-positive-advantage branch
+    beta=0.0,  # the paper's UP-DAPO setup, reported at 14B
+)
+trainer = UPTrainer(
+    model="Qwen/Qwen3-0.6B",
+    reward_funcs=...,
+    train_dataset=...,
+    args=training_args,
+)
+trainer.train()
+```
+
+`epsilon_high` has no effect with the default `delta=None`, and more generally whenever `delta >= 1 + epsilon_high`: positive advantages bypass clipping entirely, and for non-positive ones the upper bound is dominated. Only a `delta` set below `1 + epsilon_high` makes it bind. Table A1 of the paper lists no `ε_high` for UP-DAPO accordingly. `epsilon` and the optional two-sided cap `delta` still apply to the non-positive branch.
+
+Aggregation follows DAPO's global active-token normalization, matching the paper's UP-DAPO instantiation.
+
+Setting `importance_sampling_level="sequence"` changes only the non-positive branch, which then uses the sequence-level ratio of the paper's UP-GSPO (Eq. 16). The positive branch is unaffected: the global active-token normalization exactly cancels the sequence-level length normalization, so its loss and gradient are identical to the token-level case. Aggregation also stays token-normalized rather than averaging per-sequence losses as the paper's UP-GSPO does.
+
+The paper's UP-DAPO results are at 14B with `beta=0.0`. At smaller scale, consider keeping a KL term (`beta > 0`), as the paper's UP-GRPO variant does.
+
+## UPTrainer
+
+[[autodoc]] experimental.up.UPTrainer
+    - train
+    - save_model
+    - push_to_hub
+
+## UPConfig
+
+[[autodoc]] experimental.up.UPConfig

--- a/tests/experimental/test_up_trainer.py
+++ b/tests/experimental/test_up_trainer.py
@@ -1,0 +1,264 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from datasets import load_dataset
+
+from trl.experimental.up import UPConfig, UPTrainer
+from trl.trainer.grpo_trainer import GRPOTrainer
+
+from ..testing_utils import TrlTestCase
+
+
+class TestUPTrainer(TrlTestCase):
+    def _make_trainer_and_inputs(self, advantages, importance_sampling_level="token", **config_kwargs):
+        """Build a tiny UP trainer plus a hand-crafted `_compute_loss` inputs dict."""
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def dummy_reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        config_kwargs.setdefault("beta", 0.0)  # no KL term by default, so no reference model is needed
+        training_args = UPConfig(
+            output_dir=self.tmp_dir,
+            bf16=False,  # gradients are compared in full fp32 precision
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            importance_sampling_level=importance_sampling_level,
+            report_to="none",
+            **config_kwargs,
+        )
+        trainer = UPTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=dummy_reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+        device = trainer.accelerator.device
+        generator = torch.Generator().manual_seed(42)
+        vocab_size = trainer.model.config.vocab_size
+        prompt_ids = torch.randint(0, vocab_size, (3, 4), generator=generator).to(device)
+        completion_ids = torch.randint(0, vocab_size, (3, 6), generator=generator).to(device)
+        completion_mask = torch.ones_like(completion_ids)
+        completion_mask[-1, -2:] = 0  # ragged completion lengths, to exercise masking
+        inputs = {
+            "prompt_ids": prompt_ids,
+            "prompt_mask": torch.ones_like(prompt_ids),
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
+            "advantages": advantages.to(device),
+            # Deliberately not equal to `mask.sum()`, so that the global (DAPO) normalization UP uses is
+            # distinguishable from a local (BNPO) one.
+            "num_items_in_batch": completion_mask.sum() * 2,
+        }
+        return trainer, inputs
+
+    def _grads(self, trainer, loss):
+        params = [p for p in trainer.model.parameters() if p.requires_grad]
+        return torch.autograd.grad(loss, params)
+
+    @pytest.mark.parametrize("importance_sampling_level", ["token", "sequence"])
+    def test_positive_advantages_match_reinforce_and_ignore_old_logps(self, importance_sampling_level):
+        # For positive advantages, the gradient of the UP loss must equal the plain REINFORCE gradient
+        # Â · ∇ log π_θ (with the same global-token normalization), and must not depend on old_per_token_logps.
+        # This also holds at the sequence level: the global active-token normalization weights each sequence by its
+        # length, which exactly cancels the length normalization of the sequence-level anchored ratio.
+        advantages = torch.tensor([0.3, 1.5, 0.8])  # all positive: every token goes through the UP branch
+        trainer, inputs = self._make_trainer_and_inputs(advantages, importance_sampling_level)
+
+        input_ids = torch.cat([inputs["prompt_ids"], inputs["completion_ids"]], dim=1)
+        attention_mask = torch.cat([inputs["prompt_mask"], inputs["completion_mask"]], dim=1)
+        logits_to_keep = inputs["completion_ids"].size(1)
+        per_token_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+            trainer.model, input_ids, attention_mask, logits_to_keep
+        )
+
+        # Simulate a stale (off-policy) old policy
+        inputs["old_per_token_logps"] = per_token_logps.detach() - 0.7
+        up_loss = trainer._compute_loss(trainer.model, inputs)
+        up_grads = self._grads(trainer, up_loss)
+
+        # The self-anchored ratio has forward value exactly 1, so the loss reduces to -Â summed over active tokens
+        # and divided by the global token count. Asserting the value (not just the gradient) pins that: dropping the
+        # exp() would leave every gradient unchanged while silently changing the reported loss.
+        expected = (
+            -(inputs["advantages"].unsqueeze(1) * inputs["completion_mask"]).sum() / inputs["num_items_in_batch"]
+        )
+        torch.testing.assert_close(up_loss, expected)
+
+        # REINFORCE reference: -Â · log π_θ, aggregated with the same global-token normalization
+        mask = inputs["completion_mask"]
+        reinforce_loss = (
+            -(inputs["advantages"].unsqueeze(1) * per_token_logps * mask).sum() / inputs["num_items_in_batch"]
+        )
+        reinforce_grads = self._grads(trainer, reinforce_loss)
+
+        for up_grad, reinforce_grad in zip(up_grads, reinforce_grads, strict=True):
+            torch.testing.assert_close(up_grad, reinforce_grad, rtol=1e-6, atol=1e-8)
+
+        # A different old policy must yield the exact same loss and gradients: the UP branch is anchored to
+        # sg(π_θ), not π_old
+        inputs["old_per_token_logps"] = per_token_logps.detach() + 0.9
+        other_loss = trainer._compute_loss(trainer.model, inputs)
+        other_grads = self._grads(trainer, other_loss)
+        assert torch.equal(up_loss.detach(), other_loss.detach())
+        for up_grad, other_grad in zip(up_grads, other_grads, strict=True):
+            assert torch.equal(up_grad, other_grad)
+
+    def test_non_positive_advantages_match_dapo(self):
+        # For non-positive advantages, the UP loss must fall back to the clipped surrogate: same loss and same
+        # gradients as GRPOTrainer's `dapo`, which shares the global-token normalization. `UPConfig.loss_type`
+        # inherits GRPOConfig's `"dapo"` default, so calling the parent implementation on the same trainer runs
+        # exactly that path over the same parameters.
+        advantages = torch.tensor([-0.3, 0.0, -1.2])  # all non-positive: every token takes the clipped branch
+        trainer, inputs = self._make_trainer_and_inputs(advantages)
+        assert trainer.loss_type == "dapo"
+
+        input_ids = torch.cat([inputs["prompt_ids"], inputs["completion_ids"]], dim=1)
+        attention_mask = torch.cat([inputs["prompt_mask"], inputs["completion_mask"]], dim=1)
+        logits_to_keep = inputs["completion_ids"].size(1)
+        per_token_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+            trainer.model, input_ids, attention_mask, logits_to_keep
+        )
+        # Stale old policy, shifted enough for some ratios to be clipped and others not
+        generator = torch.Generator().manual_seed(0)
+        shift = torch.empty(per_token_logps.shape).uniform_(-0.5, 0.5, generator=generator)
+        inputs["old_per_token_logps"] = per_token_logps.detach() + shift.to(per_token_logps.device)
+
+        up_loss = trainer._compute_loss(trainer.model, inputs)
+        up_grads = self._grads(trainer, up_loss)
+
+        dapo_loss = GRPOTrainer._compute_loss(trainer, trainer.model, inputs)
+        dapo_grads = self._grads(trainer, dapo_loss)
+
+        assert torch.equal(up_loss.detach(), dapo_loss.detach())
+        for up_grad, dapo_grad in zip(up_grads, dapo_grads, strict=True):
+            assert torch.equal(up_grad, dapo_grad)
+
+    def _loss_with(self, advantages, shift, ragged_shift=False, **config_kwargs):
+        """Loss on a fixed off-policy batch, for a given config.
+
+        A uniform `shift` makes the sequence-level mean log-ratio equal every token's, so token and sequence levels
+        coincide by construction. Pass `ragged_shift=True` to vary the shift within each sequence and tell them apart.
+        """
+        trainer, inputs = self._make_trainer_and_inputs(advantages, **config_kwargs)
+        input_ids = torch.cat([inputs["prompt_ids"], inputs["completion_ids"]], dim=1)
+        attention_mask = torch.cat([inputs["prompt_mask"], inputs["completion_mask"]], dim=1)
+        per_token_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+            trainer.model, input_ids, attention_mask, inputs["completion_ids"].size(1)
+        )
+        offset = torch.full_like(per_token_logps, shift)
+        if ragged_shift:
+            offset = offset + torch.linspace(-0.4, 0.4, per_token_logps.size(1), device=per_token_logps.device)
+        inputs["old_per_token_logps"] = per_token_logps.detach() + offset
+        return trainer._compute_loss(trainer.model, inputs).item()
+
+    def test_sequence_level_leaves_the_positive_branch_unchanged(self):
+        # The positive branch is anchored to sg(π_θ), and the global active-token normalization exactly cancels the
+        # sequence-level length normalization, so `importance_sampling_level` cannot change it. Only the
+        # non-positive branch, which uses the real importance ratio, responds to the level.
+        positive = torch.tensor([0.3, 1.5, 0.8])
+        negative = torch.tensor([-0.3, -0.9, -1.2])
+        # `ragged_shift` varies the log-ratio within each sequence; without it the sequence mean equals every token
+        # and the two levels would agree trivially.
+        assert self._loss_with(positive, -0.7, ragged_shift=True, importance_sampling_level="token") == pytest.approx(
+            self._loss_with(positive, -0.7, ragged_shift=True, importance_sampling_level="sequence")
+        )
+        assert self._loss_with(negative, -0.7, ragged_shift=True, importance_sampling_level="token") != pytest.approx(
+            self._loss_with(negative, -0.7, ragged_shift=True, importance_sampling_level="sequence")
+        )
+
+    def test_delta_caps_the_non_positive_branch_and_gates_epsilon_high(self):
+        # `delta` clamps the ratio before the min, so it bounds the non-positive branch. `epsilon_high` only ever
+        # binds through that same min, i.e. when `delta < 1 + epsilon_high`; otherwise it is dominated and inert.
+        negative = torch.tensor([-0.3, -0.9, -1.2])
+        shift = -2.0  # push ratios well above 1, so the caps are reachable
+
+        uncapped = self._loss_with(negative, shift)
+        assert self._loss_with(negative, shift, delta=1.05) < uncapped  # delta bites
+
+        # epsilon_high is inert without delta, and inert while delta stays above 1 + epsilon_high
+        assert self._loss_with(negative, shift, epsilon_high=5.0) == pytest.approx(uncapped)
+        assert self._loss_with(negative, shift, delta=4.0, epsilon_high=0.2) == pytest.approx(
+            self._loss_with(negative, shift, delta=4.0, epsilon_high=1.0)  # 1 + 1.0 < 4.0, still dominated
+        )
+        # but it binds once delta drops below 1 + epsilon_high
+        assert self._loss_with(negative, shift, delta=1.05, epsilon_high=0.2) != pytest.approx(
+            self._loss_with(negative, shift, delta=1.05, epsilon_high=5.0)
+        )
+
+    def test_beta_adds_the_kl_term(self):
+        # With beta > 0 the KL penalty is added to the per-token loss and logged, on both branches.
+        advantages = torch.tensor([0.7, -0.4, 0.0])
+        trainer, inputs = self._make_trainer_and_inputs(advantages, beta=0.04)
+        input_ids = torch.cat([inputs["prompt_ids"], inputs["completion_ids"]], dim=1)
+        attention_mask = torch.cat([inputs["prompt_mask"], inputs["completion_mask"]], dim=1)
+        per_token_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+            trainer.model, input_ids, attention_mask, inputs["completion_ids"].size(1)
+        )
+        inputs["old_per_token_logps"] = per_token_logps.detach() - 0.7
+        # A reference policy that differs from the current one, so the KL term is non-zero
+        inputs["ref_per_token_logps"] = per_token_logps.detach() - 0.5
+
+        loss_with_kl = trainer._compute_loss(trainer.model, inputs).item()
+        trainer.beta = 0.0
+        loss_without_kl = trainer._compute_loss(trainer.model, inputs).item()
+
+        assert loss_with_kl != pytest.approx(loss_without_kl)
+        mode = "train" if trainer.model.training else "eval"
+        assert trainer._metrics[mode]["kl"], "the KL metric must be logged when beta > 0"
+        assert trainer._metrics[mode]["kl"][0] > 0.0
+
+    def test_liger_kernel_not_supported(self):
+        # `GRPOTrainer.compute_loss` routes to the fused Liger loss before `_compute_loss`, which would silently
+        # optimize the GRPO objective instead of UP, so the trainer refuses the combination up front.
+        training_args = UPConfig(output_dir=self.tmp_dir, bf16=False, use_liger_kernel=True, report_to="none")
+        with pytest.raises(NotImplementedError, match="not supported by `UPTrainer`"):
+            UPTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs=lambda completions, **kwargs: [0.0] * len(completions),
+                args=training_args,
+            )
+
+    def test_train(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = UPConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            num_iterations=2,  # the importance sampling weights won't be 1 in this case
+            report_to="none",
+        )
+        trainer = UPTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."

--- a/trl/experimental/up/__init__.py
+++ b/trl/experimental/up/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .up_config import UPConfig
+from .up_trainer import UPTrainer

--- a/trl/experimental/up/up_config.py
+++ b/trl/experimental/up/up_config.py
@@ -1,0 +1,42 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from ...trainer.grpo_config import GRPOConfig
+
+
+@dataclass
+class UPConfig(GRPOConfig):
+    # docstyle-ignore
+    r"""
+    Configuration class for the [`UPTrainer`].
+
+    [`UPConfig`] inherits every parameter from [`GRPOConfig`] and adds none. It exists to change which parameters are
+    meaningful: in UP, tokens with positive advantage bypass clipping entirely, so only the lower clip bound is ever
+    consulted.
+
+    - `loss_type` does not select the objective: [`UPTrainer`] always uses the UP loss with DAPO's global
+      active-token normalization, matching the paper's UP-DAPO instantiation. It is still read on inherited code
+      paths (validation and warnings in [`GRPOTrainer`]), so the default `"dapo"` is kept, since that is the
+      aggregation actually used.
+    - `epsilon` (and `delta`, if set) still apply, but only to the non-positive-advantage branch.
+    - `epsilon_high` has **no effect** with the default `delta=None`, and more generally whenever
+      `delta >= 1 + epsilon_high`: positive advantages skip clipping, and for non-positive ones the upper bound is
+      dominated. Only a `delta` set below `1 + epsilon_high` makes it bind. Table A1 of the [UP
+      paper](https://huggingface.co/papers/2607.06987) lists no `ε_high` for UP-DAPO accordingly.
+
+    The paper's UP-DAPO setup uses `beta=0.0` at 14B. At smaller scale, consider keeping a KL term (`beta > 0`), as
+    the paper's UP-GRPO variant does.
+    """

--- a/trl/experimental/up/up_trainer.py
+++ b/trl/experimental/up/up_trainer.py
@@ -1,0 +1,275 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+import torch
+from accelerate.logging import get_logger
+
+from ...trainer.grpo_trainer import GRPOTrainer
+from ...trainer.utils import get_config_model_id, nanmin
+from .up_config import UPConfig
+
+
+logger = get_logger(__name__)
+
+
+class UPTrainer(GRPOTrainer):
+    """
+    Trainer for Unbounded Positive Asymmetric Optimization (UP).
+
+    UP (https://huggingface.co/papers/2607.06987) is a GRPO variant that routes tokens asymmetrically on the sign of
+    the advantage. For positive advantages the importance sampling ratio is replaced by the self-anchored ratio `πθ /
+    sg(πθ)`, whose forward value is exactly 1 and whose gradient is the unclipped REINFORCE gradient `Â ∇ log πθ`,
+    independent of the old policy, so correct but low-confidence tokens are never truncated by the trust region.
+    Non-positive advantages keep the standard clipped surrogate as a safeguard.
+
+    Aggregation follows DAPO's global active-token normalization, matching the paper's UP-DAPO instantiation.
+
+    The only change w.r.t. [`GRPOTrainer`] is `_compute_loss`. Everything else (generation, reward computation, weight
+    syncing, metric logging) is inherited unchanged.
+    """
+
+    _tag_names = ["trl", "up"]
+    _name = "UP"
+    _paper = {
+        "title": "UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma",
+        "id": "2607.06987",
+        # docstyle-ignore
+        "citation": textwrap.dedent("""\
+            @article{fan2026up,
+                title        = {{UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma}},
+                author       = {Chongyu Fan and Pengfei Liu and Jingjia Huang and Sijia Liu and Yi Lin},
+                year         = 2026,
+                journal      = {arXiv preprint arXiv:2607.06987}
+            }"""),
+    }
+
+    def __init__(self, model, reward_funcs, args=None, **kwargs):
+        if args is None:
+            model_name = model if isinstance(model, str) else get_config_model_id(model.config)
+            args = UPConfig(f"{model_name.split('/')[-1]}-UP")
+
+        if args.use_liger_kernel:
+            # `GRPOTrainer.compute_loss` routes to the fused Liger loss before `_compute_loss` is reached, so the UP
+            # objective would be silently replaced by the GRPO one.
+            raise NotImplementedError(
+                "`use_liger_kernel=True` is not supported by `UPTrainer`: the fused Liger loss bypasses the UP "
+                "objective. Set `use_liger_kernel=False`."
+            )
+
+        super().__init__(model, reward_funcs, args=args, **kwargs)
+
+        if self.importance_sampling_level == "sequence":
+            # `GRPOTrainer.__init__` emits a generic warning here whose remedy (`loss_type='grpo'`) does nothing in
+            # this trainer, since UP ignores `loss_type` entirely. State the applicable one.
+            logger.warning(
+                "With `importance_sampling_level='sequence'`, the positive branch follows the sequence-level UP "
+                "objective (UP-GSPO), but token losses are still aggregated with the global active-token "
+                "normalization, which weights each sequence by its completion length instead of averaging "
+                "per-sequence losses as in the paper's UP-GSPO setup. To reproduce the paper's token-level UP-DAPO "
+                "setup, set `importance_sampling_level='token'` (the default)."
+            )
+
+    def _compute_loss(self, model, inputs):
+        # Compute the per-token log probabilities for the model
+        prompt_ids, prompt_mask = inputs["prompt_ids"], inputs["prompt_mask"]
+        completion_ids, completion_mask = inputs["completion_ids"], inputs["completion_mask"]
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+        logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
+        mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
+
+        # Compute the per_token_logps and the entropy at each position in the completion
+        per_token_logps, entropies, aux_loss = self._get_per_token_logps_and_entropies(
+            model,
+            input_ids,
+            attention_mask,
+            logits_to_keep,
+            compute_entropy=True,
+            compute_aux_loss=self.aux_loss_enabled,
+            pixel_values=inputs.get("pixel_values"),
+            image_grid_thw=inputs.get("image_grid_thw"),
+            num_images=inputs.get("num_images"),
+            pixel_attention_mask=inputs.get("pixel_attention_mask"),
+            spatial_shapes=inputs.get("spatial_shapes"),
+            num_tiles=inputs.get("num_tiles"),
+            image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
+            mm_token_type_ids=inputs.get("mm_token_type_ids"),
+            image_position_ids=inputs.get("image_position_ids"),
+        )
+
+        if self.top_entropy_quantile < 1.0:
+            entropy_mask = self.get_high_entropy_mask(entropies, mask, 1 - self.top_entropy_quantile)
+        else:
+            entropy_mask = None
+
+        # Compute the loss
+        advantages = inputs["advantages"]
+        if advantages.dim() == 1:
+            advantages = advantages.unsqueeze(1)
+        old_per_token_logps = inputs.get("old_per_token_logps")
+        old_per_token_logps = per_token_logps.detach() if old_per_token_logps is None else old_per_token_logps
+
+        if self.off_policy_mask_threshold is not None:
+            sampling_per_token_logps = inputs.get("sampling_per_token_logps", old_per_token_logps)
+            off_policy_mask = self.get_off_policy_mask(
+                advantages=advantages,
+                per_token_logps=per_token_logps,
+                sampling_per_token_logps=sampling_per_token_logps,
+                mask=mask,
+                off_policy_threshold=self.off_policy_mask_threshold,
+            )
+
+        log_ratio = per_token_logps - old_per_token_logps
+        if self.importance_sampling_level == "token":
+            log_importance_weights = log_ratio
+        elif self.importance_sampling_level == "sequence":
+            log_importance_weights = (log_ratio * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)
+            log_importance_weights = log_importance_weights.unsqueeze(-1)
+        else:
+            raise ValueError(
+                f"Unknown importance sampling level: {self.importance_sampling_level}. Possible values are 'token' "
+                "and 'sequence'."
+            )
+
+        coef_1 = torch.exp(log_importance_weights)
+
+        # Compute the KL divergence between the model and the reference model
+        if self.beta != 0.0:
+            ref_per_token_logps = inputs["ref_per_token_logps"]
+            per_token_kl = (
+                torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
+            )
+            # Importance sampling correction for the KL divergence
+            if self.args.use_bias_correction_kl:
+                per_token_kl = per_token_kl * coef_1
+
+        # UP objective (Eqs. 12-14). Tokens with positive advantage bypass clipping entirely: the importance
+        # sampling ratio is replaced by the self-anchored ratio πθ / sg(πθ), whose value is 1 and whose gradient is
+        # the unclipped REINFORCE gradient Â ∇ log πθ, independent of the old policy. Tokens with non-positive
+        # advantage keep the standard clipped surrogate as a safeguard against aggressive penalization.
+        if self.importance_sampling_level == "token":
+            anchored_log_ratio = per_token_logps - per_token_logps.detach()
+        else:
+            # "sequence": length-normalized sequence-level ratio (UP-GSPO, Eq. 16). Under the global active-token
+            # normalizer this is numerically identical to the token-level branch; only the non-positive branch
+            # actually changes.
+            anchored_log_ratio = ((per_token_logps - per_token_logps.detach()) * mask).sum(-1) / mask.sum(-1).clamp(
+                min=1.0
+            )
+            anchored_log_ratio = anchored_log_ratio.unsqueeze(-1)
+        up_per_token_loss = -anchored_log_ratio.exp() * advantages
+        coef_2 = torch.clamp(coef_1, 1 - self.epsilon_low, 1 + self.epsilon_high)
+        # Two-sided clipping
+        if self.args.delta is not None:
+            coef_1 = torch.clamp(coef_1, max=self.args.delta)
+        clipped_per_token_loss = -torch.min(coef_1 * advantages, coef_2 * advantages)
+        per_token_loss = torch.where(advantages > 0, up_per_token_loss, clipped_per_token_loss)
+
+        if self.off_policy_mask_threshold is not None:
+            per_token_loss = per_token_loss * off_policy_mask
+
+        if entropy_mask is not None:
+            per_token_loss = per_token_loss * entropy_mask
+
+        if self.use_vllm and self.vllm_importance_sampling_correction:
+            per_token_loss = per_token_loss * inputs["importance_sampling_ratio"]
+
+        if self.beta != 0.0:
+            per_token_loss = per_token_loss + self.beta * per_token_kl
+
+        # UP aggregates like DAPO: normalize by the number of active tokens in the global accumulated batch.
+        # `num_items_in_batch` spans the generation batch, so rescale it to one accumulation window.
+        mode = "train" if self.model.training else "eval"
+        normalizer = inputs["num_items_in_batch"].clamp(min=1.0) / self.accelerator.num_processes
+        if mode == "train":  # in eval, the batch is neither split across steps nor accumulated
+            normalizer = normalizer * self.current_gradient_accumulation_steps / self.args.steps_per_generation
+        loss = (per_token_loss * mask).sum() / normalizer
+        policy_loss = loss.detach()
+
+        # Entropy bonus: add entropy regularization to encourage exploration.
+        if self._entropy_bonus_enabled:
+            effective_mask = mask if entropy_mask is None else mask * entropy_mask
+            # `normalizer` is a global token count, so summing the entropies (instead of averaging them again) makes
+            # the term accumulate over the optimizer step to the global mean per-token entropy, as it does for the
+            # other global-token-normalized loss types.
+            entropy_loss = (entropies * effective_mask).sum() / normalizer
+
+            if self.use_adaptive_entropy:
+                apply_coef = self.entropy_coef if self._last_world_entropy <= self.args.entropy_target else 0.0
+            else:
+                apply_coef = self.entropy_coef
+
+            loss = loss - apply_coef * entropy_loss
+
+            self._metrics[mode]["policy_loss"].append(self.accelerator.gather(policy_loss).nanmean().item())
+
+            if self.use_adaptive_entropy and mode == "train":
+                stats = torch.stack([(entropies * effective_mask).sum(), effective_mask.sum()]).detach()
+                if self._entropy_window_stats is None:
+                    self._entropy_window_stats = stats
+                else:
+                    self._entropy_window_stats = self._entropy_window_stats + stats
+                if self.accelerator.sync_gradients:
+                    window_stats = self.accelerator.reduce(self._entropy_window_stats, reduction="sum")
+                    world_entropy = (window_stats[0] / window_stats[1].clamp(min=1.0)).item()
+                    if world_entropy <= self.args.entropy_target:
+                        self.entropy_coef = min(
+                            self.entropy_coef + self.args.entropy_coef_delta, self.args.entropy_coef_max
+                        )
+                    else:
+                        self.entropy_coef = max(
+                            self.entropy_coef - self.args.entropy_coef_delta, self.args.entropy_coef_min
+                        )
+                    self._last_world_entropy = world_entropy
+                    self._entropy_window_stats = None
+
+            if mode == "train" and self.accelerator.sync_gradients:
+                self._metrics[mode]["entropy_coef"].append(self.entropy_coef)
+
+        # The policy loss above is scaled for gradient accumulation (HF auto-scaling is off here), so scale aux too
+        if self.aux_loss_enabled:
+            aux_normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            loss = loss + self.router_aux_loss_coef * aux_loss / aux_normalizer
+            self._metrics[mode]["aux_loss"].append(self.accelerator.gather_for_metrics(aux_loss).mean().item())
+
+        # Log the metrics
+        def masked_seq_mean(x):
+            if x.shape[1] == 1:  # when importance_sampling_level == "sequence": already one value per sequence
+                return x.squeeze(1)
+            return (x * mask).sum(-1) / mask.sum(-1)
+
+        def global_masked_mean(x):
+            if x.shape[1] == 1:  # when importance_sampling_level == "sequence": one value per sequence
+                local_sum, local_count = x.sum(), torch.tensor(float(x.shape[0]), device=x.device)
+            else:
+                local_sum, local_count = (x * mask).sum(), mask.sum().float()
+            totals = self.accelerator.reduce(torch.stack([local_sum, local_count]), reduction="sum")
+            return (totals[0] / totals[1].clamp(min=1.0)).item()
+
+        if self.beta != 0.0:
+            self._metrics[mode]["kl"].append(global_masked_mean(per_token_kl))
+
+        self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
+
+        # Only the negative-advantage branch of UP is clipped (the positive branch is unbounded by design), so only
+        # the low-side clip ratio is meaningful.
+        is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)
+        self._metrics[mode]["clip_ratio/low_mean"].append(global_masked_mean(is_low_clipped.float()))
+        gathered_low_clip = self.accelerator.gather(masked_seq_mean(is_low_clipped.float()))
+        self._metrics[mode]["clip_ratio/low_min"].append(nanmin(gathered_low_clip).item())
+
+        return loss

--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -60,6 +60,7 @@ _TELEMETRY_TRAINERS = {
     "ServerDistillationTrainer",
     "SSDTrainer",
     "TPOTrainer",
+    "UPTrainer",
     "XPOTrainer",
 }
 


### PR DESCRIPTION
# What does this PR do?

Adds `trl/experimental/up/`, implementing Unbounded Positive Asymmetric Optimization from [the UP paper](https://huggingface.co/papers/2607.06987) as a `GRPOTrainer` subclass that overrides `_compute_loss`. It follows the `trl/experimental/gmpo/` layout.

Fixes #6407

I originally wrote this as a core `loss_type="up"` value, then noticed recent new methods have been landing in `trl/experimental/` instead, so I moved it. That branch still exists and the two are numerically identical, so if you would rather have this as a core `loss_type` I can switch it back in a few minutes. Happy either way.

## Method

UP splits on the sign of the advantage. For positive advantages it replaces the importance ratio with a self-anchored one:

```python
anchored_log_ratio = per_token_logps - per_token_logps.detach()
up_per_token_loss = -anchored_log_ratio.exp() * advantages
```

Its forward value is exactly 1 and its gradient is the plain REINFORCE gradient, so positive updates are never clipped and do not depend on `π_old`. Non-positive advantages keep the usual clipped surrogate as a safeguard. Aggregation follows DAPO's global active-token normalization, matching the paper's UP-DAPO instantiation.

## Notes for review

* One core line, in `base_trainer.py`: `"UPTrainer"` added to `_TELEMETRY_TRAINERS`, since the comment there says a new trainer needs an explicit entry. Nothing else outside `trl/experimental/up/`.
* `use_liger_kernel=True` raises `NotImplementedError`. `GRPOTrainer.compute_loss` routes to the fused Liger loss before `_compute_loss` is reached, so without the guard the trainer would silently optimize the GRPO objective instead of UP. Worth flagging that `GMPOTrainer` looks like it has the same hole; I have not opened anything about it since I may be misreading the dispatch.
* `epsilon_high` has no effect with the default `delta=None`, and more generally whenever `delta >= 1 + epsilon_high`. Positive advantages skip clipping, and for non-positive ones the upper bound is dominated. Only a `delta` below `1 + epsilon_high` makes it bind. Table A1 of the paper lists no `ε_high` for UP-DAPO accordingly. There is a test for this.
* `importance_sampling_level="sequence"` changes only the non-positive branch. The positive branch is unaffected, because the global active-token normalization exactly cancels the sequence-level length normalization. Also tested.
* `UPConfig` adds no fields. It exists as the autodoc surface for the semantics above and for symmetry with the other experimental configs.
* Only the low-side clip metrics are logged. The high-side ones would be identically zero, since `is_high_clipped` requires a positive advantage and UP routes those to the unclipped branch.

## Tests

UP's positive branch has a forward value of exactly 1, so asserting on the loss alone cannot tell a correct implementation from one that detached the wrong tensor. The gradient is what distinguishes them, so the tests check gradients, and then the loss value separately:

* positive advantages: per-parameter gradients match the REINFORCE reference, the loss equals the closed form, and both stay bitwise identical when `old_per_token_logps` changes
* non-positive advantages: loss and gradients bitwise identical to `GRPOTrainer`'s `dapo`
* `delta` caps the non-positive branch, and gates whether `epsilon_high` binds at all
* `importance_sampling_level` leaves the positive branch unchanged
* `beta > 0` adds and logs the KL term
* the Liger guard raises, and end-to-end training runs

## Verification

Rebased on `de63151`. `tests/experimental/test_up_trainer.py`: 8 passed. ruff, ruff format and the doc-builder hook pass on the changed files.

I also checked this module against the core `loss_type="up"` branch it replaces, on identical seeded inputs: loss, gradient norm and gradient sum are bit-identical across six cases (token and sequence levels, with all-positive, all-negative and mixed advantages). The move did not change the objective.

## Results, including a negative one

Small-scale runs on Qwen3-0.6B and Qwen3-4B with GSM8K. **These do not show a reward win and I am not claiming one.**

What reproduced: the clip is one-sided, and entropy separates upward for UP, matching Fig. 3(a).

What did not: with `beta=0`, UP's entropy crosses 2.0 nats for good around step 236 and reward collapses without recovering. It is capability loss rather than truncation, since completions mostly finish and still score near zero. At 4B the same pattern starts, entropy passes 2.0 by step 173 and mean reward falls from 0.87 over the first 100 steps to 0.30 over the last 100 while dapo holds 0.71, but that arm is only 500 steps and partially recovers late. So it is a weaker version of the same failure rather than a repeat, and at least not a 0.6B-only artifact.

Adding a KL anchor (`beta=0.04`) removes the collapse. Entropy stays below 2.0 for 2000 steps and reward holds around 0.35. That fits the paper: its UP-GRPO keeps the KL term (Eq. 15), and its UP-DAPO results are at 14B.

The docs carry a one-line version of that next to the config example, pointing at the paper's own UP-GRPO variant rather than at my numbers. I have no 14B run and am not extrapolating to one.

<details><summary>curves: 2000 steps at 0.6B, the KL-anchor overlay, and the 4B run</summary>

<img width="1800" height="1200" alt="2000-step dapo vs up, Qwen3-0.6B" src="https://github.com/user-attachments/assets/4dbd5247-bc8f-4976-8bdb-a6c2ae7c57be" />

<img width="1950" height="675" alt="three-arm overlay: dapo, up beta=0, up beta=0.04" src="https://github.com/user-attachments/assets/db7df442-121c-4199-afd2-74911c849539" />

<img width="1800" height="1200" alt="Qwen3-4B, 500 steps per arm" src="https://github.com/user-attachments/assets/d197d799-5c2e-472b-889b-f2fca7076a54" />

</details>

## Prior art

[verl#7022](https://github.com/verl-project/verl/pull/7022) adds the same method to verl. Opened 2026-07-13, still open and unmerged, and the author appears to be the paper's first author. The positive branch is mathematically identical. The negative branches differ only in defaults: verl's dual clip (`clip_ratio_c`) is on at 3.0, TRL's equivalent (`delta`) is off unless you set it.

`Jackie2049/trl#6` and `Jackie2049/verl#9` are fork-internal, not upstream.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. I opened #6407 for this; no maintainer has replied there yet.
- [x] Did you make sure to update the documentation with your changes? New `docs/source/up.md`, a `paper_index.md` subsection, and a `_toctree.yml` entry.
- [x] Did you write any new necessary tests? See above.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone once CI is green. @qgallouedec or @kashif may be interested, given the GRPO surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RL training behavior via a new `_compute_loss` path on GRPO; risk is mitigated by isolation under `experimental/`, explicit Liger rejection, and thorough gradient/objective tests, but incorrect loss wiring would still affect anyone who adopts the trainer.
> 
> **Overview**
> Adds **UP** as an experimental GRPO variant under `trl.experimental.up`, following the same pattern as other experimental trainers (e.g. GMPO).
> 
> `UPTrainer` subclasses `GRPOTrainer` and replaces `_compute_loss` with the paper objective: **positive-advantage** tokens use a self-anchored ratio `πθ / sg(πθ)` (unclipped REINFORCE, independent of the old policy); **non-positive** tokens keep the usual clipped surrogate. Loss is aggregated with **DAPO-style** global active-token normalization. `UPConfig` extends `GRPOConfig` without new fields and documents which clip/KL knobs matter (`epsilon` / optional `delta` on the negative branch; `epsilon_high` often inert).
> 
> The trainer **rejects `use_liger_kernel=True`** so training cannot silently fall back to the fused GRPO loss. **`UPTrainer`** is registered for telemetry in `base_trainer.py`. Docs add `up.md`, a **paper index** entry, and a toctree link; **`tests/experimental/test_up_trainer.py`** covers gradients vs REINFORCE/DAPO, `delta`/`epsilon_high`, sequence vs token IS on each branch, KL, Liger guard, and a short train smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15bb1763155edeaac8ae3c561e90ff328aa7e06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->