### PR TITLE
Require vision for VLM response parsing tests

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -205,6 +205,7 @@ class TestAddResponseSchema:
             pytest.param("trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6", id="qwen36"),
         ],
     )
+    @require_vision
     def test_add_response_schema_vlm(self, processor_name):
         # For VLM processors, `add_response_schema` must set the template/schema on the inner tokenizer, since
         # `parse_response` is a tokenizer method that reads `self.response_template` / `self.response_schema` from the
@@ -1057,17 +1058,28 @@ class TestGetTrainingChatTemplate:
             ),
         ),
         pytest.param("trl-internal-testing/tiny-Qwen3ForCausalLM-Instruct-2507", id="qwen3_instruct_2507"),
-        pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl"),
-        pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink", id="qwen35-nothink"),
-        pytest.param("trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think", id="qwen35-think"),
-        pytest.param("trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6", id="qwen36"),
+        pytest.param("trl-internal-testing/tiny-Qwen3VLForConditionalGeneration", id="qwen3_vl", marks=require_vision),
+        pytest.param(
+            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+            id="qwen35-nothink",
+            marks=require_vision,
+        ),
+        pytest.param(
+            "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-Think", id="qwen35-think", marks=require_vision
+        ),
+        pytest.param(
+            "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6", id="qwen36", marks=require_vision
+        ),
         pytest.param(
             "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
             id="gemma4",
-            marks=pytest.mark.skipif(
-                Version(transformers.__version__) < Version("5.5.0"),
-                reason="Gemma4 models were introduced in transformers-5.5.0",
-            ),
+            marks=[
+                require_vision,
+                pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ],
         ),
     ],
 )


### PR DESCRIPTION
This PR marks the VLM parametrizations of the response parsing tests as requiring vision, so they are skipped instead of failing when `Pillow` and `torchvision` are not installed.

### Motivation

`TestParseResponse` and `TestAddResponseSchema` load a `AutoProcessor` for their `*ForConditionalGeneration` parametrizations, which needs the `vlm` extra. Those parametrizations carry no `require_vision` mark, unlike every other VLM parametrization in the same file.

The gap is currently masked: both classes are decorated with `require_jmespath`, and the only CI job without the `vlm` extra ("Tests without optional dependencies") also lacks `jmespath`, so the whole class is skipped there for the wrong reason.

This surfaces as soon as the `jmespath` guard is narrowed in #6597, which correctly stops skipping these tests on transformers 5.13.0 and higher: the VLM parametrizations then run in that job and fail on the missing image processor backends.

### Solution

Guard the VLM parametrizations with `require_vision`, matching how the other VLM parametrizations in this file are already marked.

### Changes

- Mark the `*ForConditionalGeneration` parametrizations of `TestParseResponse` with `require_vision`
- Mark `test_add_response_schema_vlm` with `require_vision`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest skip markers; no production or runtime behavior changes.
> 
> **Overview**
> Adds **`require_vision`** to VLM cases in **`TestParseResponse`** and **`test_add_response_schema_vlm`** so they skip when Pillow/torchvision are missing, consistent with other VLM parametrizations in the same file.
> 
> For **`TestParseResponse`**, the Qwen3-VL / Qwen3.5 / Qwen3.6 and Gemma4 `*ForConditionalGeneration` params get `marks=require_vision` (Gemma4 keeps its transformers version skip in a combined marks list). **`test_add_response_schema_vlm`** is decorated with **`@require_vision`** at the method level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4e02ce9d4f365afd4c8c5c5ee5934133662d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->