### PR TITLE
Ignore benign bitsandbytes 4-bit blocksize alignment warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,4 +229,12 @@ filterwarnings = [
     # Triggered by the NemotronH (Nemotron 3) Mamba2 mixer fast path during training under CUDA autocast
     # Tracking issue: https://github.com/huggingface/trl/issues/6555
     "ignore:torch.get_autocast_gpu_dtype\\(\\) is deprecated:DeprecationWarning",
+
+    # bitsandbytes warns, on every forward of a 4-bit layer whose inner dimension is not a multiple of the quantization
+    # blocksize, that it falls back to the slower dequantize + linear path (upstream, not actionable in TRL)
+    # Triggered by the tiny models in the PEFT + quantization tests: their hidden_size (8) and intermediate_size (32)
+    # are not multiples of the 64 blocksize, and transformers exposes no option to change it
+    # Tracking issue: https://github.com/huggingface/trl/issues/6580
+    # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
+    "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
 ]


### PR DESCRIPTION
This PR silences the benign `bitsandbytes` 4-bit blocksize alignment `UserWarning` emitted by the PEFT + quantization tests in CI.

Fix #6580.

### Motivation

Since the release of `bitsandbytes` 0.50.0, `test_peft_with_quantization` in the DPO, KTO and SFT trainer tests emits repeated warnings:

```
/__w/trl/trl/.venv/lib/python3.14/site-packages/bitsandbytes/backends/cuda/ops.py:944: UserWarning: inner dimension (8) is not aligned for fast kernel with blocksize=64, falling back to slower implementation.
  warn(
```

The warning comes from the new `bitsandbytes::gemm_4bit` dispatch, which warns whenever a 4-bit layer's inner dimension is not a multiple of the quantization blocksize and it therefore falls back to dequantize + linear. Our tiny test models have `hidden_size=8` and `intermediate_size=32`, neither a multiple of the 64 blocksize, and `transformers` exposes no option to change the blocksize, so the fallback is unavoidable for these fixtures. The tests pass; there is nothing actionable on the TRL side.

Reported upstream: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027 (still present in 0.50.0 and on `main`).

### Solution

Suppress the warning through `filterwarnings` in `pyproject.toml`, documented like the other upstream warning filters and linked to both the tracking issue and the upstream issue, so the entry can be removed once a fixed `bitsandbytes` release is available in CI.

### Changes

- Add a `filterwarnings` entry for the `bitsandbytes` blocksize alignment `UserWarning`, with a comment explaining the cause, what triggers it, and links to the tracking and upstream issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/CI configuration only; no runtime or training behavior changes.
> 
> **Overview**
> Adds a **pytest `filterwarnings`** entry in `pyproject.toml` so CI no longer floods logs with a benign **bitsandbytes** `UserWarning` about 4-bit inner dimensions not aligning to the 64-element blocksize (slow-path fallback).
> 
> The filter is documented like the other upstream suppressions, with links to TRL issue **#6580** and bitsandbytes **#2027**, so it can be dropped when upstream fixes or test fixtures change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d15d178c167f4ed3c9e9623f5a29fc95a37a4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->