### PR TITLE
[GRPO] Fix entropy bonus normalization inconsistency across loss types

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1832,8 +1832,9 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.parametrize("top_entropy_quantile", [1.0, 0.2])
     @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "luspo"])
-    def test_entropy_bonus_scale(self, loss_type):
+    def test_entropy_bonus_scale(self, loss_type, top_entropy_quantile):
         # Regression test: the entropy bonus is the mean per-token entropy H for every loss type (documented
         # objective L = L_policy - entropy_coef * H), so it must not inherit any loss-type-specific policy
         # normalization. A previous "unified" formula divided H by a global token count for the
@@ -1853,6 +1854,7 @@ class TestGRPOTrainer(TrlTestCase):
             max_completion_length=16,  # reduce the completion length to reduce memory usage
             gradient_accumulation_steps=1,  # so contrib == entropy_coef * entropy_loss holds per step
             loss_type=loss_type,
+            top_entropy_quantile=top_entropy_quantile,
             logging_steps=1,
             report_to="none",
             entropy_coef=entropy_coef,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1833,47 +1833,64 @@ class TestGRPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @pytest.mark.parametrize("top_entropy_quantile", [1.0, 0.2])
-    @pytest.mark.parametrize("loss_type", ["grpo", "dr_grpo", "dapo", "luspo"])
-    def test_entropy_bonus_scale(self, loss_type, top_entropy_quantile):
+    def test_entropy_bonus_scale(self, top_entropy_quantile):
         # Regression test: the entropy bonus is the mean per-token entropy H for every loss type (documented
         # objective L = L_policy - entropy_coef * H), so it must not inherit any loss-type-specific policy
         # normalization. A previous "unified" formula divided H by a global token count for the
         # cispo/dapo/vespo family, making the bonus ~1/sequence_length too small; conversely, scaling the
         # bonus like the dr_grpo (fixed budget) or luspo (sequence-weighted) policy term would also be wrong.
-        # With gradient_accumulation_steps=1 the per-step entropy contribution to the loss is
-        # contrib = policy_loss - loss = entropy_coef * entropy_loss, so contrib / entropy must equal
-        # entropy_coef for all loss types.
+        #
+        # With gradient_accumulation_steps=1, contrib = policy_loss - loss = entropy_coef * entropy_loss, so
+        # contrib / entropy is entropy_coef * (H_eff / H_full): H_eff is what the bonus actually uses
+        # (over effective_mask, the entropy-quantile-filtered subset), while the logged "entropy" metric is
+        # H_full (global_masked_mean over the full completion mask, see `global_masked_mean(entropies)`
+        # above). These only coincide when top_entropy_quantile == 1.0. At 0.2, comparing contrib/entropy
+        # to a fixed entropy_coef is fixture-lucky: it only holds because this tiny, ~untrained model's
+        # entropy is ~uniform across tokens (H_eff/H_full ~= 1.0), which isn't true in general. The actual
+        # invariant this PR restores is loss-type independence, so assert that directly: every loss type's
+        # ratio must agree with every other's, at the same quantile.
         entropy_coef = 0.5
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            importance_sampling_level="sequence" if loss_type == "luspo" else "token",
-            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
-            num_generations=3,  # reduce the number of generations to reduce memory usage
-            max_completion_length=16,  # reduce the completion length to reduce memory usage
-            gradient_accumulation_steps=1,  # so contrib == entropy_coef * entropy_loss holds per step
-            loss_type=loss_type,
-            top_entropy_quantile=top_entropy_quantile,
-            logging_steps=1,
-            report_to="none",
-            entropy_coef=entropy_coef,
-        )
-        trainer = GRPOTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
-            args=training_args,
-            train_dataset=dataset,
-        )
 
-        trainer.train()
+        def ratio_for(loss_type):
+            dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+            training_args = GRPOConfig(
+                output_dir=self.tmp_dir,
+                importance_sampling_level="sequence" if loss_type == "luspo" else "token",
+                learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+                per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+                num_generations=3,  # reduce the number of generations to reduce memory usage
+                max_completion_length=16,  # reduce the completion length to reduce memory usage
+                gradient_accumulation_steps=1,  # so contrib == entropy_coef * entropy_loss holds per step
+                loss_type=loss_type,
+                top_entropy_quantile=top_entropy_quantile,
+                logging_steps=1,
+                report_to="none",
+                entropy_coef=entropy_coef,
+            )
+            trainer = GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
 
-        logs = [h for h in trainer.state.log_history if "policy_loss" in h and "loss" in h and h.get("entropy")]
-        assert logs
-        ratios = sorted((h["policy_loss"] - h["loss"]) / h["entropy"] for h in logs)
-        ratio = ratios[len(ratios) // 2]  # median, robust to per-step noise
-        # Every loss type regularizes the mean per-token entropy, so contrib == entropy_coef * entropy.
-        assert ratio == pytest.approx(entropy_coef, rel=0.3)
+            trainer.train()
+
+            logs = [h for h in trainer.state.log_history if "policy_loss" in h and "loss" in h and h.get("entropy")]
+            assert logs
+            ratios = sorted((h["policy_loss"] - h["loss"]) / h["entropy"] for h in logs)
+            return ratios[len(ratios) // 2]  # median, robust to per-step noise
+
+        ratios = {loss_type: ratio_for(loss_type) for loss_type in ["grpo", "dr_grpo", "dapo", "luspo"]}
+        baseline = ratios["grpo"]
+        for loss_type, ratio in ratios.items():
+            # Every loss type regularizes the same mean per-token entropy, so their ratios must agree with
+            # each other regardless of top_entropy_quantile, even though none of them individually needs to
+            # equal entropy_coef once quantile filtering makes H_eff diverge from the logged H_full.
+            assert ratio == pytest.approx(baseline, rel=0.3), (
+                f"entropy bonus ratio for loss_type={loss_type!r} at top_entropy_quantile={top_entropy_quantile} "
+                f"diverges from the grpo baseline ({ratio} vs {baseline})"
+            )
 
     def test_train_with_adaptive_entropy_gradient_accumulation(self):
         # Adaptive entropy must behave correctly under gradient accumulation: the coefficient and gating are

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3182,18 +3182,14 @@ class GRPOTrainer(_BaseTrainer):
             # tokens. Use the same effective mask for the entropy bonus so it acts on the same tokens.
             effective_mask = mask if entropy_mask is None else mask * entropy_mask
             # Entropy bonus = mean per-token entropy H (the documented objective L = L_policy - coef * H), so
-            # H does not depend on how each loss type normalizes its policy term. The term is computed so that
-            # it accumulates to H over the optimizer step for every loss type and matches world_entropy below.
-            # The only wrinkle is the normalizer: most loss types divide by the gradient accumulation step
-            # count, but cispo/dapo/vespo divide by a global token count.
-            if self.loss_type in ["cispo", "dapo", "vespo"]:
-                # normalizer is a global token count, so summing the entropies (instead of averaging them
-                # again) makes the term accumulate over the optimizer step to the global mean per-token
-                # entropy, like the other loss types.
-                entropy_loss = (entropies * effective_mask).sum() / normalizer
-            else:
-                # Mean per-token entropy of active tokens, scaled for gradient accumulation.
-                entropy_loss = (entropies * effective_mask).sum() / effective_mask.sum().clamp(min=1.0) / normalizer
+            # H does not depend on how each loss type normalizes its policy term. The bonus is a mean over the
+            # tokens it acts on (effective_mask), scaled only for gradient accumulation, never by a loss-type-
+            # specific policy normalizer, so this accumulates to H over the optimizer step for every loss type
+            # and matches world_entropy below.
+            accumulation_factor = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            entropy_loss = (
+                (entropies * effective_mask).sum() / effective_mask.sum().clamp(min=1.0) / accumulation_factor
+            )
 
             # Apply the coefficient and gating from the end of the previous optimizer step, so that every
             # micro-batch in the current accumulation window applies the same entropy bonus. The adaptive

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3184,8 +3184,8 @@ class GRPOTrainer(_BaseTrainer):
             # Entropy bonus = mean per-token entropy H (the documented objective L = L_policy - coef * H), so
             # H does not depend on how each loss type normalizes its policy term. The bonus is a mean over the
             # tokens it acts on (effective_mask), scaled only for gradient accumulation, never by a loss-type-
-            # specific policy normalizer, so this accumulates to H over the optimizer step for every loss type
-            # and matches world_entropy below.
+            # specific policy normalizer. (The adaptive controller below tracks a window-global token-weighted mean,
+            # which can differ from this per-micro-batch mean when token counts vary across micro-batches.)
             accumulation_factor = self.current_gradient_accumulation_steps if mode == "train" else 1.0
             entropy_loss = (
                 (entropies * effective_mask).sum() / effective_mask.sum().clamp(min=1.0) / accumulation_factor


### PR DESCRIPTION
## Description

**Current behavior:** `cispo`/`dapo`/`vespo` divide the entropy bonus by a
global token count borrowed from the policy-loss normalizer, while every
other loss type divides by the tokens that actually contributed
(`effective_mask.sum()`). These only agree when nothing gets filtered out.
Once `top_entropy_quantile < 1.0` drops most tokens, the global count
doesn't shrink with it, so the bonus gets silently crushed for those three
loss types — measured ~4.8x smaller at `top_entropy_quantile=0.2` in one
worked example (ratio ρ ≈ top_entropy_quantile ≈ 0.208; a 10x crush would
need `top_entropy_quantile≈0.1`, not 0.2 — correcting the earlier estimate
in this description).

This also contradicts what the docs already promise
(`docs/source/grpo_trainer.md`, "Entropy regularization" section):

> The bonus is always the mean per-token entropy regardless of `loss_type`;
> it is not rescaled to match a loss type's policy normalization... so
> `entropy_coef` has the same meaning for every loss type.

**Changes:** Drop the per-`loss_type` branch. The entropy term now always
divides by `effective_mask.sum()`, then by the gradient-accumulation
factor. One formula, and it now matches what the docs already said.

**Accepted regression (intentional):** `cispo`/`dapo`/`vespo` previously
got an *exact* token-weighted global average of entropy across the whole
gradient-accumulation window, because the old denominator summed real
token counts across every accumulated micro-batch. After this change they
get an unweighted mean of per-micro-batch, per-rank means instead — the
same aggregation every other loss type already used. This is deliberate:
uniform treatment across loss types is what the docs promise, and the two
aggregations only diverge meaningfully when token counts vary a lot across
micro-batches/ranks.

**Merge note:** please merge this after #6654, not just rebase on top of
it — the entropy mask is one of several things that broadcast
`per_token_loss` to `(B, T)` for `luspo` (see #6654), and this PR's new
`luspo` @ `top_entropy_quantile=0.2` case depends on that fix being in to
be meaningful.

## Test plan

### Before

`test_entropy_bonus_scale` only ran with `top_entropy_quantile=1.0` — the
one setting where the bug can't show up, since nothing gets filtered.

### After

Added `top_entropy_quantile=0.2` to the same test's parametrization, across
all 4 tested `loss_type`s. Also changed the assertion itself: comparing
`contrib / entropy` to a fixed `entropy_coef` is only exact at
`top_entropy_quantile=1.0` (where `effective_mask == mask`, so H_eff ==
H_full). Under filtering it's `entropy_coef * H_eff / H_full`, and the
logged `entropy` metric is H_full (`global_masked_mean` over the full
completion mask), not H_eff — so asserting the ratio equals `entropy_coef`
at `top_entropy_quantile=0.2` was fixture-lucky: it only held because this
tiny, near-untrained model's entropy is ~uniform across tokens
(H_eff/H_full ≈ 1.0), which isn't true in general. The test now asserts
the actual invariant instead: every loss type's ratio must agree with
every other's, at the same quantile.

Verified in both directions: reverted just the trainer hunk (restoring the
old per-`loss_type` branching) and reran. `top_entropy_quantile=0.2` fails
as expected (`1 failed, 1 passed`) — that's the case that actually
exercises the bug. `top_entropy_quantile=1.0` still passes even on the
reverted code, which is correct and not a gap in the test: at quantile
1.0 nothing is filtered, so the old and new formulas coincide by
construction, matching the "Before" note above that this is the one
setting where the bug can't show up. Restored the fix afterward and
confirmed both cases pass (`2 passed`). Full suite (145 passed, 41
skipped, 0 failed) was run before this test was rewritten to its current
parametrization; the rewrite collapsed what used to be 8 separate
parametrized cases into 2 (each now looping over all 4 loss types
internally), so that count is no longer the right one to cite.
`test_entropy_bonus_scale` itself: 2 passed, 0 failed, directly re-run
after the rewrite.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
y



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training loss math for cispo/dapo/vespo (especially with top_entropy_quantile &lt; 1), which can shift exploration strength in production GRPO runs.
> 
> **Overview**
> **Unifies GRPO entropy regularization** so `cispo`/`dapo`/`vespo` no longer scale the bonus with the policy loss’s global token normalizer. The entropy term is always the mean over `effective_mask` tokens (including `top_entropy_quantile` filtering), divided only by the gradient-accumulation factor—matching documented behavior that `entropy_coef` means the same for every `loss_type`.
> 
> **Regression test updates:** `test_entropy_bonus_scale` now runs at `top_entropy_quantile` 1.0 and 0.2, trains each of `grpo`/`dr_grpo`/`dapo`/`luspo` in one loop, and checks that `(policy_loss - loss) / entropy` is consistent across loss types rather than equaling `entropy_coef` (which only lines up with logged entropy when no quantile filtering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3643cddc5614cf60af1dfd17b8057c8e71dad1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



