### PR TITLE
Document removal criteria for pytest warning filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ norecursedirs = [
 filterwarnings = [
     # SWIG deprecations from SWIG-generated C/C++ extensions: sentencepiece
     # Upstream issue: https://github.com/google/sentencepiece/issues/1150
+    # Remove once: no supported sentencepiece version emits it
     "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
@@ -194,6 +195,7 @@ filterwarnings = [
     # Upstream issue: https://github.com/deepspeedai/DeepSpeed/issues/7835
     # Upstream PR: https://github.com/deepspeedai/DeepSpeed/pull/7840
     # Upstream fix released in deepspeed v0.18.6: https://github.com/deepspeedai/DeepSpeed/releases/tag/v0.18.6
+    # Remove once: deepspeed >= 0.18.6 is required
     "ignore:`torch.jit.script_method` is deprecated:DeprecationWarning",
     "ignore:`torch.jit.script` is deprecated:DeprecationWarning",
     # On Python 3.14+ the same deprecation is reworded to "is not supported in Python 3.14+ and may break"
@@ -202,6 +204,7 @@ filterwarnings = [
     # PyTorch DataLoader pin_memory device argument deprecations
     # Triggered internally by torch.utils.data, not by our code
     # Upstream issue: https://github.com/pytorch/pytorch/issues/174546
+    # Remove once: no supported torch version emits it
     "ignore:The argument 'device' of Tensor.pin_memory:DeprecationWarning",
     "ignore:The argument 'device' of Tensor.is_pinned:DeprecationWarning",
 
@@ -209,25 +212,30 @@ filterwarnings = [
     # Liger's SAPO branch assigns per-token loss with boolean-mask indexing, which graph-breaks under
     # torch.compile and is traced by AOTAutograd under anomaly mode
     # Tracking issue: https://github.com/huggingface/trl/issues/6435
-    # Upstream fix (merged, unreleased as of liger-kernel 0.8.0): https://github.com/linkedin/Liger-Kernel/pull/1274
+    # Upstream fix released in liger-kernel 0.8.1: https://github.com/linkedin/Liger-Kernel/pull/1274
+    # Remove once: liger-kernel >= 0.8.2 is required (0.8.1 has the fix but is excluded, see GH-6517)
     "ignore:Error detected in IndexPutBackward0:UserWarning",
 
     # bitsandbytes calls the deprecated torch._check_is_size in its CUDA quant ops (upstream, not actionable in TRL)
     # Triggered indirectly by loading bitsandbytes-quantized models in the PEFT + quantization tests
     # Tracking issue: https://github.com/huggingface/trl/issues/6447
-    # Upstream fix (merged, unreleased as of bitsandbytes 0.49.2): https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1940
+    # Upstream fix released in bitsandbytes 0.50.0: https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1940
+    # Remove once: bitsandbytes >= 0.50.0 is required
     "ignore:_check_is_size will be removed in a future PyTorch release:FutureWarning",
 
     # triton builds an ast.AnnAssign node without the required `simple` field during kernel compilation (upstream,
     # not actionable in TRL); a DeprecationWarning on Python 3.14 that becomes an error on 3.15
     # Tracking issue: https://github.com/huggingface/trl/issues/6466
     # Upstream issue: https://github.com/triton-lang/triton/issues/10981
+    # Upstream fix (merged, unreleased as of triton 3.7.1): https://github.com/triton-lang/triton/pull/10986
+    # Remove once: no supported torch resolves a triton without the fix
     "ignore:AnnAssign.__init__ missing 1 required positional argument:DeprecationWarning",
 
     # kernels-community/mamba-ssm (a Hub-hosted build of state-spaces/mamba) calls the deprecated
     # torch.get_autocast_gpu_dtype() in its Triton ssd_combined.py kernel (upstream, not actionable in TRL)
     # Triggered by the NemotronH (Nemotron 3) Mamba2 mixer fast path during training under CUDA autocast
     # Tracking issue: https://github.com/huggingface/trl/issues/6555
+    # Remove once: the resolved Hub kernel build no longer calls it
     "ignore:torch.get_autocast_gpu_dtype\\(\\) is deprecated:DeprecationWarning",
 
     # bitsandbytes warns, on every forward of a 4-bit layer whose inner dimension is not a multiple of the quantization
@@ -236,6 +244,7 @@ filterwarnings = [
     # are not multiples of the 64 blocksize, and transformers exposes no option to change it
     # Tracking issue: https://github.com/huggingface/trl/issues/6580
     # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
+    # Remove once: no supported bitsandbytes version emits it
     "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
 
     # transformers' rotary modules unconditionally forward the freshly-deprecated `device` kwarg into their own
@@ -244,5 +253,6 @@ filterwarnings = [
     # Introduced by https://github.com/huggingface/transformers/pull/47598
     # Tracking issue: https://github.com/huggingface/trl/issues/6584
     # Upstream issue: https://github.com/huggingface/transformers/issues/47641
+    # Remove once: no supported transformers version emits it
     "ignore:`device` is deprecated and will be removed in version 5.18 for `compute_default_rope_parameters`:FutureWarning",
 ]


### PR DESCRIPTION
This PR documents, next to every pytest `filterwarnings` entry in `pyproject.toml`, the condition under which that entry can be removed, and refreshes the upstream status notes that had become stale.

### Motivation

The tracking issue of each filter states its action item as removing the entry "once upstream ships the fix". For a dependency we require without a floor, that criterion is wrong: an upstream release does not stop older releases from being supported configurations, and `filterwarnings` is part of the test configuration we declare for all of them, not a snapshot of what CI happens to resolve today. Removing an entry when the fix is merely released brings the warning noise back for every supported older version, including for contributors running the suite in an existing environment.

The ambiguity is not theoretical:

- #6590 proposed dropping the `_check_is_size` filter as soon as `bitsandbytes` 0.50.0 reached CI, faithfully implementing the criterion as worded in #6447.
- We still carry the `torch.jit.script` filters although their `deepspeed` fix has been released since 0.18.6, precisely because our floor has not moved yet.

So both readings currently coexist in the same file, with nothing on the entries themselves to tell them apart. Recording the criterion at each entry puts that information where the removal decision is actually taken, rather than in an issue title.

### Solution

Add one `Remove once:` line per entry. The criterion takes one of two shapes, depending on whether TRL can constrain the component that emits the warning:

- for dependencies we declare (`bitsandbytes`, `liger-kernel`, `deepspeed`), removal is gated on our minimum required version reaching the first release that contains the fix;
- for dependencies we do not declare, either transitive (`triton`, pinned by `torch`) or resolved at runtime (the `kernels-community/mamba-ssm` Hub kernel build), there is no floor to bump, so removal is gated on no supported configuration emitting the warning any more.

The criterion lines deliberately do not restate the version we currently require, which would be one more thing to keep in sync with the requirements.

Reviewing every entry also surfaced three upstream status notes that are no longer accurate, updated here. The wording of the tracking issues (#6435, #6447, #6466, #6555) is aligned separately.

### Changes

- Add a `Remove once:` line to every `filterwarnings` entry, giving the target version for the entries gated on a requirement bump and the observable condition for the others
- Update the `liger-kernel` SAPO note: the fix is released in 0.8.1, which we exclude for an unrelated crash (GH-6517), so the criterion is 0.8.2
- Update the `bitsandbytes` `_check_is_size` note: the fix is released in 0.50.0
- Add the upstream fix PR to the `triton` `AnnAssign` entry, merged and unreleased as of 3.7.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes to test configuration documentation; no runtime or dependency requirement changes.
> 
> **Overview**
> Adds a **`Remove once:`** comment beside each pytest `filterwarnings` entry in `pyproject.toml`, so maintainers know when to drop a filter without relying on tracking-issue wording alone.
> 
> Criteria differ by dependency: filters tied to declared extras (e.g. **deepspeed**, **liger-kernel**, **bitsandbytes**) say removal waits until TRL’s minimum required version includes the upstream fix; others (sentencepiece, torch, triton, Hub mamba kernel) say removal waits until no supported configuration still emits the warning.
> 
> Also refreshes stale upstream notes: **liger-kernel** SAPO fix is in 0.8.1 with removal gated on **>= 0.8.2** (0.8.1 excluded per GH-6517), **bitsandbytes** `_check_is_size` fix is in **0.50.0**, and **triton** `AnnAssign` documents merged fix PR **#10986** (unreleased as of 3.7.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fcf571cc437878d03a770115a2522b78186bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->