### PR TITLE
Fix conversational format detection for empty message lists

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -480,6 +480,7 @@ class TestIsConversational(TrlTestCase):
     # fmt: on
 
     non_conversational_examples = [
+        {"prompt": []},
         {"prompt": "The sky is", "completion": " blue."},
         {"text": "The sky is blue."},
         {"prompt": "The sky is"},
@@ -517,6 +518,10 @@ class TestIsConversationalFromValue(TrlTestCase):
 
     def test_negative_2(self):
         example = {"text": "The sky is blue."}
+        assert not is_conversational_from_value(example)
+
+    def test_empty_conversation(self):
+        example = {"conversations": []}
         assert not is_conversational_from_value(example)
 
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -189,7 +189,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
         key = example_keys.pop()  # take the first supported key
         maybe_messages = example[key]
         # It must be a list of messages
-        if isinstance(maybe_messages, list):
+        if isinstance(maybe_messages, list) and maybe_messages:
             maybe_message = maybe_messages[0]
             # Each message must a list of dictionaries with keys "role" and "content"
             if isinstance(maybe_message, dict) and "role" in maybe_message:
@@ -963,7 +963,7 @@ def is_conversational_from_value(example: dict[str, Any]) -> bool:
     """
     maybe_messages = example.get("conversations")
     # It must be a list of messages
-    if isinstance(maybe_messages, list):
+    if isinstance(maybe_messages, list) and maybe_messages:
         maybe_message = maybe_messages[0]
         # Each message must a list of dictionaries with keys "from" and "value"
         if isinstance(maybe_message, dict) and "from" in maybe_message and "value" in maybe_message:


### PR DESCRIPTION
# What does this PR do?

Fixes #6636.

`is_conversational()` and `is_conversational_from_value()` previously indexed the first element of any list-valued conversational field. Empty lists raised `IndexError` during dataset format detection.

Both functions now require a non-empty list before inspecting the first message. Tests cover empty ChatML and legacy `from`/`value` conversations; existing non-empty cases remain unchanged.

Validation performed locally:

- reproduced the baseline `IndexError` with `{"prompt": []}`;
- executed both fixed functions from the repository source against empty and non-empty inputs;
- parsed the modified source and test files with `ast`.

The full pytest and pre-commit suites were not run because installing TRL pulls the Transformers/Datasets training stack; this limitation is explicit rather than reported as a pass.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #6636
- [ ] Did you make sure to update the documentation with your changes? Not applicable; no public API behavior changed.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is welcome to review once CI has completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard in dataset utility helpers; behavior change only for previously crashing empty-list inputs.
> 
> **Overview**
> **Fixes `IndexError` when dataset examples use empty list-valued conversational fields** (e.g. `{"prompt": []}` or `{"conversations": []}`) during format detection.
> 
> `is_conversational()` and `is_conversational_from_value()` now require a **non-empty** list before reading the first message; empty lists are treated as non-conversational instead of crashing. Tests cover empty `prompt` and legacy `conversations` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e678555de32bda69162e2909e28cdb122bea2f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->