### PR TITLE
[DistillationTrainer refactor] Re-point ServerDistillationTrainer at the stable base

### DIFF
--- a/trl/experimental/server_distillation/server_distillation_trainer.py
+++ b/trl/experimental/server_distillation/server_distillation_trainer.py
@@ -133,8 +133,7 @@ class ServerDistillationTrainer(DistillationTrainer):
     Instead of running a local teacher forward pass, per-token teacher logprobs are fetched from a vLLM server via
     [`~generation.vllm_client.VLLMClient`]. The server only returns the teacher's top-k logprobs, so the divergence is
     restricted to a sparse support (top-1 for `beta > 0`, top-k for the pure forward path `beta = 0`). Everything else
-    — the student forward, generation, buffering, metrics — is inherited from
-    [`experimental.distillation.DistillationTrainer`].
+    — the student forward, generation, buffering, metrics — is inherited from [`DistillationTrainer`].
     """
 
     _tag_names = ["trl", "server-distillation"]


### PR DESCRIPTION
# [DistillationTrainer refactor] Re-point ServerDistillationTrainer at the stable base (item 55)

*Stacked on item 54. Part of #6449.*

The server's `import` of the base trainer/config was already re-pointed at the stable `trl.trainer.distillation_*` modules in item 49 (needed to keep the interim green). This finishes the re-point: de-namespace the remaining docstring cross-reference `[`experimental.distillation.DistillationTrainer`]` → `[`DistillationTrainer`]`.

`ServerDistillationTrainer` stays experimental; the full loss migration onto the stable base is item 58 (out of scope). Server test suite green on the stable base (12 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring edit with no runtime or API impact.
> 
> **Overview**
> Completes the docstring side of re-pointing **`ServerDistillationTrainer`** at the stable distillation base (imports were already on `trl.trainer.distillation_trainer`).
> 
> The only code change is in the class docstring: the inheritance cross-reference is updated from ``[`experimental.distillation.DistillationTrainer`]`` to ``[`DistillationTrainer`]``, matching the stable module path. No behavior or implementation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4126acda9fa18a47ba989af3c58adad69fc728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->