### PR TITLE
Use accelerator device instead of hardcoded cuda in FSDP2 vLLM weight sync

### DIFF
--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -753,7 +753,7 @@ class OnlineDPOTrainer(_BaseTrainer):
             name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
 
             if param.is_cpu:
-                param = param.to(torch.device("cuda"))
+                param = param.to(self.accelerator.device)
             param = param.full_tensor()
 
             if self.vllm_mode == "server" and self.accelerator.is_main_process:

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -431,7 +431,7 @@ class VLLMGeneration:
             name = self._fix_param_name_to_vllm(name, extra_prefixes=["modules_to_save.default."])
 
             if param.is_cpu:
-                param = param.to(torch.device("cuda"))
+                param = param.to(self.accelerator.device)
             param = param.full_tensor()
 
             self._push_param_to_vllm(name, param)


### PR DESCRIPTION
## What does this PR do?

`VLLMGeneration._sync_fsdp2_params_to_vllm` and its duplicate in `OnlineDPOTrainer._sync_fsdp2_params_to_vllm` both hardcode `torch.device("cuda")` when moving a CPU-resident FSDP2 parameter back onto the accelerator, instead of using `self.accelerator.device`:

```python
if param.is_cpu:
    param = param.to(torch.device("cuda"))
```

This breaks in two ways:
- On a non-CUDA accelerator backend (e.g. Ascend NPU, which TRL explicitly supports for vLLM generation — see #3286, #5142), this silently moves the parameter to the wrong device instead of the one the trainer is actually using.
- On any torch build without CUDA support, this raises `AssertionError: Torch not compiled with CUDA enabled` outright.

The fix is a one-line swap to `self.accelerator.device`, which is already the pattern used elsewhere in both of these same methods/classes (e.g. `self.accelerator.is_main_process` a few lines below in `OnlineDPOTrainer`).

Per `.ai/AGENTS.md`'s duplication rule ("a fix in one trainer implies the same fix in others"), both copies of this pattern are updated together — a repo-wide grep confirms these are the only two occurrences of `torch.device("cuda")` in `trl/`.

## Testing

`_sync_fsdp2_params_to_vllm` is currently only exercised by the full multi-GPU FSDP2 integration tests in `tests/distributed/test_distributed.py`, which require real distributed hardware and aren't runnable here. There's no existing unit-test pattern that exercises this method in isolation, so I didn't add mock-heavy scaffolding for it — happy to add one if maintainers have a preferred lightweight approach.

I did verify the specific bug directly: constructing a bare `VLLMGeneration` instance with a stand-in `accelerator.device` and a CPU parameter reproduces the crash on `main` and confirms it's resolved on this branch (the `.to(...)` call now succeeds and respects the given device instead of hardcoding cuda).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)?
- [x] Was this discussed/approved via a GitHub issue? N/A — small, self-contained bugfix.
- [x] Did you make sure to update the documentation with your changes? N/A — no user-facing API/behavior change beyond the bugfix.
- [x] Did you write any new necessary tests? See Testing note above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line behavioral fix in distributed weight-sync helpers; no API changes and aligns device handling with existing accelerator usage.
> 
> **Overview**
> **FSDP2 → vLLM weight sync** no longer hardcodes CUDA when moving CPU-resident parameters before `full_tensor()` and pushing to vLLM.
> 
> In both `VLLMGeneration._sync_fsdp2_params_to_vllm` and `OnlineDPOTrainer._sync_fsdp2_params_to_vllm`, `param.to(torch.device("cuda"))` is replaced with `param.to(self.accelerator.device)`, matching how the rest of these trainers resolve the active device.
> 
> This fixes wrong-device moves on non-CUDA accelerators (e.g. NPU) and avoids `Torch not compiled with CUDA enabled` on CPU-only builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac934075e55e2d9383f4290ba1f4aafc6fb8ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->