### PR TITLE
[DistillationTrainer refactor] Add the `trl distillation` CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ import yaml
 from .testing_utils import TrlTestCase
 
 
-@pytest.mark.parametrize("command", ["dpo", "grpo", "kto", "reward", "rloo", "sft"])
+@pytest.mark.parametrize("command", ["distillation", "dpo", "grpo", "kto", "reward", "rloo", "sft"])
 def test_help_no_type_error(command):
     # Regression test for https://github.com/huggingface/trl/issues/5099:
     # TrainingArguments help strings with unescaped "%" caused TypeError in argparse.
@@ -35,6 +35,13 @@ def test_help_no_type_error(command):
 
 
 class TestCLI(TrlTestCase):
+    def test_distillation(self):
+        from trl.cli import main
+
+        command = f"trl distillation --output_dir {self.tmp_dir} --model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --teacher_model_name_or_path trl-internal-testing/tiny-Qwen2ForCausalLM-2.5 --dataset_name trl-internal-testing/zen --dataset_config standard_prompt_only --max_completion_length 32 --report_to none"
+        with patch("sys.argv", command.split(" ")):
+            main()
+
     def test_dpo(self):
         from trl.cli import main
 

--- a/trl/cli/commands/__init__.py
+++ b/trl/cli/commands/__init__.py
@@ -22,6 +22,7 @@ from .vllm_serve import VllmServeCommand
 def get_commands() -> list[Command]:
     """Return all registered top-level TRL CLI commands."""
     return [
+        TrainingCommand("distillation"),
         TrainingCommand("dpo"),
         EnvCommand(),
         TrainingCommand("grpo"),

--- a/trl/scripts/distillation.py
+++ b/trl/scripts/distillation.py
@@ -1,0 +1,140 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# /// script
+# dependencies = [
+#     "trl",
+#     "peft",
+#     "trackio",
+#     "kernels",
+# ]
+# ///
+
+"""
+# Full training
+```
+python trl/scripts/distillation.py \
+    --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
+    --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
+    --dataset_name trl-lib/ultrafeedback-prompt \
+    --learning_rate 2.0e-5 \
+    --num_train_epochs 1 \
+    --output_dir Qwen2.5-0.5B-Distillation
+```
+
+# LoRA
+```
+python trl/scripts/distillation.py \
+    --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
+    --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
+    --dataset_name trl-lib/ultrafeedback-prompt \
+    --learning_rate 2.0e-4 \
+    --num_train_epochs 1 \
+    --output_dir Qwen2.5-0.5B-Distillation \
+    --use_peft \
+    --lora_r 32 \
+    --lora_alpha 16
+```
+"""
+
+import argparse
+
+
+def main(script_args, training_args, model_args, dataset_args):
+    from accelerate.logging import get_logger
+    from datasets import load_dataset
+
+    from trl import DistillationTrainer, get_dataset, get_peft_config, get_quantization_config
+
+    logger = get_logger(__name__)
+
+    quantization_config = get_quantization_config(model_args)
+    training_args.model_init_kwargs = dict(
+        revision=model_args.model_revision,
+        trust_remote_code=training_args.trust_remote_code,
+        attn_implementation=model_args.attn_implementation,
+        dtype=model_args.dtype,
+        quantization_config=quantization_config,
+    )
+
+    teacher_model_init_kwargs = dict(
+        revision=training_args.teacher_model_revision,
+        trust_remote_code=training_args.trust_remote_code,
+        attn_implementation=model_args.attn_implementation,
+        dtype=model_args.dtype,
+        quantization_config=quantization_config,
+    )
+    if training_args.teacher_model_init_kwargs is not None:
+        teacher_model_init_kwargs.update(training_args.teacher_model_init_kwargs)
+    training_args.teacher_model_init_kwargs = teacher_model_init_kwargs
+
+    # Load the dataset
+    if dataset_args.datasets and script_args.dataset_name:
+        logger.warning(
+            "Both `datasets` and `dataset_name` are provided. The `datasets` argument will be used to load the "
+            "dataset and `dataset_name` will be ignored."
+        )
+        dataset = get_dataset(dataset_args)
+    elif dataset_args.datasets and not script_args.dataset_name:
+        dataset = get_dataset(dataset_args)
+    elif not dataset_args.datasets and script_args.dataset_name:
+        dataset = load_dataset(
+            script_args.dataset_name, name=script_args.dataset_config, streaming=script_args.dataset_streaming
+        )
+    else:
+        raise ValueError("Either `datasets` or `dataset_name` must be provided.")
+
+    # Initialize the Distillation trainer
+    trainer = DistillationTrainer(
+        model=model_args.model_name_or_path,
+        teacher_model=training_args.teacher_model_name_or_path,
+        args=training_args,
+        train_dataset=dataset[script_args.dataset_train_split],
+        eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
+        quantization_config=quantization_config,
+        peft_config=get_peft_config(model_args),
+    )
+
+    # Train the model
+    trainer.train()
+
+    # Log training complete
+    trainer.accelerator.print("✅ Training completed.")
+
+    # Save and push to Hub
+    trainer.save_model(training_args.output_dir)
+    trainer.accelerator.print(f"💾 Model saved to {training_args.output_dir}.")
+
+    if training_args.push_to_hub:
+        trainer.push_to_hub(dataset_name=script_args.dataset_name)
+        trainer.accelerator.print(f"🤗 Model pushed to the Hub in https://huggingface.co/{trainer.hub_model_id}.")
+
+
+def make_parser(subparsers: argparse._SubParsersAction | None = None, prog: str | None = None):
+    from trl import DatasetMixtureConfig, DistillationConfig, ModelConfig, ScriptArguments, TrlParser
+
+    dataclass_types = (ScriptArguments, DistillationConfig, ModelConfig, DatasetMixtureConfig)
+    if subparsers is not None:
+        parser = subparsers.add_parser(
+            "distillation", help="Run the distillation training script", dataclass_types=dataclass_types
+        )
+    else:
+        parser = TrlParser(dataclass_types, prog=prog)
+    return parser
+
+
+if __name__ == "__main__":
+    parser = make_parser()
+    script_args, training_args, model_args, dataset_args = parser.parse_args_and_config(fail_with_unknown_args=False)
+    main(script_args, training_args, model_args, dataset_args)

--- a/trl/scripts/distillation.py
+++ b/trl/scripts/distillation.py
@@ -59,13 +59,20 @@ def main(script_args, training_args, model_args, dataset_args):
 
     logger = get_logger(__name__)
 
+    if training_args.teacher_model_name_or_path is None:
+        raise ValueError(
+            "A teacher model is required for distillation training. Set it with `--teacher_model_name_or_path`."
+        )
+
     quantization_config = get_quantization_config(model_args)
+    # The student's quantization is passed via the trainer's `quantization_config` argument (below), so it must NOT
+    # also be set in `model_init_kwargs` — the trainer rejects that combination. Only the teacher, which has no
+    # dedicated trainer argument, carries it in `teacher_model_init_kwargs`.
     training_args.model_init_kwargs = dict(
         revision=model_args.model_revision,
         trust_remote_code=training_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
         dtype=model_args.dtype,
-        quantization_config=quantization_config,
     )
 
     teacher_model_init_kwargs = dict(


### PR DESCRIPTION
*Stacked on the item-50 telemetry PR. Part of #6449.*

- **`trl/scripts/distillation.py`** (new): `main()` + `make_parser()` mirroring `trl/scripts/sft.py`, with teacher handling — builds `teacher_model_init_kwargs` (revision/attn/dtype/quantization) and passes `teacher_model=training_args.teacher_model_name_or_path`. Uses the stable `from trl import DistillationTrainer, DistillationConfig`.
- **`trl/cli/commands/__init__.py`**: register `TrainingCommand("distillation")`.
- **`tests/test_cli.py`**: add `"distillation"` to the `--help` parametrize + a `test_distillation` end-to-end CLI test.

Verified: `trl distillation --help` registered; `test_distillation` trains end to end; ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CLI path and script that delegates to existing DistillationTrainer; no auth or core infra changes.
> 
> **Overview**
> Adds **`trl distillation`** as a first-class CLI entry point, aligned with existing training subcommands like `sft` and `dpo`.
> 
> A new **`trl/scripts/distillation.py`** wires **`DistillationTrainer`** with **`DistillationConfig`**: it requires **`--teacher_model_name_or_path`**, builds separate student vs teacher **`model_init_kwargs`** (quantization only on the teacher), loads data via mixture or **`dataset_name`**, then trains, saves, and optionally pushes to the Hub. **`TrainingCommand("distillation")`** registers the subcommand, and CLI tests cover **`--help`** and a tiny end-to-end distillation run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25112ab97fe960e110db8f900bc6c7f3c85b04d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->