### PR TITLE
[DistillationTrainer refactor] Update the example script for the stable API

### DIFF
--- a/examples/scripts/distillation.py
+++ b/examples/scripts/distillation.py
@@ -65,8 +65,7 @@ def main(script_args, training_args, model_args):
     from datasets import load_dataset
     from transformers import GenerationConfig
 
-    from trl import LogCompletionsCallback, get_peft_config, get_quantization_config
-    from trl.experimental.distillation import DistillationTrainer
+    from trl import DistillationTrainer, LogCompletionsCallback, get_peft_config, get_quantization_config
 
     ################
     # Model init kwargs
@@ -134,8 +133,7 @@ def main(script_args, training_args, model_args):
 
 
 def make_parser(subparsers: argparse._SubParsersAction | None = None, prog: str | None = None):
-    from trl import ModelConfig, ScriptArguments, TrlParser
-    from trl.experimental.distillation import DistillationConfig
+    from trl import DistillationConfig, ModelConfig, ScriptArguments, TrlParser
 
     dataclass_types = (ScriptArguments, DistillationConfig, ModelConfig)
     if subparsers is not None:


### PR DESCRIPTION
# [DistillationTrainer refactor] Update the example script for the stable API (item 54)

*Stacked on item 53. Part of #6449.*

`examples/scripts/distillation.py`: import `DistillationTrainer`/`DistillationConfig` from the stable `trl` namespace instead of `trl.experimental.distillation` (merged into the existing `from trl import …` lines). `--help` parses; ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only import path change with no effect on library behavior or training logic.
> 
> **Overview**
> Updates **`examples/scripts/distillation.py`** so it follows the promoted distillation API: **`DistillationTrainer`** and **`DistillationConfig`** are imported from **`trl`** instead of **`trl.experimental.distillation`**, merged into the existing `from trl import …` lines in `main` and `make_parser`.
> 
> No training logic, CLI flags, or runtime behavior changes—only import paths for the example script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228d8ad4c9f15152cee62d7c0a0fc82af4cf353b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->