### PR TITLE
Ignore transformers rotary `device` deprecation warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,4 +237,12 @@ filterwarnings = [
     # Tracking issue: https://github.com/huggingface/trl/issues/6580
     # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
     "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
+
+    # transformers' rotary modules unconditionally forward the freshly-deprecated `device` kwarg into their own
+    # `compute_default_rope_parameters` staticmethod, so transformers warns about its own internal call (upstream,
+    # not actionable in TRL); it fires at init for nearly every architecture in the test suite
+    # Introduced by https://github.com/huggingface/transformers/pull/47598
+    # Tracking issue: https://github.com/huggingface/trl/issues/6584
+    # Upstream issue: https://github.com/huggingface/transformers/issues/47641
+    "ignore:`device` is deprecated and will be removed in version 5.18 for `compute_default_rope_parameters`:FutureWarning",
 ]


### PR DESCRIPTION
This PR silences the self-triggered `transformers` rotary `device` `FutureWarning` emitted by the CI jobs that run with dev dependencies.

Fix #6584.

### Motivation

Since the merge of `transformers` https://github.com/huggingface/transformers/pull/47598 ("Simplify all Rotary modules"), every model instantiation emits:

```
/__w/trl/trl/.venv/lib/python3.13/site-packages/transformers/models/llama/modeling_llama.py:88: FutureWarning: `device` is deprecated and will be removed in version 5.18 for `compute_default_rope_parameters`.
  inv_freq, self.attention_scaling = rope_init_fn(self.config, device=device)
```

That same commit added both the deprecation and the internal call that trips it: the rotary module's `__init__` unconditionally forwards `device=device` into its own freshly deprecated `compute_default_rope_parameters` staticmethod, so `transformers` warns about its own internal call. The warning fires even when nothing is passed by the caller, and the pattern is repeated across roughly 146 modeling files, so it triggers for nearly every architecture in our test suite.

There is nothing actionable on the TRL side: TRL never constructs rotary embeddings nor calls the rope init functions, with zero references to `rope_init_fn`, `compute_default_rope_parameters` or `rope_parameters` in `trl/` and `tests/`.

The warning does not fail the tests, but it had become the only warning message reported in those jobs, masking any other warning signal:

| Job | Total warnings | Distinct messages in the warnings summary |
| --- | --- | --- |
| Experimental trainers (dev deps) | 437 | 1 (this warning, ~427) |
| Core trainers (dev deps) | 859 | 1 (this warning, ~787) |

The same suites report no warnings at all with released dependencies.

Reported upstream: https://github.com/huggingface/transformers/issues/47641 (still present on `main`).

### Solution

Suppress the warning through `filterwarnings` in `pyproject.toml`, documented like the other upstream warning filters and linked to both the tracking issue and the upstream issue, so the entry can be removed once the upstream fix reaches CI.

### Changes

- Add a `filterwarnings` entry for the `transformers` rotary `device` `FutureWarning`, with a comment explaining the cause, what triggers it, and links to the introducing PR plus the tracking and upstream issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test configuration only; no runtime behavior, security, or training logic changes.
> 
> **Overview**
> Adds a **pytest `filterwarnings` ignore** in `pyproject.toml` for the upstream **`transformers` rotary `device` `FutureWarning`** on `compute_default_rope_parameters`.
> 
> The entry is documented like the other upstream filters, with links to the introducing transformers PR, TRL tracking issue **#6584**, and upstream **transformers#47641**, so it can be removed once fixed upstream. **No TRL library or test code changes**—only CI warning hygiene so dev-deps jobs are not flooded by a self-triggered warning on nearly every model init, which was masking other warning signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed2fded45408e4221b110c2fcf2da2983a092b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->