### PR TITLE
[DistillationTrainer refactor] Config: GRPO parity drift fixes

### DIFF
--- a/trl/experimental/distillation/distillation_config.py
+++ b/trl/experimental/distillation/distillation_config.py
@@ -31,10 +31,6 @@ class DistillationConfig(_BaseConfig):
     [argparse](https://docs.python.org/3/library/argparse#module-argparse) arguments that can be specified on the
     command line.
 
-    > [!NOTE]
-    > Some [`~transformers.TrainingArguments`] defaults are overridden: `learning_rate` defaults to `1e-6` (instead of
-    > `5e-5`) and `remove_unused_columns` defaults to `False` (instead of `True`).
-
     Parameters:
         > Parameters that control the model and the teacher model
 
@@ -108,12 +104,12 @@ class DistillationConfig(_BaseConfig):
             Model implementation backend for vLLM. Use `"vllm"` or `"transformers"`.
         vllm_enable_sleep_mode (`bool`, *optional*, defaults to `False`):
             Enable vLLM sleep mode to offload student weights during the optimizer step.
-        vllm_structured_outputs_regex (`str` or `None`, *optional*):
+        vllm_structured_outputs_regex (`str`, *optional*):
             Regex pattern for vLLM structured outputs.
 
         > Parameters that control the vLLM server (only used when `vllm_mode` is `"server"`)
 
-        vllm_server_base_url (`str` or `None`, *optional*):
+        vllm_server_base_url (`str`, *optional*):
             Base URL for the student vLLM server. If provided, `vllm_server_host` and `vllm_server_port` are ignored.
         vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
             Host of the student vLLM server.
@@ -128,7 +124,7 @@ class DistillationConfig(_BaseConfig):
 
         vllm_gpu_memory_utilization (`float`, *optional*, defaults to `0.3`):
             GPU memory utilization for the colocated student vLLM engine.
-        vllm_max_model_length (`int` or `None`, *optional*):
+        vllm_max_model_length (`int`, *optional*):
             Maximum model sequence length for the colocated vLLM engine.
         vllm_tensor_parallel_size (`int`, *optional*, defaults to `1`):
             Tensor parallel size for the colocated student vLLM engine.
@@ -152,6 +148,13 @@ class DistillationConfig(_BaseConfig):
         log_unique_prompts (`bool`, *optional*, defaults to `False`):
             Whether to log unique prompts. If `True`, only unique prompts are logged. If `False`, all prompts are
             logged.
+
+    > [!NOTE]
+    > These parameters have default values different from [`~transformers.TrainingArguments`]:
+    > - `logging_steps`: Defaults to `10` instead of `500`.
+    > - `gradient_checkpointing`: Defaults to `True` instead of `False`.
+    > - `bf16`: Defaults to `True` if `fp16` is not set, instead of `False`.
+    > - `learning_rate`: Defaults to `1e-6` instead of `5e-5`.
     """
 
     _VALID_DICT_FIELDS = _BaseConfig._VALID_DICT_FIELDS + ["model_init_kwargs", "teacher_model_init_kwargs"]
@@ -200,7 +203,7 @@ class DistillationConfig(_BaseConfig):
     # Parameters that control the data preprocessing
     # The default `remove_unused_columns` is overwritten from the parent class: distillation trains on the raw
     # `prompt` column and generates completions on-policy, so no columns are dropped.
-    remove_unused_columns: bool = field(
+    remove_unused_columns: bool | None = field(
         default=False,
         metadata={
             "help": "Whether to only keep the column 'prompt' in the dataset. The trainer consumes the raw prompt "
@@ -374,3 +377,14 @@ class DistillationConfig(_BaseConfig):
 
         if self.beta < 0.0 or self.beta > 1.0:
             raise ValueError(f"beta must be in [0.0, 1.0], got {self.beta}.")
+
+        if self.parallelism_config is not None and (
+            self.parallelism_config.cp_enabled or self.parallelism_config.sp_enabled
+        ):
+            raise ValueError(
+                "DistillationTrainer does not support sequence-dim parallelism (`parallelism_config.cp_size > 1` "
+                "or `parallelism_config.sp_size > 1`) yet. Distillation builds model inputs after generation "
+                "inside the trainer, so Transformers' context-parallel / Ulysses sequence-parallel input "
+                "sharding cannot be applied to the raw generation batch. Set both `cp_size=1` and `sp_size=1`, "
+                "or disable `parallelism_config`."
+            )


### PR DESCRIPTION
*Off `main` (the config is already merged). Part of #6449. Surfaced by a deep config↔GRPO audit. Docstring/type/validation-only.*

Drives `distillation_config.py` toward `grpo_config.py`'s conventions:
- **`> [!NOTE]` overridden-defaults block rebuilt** — was incomplete, misplaced (top), and prose. Now GRPO-verbatim: moved to the bottom of the docstring, bulleted, and lists all four `_BaseConfig` overrides (`logging_steps` 10, `gradient_checkpointing` True, `bf16` True, `learning_rate` 1e-6) — the previous block omitted the first three. `remove_unused_columns` stays documented inline (as GRPO does), not in the NOTE.
- **Docstring house-style** on three `None`-default fields: `(`X` or `None`, *optional*)` → `(`X`, *optional*)` for `vllm_structured_outputs_regex`, `vllm_server_base_url`, `vllm_max_model_length` (`max_completion_length` legitimately keeps `int or None` — both configs agree).
- **`remove_unused_columns: bool` → `bool | None`** (GRPO parity; the parent `TrainingArguments` field is `bool | None`).
- **`__post_init__` cp/sp guard** (GRPO parity): reject `parallelism_config` with `cp_enabled`/`sp_enabled`, since distillation — like GRPO — builds model inputs *after* on-policy generation, so sequence-dim sharding can't apply to the raw generation batch.

Deferred to a follow-up: restoring GRPO-verbatim wording on the paraphrased generation/vLLM `help` strings (`top_p`, `top_k`, the vLLM block) — a larger verbatim-restoration pass, no behaviour change.

Verified: ruff clean; config constructs; `beta` + new cp/sp guards fire; NOTE bullets present + moved below Parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and type-hint parity only; the new cp/sp check fails fast on unsupported configs rather than changing training paths.
> 
> **Overview**
> Aligns **`DistillationConfig`** documentation and typing with **`GRPOConfig`** after a config audit—no runtime behavior changes beyond the new validation guard.
> 
> The class docstring’s **`> [!NOTE]`** block is moved to the end and expanded to list all four `_BaseConfig` overrides that differ from **`TrainingArguments`** (`logging_steps`, `gradient_checkpointing`, `bf16`, `learning_rate`); the old top-of-doc note only mentioned `learning_rate` and `remove_unused_columns`. Three optional vLLM-related parameters drop redundant **`or None`** in their docstring type lines.
> 
> **`remove_unused_columns`** is typed as **`bool | None`** to match the parent and GRPO. **`__post_init__`** now raises if **`parallelism_config`** enables context- or sequence-parallelism, mirroring GRPO’s guard for on-policy trainers that assemble inputs after generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd2bb38b3f34c2711a69d79bacf9af42b5ea9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->