### PR TITLE
fix(dpo_trainer): use rejected_logratios in apo_down loss (Eqn 8)

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1528,7 +1528,7 @@ class DPOTrainer(_BaseTrainer):
                 # Use this loss when you believe the chosen outputs are worse than your model's default output.
                 # Decrease chosen likelihood and decrease rejected likelihood more
                 losses_chosen = torch.sigmoid(self.beta * chosen_logratios)
-                losses_rejected = 1 - torch.sigmoid(self.beta * delta_score)
+                losses_rejected = 1 - torch.sigmoid(self.beta * rejected_logratios)
                 per_sequence_loss = losses_chosen + losses_rejected
 
             elif loss_type == "discopop":


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the `apo_down` loss function in `DPOTrainer`.

The `apo_down` loss (Equation 8 of the [APO paper](https://huggingface.co/papers/2408.06266)) is used when chosen outputs are worse than the model's default. It should decrease chosen likelihood and decrease rejected likelihood more.

**Bug:** The rejected term used `delta_score` (which equals `chosen_logratios - rejected_logratios`, a combined quantity) instead of `rejected_logratios`.

**Before:**
```python
losses_rejected = 1 - torch.sigmoid(self.beta * delta_score)
```

**After:**
```python
losses_rejected = 1 - torch.sigmoid(self.beta * rejected_logratios)
```

Using `delta_score` in this position conflates the two distributions and produces incorrect gradient updates for the rejected branch, causing `apo_down` to not behave as described in the paper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gradient updates for anyone training with `loss_type="apo_down"`, so runs will differ from the buggy implementation; scope is limited to that loss path.
> 
> **Overview**
> Fixes the **`apo_down`** rejected loss term in `DPOTrainer` so it matches APO Equation 8 instead of mixing in the preference margin.
> 
> The rejected branch now uses **`1 - sigmoid(β * rejected_logratios)`**, aligned with how **`apo_zero`** uses **`rejected_logratios`** on its rejected term. Previously it used **`delta_score`** (the chosen-vs-rejected margin), which tied rejected updates to both arms and diverged from the paper’s “push down rejected likelihood more” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be55675e33531f81c5548d21d7885e08d0ceff6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->