### PR TITLE
Add OPO length-weighted reward baseline to GRPO

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -256,6 +256,26 @@ trainer = GRPOTrainer(
 )
 ```
 
+### On-Policy RL with Optimal Reward Baseline
+
+**📄 Paper**: https://huggingface.co/papers/2505.23585
+
+OPO uses exact on-policy training and replaces the arithmetic mean reward baseline with the
+completion-length-weighted mean reward of each group. It does not use reward standard deviation normalization, KL
+regularization, or entropy regularization. To reproduce the OPO algorithm with [`GRPOTrainer`], use this configuration:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    reward_baseline="length_weighted",
+    scale_rewards="none",
+    beta=0.0,
+    num_iterations=1,
+    entropy_coef=0.0,
+)
+```
+
 ### Beyond the 80/20 Rule: High-Entropy Minority Tokens Drive Effective Reinforcement Learning for LLM Reasoning
 
 **📜 Paper**: https://huggingface.co/papers/2506.01939

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2247,6 +2247,80 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_reward_baseline_config(self):
+        training_args = GRPOConfig(output_dir=self.tmp_dir, report_to="none")
+        assert training_args.reward_baseline == "mean"
+
+        with pytest.raises(ValueError, match="Invalid value for reward_baseline"):
+            GRPOConfig(output_dir=self.tmp_dir, reward_baseline="invalid", report_to="none")
+
+        with pytest.raises(ValueError, match="only supported with"):
+            GRPOConfig(
+                output_dir=self.tmp_dir,
+                reward_baseline="length_weighted",
+                multi_objective_aggregation="normalize_then_sum",
+                report_to="none",
+            )
+
+    def test_train_length_weighted_reward_baseline(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            assert len(completions) == 12
+            return [1.0, 2.0, 4.0, 1.0, 2.0, 4.0, 1.0, None, 4.0, None, None, None]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=12,
+            num_generations=3,
+            max_completion_length=4,
+            max_steps=1,
+            reward_baseline="length_weighted",
+            scale_rewards="none",
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        def fake_generate(input_ids, **kwargs):
+            # pad_token_id = 151643; eos_token_id = 151645
+            rows = [
+                [1, 151645, 151643, 151643],
+                [1, 2, 151645, 151643],
+                [1, 2, 3, 151645],
+                [1, 151645, 151643, 151643],
+                [2, 151645, 151643, 151643],
+                [3, 151645, 151643, 151643],
+                [1, 151645, 151643, 151643],
+                [1, 2, 151645, 151643],
+                [1, 2, 3, 151645],
+                [1, 151645, 151643, 151643],
+                [1, 2, 151645, 151643],
+                [1, 2, 3, 151645],
+            ]
+            completion_ids = torch.tensor(rows, device=input_ids.device)
+            return torch.cat([input_ids, completion_ids], dim=1)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        with patch.object(trainer.model, "generate", side_effect=fake_generate):
+            trainer.train()
+
+        # Group 1 uses lengths [2, 3, 4], group 2 has equal lengths, group 3 excludes the unscorable middle
+        # completion from the weighted baseline, and group 4 is entirely unscorable.
+        expected_advantages = torch.tensor(
+            [-5 / 3, -2 / 3, 4 / 3, -4 / 3, -1 / 3, 5 / 3, -2.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+        )
+        torch.testing.assert_close(torch.tensor(trainer._logs["advantages"]), expected_advantages)
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
     @patch("transformers.generation.utils.GenerationMixin.generate")
     def test_train_with_mask_truncated_completions(self, mock_generate):
         """Test that training works with mask_truncated_completions=True parameter."""

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -231,6 +231,13 @@ class GRPOConfig(_BaseConfig):
               normalized at the batch level when forming advantages. This is the suggested approach from the paper
               [GDPO: Group reward-Decoupled Normalization Policy Optimization for Multi-reward RL
               Optimization](https://huggingface.co/papers/2601.05242).
+        reward_baseline (`str`, *optional*, defaults to `"mean"`):
+            Specifies the baseline used to compute advantages. Supported values are:
+
+            - `"mean"` (default): uses the arithmetic mean reward of each group.
+            - `"length_weighted"`: uses the completion-length-weighted mean reward of each group, as proposed in the
+              [OPO paper](https://huggingface.co/papers/2505.23585). This option is only supported with
+              `multi_objective_aggregation="sum_then_normalize"`.
         scale_rewards (`str` or `bool`, *optional*, defaults to `"group"`):
             Specifies the scaling strategy for rewards. Supported values are:
 
@@ -779,6 +786,15 @@ class GRPOConfig(_BaseConfig):
             "GDPO: Group reward-Decoupled Normalization Policy Optimization for Multi-reward RL Optimization."
         },
     )
+    reward_baseline: str = field(
+        default="mean",
+        metadata={
+            "help": "Specifies the baseline used to compute advantages. Supported values are: "
+            "`'mean'` (default): uses the arithmetic mean reward of each group. "
+            "`'length_weighted'`: uses the completion-length-weighted mean reward of each group, as proposed in the "
+            "OPO paper. This option is only supported with `multi_objective_aggregation='sum_then_normalize'`."
+        },
+    )
     scale_rewards: str = field(
         default="group",
         metadata={
@@ -1061,6 +1077,17 @@ class GRPOConfig(_BaseConfig):
             )
 
         self.scale_rewards = {True: "group", False: "none"}.get(self.scale_rewards, self.scale_rewards)
+
+        if self.reward_baseline not in ["mean", "length_weighted"]:
+            raise ValueError(
+                f"Invalid value for reward_baseline: {self.reward_baseline}. Must be one of 'mean' or "
+                "'length_weighted'."
+            )
+        if self.reward_baseline == "length_weighted" and self.multi_objective_aggregation != "sum_then_normalize":
+            raise ValueError(
+                "reward_baseline='length_weighted' is only supported with "
+                "multi_objective_aggregation='sum_then_normalize'."
+            )
 
         if self.log_completions_hub_repo is not None and not self.log_completions:
             raise ValueError(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -782,6 +782,7 @@ class GRPOTrainer(_BaseTrainer):
         self.use_liger_kernel = args.use_liger_kernel
         self.loss_type = args.loss_type
         self.multi_objective_aggregation = args.multi_objective_aggregation
+        self.reward_baseline = args.reward_baseline
 
         # MoE load-balancing auxiliary loss, applied to Mixture-of-Experts models (no effect otherwise)
         text_config = model.config.get_text_config()
@@ -2707,8 +2708,20 @@ class GRPOTrainer(_BaseTrainer):
             # Apply weights to each reward function's output and sum
             rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).nansum(dim=1)
             rewards[unscorable_mask] = torch.nan
-            mean_grouped_rewards = torch.nanmean(rewards.view(-1, num_generations), dim=1)
-            mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(num_generations, dim=0)
+            grouped_rewards = rewards.view(-1, num_generations)
+            if self.reward_baseline == "mean":
+                grouped_reward_baseline = torch.nanmean(grouped_rewards, dim=1)
+            else:
+                if tool_mask_list is not None:
+                    completion_lengths = torch.tensor([sum(mask) for mask in tool_mask_list], device=device)
+                else:
+                    completion_lengths = torch.tensor([len(ids) for ids in completion_ids_list], device=device)
+                agg_completion_lengths = self.accelerator.gather(completion_lengths)
+                grouped_completion_lengths = agg_completion_lengths.view(-1, num_generations)
+                valid_grouped_lengths = grouped_completion_lengths.masked_fill(torch.isnan(grouped_rewards), 0)
+                grouped_reward_baseline = torch.nansum(grouped_rewards * grouped_completion_lengths, dim=1)
+                grouped_reward_baseline /= valid_grouped_lengths.sum(dim=1)
+            grouped_reward_baseline = grouped_reward_baseline.repeat_interleave(num_generations, dim=0)
             if self.scale_rewards in ["group", "none"]:
                 # If self.scale_rewards = "none", we'll only use std_rewards to check for zero std for logging
                 if num_generations > 1:
@@ -2727,7 +2740,7 @@ class GRPOTrainer(_BaseTrainer):
                     f"Invalid value for scale_rewards: {self.scale_rewards}. Must be one of 'batch', 'group', or 'none'."
                 )
 
-            advantages = rewards - mean_grouped_rewards
+            advantages = rewards - grouped_reward_baseline
             if self.scale_rewards != "none":
                 advantages = advantages / (std_rewards + 1e-4)
             is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))  # for logging


### PR DESCRIPTION
# What does this PR do?

This PR adds the length-weighted reward baseline from On-Policy RL with Optimal Reward Baseline (OPO) as an opt-in option in `GRPOTrainer`.

As discussed in #3540, most of OPO is already expressible through the existing GRPO configuration:

- `beta=0.0` disables the reference model and KL regularization.
- `scale_rewards="none"` disables reward standard-deviation scaling.
- `num_iterations=1` uses fresh rollouts for every optimizer update.

The remaining algorithmic difference is OPO's group baseline:

$$
b^* = \frac{\sum_i L_i R_i}{\sum_i L_i}
$$

where $L_i$ and $R_i$ are the completion length and reward of response $i$.

### Changes

- Add `reward_baseline` to `GRPOConfig`:
  - `"mean"` preserves the existing GRPO behavior and remains the default.
  - `"length_weighted"` enables the OPO baseline.
- Compute the length-weighted baseline from completion lengths gathered across processes.
- Exclude unscorable completions from both the numerator and denominator.
- Reject `reward_baseline="length_weighted"` with `multi_objective_aggregation="normalize_then_sum"`, where the OPO scalar-reward baseline is not defined.
- Add an OPO entry and configuration example to `docs/source/paper_index.md`.
- Add deterministic coverage for unequal lengths, equal-length equivalence, partially unscorable groups, fully unscorable groups, configuration validation, and a complete training step.

The default GRPO behavior is unchanged, and this PR adds no new dependencies.

### Usage

```python
from trl import GRPOConfig

training_args = GRPOConfig(
    reward_baseline="length_weighted",
    scale_rewards="none",
    beta=0.0,
    num_iterations=1,
    entropy_coef=0.0,
)
```

### Validation

```text
python -m pytest tests/test_grpo_trainer.py \
  -k "reward_baseline or train_scale_rewards or train_normalize_then_sum_aggregation or warning_raised_all_rewards_none" \
  -q

9 passed, 176 deselected
```

The length-weighted training test runs through generation, reward calculation, advantage computation, and parameter updates with fixed completions and analytically computed expected advantages.

Fixes #3540

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. See #3540.
- [x] Did you make sure to update the documentation with your changes? Added the OPO entry and usage example to `paper_index.md`.
- [x] Did you write any new necessary tests? Added deterministic baseline and end-to-end training coverage.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

cc @qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes advantage computation in a core GRPO training path, but only when explicitly opting into `length_weighted`; default training is unchanged.
> 
> **Overview**
> Adds opt-in **`reward_baseline`** on `GRPOConfig` so `GRPOTrainer` can use OPO’s completion-length-weighted group baseline instead of the default arithmetic mean when `multi_objective_aggregation="sum_then_normalize"`.
> 
> **`length_weighted`** computes advantages from ∑(LᵢRᵢ)/∑Lᵢ per prompt group, using gathered completion lengths (or tool masks when present) and excluding unscorable completions from both numerator and denominator; **`normalize_then_sum`** is rejected for this mode. Default **`mean`** behavior is unchanged.
> 
> Documentation adds an OPO section in `paper_index.md` with a sample `GRPOConfig`, and tests cover config validation plus deterministic advantage values through a full training step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9cf80b9e702649d74a69db955c5ba3a209a7d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->