### PR TITLE
Remove bitsandbytes `_check_is_size` warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,12 +212,6 @@ filterwarnings = [
     # Upstream fix (merged, unreleased as of liger-kernel 0.8.0): https://github.com/linkedin/Liger-Kernel/pull/1274
     "ignore:Error detected in IndexPutBackward0:UserWarning",
 
-    # bitsandbytes calls the deprecated torch._check_is_size in its CUDA quant ops (upstream, not actionable in TRL)
-    # Triggered indirectly by loading bitsandbytes-quantized models in the PEFT + quantization tests
-    # Tracking issue: https://github.com/huggingface/trl/issues/6447
-    # Upstream fix (merged, unreleased as of bitsandbytes 0.49.2): https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1940
-    "ignore:_check_is_size will be removed in a future PyTorch release:FutureWarning",
-
     # triton builds an ast.AnnAssign node without the required `simple` field during kernel compilation (upstream,
     # not actionable in TRL); a DeprecationWarning on Python 3.14 that becomes an error on 3.15
     # Tracking issue: https://github.com/huggingface/trl/issues/6466


### PR DESCRIPTION
# What does this PR do?

Removes the `_check_is_size` `filterwarnings` entry from `pyproject.toml`, which is the action item in #6447.

Fixes #6447

The entry was added because bitsandbytes called the deprecated `torch._check_is_size` in its CUDA quant ops. The upstream fix (bitsandbytes-foundation/bitsandbytes#1940) was merged but unreleased at the time, so the issue asked to remove the filter once a release containing it reached CI. `bitsandbytes 0.50.0` is that release, and CI is already on it (#6546).

## Verification

Ran the three tests named in the issue with the filter removed, on an aarch64 GB10, torch 2.13.0+cu130, capturing all warnings:

| bitsandbytes | result | `_check_is_size` warnings |
|---|---|---|
| 0.50.0 | 3 passed | **0** |
| 0.49.2 | 3 passed | 14, from `bitsandbytes/backends/cuda/ops.py:213` |

So the filter is genuinely dead on 0.50.0, and the 0.49.2 row confirms the check is meaningful rather than vacuous: it does still catch the warning on the older release. Independently, `_check_is_size` appears 0 times anywhere in the installed 0.50.0 package and 6 times in 0.49.2.

Worth noting that `filterwarnings` does not start with `error`, so this cannot fail CI on an older bitsandbytes either. It would only restore log noise.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. Yes, #6447, which states this removal as its action item.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? No new tests, the three existing `test_peft_with_quantization` tests already cover it; results above.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone once CI is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-configuration-only change with no runtime or dependency logic; worst case on an older bitsandbytes is extra warning noise in logs, not CI failure.
> 
> **Overview**
> Removes the pytest `filterwarnings` ignore for bitsandbytes’ deprecated `torch._check_is_size` `FutureWarning` from `pyproject.toml`, closing the follow-up in #6447.
> 
> That entry was only needed while CI still pulled bitsandbytes before the upstream fix shipped; with **bitsandbytes 0.50.0** on CI, PEFT + quantization tests no longer emit that warning, so the filter is dead weight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f232d09448f07172e8ffbed69f3a39e5478cf0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->