### PR TITLE
Revert transformers rotary device deprecation warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,12 +237,4 @@ filterwarnings = [
     # Tracking issue: https://github.com/huggingface/trl/issues/6580
     # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
     "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
-
-    # transformers' rotary modules unconditionally forward the freshly-deprecated `device` kwarg into their own
-    # `compute_default_rope_parameters` staticmethod, so transformers warns about its own internal call (upstream,
-    # not actionable in TRL); it fires at init for nearly every architecture in the test suite
-    # Introduced by https://github.com/huggingface/transformers/pull/47598
-    # Tracking issue: https://github.com/huggingface/trl/issues/6584
-    # Upstream issue: https://github.com/huggingface/transformers/issues/47641
-    "ignore:`device` is deprecated and will be removed in version 5.18 for `compute_default_rope_parameters`:FutureWarning",
 ]


### PR DESCRIPTION
This PR reverts the `filterwarnings` entry added in #6585, now that the underlying `transformers` warning has been fixed upstream.

Fix #6584.

### Motivation

#6585 suppressed a self-triggered `FutureWarning` introduced by 
- https://github.com/huggingface/transformers/pull/47598

where the rotary modules forwarded the freshly deprecated device kwarg into their own `compute_default_rope_parameters` staticmethod:

> FutureWarning: `device` is deprecated and will be removed in version 5.18 for `compute_default_rope_parameters`.

It has since been fixed upstream in two PRs:

- https://github.com/huggingface/transformers/pull/47642, which covered the plain `rope_init_fn(self.config, device=device)` variant
  - I reported some occurrences were missing: https://github.com/huggingface/transformers/pull/47642#issuecomment-5131324623
- https://github.com/huggingface/transformers/pull/47664, which covered the remaining per-layer-type `rope_init_fn(rope_config, layer_type=layer_type, device=device)` variant in `gemma4`, `gemma4_unified` and `diffusion_gemma`

There are no longer any call sites on `transformers` `main` forwarding device into a` @deprecate_kwarg("device", version="5.18")` decorated rope init, so the filter is now dead configuration. Keeping it would also mask the warning if the pattern were reintroduced upstream.

### Solution

Revert the commit from 
- #6585

restoring the `filterwarnings` list to its previous state.

### Changes

- Remove the filterwarnings entry that ignored the transformers rotary device deprecation warning, along with its explanatory comment and issue links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-configuration-only change with no runtime or dependency behavior changes.
> 
> **Overview**
> Removes the pytest **`filterwarnings`** entry (and its comment/issue links) that suppressed **`FutureWarning`** about a deprecated **`device`** argument on **`compute_default_rope_parameters`**. That warning came from transformers' own rotary init paths and was previously worked around in TRL (#6585); upstream has since stopped forwarding **`device`**, so the filter is unused and would hide regressions if the pattern returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b15c7acc46d9c79a1e0d03ac93078ebb5351cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->