### PR TITLE
Fix incorrect example script path in Online DPO docs

### DIFF
--- a/docs/source/online_dpo_trainer.md
+++ b/docs/source/online_dpo_trainer.md
@@ -93,12 +93,12 @@ This callback logs the model's generated completions directly to Weights & Biase
 
 ## Example script
 
-We provide an example script to train a model using the online DPO method. The script is available in [`examples/scripts/dpo_online.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/dpo_online.py)
+We provide an example script to train a model using the online DPO method. The script is available in [`examples/scripts/online_dpo.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/online_dpo.py)
 
 To test the online DPO script with the [Qwen2.5 0.5B model](https://huggingface.co/trl-lib/Qwen/Qwen2.5-0.5B-Instruct) on the [UltraFeedback dataset](https://huggingface.co/datasets/openbmb/UltraFeedback), run the following command:
 
 ```bash
-python examples/scripts/dpo_online.py \
+python examples/scripts/online_dpo.py \
     --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
     --reward_model_path trl-lib/Qwen2-0.5B-Reward \
     --dataset_name trl-lib/ultrafeedback-prompt \
@@ -134,7 +134,7 @@ To validate the online DPO implementation works, we ran experiments with the Pyt
 ```shell
 # 1B Online DPO experiment
 accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml \
-    examples/scripts/dpo_online.py \
+    examples/scripts/online_dpo.py \
     --model_name_or_path trl-lib/pythia-1b-deduped-tldr-sft  \
     --reward_model_path trl-lib/pythia-1b-deduped-tldr-rm \
     --dataset_name trl-lib/tldr \
@@ -152,7 +152,7 @@ accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml \
 
 # 2.8B Online DPO experiment
 accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
-    examples/scripts/dpo_online.py \
+    examples/scripts/online_dpo.py \
     --model_name_or_path trl-lib/pythia-2.8b-deduped-tldr-sft  \
     --reward_model_path trl-lib/pythia-2.8b-deduped-tldr-rm \
     --dataset_name trl-lib/tldr \
@@ -170,7 +170,7 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml
 
 # 6.9B Online DPO experiment
 accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
-    examples/scripts/dpo_online.py \
+    examples/scripts/online_dpo.py \
     --model_name_or_path trl-lib/pythia-6.9b-deduped-tldr-sft  \
     --reward_model_path trl-lib/pythia-6.9b-deduped-tldr-rm \
     --dataset_name trl-lib/tldr \


### PR DESCRIPTION
# What does this PR do?

The Online DPO documentation (`docs/source/online_dpo_trainer.md`) references `examples/scripts/dpo_online.py` in five places — a source link plus four runnable `python examples/scripts/dpo_online.py ...` command blocks — but that file does not exist. The script is **`examples/scripts/online_dpo.py`** (the words are transposed); its own docstring invokes it as `python examples/scripts/online_dpo.py`.

So the documented commands currently fail with:

```
python: can't open file '.../examples/scripts/dpo_online.py': [Errno 2] No such file or directory
```

and the source link 404s. This corrects the five references to the real path.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path corrections with no runtime or training code changes.
> 
> **Overview**
> Fixes **Online DPO** documentation so example commands and the GitHub link point at **`examples/scripts/online_dpo.py`** instead of the non-existent **`dpo_online.py`**.
> 
> Updates five references in `docs/source/online_dpo_trainer.md`: the example script link in **Example script**, the standalone `python` invocation, and the three **Benchmark experiments** `accelerate launch` blocks (1B, 2.8B, 6.9B Pythia runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02054c7fa3251588ea5ce754b42e05042bca622d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->