### PR TITLE
Fix vLLM server hangs after worker errors

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess
+from multiprocessing import Pipe, Process
 from types import SimpleNamespace
 
 import pytest
@@ -24,7 +25,7 @@ from transformers.testing_utils import torch_device
 from trl.generation.vllm_client import VLLMClient
 from trl.generation.vllm_generation import extract_logprobs
 from trl.import_utils import is_vllm_available
-from trl.scripts.vllm_serve import chunk_list
+from trl.scripts.vllm_serve import _recv_worker_result, _run_llm_worker, chunk_list
 
 from .testing_utils import (
     TrlTestCase,
@@ -43,6 +44,38 @@ if is_vllm_available():
     _is_vllm_ge_014 = Version(vllm.__version__) >= Version("0.14.0")
 else:
     _is_vllm_ge_014 = False
+
+
+class _FailingLLM:
+    def generate(self):
+        raise ValueError("prompt is too long")
+
+
+class TestLLMWorker(TrlTestCase):
+    def test_call_error_is_returned_to_parent(self):
+        parent_connection, child_connection = Pipe()
+        process = Process(target=_run_llm_worker, args=(_FailingLLM(), child_connection))
+        process.start()
+        child_connection.close()
+
+        try:
+            assert parent_connection.poll(5)
+            assert parent_connection.recv() == {"status": "ready"}
+
+            parent_connection.send({"type": "call", "method": "generate"})
+            assert parent_connection.poll(5)
+            with pytest.raises(RuntimeError, match="vLLM worker failed with ValueError: prompt is too long"):
+                _recv_worker_result(parent_connection)
+
+            parent_connection.send({"type": "shutdown"})
+            process.join(timeout=5)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+        finally:
+            if process.is_alive():
+                process.terminate()
+                process.join()
+            parent_connection.close()
 
 
 class TestChunkList(TrlTestCase):

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -25,7 +25,7 @@ from transformers.testing_utils import torch_device
 from trl.generation.vllm_client import VLLMClient
 from trl.generation.vllm_generation import extract_logprobs
 from trl.import_utils import is_vllm_available
-from trl.scripts.vllm_serve import _recv_worker_result, _run_llm_worker, chunk_list
+from trl.scripts.vllm_serve import _recv_worker_results, _run_llm_worker, chunk_list
 
 from .testing_utils import (
     TrlTestCase,
@@ -46,26 +46,21 @@ else:
     _is_vllm_ge_014 = False
 
 
-class _FailingLLM:
-    def generate(self):
-        raise ValueError("prompt is too long")
-
-
 class TestLLMWorker(TrlTestCase):
     def test_call_error_is_returned_to_parent(self):
         parent_connection, child_connection = Pipe()
-        process = Process(target=_run_llm_worker, args=(_FailingLLM(), child_connection))
+        process = Process(target=_run_llm_worker, args=({}, child_connection))
         process.start()
         child_connection.close()
 
         try:
-            assert parent_connection.poll(5)
+            assert parent_connection.poll(10)
             assert parent_connection.recv() == {"status": "ready"}
 
-            parent_connection.send({"type": "call", "method": "generate"})
+            parent_connection.send({"type": "call", "method": "__getitem__", "args": ("missing",)})
             assert parent_connection.poll(5)
-            with pytest.raises(RuntimeError, match="vLLM worker failed with ValueError: prompt is too long"):
-                _recv_worker_result(parent_connection)
+            with pytest.raises(RuntimeError, match="vLLM worker failed with KeyError: 'missing'"):
+                _recv_worker_results([parent_connection])
 
             parent_connection.send({"type": "shutdown"})
             process.join(timeout=5)
@@ -76,6 +71,24 @@ class TestLLMWorker(TrlTestCase):
                 process.terminate()
                 process.join()
             parent_connection.close()
+
+    def test_call_error_drains_other_worker_results(self):
+        pipe_pairs = [Pipe(), Pipe()]
+        parent_connections = [parent_connection for parent_connection, _ in pipe_pairs]
+        child_connections = [child_connection for _, child_connection in pipe_pairs]
+
+        try:
+            child_connections[0].send({"error": {"type": "ValueError", "message": "prompt is too long"}})
+            child_connections[1].send({"result": 1})
+            with pytest.raises(RuntimeError, match="vLLM worker failed with ValueError: prompt is too long"):
+                _recv_worker_results(parent_connections)
+
+            for child_connection in child_connections:
+                child_connection.send({"result": 2})
+            assert _recv_worker_results(parent_connections) == [2, 2]
+        finally:
+            for connection in parent_connections + child_connections:
+                connection.close()
 
 
 class TestChunkList(TrlTestCase):

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -359,12 +359,13 @@ def _run_llm_worker(llm, connection: Connection) -> None:
             break
 
 
-def _recv_worker_result(connection: Connection):
-    response = connection.recv()
-    if "error" in response:
-        error = response["error"]
-        raise RuntimeError(f"vLLM worker failed with {error['type']}: {error['message']}")
-    return response["result"]
+def _recv_worker_results(connections: list[Connection]):
+    responses = [connection.recv() for connection in connections]
+    for response in responses:
+        if "error" in response:
+            error = response["error"]
+            raise RuntimeError(f"vLLM worker failed with {error['type']}: {error['message']}")
+    return [response["result"] for response in responses]
 
 
 def llm_worker(
@@ -660,7 +661,7 @@ def main(script_args: ScriptArguments):
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
 
         # Receive results
-        all_outputs = [_recv_worker_result(connection) for connection in connections]
+        all_outputs = _recv_worker_results(connections)
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_prompts, strict=True) if prompts]
@@ -704,7 +705,7 @@ def main(script_args: ScriptArguments):
                 chunk = [{"prompt_token_ids": [0]}]
             kwargs = {"prompts": chunk, "sampling_params": sampling_params}
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
-        all_outputs = [_recv_worker_result(connection) for connection in connections]
+        all_outputs = _recv_worker_results(connections)
         all_outputs = [output for output, chunk in zip(all_outputs, chunked_prompts, strict=True) if chunk]
         return list(chain.from_iterable(all_outputs))
 
@@ -1116,7 +1117,7 @@ def main(script_args: ScriptArguments):
             connection.send({"type": "call", "method": "chat", "kwargs": kwargs})
 
         # Receive results
-        all_outputs = [_recv_worker_result(connection) for connection in connections]
+        all_outputs = _recv_worker_results(connections)
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_messages, strict=True) if prompts]
@@ -1203,7 +1204,7 @@ def main(script_args: ScriptArguments):
         for connection in connections:
             connection.send({"type": "call", "method": "reset_prefix_cache"})
         # Wait for and collect all results
-        all_outputs = [_recv_worker_result(connection) for connection in connections]
+        all_outputs = _recv_worker_results(connections)
         success = all(output for output in all_outputs)
         return {"message": "Request received, resetting prefix cache status: " + str(success)}
 

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -329,6 +329,44 @@ class ScriptArguments:
     )
 
 
+def _run_llm_worker(llm, connection: Connection) -> None:
+    # Send ready signal to parent process
+    connection.send({"status": "ready"})
+
+    while True:
+        # Wait for commands from the parent process
+        try:
+            command = connection.recv()
+        except KeyboardInterrupt:
+            llm.collective_rpc(method="close_communicator")
+            break
+
+        # Handle commands
+        if command["type"] in ["call", "fire_and_forget"]:
+            method_name = command["method"]
+            args, kwargs = command.get("args", ()), command.get("kwargs", {})
+            method = getattr(llm, method_name)
+            try:
+                result = method(*args, **kwargs)
+            except Exception as error:
+                if command["type"] == "call":
+                    connection.send({"error": {"type": type(error).__name__, "message": str(error)}})
+                    continue
+                raise
+            if command["type"] == "call":
+                connection.send({"result": result})
+        elif command["type"] == "shutdown":
+            break
+
+
+def _recv_worker_result(connection: Connection):
+    response = connection.recv()
+    if "error" in response:
+        error = response["error"]
+        raise RuntimeError(f"vLLM worker failed with {error['type']}: {error['message']}")
+    return response["result"]
+
+
 def llm_worker(
     script_args: ScriptArguments, data_parallel_rank: int, master_port: int, connection: Connection
 ) -> None:
@@ -362,27 +400,7 @@ def llm_worker(
         speculative_config=json.loads(script_args.speculative_config) if script_args.speculative_config else None,
     )
 
-    # Send ready signal to parent process
-    connection.send({"status": "ready"})
-
-    while True:
-        # Wait for commands from the parent process
-        try:
-            command = connection.recv()
-        except KeyboardInterrupt:
-            llm.collective_rpc(method="close_communicator")
-            break
-
-        # Handle commands
-        if command["type"] in ["call", "fire_and_forget"]:
-            method_name = command["method"]
-            args, kwargs = command.get("args", ()), command.get("kwargs", {})
-            method = getattr(llm, method_name)
-            result = method(*args, **kwargs)
-            if command["type"] == "call":
-                connection.send(result)
-        elif command["type"] == "shutdown":
-            break
+    _run_llm_worker(llm, connection)
 
 
 def chunk_list(lst: list, n: int) -> list[list]:
@@ -456,6 +474,7 @@ def main(script_args: ScriptArguments):
         parent_connection, child_connection = Pipe()
         process = Process(target=llm_worker, args=(script_args, data_parallel_rank, master_port, child_connection))
         process.start()
+        child_connection.close()
         connections.append(parent_connection)
         processes.append(process)
 
@@ -641,7 +660,7 @@ def main(script_args: ScriptArguments):
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
 
         # Receive results
-        all_outputs = [connection.recv() for connection in connections]
+        all_outputs = [_recv_worker_result(connection) for connection in connections]
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_prompts, strict=True) if prompts]
@@ -685,7 +704,7 @@ def main(script_args: ScriptArguments):
                 chunk = [{"prompt_token_ids": [0]}]
             kwargs = {"prompts": chunk, "sampling_params": sampling_params}
             connection.send({"type": "call", "method": "generate", "kwargs": kwargs})
-        all_outputs = [connection.recv() for connection in connections]
+        all_outputs = [_recv_worker_result(connection) for connection in connections]
         all_outputs = [output for output, chunk in zip(all_outputs, chunked_prompts, strict=True) if chunk]
         return list(chain.from_iterable(all_outputs))
 
@@ -1097,7 +1116,7 @@ def main(script_args: ScriptArguments):
             connection.send({"type": "call", "method": "chat", "kwargs": kwargs})
 
         # Receive results
-        all_outputs = [connection.recv() for connection in connections]
+        all_outputs = [_recv_worker_result(connection) for connection in connections]
 
         # Handle empty prompts (see above)
         all_outputs = [output for output, prompts in zip(all_outputs, chunked_messages, strict=True) if prompts]
@@ -1184,7 +1203,7 @@ def main(script_args: ScriptArguments):
         for connection in connections:
             connection.send({"type": "call", "method": "reset_prefix_cache"})
         # Wait for and collect all results
-        all_outputs = [connection.recv() for connection in connections]
+        all_outputs = [_recv_worker_result(connection) for connection in connections]
         success = all(output for output in all_outputs)
         return {"message": "Request received, resetting prefix cache status: " + str(success)}
 


### PR DESCRIPTION
# What does this PR do?

A vLLM data-parallel worker currently exits when an engine call raises. The server then waits indefinitely on its pipe, which leaves the HTTP request hanging and can surface as an NCCL timeout on the training ranks.

This change:

- returns worker-call failures through the existing pipe and raises them promptly in the request path;
- wraps successful call results in the same response protocol;
- closes each unused child pipe endpoint in the parent after starting the worker;
- adds a CPU multiprocessing regression covering the failure path and clean worker shutdown.

No user-facing API changes or new dependencies are introduced.

Fixes #3433

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #3433 and the maintainer diagnosis in https://github.com/huggingface/trl/issues/3433#issuecomment-5160139998.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this internal error-path fix.
- [x] Did you write any new necessary tests?

Validation:

- `python -m pytest tests/test_vllm_client_server.py -m "not slow" -q` (11 passed, 42 deselected)
- `ruff check trl/scripts/vllm_serve.py tests/test_vllm_client_server.py`
- `ruff format --check trl/scripts/vllm_serve.py tests/test_vllm_client_server.py`

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all DP parent?worker pipe paths for generation and related endpoints; behavior on failure changes from hang to RuntimeError, which is intended but affects production error handling during RL training.
> 
> **Overview**
> Fixes **indefinite hangs** on the vLLM data-parallel serve path when a worker?s engine call fails (e.g. prompt too long) instead of returning a response.
> 
> Worker IPC now uses a small protocol: successful **`call`** replies are `{"result": ...}` and failures are `{"error": {"type", "message"}}` so the worker stays alive. The parent uses **`_recv_worker_results`** everywhere it used to block on raw `recv()` (generate, chat, logprobs dispatch, reset prefix cache), raising **`RuntimeError`** with the worker error when any DP rank fails. The parent also **closes the child pipe end** after spawning each worker.
> 
> CPU multiprocessing tests cover error round-trip through **`_run_llm_worker`** and that one worker?s error still drains paired results before the next receive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a909ab5f801406d6eb79dd38a8a5fe2b9176e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
