### PR TITLE
Add activation offloading to GRPO and RLOO

### DIFF
--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -230,12 +230,14 @@ training_args = SFTConfig(..., padding_free=True, model_init_kwargs={"attn_imple
 
 Activation offloading is a memory efficiency technique that reduces GPU VRAM usage by temporarily moving activation tensors to CPU RAM during the forward pass and bringing them back only when needed for the backward pass. This significantly reduces peak memory usage at the cost of slightly increased training time.
 
-To enable activation offloading in your SFT training configuration:
+Activation offloading is available in [`SFTConfig`], [`RewardConfig`], [`DPOConfig`], [`KTOConfig`], [`GRPOConfig`],
+and [`RLOOConfig`]. To enable it, set `activation_offloading=True` in the training configuration. For example, with
+GRPO:
 
 ```python
-from trl import SFTConfig
+from trl import GRPOConfig
 
-training_args = SFTConfig(..., activation_offloading=True)
+training_args = GRPOConfig(..., activation_offloading=True)
 ```
 
 Under the hood, activation offloading implements PyTorch's [`saved_tensors_hooks`](https://pytorch.org/tutorials/intermediate/autograd_saved_tensors_hooks_tutorial.html#hooks-for-autograd-saved-tensors) to intercept activations during the forward pass. It intelligently manages which tensors to offload based on size and context, avoiding offloading output tensors that would be inefficient. For performance optimization, it can, via a flag (which is true by default), use CUDA streams to overlap computation with CPU-GPU transfers.

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -340,6 +340,35 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_train_with_activation_offloading(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        offload_context = MagicMock()
+
+        with patch(
+            "trl.trainer.grpo_trainer.get_act_offloading_ctx_manager", return_value=offload_context
+        ) as mock_get_context:
+            training_args = GRPOConfig(
+                output_dir=self.tmp_dir,
+                learning_rate=0.1,
+                per_device_train_batch_size=3,
+                num_generations=3,
+                max_completion_length=8,
+                max_steps=2,
+                activation_offloading=True,
+                report_to="none",
+            )
+            trainer = GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+            trainer.train()
+
+        mock_get_context.assert_called_once_with(model=trainer.model)
+        assert offload_context.__enter__.call_count == offload_context.__exit__.call_count == 2
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_train_dataset_format(self, config_name):
         dataset = load_dataset("trl-internal-testing/zen", config_name, split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -102,6 +102,35 @@ class TestRLOOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_with_activation_offloading(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        offload_context = MagicMock()
+
+        with patch(
+            "trl.trainer.rloo_trainer.get_act_offloading_ctx_manager", return_value=offload_context
+        ) as mock_get_context:
+            training_args = RLOOConfig(
+                output_dir=self.tmp_dir,
+                learning_rate=0.1,
+                per_device_train_batch_size=3,
+                num_generations=3,
+                max_completion_length=8,
+                max_steps=2,
+                activation_offloading=True,
+                report_to="none",
+            )
+            trainer = RLOOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+            trainer.train()
+
+        mock_get_context.assert_called_once_with(model=trainer.model)
+        assert offload_context.__enter__.call_count == offload_context.__exit__.call_count == 2
+        assert trainer.state.log_history[-1]["train_loss"] is not None
 
     def test_reward_func_wrong_number_of_rewards(self):
         # A reward function that returns the wrong number of rewards should raise a clear error instead of silently

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -364,6 +364,9 @@ class GRPOConfig(_BaseConfig):
             value is exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level="token"`; with
             `"sequence"` a sequence-level weight is broadcast onto the per-token KL.
 
+        activation_offloading (`bool`, *optional*, defaults to `False`):
+            Whether to offload the activations to the CPU.
+
         > Parameters that control the logging
 
         log_completions (`bool`, *optional*, defaults to `False`):
@@ -972,6 +975,11 @@ class GRPOConfig(_BaseConfig):
             "exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level='token'`; with "
             "'sequence' a sequence-level weight is broadcast onto the per-token KL."
         },
+    )
+
+    activation_offloading: bool = field(
+        default=False,
+        metadata={"help": "Whether to offload the activations to the CPU."},
     )
 
     # Parameters that control the logging

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import atexit
+import contextlib
 import copy
 import importlib.resources as pkg_resources
 import inspect
@@ -70,7 +71,7 @@ from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
 from ..import_utils import is_jmespath_available, is_liger_kernel_available
-from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
+from ..models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import _ForwardRedirection, disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer
 from .callbacks import SyncRefModelCallback
@@ -1053,6 +1054,12 @@ class GRPOTrainer(_BaseTrainer):
                 vespo_lambda_neg=args.vespo_lambda_neg,
             )
 
+        # Initialize activation offloading context
+        if self.args.activation_offloading:
+            self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
+        else:
+            self.maybe_activation_offload_context = contextlib.nullcontext()
+
         # Initialize the metrics
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
@@ -1552,7 +1559,8 @@ class GRPOTrainer(_BaseTrainer):
 
     def training_step(self, model, inputs, num_items_in_batch):
         time_before = time.perf_counter()
-        output = super().training_step(model, inputs, num_items_in_batch)
+        with self.maybe_activation_offload_context:
+            output = super().training_step(model, inputs, num_items_in_batch)
         self._step += 1
         time_after = time.perf_counter()
         self._current_train_step_time += time_after - time_before

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -207,6 +207,9 @@ class RLOOConfig(_BaseConfig):
             frequently the current policy is synchronized with the reference policy. To use this parameter, you must
             set `sync_ref_model=True`.
 
+        activation_offloading (`bool`, *optional*, defaults to `False`):
+            Whether to offload the activations to the CPU.
+
         > Parameters that control the logging
 
         log_completions (`bool`, *optional*, defaults to `False`):
@@ -560,6 +563,11 @@ class RLOOConfig(_BaseConfig):
             "help": "τ parameter from the TR-DPO paper, which determines how frequently the current policy is "
             "synchronized with the reference policy. To use this parameter, you must set `sync_ref_model=True`."
         },
+    )
+
+    activation_offloading: bool = field(
+        default=False,
+        metadata={"help": "Whether to offload the activations to the CPU."},
     )
 
     # Parameters that control the logging

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import atexit
+import contextlib
 import copy
 import inspect
 import math
@@ -54,7 +55,7 @@ from ..data_utils import apply_chat_template, is_conversational, prepare_multimo
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
-from ..models import prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
+from ..models import get_act_offloading_ctx_manager, prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 from ..models.utils import disable_gradient_checkpointing
 from .base_trainer import _BaseTrainer
 from .callbacks import SyncRefModelCallback
@@ -624,6 +625,12 @@ class RLOOTrainer(_BaseTrainer):
             if self.ref_model is not None:
                 disable_dropout_in_model(self.ref_model)
 
+        # Initialize activation offloading context
+        if self.args.activation_offloading:
+            self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
+        else:
+            self.maybe_activation_offload_context = contextlib.nullcontext()
+
         # Initialize the metrics
         self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
         self._total_train_tokens = 0
@@ -993,7 +1000,8 @@ class RLOOTrainer(_BaseTrainer):
 
     def training_step(self, model, inputs, num_items_in_batch):
         time_before = time.perf_counter()
-        output = super().training_step(model, inputs, num_items_in_batch)
+        with self.maybe_activation_offload_context:
+            output = super().training_step(model, inputs, num_items_in_batch)
         self._step += 1
         time_after = time.perf_counter()
         self._current_train_step_time += time_after - time_before


### PR DESCRIPTION
# What does this PR do?

Adds opt-in activation offloading to `GRPOTrainer` and `RLOOTrainer`, completing the remaining trainer scope discussed in #3717.

The implementation mirrors the existing DPO/KTO/SFT integration:

- adds `activation_offloading=False` to both trainer configs;
- initializes the activation-offloading context once and enters it for every training step;
- keeps the duplicated GRPO/RLOO paths synchronized;
- adds paired regression tests for context initialization and per-step entry/exit;
- updates the memory-usage guide with the complete list of supported configs.

Validation performed locally:

- `pre-commit run --files ...` (ruff check, ruff format, and doc-builder): passed;
- paired GRPO/RLOO regression tests: 2 passed;
- activation-offloading unit suite: 8 passed after pre-initializing Accelerate state for the local high-virtual-memory warning path;
- real single-GPU CUDA smoke training for both trainers: passed on an RTX 4060 Laptop GPU with PyTorch 2.13.0+cu130.

Multi-GPU/FSDP validation was not run because only one GPU is available locally.

Fixes #3717

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

cc @qgallouedec
