### PR TITLE
fix(vllm): support bracketed IPv6 communicator hosts

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -14,17 +14,20 @@
 
 import os
 import subprocess
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
 from transformers.testing_utils import torch_device
 
+from trl.generation import vllm_client as vllm_client_module
 from trl.generation.vllm_client import VLLMClient
 from trl.generation.vllm_generation import extract_logprobs
 from trl.import_utils import is_vllm_available
-from trl.scripts.vllm_serve import chunk_list
+from trl.scripts.vllm_serve import WeightSyncWorkerExtension, chunk_list
 
 from .testing_utils import (
     TrlTestCase,
@@ -122,6 +125,79 @@ class TestExtractLogprobs(TrlTestCase):
 
         assert all_logprobs is None
         assert all_token_ids is None
+
+
+class TestVLLMClientCommunicator(TrlTestCase):
+    @pytest.mark.parametrize(
+        ("host", "expected_communicator_host"),
+        [("[2001:db8::1]", "2001:db8::1"), ("127.0.0.1", "127.0.0.1")],
+    )
+    def test_init_communicator_host(self, host, expected_communicator_host):
+        client = object.__new__(VLLMClient)
+        client.host = host
+        client.base_url = f"http://{host}:8000"
+        client.group_port = 51216
+        client.session = MagicMock()
+        client.session.post.return_value.status_code = 200
+
+        get_response = MagicMock(status_code=200)
+        get_response.json.return_value = {"world_size": 1}
+        stateless_process_group = MagicMock()
+
+        with (
+            patch.object(vllm_client_module, "is_torch_xpu_available", return_value=False),
+            patch.object(
+                vllm_client_module.torch.cuda, "get_device_properties", return_value=SimpleNamespace(uuid="uuid")
+            ),
+            patch.object(vllm_client_module.requests, "get", return_value=get_response),
+            patch.object(vllm_client_module, "StatelessProcessGroup", stateless_process_group, create=True),
+            patch.object(vllm_client_module, "PyNcclCommunicator", create=True),
+            patch.object(vllm_client_module.time, "sleep"),
+            patch.object(vllm_client_module.atexit, "register"),
+        ):
+            client.init_communicator()
+
+        stateless_process_group.create.assert_called_once_with(
+            host=expected_communicator_host, port=51216, rank=1, world_size=2
+        )
+        assert client.host == host
+        assert client.base_url == f"http://{host}:8000"
+
+    @pytest.mark.parametrize(
+        ("host", "expected_communicator_host"),
+        [("[2001:db8::1]", "2001:db8::1"), ("127.0.0.1", "127.0.0.1")],
+    )
+    def test_server_init_communicator_host(self, host, expected_communicator_host):
+        worker = WeightSyncWorkerExtension()
+        worker.device = 0
+        worker.communicator = None
+
+        stateless_process_group = MagicMock()
+        pynccl_communicator = MagicMock()
+        pynccl_module = ModuleType("vllm.distributed.device_communicators.pynccl")
+        pynccl_module.PyNcclCommunicator = pynccl_communicator
+        parallel_state_module = ModuleType("vllm.distributed.parallel_state")
+        parallel_state_module.get_world_group = MagicMock(return_value=SimpleNamespace(rank=0))
+        utils_module = ModuleType("vllm.distributed.utils")
+        utils_module.StatelessProcessGroup = stateless_process_group
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "vllm.distributed.device_communicators.pynccl": pynccl_module,
+                    "vllm.distributed.parallel_state": parallel_state_module,
+                    "vllm.distributed.utils": utils_module,
+                },
+            ),
+            patch("torch.cuda.is_available", return_value=False),
+            patch("transformers.is_torch_xpu_available", return_value=False),
+        ):
+            worker.init_communicator(host, port=51216, world_size=2, client_device_uuid="client-uuid")
+
+        stateless_process_group.create.assert_called_once_with(
+            host=expected_communicator_host, port=51216, rank=0, world_size=2
+        )
 
 
 @pytest.mark.slow

--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -464,9 +464,10 @@ class VLLMClient:
         time.sleep(0.1)
 
         # Set up the communication group for weight broadcasting
+        communicator_host = self.host.strip("[]")
         if is_torch_xpu_available():
             store = torch.distributed.TCPStore(
-                host_name=self.host, port=self.group_port, world_size=world_size, is_master=(self.rank == 0)
+                host_name=communicator_host, port=self.group_port, world_size=world_size, is_master=(self.rank == 0)
             )
             prefixed_store = c10d.PrefixStore("client2server", store)
             xccl_options = c10d.ProcessGroupXCCL.Options()
@@ -479,7 +480,7 @@ class VLLMClient:
             self.communicator = pg
         else:
             pg = StatelessProcessGroup.create(
-                host=self.host, port=self.group_port, rank=self.rank, world_size=world_size
+                host=communicator_host, port=self.group_port, rank=self.rank, world_size=world_size
             )
             self.communicator = PyNcclCommunicator(pg, device=device)
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -94,8 +94,11 @@ class WeightSyncWorkerExtension:
         # Get the rank of the current worker in the global world group.
         rank = get_world_group().rank
 
+        communicator_host = host.strip("[]")
         if is_torch_xpu_available():
-            store = torch.distributed.TCPStore(host_name=host, port=port, world_size=world_size, is_master=(rank == 0))
+            store = torch.distributed.TCPStore(
+                host_name=communicator_host, port=port, world_size=world_size, is_master=(rank == 0)
+            )
             prefixed_store = c10d.PrefixStore("client2server", store)
             xccl_options = c10d.ProcessGroupXCCL.Options()
             pg = c10d.ProcessGroupXCCL(
@@ -108,7 +111,7 @@ class WeightSyncWorkerExtension:
         else:
             # Create a stateless process group to manage communication between training processes and vLLM workers.
             # Initialize the NCCL-based communicator for weight synchronization.
-            pg = StatelessProcessGroup.create(host=host, port=port, rank=rank, world_size=world_size)
+            pg = StatelessProcessGroup.create(host=communicator_host, port=port, rank=rank, world_size=world_size)
             self.communicator = PyNcclCommunicator(pg, device=self.device)
 
         # The client process that sends updated weights has the highest rank (world_size - 1).


### PR DESCRIPTION
# What does this PR do?

Fixes #3164.

The vLLM client/server path needs two representations of an IPv6 literal:

- HTTP URLs require the bracketed form, such as `[2001:db8::1]`.
- `StatelessProcessGroup.create` and `TCPStore` require the bare address, such as `2001:db8::1`.

This change follows the approach suggested by the maintainer in #3164: it strips surrounding brackets only at the communicator call sites on both the client and server. `self.host` and `base_url` remain unchanged, so URL construction keeps the correct bracketed form.

## Regression coverage

Focused client and server tests cover both bracketed IPv6 and ordinary IPv4 hosts. They verify that:

- communicator creation receives the bare IPv6 address;
- IPv4 behavior is unchanged;
- the client's stored host and HTTP base URL remain bracketed.

```text
uv run --with pytest pytest tests/test_vllm_client_server.py -k 'communicator_host' -q
....                                                                     [100%]
4 passed, 51 deselected
```

No documentation change is needed because this is an internal host-normalization fix with no public API change.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.
