### PR TITLE
Add `test_train_moe_peft_model` for KTO

### DIFF
--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -812,6 +812,43 @@ class TestKTOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @require_peft
+    def test_train_moe_peft_model(self):
+        # Regression test for https://github.com/huggingface/trl/issues/5222. PEFT only supports one adapter per model
+        # when the LoRA config uses `target_parameters` (see peft#3340), so no "ref" adapter can be created and the
+        # reference log probs are computed with adapters disabled instead.
+        model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
+        model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+        base_param_names = [f"base_model.model.{n}" for n, _ in model.named_parameters()]
+
+        lora_config = LoraConfig(target_parameters=["mlp.experts.down_proj", "mlp.experts.gate_up_proj"])
+        model = get_peft_model(model, lora_config)
+
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=1.0,  # use higher lr because gradients are tiny and default lr can stall updates
+            report_to="none",
+        )
+        trainer = KTOTrainer(model=model, args=training_args, train_dataset=dataset)
+
+        assert "ref" not in trainer.model.peft_config
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the peft params have changed and the base model params have not changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if n in base_param_names:  # We expect the base model params to be the same
+                torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
+            elif "base_layer" not in n:  # We expect the peft params to be different (except for the base layer)
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
     # In practice, this test is the same as `test_kto_trainer_without_providing_ref_model_with_lora`, since gradient
     # checkpointing is enabled by default in `KTOTrainer`. We keep it as a regression guard: if the default ever
     # changes, we still explicitly test PEFT + gradient checkpointing, which has caused issues in the past.


### PR DESCRIPTION
This PR adds a regression test covering KTO training with a pre-wrapped PEFT model whose LoRA config uses `target_parameters`, mirroring the equivalent tests already present for GRPO, DPO and RLOO.

Related to #5222.

### Motivation

`KTOTrainer` carries the same huggingface/peft#3340 guard as the GRPO, DPO and RLOO trainers: when the pretrained adapter uses `target_parameters`, no `"ref"` adapter can be added, so the reference log probs are computed with adapters disabled instead. The other three trainers have a test for this path, KTO did not.

Trainers in TRL are self-contained by design, so duplicated logic must stay aligned, and that includes the tests covering it.

### Changes

- Add `test_train_moe_peft_model` to `TestKTOTrainer`, kept aligned with the DPO copy apart from the trainer and config classes, the dataset config, and the learning rate, which follows the convention of the other PEFT tests in this file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or trainer logic modifications.
> 
> **Overview**
> Adds **`test_train_moe_peft_model`** to `TestKTOTrainer`, matching the existing DPO/GRPO/RLOO coverage for [trl#5222](https://github.com/huggingface/trl/issues/5222).
> 
> The test wraps **tiny-GptOss** with LoRA using **`target_parameters`** on MoE expert projections, asserts no **`ref`** PEFT adapter is registered, runs a short **`KTOTrainer`** step on unpaired preference data, and checks trainable LoRA weights update while the frozen base stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c32cc208f3740475a65792b5437aa2d63a85e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->