### PR TITLE
[DistillationTrainer refactor] Reject `use_liger_kernel` with `logit_scale` / `final_logit_softcapping`

### DIFF
--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -528,6 +528,23 @@ class TestDistillationTrainer(TrlTestCase):
                 processing_class=self.tokenizer,
             )
 
+    @require_liger_kernel
+    def test_liger_incompatible_with_logit_softcapping_raises(self):
+        # The Liger fused JSD kernel can't apply Cohere `logit_scale` / Gemma `final_logit_softcapping`, so unlike the
+        # chunked path it would optimize a different objective than the model's real forward. Reject rather than train
+        # silently wrong.
+        student = AutoModelForCausalLM.from_pretrained(self.model_id)
+        student.config.final_logit_softcapping = 30.0
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+        with pytest.raises(ValueError, match="final_logit_softcapping"):
+            DistillationTrainer(
+                model=student,
+                teacher_model=self.model_id,
+                args=self._make_args(use_liger_kernel=True),
+                train_dataset=dataset,
+                processing_class=self.tokenizer,
+            )
+
     def test_teacher_model_init_kwargs_with_instantiated_teacher_raises(self):
         # `teacher_model_init_kwargs` only applies when the teacher is a model id; passing it alongside an already
         # instantiated teacher is a mistake worth surfacing.

--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -545,6 +545,20 @@ class TestDistillationTrainer(TrlTestCase):
                 processing_class=self.tokenizer,
             )
 
+    @require_liger_kernel
+    def test_liger_allows_none_logit_scale(self):
+        # `logit_scale = None` (e.g. MPT) means unscaled, like `1.0`; the Liger guard must not reject it.
+        student = AutoModelForCausalLM.from_pretrained(self.model_id)
+        student.config.logit_scale = None
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+        DistillationTrainer(  # must not raise
+            model=student,
+            teacher_model=self.model_id,
+            args=self._make_args(use_liger_kernel=True),
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+
     def test_teacher_model_init_kwargs_with_instantiated_teacher_raises(self):
         # `teacher_model_init_kwargs` only applies when the teacher is a model id; passing it alongside an already
         # instantiated teacher is a mistake worth surfacing.

--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -546,12 +546,10 @@ class TestDistillationTrainer(TrlTestCase):
             )
 
     @require_liger_kernel
-    @pytest.mark.parametrize("logit_scale", [None, 0])
-    def test_liger_allows_unscaled_logit_scale(self, logit_scale):
-        # `logit_scale` of `None` (e.g. MPT) or `0` means unscaled, like `1.0`; the Liger guard must not reject it,
-        # consistent with the chunked path which reads it as `logit_scale or 1.0`.
+    def test_liger_allows_none_logit_scale(self):
+        # `logit_scale = None` (e.g. MPT) means unscaled, like `1.0`; the Liger guard must not reject it.
         student = AutoModelForCausalLM.from_pretrained(self.model_id)
-        student.config.logit_scale = logit_scale
+        student.config.logit_scale = None
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
         DistillationTrainer(  # must not raise
             model=student,
@@ -560,6 +558,22 @@ class TestDistillationTrainer(TrlTestCase):
             train_dataset=dataset,
             processing_class=self.tokenizer,
         )
+
+    @require_liger_kernel
+    def test_liger_rejects_zero_logit_scale(self):
+        # `logit_scale = 0.0` is a real (degenerate) scale, not "unscaled" — it zeroes the logits. The Liger kernel
+        # can't apply it, so like any other non-1.0 scale it must be rejected, not silently read as 1.0.
+        student = AutoModelForCausalLM.from_pretrained(self.model_id)
+        student.config.logit_scale = 0.0
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
+        with pytest.raises(ValueError, match="logit_scale"):
+            DistillationTrainer(
+                model=student,
+                teacher_model=self.model_id,
+                args=self._make_args(use_liger_kernel=True),
+                train_dataset=dataset,
+                processing_class=self.tokenizer,
+            )
 
     def test_teacher_model_init_kwargs_with_instantiated_teacher_raises(self):
         # `teacher_model_init_kwargs` only applies when the teacher is a model id; passing it alongside an already

--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -546,10 +546,12 @@ class TestDistillationTrainer(TrlTestCase):
             )
 
     @require_liger_kernel
-    def test_liger_allows_none_logit_scale(self):
-        # `logit_scale = None` (e.g. MPT) means unscaled, like `1.0`; the Liger guard must not reject it.
+    @pytest.mark.parametrize("logit_scale", [None, 0])
+    def test_liger_allows_unscaled_logit_scale(self, logit_scale):
+        # `logit_scale` of `None` (e.g. MPT) or `0` means unscaled, like `1.0`; the Liger guard must not reject it,
+        # consistent with the chunked path which reads it as `logit_scale or 1.0`.
         student = AutoModelForCausalLM.from_pretrained(self.model_id)
-        student.config.logit_scale = None
+        student.config.logit_scale = logit_scale
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_only", split="train")
         DistillationTrainer(  # must not raise
             model=student,

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -597,7 +597,7 @@ class DistillationTrainer(_BaseTrainer):
             # objective than the model's real forward.
             if self.use_liger_loss:
                 for name, config in [("student", self.model.config), ("teacher", teacher_model.config)]:
-                    scaled = getattr(config, "logit_scale", 1.0) != 1.0
+                    scaled = getattr(config, "logit_scale", 1.0) not in (None, 1.0)
                     softcapped = getattr(config, "final_logit_softcapping", None) is not None
                     if scaled or softcapped:
                         raise ValueError(
@@ -1231,8 +1231,8 @@ class DistillationTrainer(_BaseTrainer):
             num_items_in_batch=num_items_in_batch,
             student_lm_head_bias=student_lm_head.bias,
             teacher_lm_head_bias=teacher_lm_head.bias,
-            student_logit_scale=getattr(student_config, "logit_scale", 1.0),
-            teacher_logit_scale=getattr(teacher_config, "logit_scale", 1.0),
+            student_logit_scale=getattr(student_config, "logit_scale", 1.0) or 1.0,
+            teacher_logit_scale=getattr(teacher_config, "logit_scale", 1.0) or 1.0,
             student_final_logit_softcapping=getattr(student_config, "final_logit_softcapping", None),
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -591,6 +591,22 @@ class DistillationTrainer(_BaseTrainer):
                     f"requires a shared vocabulary. Use a teacher with the same vocab_size, or GOLD for "
                     f"cross-tokenizer distillation."
                 )
+            # The Liger fused JSD kernel projects `h @ Wᵀ` directly and has no `logit_scale` /
+            # `final_logit_softcapping` parameters, so (unlike the chunked path) it cannot reproduce Cohere
+            # `logit_scale` or Gemma `final_logit_softcapping`. Refuse rather than silently optimize a different
+            # objective than the model's real forward.
+            if self.use_liger_loss:
+                for name, config in [("student", self.model.config), ("teacher", teacher_model.config)]:
+                    scaled = getattr(config, "logit_scale", 1.0) != 1.0
+                    softcapped = getattr(config, "final_logit_softcapping", None) is not None
+                    if scaled or softcapped:
+                        raise ValueError(
+                            f"`use_liger_kernel=True` is incompatible with the {name} model's `logit_scale` / "
+                            f"`final_logit_softcapping` (e.g. Cohere / Gemma models): the Liger fused JSD loss reads "
+                            f"`lm_head.weight` directly and cannot apply them, so it would optimize a different "
+                            f"objective than the model's real forward. Set `use_liger_kernel=False` to use the chunked "
+                            f"loss, which applies both."
+                        )
             if self.is_deepspeed_enabled:
                 self.teacher_model = prepare_deepspeed(teacher_model, self.accelerator)
             else:

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -597,7 +597,7 @@ class DistillationTrainer(_BaseTrainer):
             # objective than the model's real forward.
             if self.use_liger_loss:
                 for name, config in [("student", self.model.config), ("teacher", teacher_model.config)]:
-                    scaled = getattr(config, "logit_scale", 1.0) not in (None, 1.0)
+                    scaled = (getattr(config, "logit_scale", 1.0) or 1.0) != 1.0
                     softcapped = getattr(config, "final_logit_softcapping", None) is not None
                     if scaled or softcapped:
                         raise ValueError(

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -597,7 +597,7 @@ class DistillationTrainer(_BaseTrainer):
             # objective than the model's real forward.
             if self.use_liger_loss:
                 for name, config in [("student", self.model.config), ("teacher", teacher_model.config)]:
-                    scaled = (getattr(config, "logit_scale", 1.0) or 1.0) != 1.0
+                    scaled = getattr(config, "logit_scale", 1.0) not in (None, 1.0)
                     softcapped = getattr(config, "final_logit_softcapping", None) is not None
                     if scaled or softcapped:
                         raise ValueError(
@@ -1220,6 +1220,12 @@ class DistillationTrainer(_BaseTrainer):
             return loss
 
         student_config, teacher_config = unwrapped_student.config, unwrapped_teacher.config
+        # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept
+        # as-is: the Liger guard rejects it, and the chunked path applies it faithfully.
+        student_logit_scale = getattr(student_config, "logit_scale", 1.0)
+        teacher_logit_scale = getattr(teacher_config, "logit_scale", 1.0)
+        student_logit_scale = 1.0 if student_logit_scale is None else student_logit_scale
+        teacher_logit_scale = 1.0 if teacher_logit_scale is None else teacher_logit_scale
         loss, _, _ = _chunked_divergence_loss(
             student_hidden_states,
             teacher_hidden_states,
@@ -1231,8 +1237,8 @@ class DistillationTrainer(_BaseTrainer):
             num_items_in_batch=num_items_in_batch,
             student_lm_head_bias=student_lm_head.bias,
             teacher_lm_head_bias=teacher_lm_head.bias,
-            student_logit_scale=getattr(student_config, "logit_scale", 1.0) or 1.0,
-            teacher_logit_scale=getattr(teacher_config, "logit_scale", 1.0) or 1.0,
+            student_logit_scale=student_logit_scale,
+            teacher_logit_scale=teacher_logit_scale,
             student_final_logit_softcapping=getattr(student_config, "final_logit_softcapping", None),
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,


### PR DESCRIPTION
Part of #6449. Correctness fix surfaced by a deep loss audit.*

The chunked JSD loss applies each model's Cohere `logit_scale` and Gemma-2 `final_logit_softcapping` inside `_chunk`, matching the model's real forward. `LigerFusedLinearJSDLoss` has **no** such parameters and the trainer never applies them — so for a Gemma-2 or Cohere student/teacher with `use_liger_kernel=True`, the Liger path **silently optimizes a different objective** than the default chunked path (and one that no longer matches the model's forward). `test_liger_loss_agrees_with_chunked` doesn't catch it (tiny-Qwen2 has neither).

- `__init__` now raises when `use_liger_kernel=True` and either the student or teacher config sets `logit_scale != 1.0` or `final_logit_softcapping is not None`, pointing users to `use_liger_kernel=False` (the chunked path applies both).
- Test `test_liger_incompatible_with_logit_softcapping_raises`.

Verified: ruff clean; guard raises for softcap+Liger, allows softcap+chunked and plain+Liger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distillation training correctness and init-time validation for Liger users on Cohere/Gemma-style models; chunked-path behavior for `logit_scale=None` is a small semantic fix.
> 
> **Overview**
> **`DistillationTrainer` now fails fast** when `use_liger_kernel=True` and the student or teacher config uses Cohere-style `logit_scale` (anything other than `None` or `1.0`) or Gemma-style `final_logit_softcapping`, because the fused Liger JSD path cannot mirror those transforms and would otherwise train on the wrong objective. The error tells users to turn Liger off and use the chunked loss.
> 
> On the **chunked loss path**, `logit_scale=None` is treated as unscaled (`1.0`) while a real `0.0` is still passed through; that matches how MPT-style configs differ from a degenerate zero scale.
> 
> **Tests** cover softcapping + Liger (raises), `logit_scale=None` + Liger (allowed), and `logit_scale=0.0` + Liger (raises).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408250e8c45cb883a3631f0fd5d5cbd03463b221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->