### PR TITLE
[DistillationTrainer refactor] Promote DistillationTrainer to the stable API

### DIFF
--- a/tests/experimental/test_distillation_trainer.py
+++ b/tests/experimental/test_distillation_trainer.py
@@ -20,9 +20,9 @@ from datasets import DatasetDict, IterableDatasetDict, load_dataset
 from transformers import AutoModelForCausalLM
 from transformers.utils import is_peft_available
 
-from trl.experimental.distillation import DistillationConfig, DistillationTrainer
-from trl.experimental.distillation.distillation_trainer import _chunked_divergence_loss
+from trl import DistillationConfig, DistillationTrainer
 from trl.experimental.gkd.gkd_trainer import GKDTrainer
+from trl.trainer.distillation_trainer import _chunked_divergence_loss
 
 from ..testing_utils import TrlTestCase, require_liger_kernel, require_peft, require_torch_accelerator, require_vllm
 

--- a/trl/__init__.py
+++ b/trl/__init__.py
@@ -50,6 +50,8 @@ _import_structure = {
     "scripts": ["DatasetMixtureConfig", "ScriptArguments", "TrlParser", "get_dataset", "init_zero_verbose"],
     "trainer": [
         "BEMACallback",
+        "DistillationConfig",
+        "DistillationTrainer",
         "DPOConfig",
         "DPOTrainer",
         "GRPOConfig",
@@ -97,6 +99,8 @@ if TYPE_CHECKING:
     from .scripts import DatasetMixtureConfig, ScriptArguments, TrlParser, get_dataset, init_zero_verbose
     from .trainer import (
         BEMACallback,
+        DistillationConfig,
+        DistillationTrainer,
         DPOConfig,
         DPOTrainer,
         GRPOConfig,

--- a/trl/experimental/distillation/__init__.py
+++ b/trl/experimental/distillation/__init__.py
@@ -12,8 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .distillation_config import DistillationConfig
-from .distillation_trainer import DistillationTrainer
+import warnings
+from dataclasses import dataclass
+
+from ...trainer import DistillationConfig as _DistillationConfig
+from ...trainer import DistillationTrainer as _DistillationTrainer
 
 
 __all__ = ["DistillationConfig", "DistillationTrainer"]
+
+
+@dataclass
+class DistillationConfig(_DistillationConfig):
+    def __post_init__(self):
+        warnings.warn(
+            "This import path is deprecated and will be removed in v2.0.0. "
+            "The `DistillationConfig` has been promoted to the stable API. "
+            "Update your imports to `from trl import DistillationConfig`.",
+            FutureWarning,
+            stacklevel=3,
+        )
+        super().__post_init__()
+
+
+@dataclass
+class DistillationTrainer(_DistillationTrainer):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This import path is deprecated and will be removed in v2.0.0. "
+            "The `DistillationTrainer` has been promoted to the stable API. "
+            "Update your imports to `from trl import DistillationTrainer`.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/trl/experimental/server_distillation/server_distillation_config.py
+++ b/trl/experimental/server_distillation/server_distillation_config.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass, field
 
-from ..distillation.distillation_config import DistillationConfig
+from ...trainer.distillation_config import DistillationConfig
 
 
 @dataclass

--- a/trl/experimental/server_distillation/server_distillation_trainer.py
+++ b/trl/experimental/server_distillation/server_distillation_trainer.py
@@ -18,7 +18,7 @@ import torch
 import torch.nn.functional as F
 
 from ...extras.profiling import profiling_decorator
-from ..distillation.distillation_trainer import DistillationTrainer
+from ...trainer.distillation_trainer import DistillationTrainer
 from .server_distillation_config import ServerDistillationConfig
 
 

--- a/trl/trainer/__init__.py
+++ b/trl/trainer/__init__.py
@@ -25,6 +25,8 @@ _import_structure = {
         "SyncRefModelCallback",
         "WeaveCallback",
     ],
+    "distillation_config": ["DistillationConfig"],
+    "distillation_trainer": ["DistillationTrainer"],
     "dpo_config": ["DPOConfig"],
     "dpo_trainer": ["DPOTrainer"],
     "grpo_config": ["GRPOConfig"],
@@ -55,6 +57,8 @@ if TYPE_CHECKING:
         SyncRefModelCallback,
         WeaveCallback,
     )
+    from .distillation_config import DistillationConfig
+    from .distillation_trainer import DistillationTrainer
     from .dpo_config import DPOConfig
     from .dpo_trainer import DPOTrainer
     from .grpo_config import GRPOConfig

--- a/trl/trainer/distillation_config.py
+++ b/trl/trainer/distillation_config.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from ...trainer.base_config import _BaseConfig
+from .base_config import _BaseConfig
 
 
 @dataclass

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -44,15 +44,16 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ...data_utils import is_conversational
-from ...distributed import DistributedBackend
-from ...extras.profiling import profiling_context, profiling_decorator
-from ...generation.vllm_generation import VLLMGeneration
-from ...import_utils import is_vllm_available
-from ...models import prepare_deepspeed
-from ...models.utils import _ForwardRedirection, unwrap_model_for_generation
-from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import (
+from ..data_utils import is_conversational
+from ..distributed import DistributedBackend
+from ..extras.profiling import profiling_context, profiling_decorator
+from ..generation.vllm_generation import VLLMGeneration
+from ..import_utils import is_vllm_available
+from ..models import prepare_deepspeed
+from ..models.utils import _ForwardRedirection, unwrap_model_for_generation
+from .base_trainer import _BaseTrainer
+from .distillation_config import DistillationConfig
+from .utils import (
     RepeatSampler,
     create_model_from_path,
     disable_dropout_in_model,
@@ -65,7 +66,6 @@ from ...trainer.utils import (
     shuffle_sequence_dict,
     split_tensor_dict,
 )
-from .distillation_config import DistillationConfig
 
 
 if is_liger_kernel_available():

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -294,7 +294,7 @@ class DistillationTrainer(_BaseTrainer):
     Example:
 
     ```python
-    >>> from trl.experimental.distillation import DistillationTrainer
+    >>> from trl import DistillationTrainer
     >>> from datasets import load_dataset
 
     >>> dataset = load_dataset("trl-lib/tldr", split="train")

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -293,7 +293,7 @@ class DistillationTrainer(_BaseTrainer):
     Example:
 
     ```python
-    >>> from trl.experimental.distillation import DistillationTrainer
+    >>> from trl import DistillationTrainer
     >>> from datasets import load_dataset
 
     >>> dataset = load_dataset("trl-lib/tldr", split="train")

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -43,15 +43,16 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ...data_utils import is_conversational
-from ...distributed import DistributedBackend
-from ...extras.profiling import profiling_context, profiling_decorator
-from ...generation.vllm_generation import VLLMGeneration
-from ...import_utils import is_vllm_available
-from ...models import prepare_deepspeed
-from ...models.utils import _ForwardRedirection, unwrap_model_for_generation
-from ...trainer.base_trainer import _BaseTrainer
-from ...trainer.utils import (
+from ..data_utils import is_conversational
+from ..distributed import DistributedBackend
+from ..extras.profiling import profiling_context, profiling_decorator
+from ..generation.vllm_generation import VLLMGeneration
+from ..import_utils import is_vllm_available
+from ..models import prepare_deepspeed
+from ..models.utils import _ForwardRedirection, unwrap_model_for_generation
+from .base_trainer import _BaseTrainer
+from .distillation_config import DistillationConfig
+from .utils import (
     RepeatSampler,
     create_model_from_path,
     disable_dropout_in_model,
@@ -64,7 +65,6 @@ from ...trainer.utils import (
     shuffle_sequence_dict,
     split_tensor_dict,
 )
-from .distillation_config import DistillationConfig
 
 
 if is_liger_kernel_available():


### PR DESCRIPTION
*Stacked on the item-48 docs PR. Part of #6449. Phase 10 (promotion), atomic move + register + shim.*

Move the trainer out of `trl.experimental` into the stable API, following the KTO promotion precedent (#6175):

- **Move**: `git mv trl/experimental/distillation/distillation_{trainer,config}.py → trl/trainer/`; rebase their relative imports (`from ...X` → `from ..X`, `from ...trainer.Y` → `from .Y`), matching `grpo_trainer.py`.
- **Register**: `trl/trainer/__init__.py` (`_import_structure` + `TYPE_CHECKING`) and `trl/__init__.py` (trainer `__all__` list + `from .trainer import …`) — all four blocks, so `from trl import DistillationConfig, DistillationTrainer` works.
- **Experimental shim**: replace `trl/experimental/distillation/__init__.py` with the KTO-style `FutureWarning` wrapper re-exporting the stable classes (removal in v2.0.0).
- **Repoint dependents** (the forced sliver of item 55, so nothing breaks in the interim): `ServerDistillationTrainer`/`ServerDistillationConfig` and the test's `_chunked_divergence_loss` import now point at `trl.trainer.distillation_*`; the test's trainer/config imports use `from trl import …`.

Deferred to their own promotion PRs: telemetry allowlist (50), CLI (51), test move to `tests/` (52), docs de-namespacing (53), example script (54), full server re-point (55).

Verified: all import paths resolve (stable, shim-with-warning, server subclass); ruff clean; distillation + server suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical relocation and export wiring with backward-compatible deprecation shims; training logic is unchanged aside from import paths.
> 
> **Overview**
> **Promotes `DistillationConfig` and `DistillationTrainer` from `trl.experimental.distillation` to `trl.trainer`**, following the same pattern as KTO: modules live under `trl/trainer/` with imports adjusted to match other stable trainers (`from ..X` / `from .Y`).
> 
> **`from trl import DistillationConfig, DistillationTrainer`** is now supported via `trl/__init__.py` and `trl/trainer/__init__.py`. The old experimental path remains as a **KTO-style shim** that subclasses the stable types and emits a **`FutureWarning`** (removal in v2.0.0).
> 
> **Dependents are repointed** so nothing breaks: `ServerDistillation*` imports the stable config/trainer; distillation tests use top-level `trl` imports and `trl.trainer.distillation_trainer` for `_chunked_divergence_loss`. The trainer docstring example now shows `from trl import DistillationTrainer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775c02398bdd5d66194a6934639fcb1a3932ef8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->