### PR TITLE
[DistillationTrainer refactor] Log the student entropy metric

### DIFF
--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1276,7 +1276,7 @@ class DistillationTrainer(_BaseTrainer):
             return loss
 
         student_config, teacher_config = unwrapped_student.config, unwrapped_teacher.config
-        loss, _, _ = _chunked_divergence_loss(
+        loss, entropy_sum, n_valid = _chunked_divergence_loss(
             student_hidden_states,
             teacher_hidden_states,
             student_lm_head.weight,
@@ -1293,6 +1293,12 @@ class DistillationTrainer(_BaseTrainer):
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,
         )
+        # Log the mean per-token student entropy (in nats) over the global batch. `_chunked_divergence_loss` returns
+        # raw sums, so gather across ranks and divide to get a valid-token-weighted mean (gradient-free).
+        mode = "train" if self.model.training else "eval"
+        total_entropy = self.accelerator.gather(entropy_sum.detach().reshape(1)).sum()
+        total_valid = self.accelerator.gather(n_valid.reshape(1)).sum().clamp_min(1)
+        self._metrics[mode]["entropy"].append((total_entropy / total_valid).item())
         return loss
 
     def training_step(self, model, inputs, num_items_in_batch):

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1199,9 +1199,20 @@ class DistillationTrainer(_BaseTrainer):
         # `_forward_redirection`, so DDP.forward() fires `prepare_for_backward()` and FSDP/DeepSpeed keep the student's
         # sharded parameters (including the `lm_head`) materialized for the projection.
         unwrapped_student = self.accelerator.unwrap_model(model)
-        loss = self._forward_redirection(
+        loss, entropy_sum, num_valid_tokens = self._forward_redirection(
             model, unwrapped_student, self._compute_loss, unwrapped_student, inputs, num_items_in_batch
         )
+
+        # Log the mean per-token student entropy (in nats). The reduction runs here, after `_forward_redirection`
+        # returns, so the `gather_for_metrics` collective does not run inside the DDP/FSDP-wrapped forward (a hang/
+        # ordering risk). The Liger path produces no entropy, so it logs none. Mirrors `SFTTrainer.compute_loss`.
+        if entropy_sum is not None:
+            mode = "train" if self.model.training else "eval"
+            num_valid_tokens = self.accelerator.gather_for_metrics(num_valid_tokens).sum()
+            entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
+            entropy = (entropy_sum / num_valid_tokens).item() if num_valid_tokens > 0 else 0.0
+            self._metrics[mode]["entropy"].append(entropy)
+
         return (loss, None) if return_outputs else loss
 
     def _compute_loss(self, unwrapped_student, inputs, num_items_in_batch):
@@ -1273,7 +1284,8 @@ class DistillationTrainer(_BaseTrainer):
                 if isinstance(num_items_in_batch, torch.Tensor):
                     num_items_in_batch = num_items_in_batch.to(loss.device)
                 loss = loss * num_valid_local / num_items_in_batch
-            return loss
+            # The fused kernel produces no entropy; `compute_loss` logs none for the Liger path.
+            return loss, None, None
 
         student_config, teacher_config = unwrapped_student.config, unwrapped_teacher.config
         loss, entropy_sum, n_valid = _chunked_divergence_loss(
@@ -1293,13 +1305,9 @@ class DistillationTrainer(_BaseTrainer):
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,
         )
-        # Log the mean per-token student entropy (in nats) over the global batch. `_chunked_divergence_loss` returns
-        # raw sums, so gather across ranks and divide to get a valid-token-weighted mean (gradient-free).
-        mode = "train" if self.model.training else "eval"
-        total_entropy = self.accelerator.gather(entropy_sum.detach().reshape(1)).sum()
-        total_valid = self.accelerator.gather(n_valid.reshape(1)).sum().clamp_min(1)
-        self._metrics[mode]["entropy"].append((total_entropy / total_valid).item())
-        return loss
+        # Return the raw entropy sum and valid-token count for `compute_loss` to aggregate and log after the forward
+        # returns (see there). Detached: the metric is gradient-free.
+        return loss, entropy_sum.detach(), n_valid
 
     def training_step(self, model, inputs, num_items_in_batch):
         time_before = time.perf_counter()

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1281,7 +1281,7 @@ class DistillationTrainer(_BaseTrainer):
         teacher_logit_scale = getattr(teacher_config, "logit_scale", 1.0)
         student_logit_scale = 1.0 if student_logit_scale is None else student_logit_scale
         teacher_logit_scale = 1.0 if teacher_logit_scale is None else teacher_logit_scale
-        loss, _, _ = _chunked_divergence_loss(
+        loss, entropy_sum, n_valid = _chunked_divergence_loss(
             student_hidden_states,
             teacher_hidden_states,
             student_lm_head.weight,
@@ -1298,6 +1298,12 @@ class DistillationTrainer(_BaseTrainer):
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,
         )
+        # Log the mean per-token student entropy (in nats) over the global batch. `_chunked_divergence_loss` returns
+        # raw sums, so gather across ranks and divide to get a valid-token-weighted mean (gradient-free).
+        mode = "train" if self.model.training else "eval"
+        total_entropy = self.accelerator.gather(entropy_sum.detach().reshape(1)).sum()
+        total_valid = self.accelerator.gather(n_valid.reshape(1)).sum().clamp_min(1)
+        self._metrics[mode]["entropy"].append((total_entropy / total_valid).item())
         return loss
 
     def training_step(self, model, inputs, num_items_in_batch):

--- a/trl/experimental/distillation/distillation_trainer.py
+++ b/trl/experimental/distillation/distillation_trainer.py
@@ -1198,9 +1198,20 @@ class DistillationTrainer(_BaseTrainer):
         # `_forward_redirection`, so DDP.forward() fires `prepare_for_backward()` and FSDP/DeepSpeed keep the student's
         # sharded parameters (including the `lm_head`) materialized for the projection.
         unwrapped_student = self.accelerator.unwrap_model(model)
-        loss = self._forward_redirection(
+        loss, entropy_sum, num_valid_tokens = self._forward_redirection(
             model, unwrapped_student, self._compute_loss, unwrapped_student, inputs, num_items_in_batch
         )
+
+        # Log the mean per-token student entropy (in nats). The reduction runs here, after `_forward_redirection`
+        # returns, so the `gather_for_metrics` collective does not run inside the DDP/FSDP-wrapped forward (a hang/
+        # ordering risk). The Liger path produces no entropy, so it logs none. Mirrors `SFTTrainer.compute_loss`.
+        if entropy_sum is not None:
+            mode = "train" if self.model.training else "eval"
+            num_valid_tokens = self.accelerator.gather_for_metrics(num_valid_tokens).sum()
+            entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
+            entropy = (entropy_sum / num_valid_tokens).item() if num_valid_tokens > 0 else 0.0
+            self._metrics[mode]["entropy"].append(entropy)
+
         return (loss, None) if return_outputs else loss
 
     def _compute_loss(self, unwrapped_student, inputs, num_items_in_batch):
@@ -1272,7 +1283,8 @@ class DistillationTrainer(_BaseTrainer):
                 if isinstance(num_items_in_batch, torch.Tensor):
                     num_items_in_batch = num_items_in_batch.to(loss.device)
                 loss = loss * num_valid_local / num_items_in_batch
-            return loss
+            # The fused kernel produces no entropy; `compute_loss` logs none for the Liger path.
+            return loss, None, None
 
         student_config, teacher_config = unwrapped_student.config, unwrapped_teacher.config
         # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept
@@ -1298,13 +1310,9 @@ class DistillationTrainer(_BaseTrainer):
             teacher_final_logit_softcapping=getattr(teacher_config, "final_logit_softcapping", None),
             temperature=self.temperature,
         )
-        # Log the mean per-token student entropy (in nats) over the global batch. `_chunked_divergence_loss` returns
-        # raw sums, so gather across ranks and divide to get a valid-token-weighted mean (gradient-free).
-        mode = "train" if self.model.training else "eval"
-        total_entropy = self.accelerator.gather(entropy_sum.detach().reshape(1)).sum()
-        total_valid = self.accelerator.gather(n_valid.reshape(1)).sum().clamp_min(1)
-        self._metrics[mode]["entropy"].append((total_entropy / total_valid).item())
-        return loss
+        # Return the raw entropy sum and valid-token count for `compute_loss` to aggregate and log after the forward
+        # returns (see there). Detached: the metric is gradient-free.
+        return loss, entropy_sum.detach(), n_valid
 
     def training_step(self, model, inputs, num_items_in_batch):
         time_before = time.perf_counter()


### PR DESCRIPTION
*Off `main`. Part of #6449. Surfaced by a deep review — resolves a computed-then-discarded inconsistency.*

`_chunked_divergence_loss` already computes and returns the student's per-token entropy (`entropy_sum`) and the valid-token count (`n_valid`), but `_compute_loss` discarded them (`loss, _, _ = ...`) — so the trainer logged **no metric about its own objective** (only completion-length + `step_time`), while GRPO/SFT log `entropy`.

- `_compute_loss` (chunked path) now captures `entropy_sum`/`n_valid`, gathers them across ranks, and logs a valid-token-weighted mean to `_metrics[mode]["entropy"]` (gradient-free, `detach`ed). The Liger fast path produces no entropy, so it logs none (acceptable asymmetry).

Note: the entropy term is still recomputed on the backward pass under gradient checkpointing (its value is now *used*, so no longer pure waste); moving the computation out of the checkpointed body is a possible micro-optimization, out of scope here.

Verified: ruff clean; train smoke logs `entropy` (~`ln(vocab)` for the untrained tiny model, as expected); full suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with distributed collectives moved outside the wrapped forward; no change to loss computation or training objective beyond using already-computed entropy for logging.
> 
> **Overview**
> **DistillationTrainer** now records mean per-token **student entropy** (nats) in `_metrics`, aligning with GRPO/SFT instead of only logging completion length and step time.
> 
> The chunked JSD path already returned `entropy_sum` and valid-token counts from `_chunked_divergence_loss`; `_compute_loss` now passes them through and `compute_loss` gathers across ranks and appends a valid-token-weighted mean to `_metrics[mode]["entropy"]`. Aggregation runs **after** `_forward_redirection` returns so `gather_for_metrics` is not executed inside the DDP/FSDP forward (avoids hang/ordering issues). Entropy is detached and does not affect gradients.
> 
> The **Liger** fused path still returns `(loss, None, None)` and logs no entropy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385bbe3ea3b00d9e511f20dfdbc461f386c7c534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->