### PR TITLE
[DistillationTrainer refactor] Move DistillationTrainer to the Stable telemetry group

### DIFF
--- a/trl/trainer/base_trainer.py
+++ b/trl/trainer/base_trainer.py
@@ -32,6 +32,7 @@ if is_wandb_available():
 # private names never leak. Adding a new trainer requires an explicit entry here.
 _TELEMETRY_TRAINERS = {
     # Stable
+    "DistillationTrainer",
     "DPOTrainer",
     "GRPOTrainer",
     "KTOTrainer",
@@ -43,7 +44,6 @@ _TELEMETRY_TRAINERS = {
     "AsyncGRPOTrainer",
     "BCOTrainer",
     "CPOTrainer",
-    "DistillationTrainer",
     "GKDTrainer",
     "GMPOTrainer",
     "GOLDTrainer",


### PR DESCRIPTION
*Stacked on the item-49 promotion PR. Part of #6449.*

`DistillationTrainer` is now a stable trainer (item 49), so move its entry in `_TELEMETRY_TRAINERS` (`base_trainer.py`) from the `# Experimental` group to the `# Stable` group. `ServerDistillationTrainer` remains experimental.

One-line data change; ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only regrouping in a telemetry allowlist with no functional code changes.
> 
> **Overview**
> **Reclassifies `DistillationTrainer` in the telemetry allowlist** so it sits under the `# Stable` block in `_TELEMETRY_TRAINERS` instead of `# Experimental`, matching its promotion to the stable API.
> 
> `ServerDistillationTrainer` is unchanged and remains in the experimental list. Telemetry still keys off set membership only; this is an organizational update to the documented trainer tiers, not a change to training or reporting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b93f34f985834db2098691020046e42297c70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->