### PR TITLE
[DistillationTrainer refactor] Support Vision Language Models

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -178,6 +178,20 @@ Set `use_liger_kernel=True` in the [`DistillationConfig`] to compute the JSD wit
 > [!WARNING]
 > The fused Liger kernel cannot apply per-model `logit_scale` (e.g. Cohere) or `final_logit_softcapping` (e.g. Gemma), so it is rejected for models that set them — use the default chunked path for those.
 
+## Training Vision Language Models
+
+[`DistillationTrainer`] supports distilling Vision-Language Models (VLMs) on multimodal datasets containing both text and images. Pass a VLM as both the student and the teacher, and provide a prompt-only dataset with either an `image` column (single image per sample) or an `images` column (list of images per sample). For more information on the expected dataset structure, see the [Dataset Format — Vision datasets](dataset_formats#vision-datasets) section.
+
+Tested with:
+
+- **Gemma 3** — e.g., `google/gemma-3-4b-it`
+- **LLaVA-NeXT** — e.g., `llava-hf/llava-v1.6-mistral-7b-hf`
+- **Qwen2-VL** — e.g., `Qwen/Qwen2-VL-2B-Instruct`
+- **Qwen2.5-VL** — e.g., `Qwen/Qwen2.5-VL-3B-Instruct`
+
+> [!TIP]
+> Compatibility with all VLMs is not guaranteed. If you believe a model should be supported, feel free to open an issue on GitHub — or better yet, submit a pull request with the required changes.
+
 ## Example script
 
 Use [`examples/scripts/distillation.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/distillation.py) to launch distillation training from the command line. The script supports full training and LoRA via the standard `ModelConfig` flags.

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1237,3 +1237,45 @@ class TestDistillationTrainerVLM(TrlTestCase):
         train_loss = trainer.state.log_history[-1]["train_loss"]
         assert train_loss is not None
         assert torch.isfinite(torch.tensor(train_loss))
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ),
+        ],
+    )
+    @require_vllm
+    @pytest.mark.skip(reason="We should add a mock for the vLLM server.")
+    def test_train_vlm_and_vllm(self, model_id) -> None:
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+            use_vllm=True,
+            vllm_mode="server",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        # Self-distillation gives a near-zero teacher signal, so we assert the multimodal path ran end to end and the
+        # loss stayed finite, rather than params-changed (see `test_train_dataset_format`).
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -15,8 +15,10 @@
 import pytest
 import torch
 import torch.nn.functional as F
+import transformers
 from accelerate.utils.memory import release_memory
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
+from packaging.version import Version
 from transformers import AutoModelForCausalLM
 from transformers.utils import is_peft_available
 
@@ -24,7 +26,14 @@ from trl import DistillationConfig, DistillationTrainer
 from trl.experimental.gkd.gkd_trainer import GKDTrainer
 from trl.trainer.distillation_trainer import _chunked_divergence_loss
 
-from .testing_utils import TrlTestCase, require_liger_kernel, require_peft, require_torch_accelerator, require_vllm
+from .testing_utils import (
+    TrlTestCase,
+    require_liger_kernel,
+    require_peft,
+    require_torch_accelerator,
+    require_vision,
+    require_vllm,
+)
 
 
 if is_peft_available():
@@ -1170,3 +1179,61 @@ class TestDistillationTrainer(TrlTestCase):
             args=DistillationConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none"),
             train_dataset=dataset,
         )
+
+
+@require_vision
+class TestDistillationTrainerVLM(TrlTestCase):
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ),
+            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+            # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
+        ],
+    )
+    def test_train_vlm(self, model_id):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        # Self-distillation gives a near-zero teacher signal, so we assert the multimodal path ran end to end and the
+        # loss stayed finite, rather than params-changed (see `test_train_dataset_format`).
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1241,6 +1241,38 @@ class TestDistillationTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",  # image_grid_thw path
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",  # image_position_ids path
+        ],
+    )
+    def test_train_vlm_gradient_accumulation(self, model_id):
+        # With gradient accumulation the packed `pixel_values` are split across micro-batches via `num_images`; train a
+        # couple of steps to exercise that path (a missing `num_images` would misalign images and text).
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            gradient_accumulation_steps=2,  # split the packed pixel_values across micro-batches
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             pytest.param(

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1256,6 +1256,38 @@ class TestDistillationTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",  # image_grid_thw path
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",  # image_position_ids path
+        ],
+    )
+    def test_train_vlm_gradient_accumulation(self, model_id):
+        # With gradient accumulation the packed `pixel_values` are split across micro-batches via `num_images`; train a
+        # couple of steps to exercise that path (a missing `num_images` would misalign images and text).
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            gradient_accumulation_steps=2,  # split the packed pixel_values across micro-batches
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             pytest.param(

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1252,3 +1252,45 @@ class TestDistillationTrainerVLM(TrlTestCase):
         train_loss = trainer.state.log_history[-1]["train_loss"]
         assert train_loss is not None
         assert torch.isfinite(torch.tensor(train_loss))
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ),
+        ],
+    )
+    @require_vllm
+    @pytest.mark.skip(reason="We should add a mock for the vLLM server.")
+    def test_train_vlm_and_vllm(self, model_id) -> None:
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+            use_vllm=True,
+            vllm_mode="server",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        # Self-distillation gives a near-zero teacher signal, so we assert the multimodal path ran end to end and the
+        # loss stayed finite, rather than params-changed (see `test_train_dataset_format`).
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -15,8 +15,10 @@
 import pytest
 import torch
 import torch.nn.functional as F
+import transformers
 from accelerate.utils.memory import release_memory
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
+from packaging.version import Version
 from transformers import AutoModelForCausalLM
 from transformers.utils import is_peft_available
 
@@ -24,7 +26,14 @@ from trl import DistillationConfig, DistillationTrainer
 from trl.experimental.gkd.gkd_trainer import GKDTrainer
 from trl.trainer.distillation_trainer import _chunked_divergence_loss
 
-from .testing_utils import TrlTestCase, require_liger_kernel, require_peft, require_torch_accelerator, require_vllm
+from .testing_utils import (
+    TrlTestCase,
+    require_liger_kernel,
+    require_peft,
+    require_torch_accelerator,
+    require_vision,
+    require_vllm,
+)
 
 
 if is_peft_available():
@@ -1185,3 +1194,61 @@ class TestDistillationTrainer(TrlTestCase):
                 args=DistillationConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none"),
                 train_dataset=dataset,
             )
+
+
+@require_vision
+class TestDistillationTrainerVLM(TrlTestCase):
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.5.0"),
+                    reason="Gemma4 models were introduced in transformers-5.5.0",
+                ),
+            ),
+            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+            pytest.param(
+                "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.2.0"),
+                    reason="Qwen3.5 models were introduced in transformers-5.2.0",
+                ),
+            ),
+            # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
+        ],
+    )
+    def test_train_vlm(self, model_id):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        training_args = DistillationConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = DistillationTrainer(
+            model=model_id,
+            teacher_model=model_id,  # self-distillation: no tiny+small VLM fixture pair exists
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        # Self-distillation gives a near-zero teacher signal, so we assert the multimodal path ran end to end and the
+        # loss stayed finite, rather than params-changed (see `test_train_dataset_format`).
+        train_loss = trainer.state.log_history[-1]["train_loss"]
+        assert train_loss is not None
+        assert torch.isfinite(torch.tensor(train_loss))

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1201,7 +1201,13 @@ class TestDistillationTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
-            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("4.57.0"),
+                    reason="transformers<4.57 Gemma3 image processor can't batch variable-size images",
+                ),
+            ),
             pytest.param(
                 "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
                 marks=pytest.mark.skipif(
@@ -1257,7 +1263,13 @@ class TestDistillationTrainerVLM(TrlTestCase):
         "model_id",
         [
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",  # image_grid_thw path
-            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",  # image_position_ids path
+            pytest.param(
+                "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",  # image_position_ids path
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("4.57.0"),
+                    reason="transformers<4.57 Gemma3 image processor can't batch variable-size images",
+                ),
+            ),
         ],
     )
     def test_train_vlm_gradient_accumulation(self, model_id):

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -45,7 +45,7 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ..data_utils import is_conversational, prepare_multimodal_messages
+from ..data_utils import apply_chat_template, is_conversational, prepare_multimodal_messages
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
@@ -1086,7 +1086,7 @@ class DistillationTrainer(_BaseTrainer):
         self._metrics[mode]["completions/min_terminated_length"].append(term_completion_lengths.float().min().item())
         self._metrics[mode]["completions/max_terminated_length"].append(term_completion_lengths.float().max().item())
 
-        return prompt_ids, completion_ids, multimodal_fields
+        return prompt_ids, completion_ids
 
     @profiling_decorator
     def _get_last_hidden_state(
@@ -1100,6 +1100,8 @@ class DistillationTrainer(_BaseTrainer):
         pixel_attention_mask=None,
         spatial_shapes=None,
         image_sizes=None,
+        token_type_ids=None,
+        mm_token_type_ids=None,
         image_position_ids=None,
     ):
         if is_peft_model(unwrapped_model):
@@ -1123,6 +1125,10 @@ class DistillationTrainer(_BaseTrainer):
         # For LLaVa-Next
         if image_sizes is not None:
             model_inputs["image_sizes"] = image_sizes
+        if token_type_ids is not None:
+            model_inputs["token_type_ids"] = token_type_ids
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         if image_position_ids is not None:
             model_inputs["image_position_ids"] = image_position_ids
 
@@ -1136,7 +1142,12 @@ class DistillationTrainer(_BaseTrainer):
         # `base_model` gives the backbone model (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
         # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
         # returns just the text stack and feeds image-placeholder IDs through it.
-        backbone = unwrapped_model.base_model
+        # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `base_model is self` (re-runs `lm_head`).
+        # Fall back to `.model` there.
+        if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
+            backbone = unwrapped_model.model
+        else:
+            backbone = unwrapped_model.base_model
         last_hidden_state = backbone(**model_inputs).last_hidden_state
         # Exclude the last value: it corresponds to the next token pred
         last_hidden_state = last_hidden_state[:, :-1, :]  # (B, L-1, H)
@@ -1150,7 +1161,33 @@ class DistillationTrainer(_BaseTrainer):
 
         prompts = [x["prompt"] for x in inputs]
 
-        prompt_ids_list, completion_ids_list, multimodal_fields = self._generate(prompts)
+        if "images" in inputs[0]:
+            images = [example.get("images") for example in inputs]
+        elif "image" in inputs[0]:
+            images = [[example.get("image")] if example.get("image") is not None else None for example in inputs]
+        else:
+            images = None
+        # Transformers requires at least one image in the batch, otherwise it throws an error
+        if images is not None and all(img_list == [] for img_list in images):
+            images = None
+
+        # If the prompts are conversational and the inputs contain images, we need to convert the prompts from
+        # [{"role": "user", "content": "What color is the sky?"}] to
+        # [{"role": "user", "content": [{"type": "image", "image": <Image>}, {"type": "text", "text": "What color is the sky?"}]}]
+        if images is not None:
+            if not is_conversational(inputs[0]):
+                raise ValueError(
+                    "Multimodal training requires conversational prompts. It looks like the dataset contains "
+                    "non-conversational inputs, likely because a chat template was applied before passing the dataset "
+                    "to the trainer. Please provide the raw conversational prompts and let the trainer apply the chat "
+                    "template internally."
+                )
+            prompts = [
+                prepare_multimodal_messages(prompt, images=image_list)
+                for prompt, image_list in zip(prompts, images, strict=True)
+            ]
+
+        prompt_ids_list, completion_ids_list = self._generate(prompts)
 
         # Convert lists of token IDs to padded tensors
         prompt_ids = [torch.tensor(ids) for ids in prompt_ids_list]
@@ -1178,6 +1215,59 @@ class DistillationTrainer(_BaseTrainer):
 
         num_items_in_batch = self.accelerator.gather(completion_mask.sum()).sum()
 
+        num_images = [len(img_list) if img_list else 0 for img_list in images] if images is not None else None
+
+        # Get forward_kwargs for models with multimodal inputs.
+        if images is not None:
+            prompts_text = [
+                apply_chat_template({"prompt": prompt}, self.processing_class, **self.chat_template_kwargs)["prompt"]
+                for prompt in prompts
+            ]
+            prompt_inputs = self.processing_class(images=images, text=prompts_text, padding=True, return_tensors="pt")
+            prompt_inputs = super()._prepare_inputs(prompt_inputs)
+            forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
+        else:
+            forward_kwargs = {}
+
+        # Recover LFM2-VL tile counts; the full processor drops row/column metadata.
+        num_tiles = None
+        if images is not None and "spatial_shapes" in forward_kwargs:
+            image_info = self.processing_class.image_processor(
+                images=images, return_tensors="pt", return_row_col_info=True
+            )
+            tiles_per_image = image_info["image_rows"] * image_info["image_cols"]
+            if self.processing_class.image_processor.use_thumbnail:
+                tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(tiles_per_image.dtype)
+            num_tiles = [group.sum().item() for group in torch.split(tiles_per_image, num_images)]
+
+        # If token_type_ids are used, extend them with zeros for the completion part
+        if "token_type_ids" in forward_kwargs:
+            token_type_ids = forward_kwargs["token_type_ids"]
+            if self.pad_to_multiple_of is not None:
+                # Needed only with pad_to_multiple_of: otherwise prompt_ids and token_type_ids must have equal len
+                padding_size = prompt_ids.size(1) - token_type_ids.size(1)
+                if padding_size > 0:
+                    token_type_ids = torch.cat(
+                        [token_type_ids.new_zeros((token_type_ids.size(0), padding_size)), token_type_ids], dim=1
+                    )
+            forward_kwargs["token_type_ids"] = torch.cat(
+                [token_type_ids, token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
+        # If mm_token_type_ids are used, extend them with zeros for the completion part
+        if "mm_token_type_ids" in forward_kwargs:
+            mm_token_type_ids = forward_kwargs["mm_token_type_ids"]
+            if self.pad_to_multiple_of is not None:
+                # Needed only with pad_to_multiple_of: otherwise prompt_ids and mm_token_type_ids must have equal len
+                padding_size = prompt_ids.size(1) - mm_token_type_ids.size(1)
+                if padding_size > 0:
+                    mm_token_type_ids = torch.cat(
+                        [mm_token_type_ids.new_zeros((mm_token_type_ids.size(0), padding_size)), mm_token_type_ids],
+                        dim=1,
+                    )
+            forward_kwargs["mm_token_type_ids"] = torch.cat(
+                [mm_token_type_ids, mm_token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
+
         # Log the prompt and completion texts
         if self.log_completions:
             prompts_text = self.processing_class.batch_decode(prompt_ids, skip_special_tokens=True)
@@ -1192,22 +1282,26 @@ class DistillationTrainer(_BaseTrainer):
             "completion_mask": completion_mask,
             "num_items_in_batch": num_items_in_batch,
         }
-        if "pixel_values" in multimodal_fields:
-            output["pixel_values"] = multimodal_fields["pixel_values"]
-        if "image_grid_thw" in multimodal_fields:
-            output["image_grid_thw"] = multimodal_fields["image_grid_thw"]
-        if "pixel_attention_mask" in multimodal_fields:
-            output["pixel_attention_mask"] = multimodal_fields["pixel_attention_mask"]
-        if "spatial_shapes" in multimodal_fields:
-            output["spatial_shapes"] = multimodal_fields["spatial_shapes"]
-        if "image_sizes" in multimodal_fields:
-            output["image_sizes"] = multimodal_fields["image_sizes"]
-        if "token_type_ids" in multimodal_fields:
-            output["token_type_ids"] = multimodal_fields["token_type_ids"]
-        if "mm_token_type_ids" in multimodal_fields:
-            output["mm_token_type_ids"] = multimodal_fields["mm_token_type_ids"]
-        if "image_position_ids" in multimodal_fields:
-            output["image_position_ids"] = multimodal_fields["image_position_ids"]
+        if "pixel_values" in forward_kwargs:
+            output["pixel_values"] = forward_kwargs["pixel_values"]
+        if "image_grid_thw" in forward_kwargs:
+            output["image_grid_thw"] = forward_kwargs["image_grid_thw"]
+        if "pixel_attention_mask" in forward_kwargs:
+            output["pixel_attention_mask"] = forward_kwargs["pixel_attention_mask"]
+        if "spatial_shapes" in forward_kwargs:
+            output["spatial_shapes"] = forward_kwargs["spatial_shapes"]
+        if "image_sizes" in forward_kwargs:
+            output["image_sizes"] = forward_kwargs["image_sizes"]
+        if "token_type_ids" in forward_kwargs:
+            output["token_type_ids"] = forward_kwargs["token_type_ids"]
+        if "mm_token_type_ids" in forward_kwargs:
+            output["mm_token_type_ids"] = forward_kwargs["mm_token_type_ids"]
+        if "image_position_ids" in forward_kwargs:
+            output["image_position_ids"] = forward_kwargs["image_position_ids"]
+        if images is not None:
+            output["num_images"] = num_images
+            if num_tiles is not None:
+                output["num_tiles"] = num_tiles
         return output
 
     @profiling_decorator
@@ -1287,6 +1381,8 @@ class DistillationTrainer(_BaseTrainer):
             "pixel_attention_mask",
             "spatial_shapes",
             "image_sizes",
+            "token_type_ids",
+            "mm_token_type_ids",
             "image_position_ids",
         )
         multimodal_inputs = {k: inputs[k] for k in multimodal_keys if k in inputs}

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -33,7 +33,7 @@ from datasets import Dataset, IterableDataset
 from packaging.version import Version
 from torch.utils.data import DataLoader, Sampler
 from transformers import (
-    AutoTokenizer,
+    AutoProcessor,
     BitsAndBytesConfig,
     GenerationConfig,
     PreTrainedModel,
@@ -345,9 +345,10 @@ class DistillationTrainer(_BaseTrainer):
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):
-            Processing class used to process the data. If `None`, it is loaded from the model's name with
-            [`~transformers.AutoTokenizer.from_pretrained`]. A padding token, `tokenizer.pad_token`, must be set; if
-            the processing class has not set one, `tokenizer.eos_token` is used as the default.
+            Processing class used to process the data. The padding side must be set to "left". If `None`, the
+            processing class is loaded from the model's name with [`~transformers.AutoProcessor.from_pretrained`]. A
+            padding token, `tokenizer.pad_token`, must be set. If the processing class has not set a padding token,
+            `tokenizer.eos_token` will be used as the default.
         callbacks (list of [`~transformers.TrainerCallback`], *optional*):
             List of callbacks to customize the training loop. Will add those to the list of default callbacks detailed
             in [here](https://huggingface.co/docs/transformers/main_classes/callback).
@@ -441,14 +442,16 @@ class DistillationTrainer(_BaseTrainer):
             else inspect.signature(model.get_base_model().forward).parameters.keys()
         )
 
-        # Processing class (tokenizer)
-        if processing_class is None and model_name_or_path is not None:
-            processing_class = AutoTokenizer.from_pretrained(
-                model_name_or_path, trust_remote_code=args.trust_remote_code
+        # Processing class
+        if processing_class is None:
+            processing_class = AutoProcessor.from_pretrained(
+                model_name_or_path,
+                truncation_side="left",
+                padding_side="left",
+                trust_remote_code=args.trust_remote_code,
             )
-        if processing_class is not None:
-            if processing_class.pad_token is None:
-                processing_class.pad_token = processing_class.eos_token
+
+        # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):
             self._tokenizer = processing_class.tokenizer
             self._is_vlm = True
@@ -457,6 +460,9 @@ class DistillationTrainer(_BaseTrainer):
             self._is_vlm = False
         else:
             raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
+
+        if self._tokenizer.pad_token is None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
 
         # PEFT
         if peft_config is not None:
@@ -1274,8 +1280,19 @@ class DistillationTrainer(_BaseTrainer):
         completion_mask = inputs["completion_mask"]
         logits_to_keep = inputs["completion_ids"].size(1)  # only the completion tokens are trained on
 
+        # Multimodal (VLM) fields, extracted during generation and split to this micro-batch by `_prepare_inputs`.
+        multimodal_keys = (
+            "pixel_values",
+            "image_grid_thw",
+            "pixel_attention_mask",
+            "spatial_shapes",
+            "image_sizes",
+            "image_position_ids",
+        )
+        multimodal_inputs = {k: inputs[k] for k in multimodal_keys if k in inputs}
+
         student_hidden_states = self._get_last_hidden_state(
-            unwrapped_student, input_ids, attention_mask, logits_to_keep
+            unwrapped_student, input_ids, attention_mask, logits_to_keep, **multimodal_inputs
         )
 
         # Route the teacher backbone through its own wrapper via `_forward_redirection` too, so FSDP/DeepSpeed
@@ -1291,6 +1308,7 @@ class DistillationTrainer(_BaseTrainer):
                 input_ids,
                 attention_mask,
                 logits_to_keep,
+                **multimodal_inputs,
             )
 
         student_lm_head = unwrapped_student.get_output_embeddings()

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -1078,7 +1078,7 @@ class DistillationTrainer(_BaseTrainer):
         self._metrics[mode]["completions/min_terminated_length"].append(term_completion_lengths.float().min().item())
         self._metrics[mode]["completions/max_terminated_length"].append(term_completion_lengths.float().max().item())
 
-        return prompt_ids, completion_ids
+        return prompt_ids, completion_ids, multimodal_fields
 
     @profiling_decorator
     def _get_last_hidden_state(
@@ -1142,7 +1142,7 @@ class DistillationTrainer(_BaseTrainer):
 
         prompts = [x["prompt"] for x in inputs]
 
-        prompt_ids_list, completion_ids_list = self._generate(prompts)
+        prompt_ids_list, completion_ids_list, multimodal_fields = self._generate(prompts)
 
         # Convert lists of token IDs to padded tensors
         prompt_ids = [torch.tensor(ids) for ids in prompt_ids_list]
@@ -1184,6 +1184,22 @@ class DistillationTrainer(_BaseTrainer):
             "completion_mask": completion_mask,
             "num_items_in_batch": num_items_in_batch,
         }
+        if "pixel_values" in multimodal_fields:
+            output["pixel_values"] = multimodal_fields["pixel_values"]
+        if "image_grid_thw" in multimodal_fields:
+            output["image_grid_thw"] = multimodal_fields["image_grid_thw"]
+        if "pixel_attention_mask" in multimodal_fields:
+            output["pixel_attention_mask"] = multimodal_fields["pixel_attention_mask"]
+        if "spatial_shapes" in multimodal_fields:
+            output["spatial_shapes"] = multimodal_fields["spatial_shapes"]
+        if "image_sizes" in multimodal_fields:
+            output["image_sizes"] = multimodal_fields["image_sizes"]
+        if "token_type_ids" in multimodal_fields:
+            output["token_type_ids"] = multimodal_fields["token_type_ids"]
+        if "mm_token_type_ids" in multimodal_fields:
+            output["mm_token_type_ids"] = multimodal_fields["mm_token_type_ids"]
+        if "image_position_ids" in multimodal_fields:
+            output["image_position_ids"] = multimodal_fields["image_position_ids"]
         return output
 
     @profiling_decorator

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -26,6 +26,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import transformers
 from accelerate.logging import get_logger
 from accelerate.utils import gather_object, is_peft_model, set_seed
 from datasets import Dataset, IterableDataset
@@ -44,7 +45,7 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ..data_utils import is_conversational
+from ..data_utils import is_conversational, prepare_multimodal_messages
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
@@ -446,9 +447,14 @@ class DistillationTrainer(_BaseTrainer):
         if processing_class is not None:
             if processing_class.pad_token is None:
                 processing_class.pad_token = processing_class.eos_token
-        self._tokenizer = (
-            processing_class.tokenizer if isinstance(processing_class, ProcessorMixin) else processing_class
-        )
+        if isinstance(processing_class, ProcessorMixin):
+            self._tokenizer = processing_class.tokenizer
+            self._is_vlm = True
+        elif isinstance(processing_class, PreTrainedTokenizerBase):
+            self._tokenizer = processing_class
+            self._is_vlm = False
+        else:
+            raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
 
         # PEFT
         if peft_config is not None:
@@ -918,27 +924,52 @@ class DistillationTrainer(_BaseTrainer):
                 self.args.dataloader_num_workers = num_workers
 
     def _tokenize_prompts(self, prompts: list):
-        """Tokenize prompts and extract multimodal fields for generation.
-
-        Conversational prompts (a list of chat messages) are rendered with the chat template and a trailing generation
-        prompt; standard prompts (plain strings) are tokenized directly. The per-example tools/environments path and
-        the image extraction are added with VLM support later (issue #6449).
-        """
+        """Tokenize prompts and extract images/multimodal fields for generation."""
         if is_conversational({"prompt": prompts[0]}):
+            # Normalize string content to content blocks for VLM processors that don't handle plain strings.
+            if self._is_vlm:
+                prompts = [prepare_multimodal_messages(prompt) for prompt in prompts]
+
+            # Extract images from messages for VLM support
+            images = []
+            has_images = False
+            for prompt in prompts:
+                prompt_images = []
+                for message in prompt:
+                    if isinstance(message["content"], list):
+                        for part in message["content"]:
+                            if part["type"] == "image":
+                                prompt_images.append(part["image"])
+                                has_images = True
+                images.append(prompt_images if prompt_images else None)
+            images = images if has_images else None
+
+            # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
+            # batched unpadded input (transformers#44514).
+            # Fixed in transformers 5.4.0 (transformers#44563).
+            needs_padding_workaround = Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,
+                **({"padding": True} if needs_padding_workaround else {}),
                 **self.chat_template_kwargs,
             )
-            prompt_ids = tokenized["input_ids"]
+            if needs_padding_workaround:
+                # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
+                prompt_ids = [
+                    [tok for tok, m in zip(ids, mask, strict=True) if m]
+                    for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
+                ]
+            else:
+                prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
         else:
             prompt_ids = self.processing_class(text=prompts)["input_ids"]
+            images = None
             multimodal_fields = {}
-        images = None  # extracted from the messages once VLM support lands
         return prompt_ids, images, multimodal_fields
 
     def _generate_single_turn(self, prompt_ids, images, multimodal_fields):

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -65,7 +65,9 @@ from .utils import (
     print_prompt_completions_sample,
     repeat_iterable_dataset,
     shuffle_sequence_dict,
+    split_pixel_values_by_grid,
     split_tensor_dict,
+    unsplit_pixel_values_by_grid,
 )
 
 
@@ -1223,9 +1225,10 @@ class DistillationTrainer(_BaseTrainer):
             if self._step % generate_every == 0 or self._buffered_inputs is None:
                 # self._buffered_inputs=None can occur when resuming from a checkpoint
                 generation_batch = self._generate_and_score_completions(generation_batch)
+                generation_batch = split_pixel_values_by_grid(generation_batch)
                 generation_batch = shuffle_sequence_dict(generation_batch)
                 generation_batches = split_tensor_dict(generation_batch, self.args.gradient_accumulation_steps)
-                self._buffered_inputs = generation_batches
+                self._buffered_inputs = [unsplit_pixel_values_by_grid(batch) for batch in generation_batches]
             inputs = self._buffered_inputs[self._step % self.args.gradient_accumulation_steps]
         else:
             # In evaluation, there is neither batch grouping for generation, nor multiple iterations, hence

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 import numpy as np
 import torch
 import torch.nn.functional as F
+import transformers
 from accelerate.logging import get_logger
 from accelerate.utils import gather_object, is_peft_model, set_seed
 from datasets import Dataset, IterableDataset
@@ -43,7 +44,7 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ..data_utils import is_conversational
+from ..data_utils import is_conversational, prepare_multimodal_messages
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
@@ -445,9 +446,14 @@ class DistillationTrainer(_BaseTrainer):
         if processing_class is not None:
             if processing_class.pad_token is None:
                 processing_class.pad_token = processing_class.eos_token
-        self._tokenizer = (
-            processing_class.tokenizer if isinstance(processing_class, ProcessorMixin) else processing_class
-        )
+        if isinstance(processing_class, ProcessorMixin):
+            self._tokenizer = processing_class.tokenizer
+            self._is_vlm = True
+        elif isinstance(processing_class, PreTrainedTokenizerBase):
+            self._tokenizer = processing_class
+            self._is_vlm = False
+        else:
+            raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
 
         # PEFT
         if peft_config is not None:
@@ -917,27 +923,52 @@ class DistillationTrainer(_BaseTrainer):
                 self.args.dataloader_num_workers = num_workers
 
     def _tokenize_prompts(self, prompts: list):
-        """Tokenize prompts and extract multimodal fields for generation.
-
-        Conversational prompts (a list of chat messages) are rendered with the chat template and a trailing generation
-        prompt; standard prompts (plain strings) are tokenized directly. The per-example tools/environments path and
-        the image extraction are added with VLM support later (issue #6449).
-        """
+        """Tokenize prompts and extract images/multimodal fields for generation."""
         if is_conversational({"prompt": prompts[0]}):
+            # Normalize string content to content blocks for VLM processors that don't handle plain strings.
+            if self._is_vlm:
+                prompts = [prepare_multimodal_messages(prompt) for prompt in prompts]
+
+            # Extract images from messages for VLM support
+            images = []
+            has_images = False
+            for prompt in prompts:
+                prompt_images = []
+                for message in prompt:
+                    if isinstance(message["content"], list):
+                        for part in message["content"]:
+                            if part["type"] == "image":
+                                prompt_images.append(part["image"])
+                                has_images = True
+                images.append(prompt_images if prompt_images else None)
+            images = images if has_images else None
+
+            # Workaround for a bug in transformers 5.3.0 where some processors (e.g. Qwen2.5-VL) crash on
+            # batched unpadded input (transformers#44514).
+            # Fixed in transformers 5.4.0 (transformers#44563).
+            needs_padding_workaround = Version("5.3.0") <= Version(transformers.__version__) < Version("5.4.0")
             tokenized = self.processing_class.apply_chat_template(
                 conversation=prompts,
                 add_generation_prompt=True,
                 tokenize=True,
                 return_dict=True,
+                **({"padding": True} if needs_padding_workaround else {}),
                 **self.chat_template_kwargs,
             )
-            prompt_ids = tokenized["input_ids"]
+            if needs_padding_workaround:
+                # Unpad input_ids: remove padding tokens using attention_mask to get per-sequence lists
+                prompt_ids = [
+                    [tok for tok, m in zip(ids, mask, strict=True) if m]
+                    for ids, mask in zip(tokenized["input_ids"], tokenized["attention_mask"], strict=True)
+                ]
+            else:
+                prompt_ids = tokenized["input_ids"]
             # For VLMs, the processor returns extra multimodal fields (pixel_values, image_grid_thw, etc.)
             multimodal_fields = {k: v for k, v in tokenized.items() if k not in ("input_ids", "attention_mask")}
         else:
             prompt_ids = self.processing_class(text=prompts)["input_ids"]
+            images = None
             multimodal_fields = {}
-        images = None  # extracted from the messages once VLM support lands
         return prompt_ids, images, multimodal_fields
 
     def _generate_single_turn(self, prompt_ids, images, multimodal_fields):

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -32,7 +32,7 @@ from datasets import Dataset, IterableDataset
 from packaging.version import Version
 from torch.utils.data import DataLoader, Sampler
 from transformers import (
-    AutoTokenizer,
+    AutoProcessor,
     BitsAndBytesConfig,
     GenerationConfig,
     PreTrainedModel,
@@ -344,9 +344,10 @@ class DistillationTrainer(_BaseTrainer):
         eval_dataset ([`~datasets.Dataset`], [`~datasets.IterableDataset`], [`~datasets.DatasetDict`], [`~datasets.IterableDatasetDict`] or `dict[str, Dataset | IterableDataset]`):
             Dataset to use for evaluation. It must meet the same requirements as `train_dataset`.
         processing_class ([`~transformers.PreTrainedTokenizerBase`], [`~transformers.ProcessorMixin`], *optional*):
-            Processing class used to process the data. If `None`, it is loaded from the model's name with
-            [`~transformers.AutoTokenizer.from_pretrained`]. A padding token, `tokenizer.pad_token`, must be set; if
-            the processing class has not set one, `tokenizer.eos_token` is used as the default.
+            Processing class used to process the data. The padding side must be set to "left". If `None`, the
+            processing class is loaded from the model's name with [`~transformers.AutoProcessor.from_pretrained`]. A
+            padding token, `tokenizer.pad_token`, must be set. If the processing class has not set a padding token,
+            `tokenizer.eos_token` will be used as the default.
         callbacks (list of [`~transformers.TrainerCallback`], *optional*):
             List of callbacks to customize the training loop. Will add those to the list of default callbacks detailed
             in [here](https://huggingface.co/docs/transformers/main_classes/callback).
@@ -440,14 +441,16 @@ class DistillationTrainer(_BaseTrainer):
             else inspect.signature(model.get_base_model().forward).parameters.keys()
         )
 
-        # Processing class (tokenizer)
-        if processing_class is None and model_name_or_path is not None:
-            processing_class = AutoTokenizer.from_pretrained(
-                model_name_or_path, trust_remote_code=args.trust_remote_code
+        # Processing class
+        if processing_class is None:
+            processing_class = AutoProcessor.from_pretrained(
+                model_name_or_path,
+                truncation_side="left",
+                padding_side="left",
+                trust_remote_code=args.trust_remote_code,
             )
-        if processing_class is not None:
-            if processing_class.pad_token is None:
-                processing_class.pad_token = processing_class.eos_token
+
+        # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):
             self._tokenizer = processing_class.tokenizer
             self._is_vlm = True
@@ -456,6 +459,9 @@ class DistillationTrainer(_BaseTrainer):
             self._is_vlm = False
         else:
             raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
+
+        if self._tokenizer.pad_token is None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
 
         # PEFT
         if peft_config is not None:
@@ -1273,8 +1279,19 @@ class DistillationTrainer(_BaseTrainer):
         completion_mask = inputs["completion_mask"]
         logits_to_keep = inputs["completion_ids"].size(1)  # only the completion tokens are trained on
 
+        # Multimodal (VLM) fields, extracted during generation and split to this micro-batch by `_prepare_inputs`.
+        multimodal_keys = (
+            "pixel_values",
+            "image_grid_thw",
+            "pixel_attention_mask",
+            "spatial_shapes",
+            "image_sizes",
+            "image_position_ids",
+        )
+        multimodal_inputs = {k: inputs[k] for k in multimodal_keys if k in inputs}
+
         student_hidden_states = self._get_last_hidden_state(
-            unwrapped_student, input_ids, attention_mask, logits_to_keep
+            unwrapped_student, input_ids, attention_mask, logits_to_keep, **multimodal_inputs
         )
 
         # Route the teacher backbone through its own wrapper via `_forward_redirection` too, so FSDP/DeepSpeed
@@ -1290,6 +1307,7 @@ class DistillationTrainer(_BaseTrainer):
                 input_ids,
                 attention_mask,
                 logits_to_keep,
+                **multimodal_inputs,
             )
 
         student_lm_head = unwrapped_student.get_output_embeddings()

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -44,7 +44,7 @@ from transformers import (
 )
 from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
 
-from ..data_utils import is_conversational, prepare_multimodal_messages
+from ..data_utils import apply_chat_template, is_conversational, prepare_multimodal_messages
 from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
@@ -1085,7 +1085,7 @@ class DistillationTrainer(_BaseTrainer):
         self._metrics[mode]["completions/min_terminated_length"].append(term_completion_lengths.float().min().item())
         self._metrics[mode]["completions/max_terminated_length"].append(term_completion_lengths.float().max().item())
 
-        return prompt_ids, completion_ids, multimodal_fields
+        return prompt_ids, completion_ids
 
     @profiling_decorator
     def _get_last_hidden_state(
@@ -1099,6 +1099,8 @@ class DistillationTrainer(_BaseTrainer):
         pixel_attention_mask=None,
         spatial_shapes=None,
         image_sizes=None,
+        token_type_ids=None,
+        mm_token_type_ids=None,
         image_position_ids=None,
     ):
         if is_peft_model(unwrapped_model):
@@ -1122,6 +1124,10 @@ class DistillationTrainer(_BaseTrainer):
         # For LLaVa-Next
         if image_sizes is not None:
             model_inputs["image_sizes"] = image_sizes
+        if token_type_ids is not None:
+            model_inputs["token_type_ids"] = token_type_ids
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         if image_position_ids is not None:
             model_inputs["image_position_ids"] = image_position_ids
 
@@ -1135,7 +1141,12 @@ class DistillationTrainer(_BaseTrainer):
         # `base_model` gives the backbone model (skipping `lm_head`) — text decoder for LMs, multimodal wrapper for
         # VLMs (so vision-token injection runs before the text decoder). `get_decoder()` won't do: on VLMs it
         # returns just the text stack and feeds image-placeholder IDs through it.
-        backbone = unwrapped_model.base_model
+        # Pre-5.0 transformers VLMs set `base_model_prefix = ""` so `base_model is self` (re-runs `lm_head`).
+        # Fall back to `.model` there.
+        if self._is_vlm and Version(transformers.__version__) < Version("5.0.0"):
+            backbone = unwrapped_model.model
+        else:
+            backbone = unwrapped_model.base_model
         last_hidden_state = backbone(**model_inputs).last_hidden_state
         # Exclude the last value: it corresponds to the next token pred
         last_hidden_state = last_hidden_state[:, :-1, :]  # (B, L-1, H)
@@ -1149,7 +1160,33 @@ class DistillationTrainer(_BaseTrainer):
 
         prompts = [x["prompt"] for x in inputs]
 
-        prompt_ids_list, completion_ids_list, multimodal_fields = self._generate(prompts)
+        if "images" in inputs[0]:
+            images = [example.get("images") for example in inputs]
+        elif "image" in inputs[0]:
+            images = [[example.get("image")] if example.get("image") is not None else None for example in inputs]
+        else:
+            images = None
+        # Transformers requires at least one image in the batch, otherwise it throws an error
+        if images is not None and all(img_list == [] for img_list in images):
+            images = None
+
+        # If the prompts are conversational and the inputs contain images, we need to convert the prompts from
+        # [{"role": "user", "content": "What color is the sky?"}] to
+        # [{"role": "user", "content": [{"type": "image", "image": <Image>}, {"type": "text", "text": "What color is the sky?"}]}]
+        if images is not None:
+            if not is_conversational(inputs[0]):
+                raise ValueError(
+                    "Multimodal training requires conversational prompts. It looks like the dataset contains "
+                    "non-conversational inputs, likely because a chat template was applied before passing the dataset "
+                    "to the trainer. Please provide the raw conversational prompts and let the trainer apply the chat "
+                    "template internally."
+                )
+            prompts = [
+                prepare_multimodal_messages(prompt, images=image_list)
+                for prompt, image_list in zip(prompts, images, strict=True)
+            ]
+
+        prompt_ids_list, completion_ids_list = self._generate(prompts)
 
         # Convert lists of token IDs to padded tensors
         prompt_ids = [torch.tensor(ids) for ids in prompt_ids_list]
@@ -1177,6 +1214,59 @@ class DistillationTrainer(_BaseTrainer):
 
         num_items_in_batch = self.accelerator.gather(completion_mask.sum()).sum()
 
+        num_images = [len(img_list) if img_list else 0 for img_list in images] if images is not None else None
+
+        # Get forward_kwargs for models with multimodal inputs.
+        if images is not None:
+            prompts_text = [
+                apply_chat_template({"prompt": prompt}, self.processing_class, **self.chat_template_kwargs)["prompt"]
+                for prompt in prompts
+            ]
+            prompt_inputs = self.processing_class(images=images, text=prompts_text, padding=True, return_tensors="pt")
+            prompt_inputs = super()._prepare_inputs(prompt_inputs)
+            forward_kwargs = {k: v for k, v in prompt_inputs.items() if k not in ["input_ids", "attention_mask"]}
+        else:
+            forward_kwargs = {}
+
+        # Recover LFM2-VL tile counts; the full processor drops row/column metadata.
+        num_tiles = None
+        if images is not None and "spatial_shapes" in forward_kwargs:
+            image_info = self.processing_class.image_processor(
+                images=images, return_tensors="pt", return_row_col_info=True
+            )
+            tiles_per_image = image_info["image_rows"] * image_info["image_cols"]
+            if self.processing_class.image_processor.use_thumbnail:
+                tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(tiles_per_image.dtype)
+            num_tiles = [group.sum().item() for group in torch.split(tiles_per_image, num_images)]
+
+        # If token_type_ids are used, extend them with zeros for the completion part
+        if "token_type_ids" in forward_kwargs:
+            token_type_ids = forward_kwargs["token_type_ids"]
+            if self.pad_to_multiple_of is not None:
+                # Needed only with pad_to_multiple_of: otherwise prompt_ids and token_type_ids must have equal len
+                padding_size = prompt_ids.size(1) - token_type_ids.size(1)
+                if padding_size > 0:
+                    token_type_ids = torch.cat(
+                        [token_type_ids.new_zeros((token_type_ids.size(0), padding_size)), token_type_ids], dim=1
+                    )
+            forward_kwargs["token_type_ids"] = torch.cat(
+                [token_type_ids, token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
+        # If mm_token_type_ids are used, extend them with zeros for the completion part
+        if "mm_token_type_ids" in forward_kwargs:
+            mm_token_type_ids = forward_kwargs["mm_token_type_ids"]
+            if self.pad_to_multiple_of is not None:
+                # Needed only with pad_to_multiple_of: otherwise prompt_ids and mm_token_type_ids must have equal len
+                padding_size = prompt_ids.size(1) - mm_token_type_ids.size(1)
+                if padding_size > 0:
+                    mm_token_type_ids = torch.cat(
+                        [mm_token_type_ids.new_zeros((mm_token_type_ids.size(0), padding_size)), mm_token_type_ids],
+                        dim=1,
+                    )
+            forward_kwargs["mm_token_type_ids"] = torch.cat(
+                [mm_token_type_ids, mm_token_type_ids.new_zeros(completion_ids.shape)], dim=1
+            )
+
         # Log the prompt and completion texts
         if self.log_completions:
             prompts_text = self.processing_class.batch_decode(prompt_ids, skip_special_tokens=True)
@@ -1191,22 +1281,26 @@ class DistillationTrainer(_BaseTrainer):
             "completion_mask": completion_mask,
             "num_items_in_batch": num_items_in_batch,
         }
-        if "pixel_values" in multimodal_fields:
-            output["pixel_values"] = multimodal_fields["pixel_values"]
-        if "image_grid_thw" in multimodal_fields:
-            output["image_grid_thw"] = multimodal_fields["image_grid_thw"]
-        if "pixel_attention_mask" in multimodal_fields:
-            output["pixel_attention_mask"] = multimodal_fields["pixel_attention_mask"]
-        if "spatial_shapes" in multimodal_fields:
-            output["spatial_shapes"] = multimodal_fields["spatial_shapes"]
-        if "image_sizes" in multimodal_fields:
-            output["image_sizes"] = multimodal_fields["image_sizes"]
-        if "token_type_ids" in multimodal_fields:
-            output["token_type_ids"] = multimodal_fields["token_type_ids"]
-        if "mm_token_type_ids" in multimodal_fields:
-            output["mm_token_type_ids"] = multimodal_fields["mm_token_type_ids"]
-        if "image_position_ids" in multimodal_fields:
-            output["image_position_ids"] = multimodal_fields["image_position_ids"]
+        if "pixel_values" in forward_kwargs:
+            output["pixel_values"] = forward_kwargs["pixel_values"]
+        if "image_grid_thw" in forward_kwargs:
+            output["image_grid_thw"] = forward_kwargs["image_grid_thw"]
+        if "pixel_attention_mask" in forward_kwargs:
+            output["pixel_attention_mask"] = forward_kwargs["pixel_attention_mask"]
+        if "spatial_shapes" in forward_kwargs:
+            output["spatial_shapes"] = forward_kwargs["spatial_shapes"]
+        if "image_sizes" in forward_kwargs:
+            output["image_sizes"] = forward_kwargs["image_sizes"]
+        if "token_type_ids" in forward_kwargs:
+            output["token_type_ids"] = forward_kwargs["token_type_ids"]
+        if "mm_token_type_ids" in forward_kwargs:
+            output["mm_token_type_ids"] = forward_kwargs["mm_token_type_ids"]
+        if "image_position_ids" in forward_kwargs:
+            output["image_position_ids"] = forward_kwargs["image_position_ids"]
+        if images is not None:
+            output["num_images"] = num_images
+            if num_tiles is not None:
+                output["num_tiles"] = num_tiles
         return output
 
     @profiling_decorator
@@ -1286,6 +1380,8 @@ class DistillationTrainer(_BaseTrainer):
             "pixel_attention_mask",
             "spatial_shapes",
             "image_sizes",
+            "token_type_ids",
+            "mm_token_type_ids",
             "image_position_ids",
         )
         multimodal_inputs = {k: inputs[k] for k in multimodal_keys if k in inputs}

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -64,7 +64,9 @@ from .utils import (
     print_prompt_completions_sample,
     repeat_iterable_dataset,
     shuffle_sequence_dict,
+    split_pixel_values_by_grid,
     split_tensor_dict,
+    unsplit_pixel_values_by_grid,
 )
 
 
@@ -1222,9 +1224,10 @@ class DistillationTrainer(_BaseTrainer):
             if self._step % generate_every == 0 or self._buffered_inputs is None:
                 # self._buffered_inputs=None can occur when resuming from a checkpoint
                 generation_batch = self._generate_and_score_completions(generation_batch)
+                generation_batch = split_pixel_values_by_grid(generation_batch)
                 generation_batch = shuffle_sequence_dict(generation_batch)
                 generation_batches = split_tensor_dict(generation_batch, self.args.gradient_accumulation_steps)
-                self._buffered_inputs = generation_batches
+                self._buffered_inputs = [unsplit_pixel_values_by_grid(batch) for batch in generation_batches]
             inputs = self._buffered_inputs[self._step % self.args.gradient_accumulation_steps]
         else:
             # In evaluation, there is neither batch grouping for generation, nor multiple iterations, hence

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -1077,7 +1077,7 @@ class DistillationTrainer(_BaseTrainer):
         self._metrics[mode]["completions/min_terminated_length"].append(term_completion_lengths.float().min().item())
         self._metrics[mode]["completions/max_terminated_length"].append(term_completion_lengths.float().max().item())
 
-        return prompt_ids, completion_ids
+        return prompt_ids, completion_ids, multimodal_fields
 
     @profiling_decorator
     def _get_last_hidden_state(
@@ -1141,7 +1141,7 @@ class DistillationTrainer(_BaseTrainer):
 
         prompts = [x["prompt"] for x in inputs]
 
-        prompt_ids_list, completion_ids_list = self._generate(prompts)
+        prompt_ids_list, completion_ids_list, multimodal_fields = self._generate(prompts)
 
         # Convert lists of token IDs to padded tensors
         prompt_ids = [torch.tensor(ids) for ids in prompt_ids_list]
@@ -1183,6 +1183,22 @@ class DistillationTrainer(_BaseTrainer):
             "completion_mask": completion_mask,
             "num_items_in_batch": num_items_in_batch,
         }
+        if "pixel_values" in multimodal_fields:
+            output["pixel_values"] = multimodal_fields["pixel_values"]
+        if "image_grid_thw" in multimodal_fields:
+            output["image_grid_thw"] = multimodal_fields["image_grid_thw"]
+        if "pixel_attention_mask" in multimodal_fields:
+            output["pixel_attention_mask"] = multimodal_fields["pixel_attention_mask"]
+        if "spatial_shapes" in multimodal_fields:
+            output["spatial_shapes"] = multimodal_fields["spatial_shapes"]
+        if "image_sizes" in multimodal_fields:
+            output["image_sizes"] = multimodal_fields["image_sizes"]
+        if "token_type_ids" in multimodal_fields:
+            output["token_type_ids"] = multimodal_fields["token_type_ids"]
+        if "mm_token_type_ids" in multimodal_fields:
+            output["mm_token_type_ids"] = multimodal_fields["mm_token_type_ids"]
+        if "image_position_ids" in multimodal_fields:
+            output["image_position_ids"] = multimodal_fields["image_position_ids"]
         return output
 
     @profiling_decorator


### PR DESCRIPTION
Stacked on item 55. Part of #6449.*

Enable VLM distillation, mirroring GRPO's multimodal path:

- Thread `images`/`multimodal_fields` from `_tokenize_prompts` → generation → the batch → `_compute_loss` (student + teacher hidden-state forward).
- Split/unsplit `pixel_values` across micro-batches in `_prepare_inputs`.
- Auto-build a processor (`AutoProcessor` instead of `AutoTokenizer`) and resolve `pad_token` via `self._tokenizer` after the `_is_vlm` split — so VLM processors work.
- `TestDistillationTrainerVLM`: trains on `zen-image` across the tiny VLM checkpoints (Gemma3, LLaVA-NeXT, Qwen2-VL, Qwen2.5-VL, Qwen3.5). Self-distillation (no tiny+small VLM fixture pair), so it asserts the loss stayed finite rather than params-changed. Plus a skipped `test_train_vlm_and_vllm` mirroring GRPO's server placeholder.
- Docs: a "Training Vision Language Models" section.

The colocate vLLM path already threads `images` identically to GRPO; the server+images test stays skipped pending a vLLM server mock (as in GRPO).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core on-policy generation → loss path and gradient-accumulation batching for multimodal tensors; regressions could misalign images and text or break text-only training, though existing LM tests remain and changes largely mirror proven GRPO logic.
> 
> **Overview**
> **`DistillationTrainer` can now distill vision-language models** on prompt-only multimodal datasets (`image` / `images` plus conversational prompts), aligned with GRPO’s multimodal flow.
> 
> Initialization switches default loading from **`AutoTokenizer` to `AutoProcessor`** (left truncation/padding), sets **`_is_vlm`** from a `ProcessorMixin`, and documents left-padding requirements. **`_tokenize_prompts`** pulls images from chat content, normalizes messages for VLMs, and includes a transformers 5.3.0 padding workaround. **`_generate_and_score_completions`** injects dataset images into prompts, builds multimodal forward kwargs (`pixel_values`, `image_grid_thw`, `token_type_ids`, etc.), and extends token-type tensors through completions. **`_prepare_inputs`** splits/unsplits packed **`pixel_values`** across gradient-accumulation micro-batches; **`_get_last_hidden_state` / `_compute_loss`** pass those tensors to student and teacher backbones (with a pre-5.0 VLM backbone fallback).
> 
> **Tests** add `TestDistillationTrainerVLM` on `zen-image` across several tiny VLMs (plus grad-accum and a skipped vLLM-server case). **Docs** add a “Training Vision Language Models” section listing supported families.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20391903b5aa1eada9966b81b4eb640a873378c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->