### PR TITLE
Allow vLLM weight-update group re-init after a client crash (#3408)

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -1044,8 +1044,8 @@ class TestVLLMClientServerReinit(TrlTestCase):
     """Regression test for #3408.
 
     A relaunched client must be able to re-initialize the weight update group when a previous client left it
-    initialized (e.g. a training run crashed before its atexit `close_communicator` ran). The server should
-    close the stale group and re-initialize rather than hard-failing with "already initialized".
+    initialized (e.g. a training run crashed before its atexit `close_communicator` ran). The server should close the
+    stale group and re-initialize rather than hard-failing with "already initialized".
     """
 
     model_id = "Qwen/Qwen2.5-1.5B"

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import os
 import subprocess
 from types import SimpleNamespace
@@ -1030,6 +1031,52 @@ class TestVLLMClientServerVLM(TrlTestCase):
         assert all(isinstance(tok, int) for tok in prompt_ids[1])
         assert all(isinstance(tok, int) for tok in completion_ids[0])
         assert all(isinstance(tok, int) for tok in completion_ids[1])
+
+    @classmethod
+    def teardown_class(cls):
+        kill_process(cls.server_process)
+
+
+@pytest.mark.slow
+@require_torch_multi_accelerator
+@require_vllm
+class TestVLLMClientServerReinit(TrlTestCase):
+    """Regression test for #3408.
+
+    A relaunched client must be able to re-initialize the weight update group when a previous client left it
+    initialized (e.g. a training run crashed before its atexit `close_communicator` ran). The server should
+    close the stale group and re-initialize rather than hard-failing with "already initialized".
+    """
+
+    model_id = "Qwen/Qwen2.5-1.5B"
+
+    @classmethod
+    def setup_class(cls):
+        env = os.environ.copy()
+        VISIBLE_DEVICES = "ZE_AFFINITY_MASK" if torch_device == "xpu" else "CUDA_VISIBLE_DEVICES"
+        env[VISIBLE_DEVICES] = "1"  # Restrict the server to accelerator 1
+        cls.server_process = subprocess.Popen(
+            ["trl", "vllm-serve", "--model", cls.model_id], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+
+    def test_reinit_after_stale_group(self):
+        # A first client initializes the weight update group, then goes away WITHOUT closing it, leaving the
+        # server's group stale (what happens when a training run crashes before its atexit close runs).
+        first_client = VLLMClient(connection_timeout=240, host="localhost")
+        first_client.init_communicator()
+        atexit.unregister(first_client.close_communicator)  # simulate a crash: no cleanup
+        del first_client
+
+        # A relaunched client must be able to re-initialize against the stale group: the server closes the
+        # stale group and re-initializes instead of raising "already initialized".
+        second_client = VLLMClient(connection_timeout=240, host="localhost")
+        second_client.init_communicator()
+        try:
+            # The re-initialized group is functional end to end.
+            model = AutoModelForCausalLM.from_pretrained(self.model_id, device_map=torch_device)
+            second_client.update_model_params(model)
+        finally:
+            second_client.close_communicator()
 
     @classmethod
     def teardown_class(cls):

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -32,6 +32,8 @@ from multiprocessing.connection import Connection
 # the 'spawn' start method
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
+logger = logging.getLogger(__name__)
+
 
 class WeightSyncWorkerExtension:
     """
@@ -78,7 +80,14 @@ class WeightSyncWorkerExtension:
             from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator
 
         if self.communicator is not None:
-            raise RuntimeError("Weight update group already initialized. Call close_communicator first.")
+            # A previous client left a stale weight update group, e.g. it crashed (OOM) before its atexit
+            # `close_communicator` could run, so the group was never torn down. Close it here so a relaunched
+            # client can re-initialize instead of hard-failing. See https://github.com/huggingface/trl/issues/3408.
+            logger.warning(
+                "A weight update group is already initialized, likely left by a client that exited without closing "
+                "it. Closing the stale group before re-initializing."
+            )
+            self.close_communicator()
 
         # TODO: will remove after torch xpu 2.9 support uuid in get_device_properties
         if torch.cuda.is_available() or (


### PR DESCRIPTION
### Problem

`WeightSyncWorkerExtension.init_communicator` raised `Weight update group already initialized. Call close_communicator first.` whenever the server still held a weight update group from a previous client. This happens in practice when a training run crashes (for example an OOM) before its `atexit` `close_communicator` hook can run, so the group is never torn down. After that, every relaunched client fails to re-initialize and the only recovery is to restart the vLLM server. See #3408.

### Fix

When a stale group is present, close it before re-initializing instead of hard-failing. A warning is logged so the leftover group stays visible:

```python
if self.communicator is not None:
    # A previous client left a stale weight update group, e.g. it crashed (OOM) before its atexit
    # `close_communicator` could run, so the group was never torn down. Close it here so a relaunched
    # client can re-initialize instead of hard-failing. See https://github.com/huggingface/trl/issues/3408.
    logger.warning(
        "A weight update group is already initialized, likely left by a client that exited without closing "
        "it. Closing the stale group before re-initializing."
    )
    self.close_communicator()
```

### Test

`TestVLLMClientServerReinit` reproduces the crash: a first client initializes the group, then goes away without closing it (its `atexit` hook is unregistered to simulate a crash), leaving the server group stale. A relaunched client must then re-initialize and complete a weight sync.

### Validation (real 2x H100)

Ran on 2x H100 with `Qwen/Qwen2.5-1.5B` (server on one device, client and model on the other):

- With the fix: `test_reinit_after_stale_group` **PASSED**. The weight sync completes through the re-initialized group.
- Without the fix (guard reverted, everything else identical): the same test **FAILED** at the relaunched client's `ncclCommInitRank` with `NCCL error: remote process exited or there was a network error`. That is exactly the #3408 symptom: the server raises on the worker and never joins the new rendezvous, so the client's NCCL init dies.

So the test is a genuine regression guard (it fails without the fix and passes with it) and it reproduces the user visible failure rather than an internal assertion.

The test is marked `@pytest.mark.slow`, `@require_torch_multi_accelerator`, and `@require_vllm`, so it runs in the vLLM multi accelerator CI lane.

Fixes #3408

cc @qgallouedec @kashif

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NCCL/XCCL communicator lifecycle on the vLLM weight-sync path; behavior is narrower (recovery vs hard fail) but affects distributed training reliability.
> 
> **Overview**
> Fixes **#3408** by letting a new training client recover when the vLLM server still holds a weight-update communicator from a crashed client (e.g. OOM before `atexit` runs `close_communicator`).
> 
> In `WeightSyncWorkerExtension.init_communicator`, a stale group no longer triggers a hard **"already initialized"** error. The server **logs a warning**, calls **`close_communicator()`**, then proceeds with a fresh init so relaunched jobs do not require restarting `trl vllm-serve`.
> 
> Adds slow multi-GPU integration test **`TestVLLMClientServerReinit`**: first client inits and exits without cleanup (`atexit.unregister`); second client must re-init and complete **`update_model_params`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3026eff6ca9c752828739bf5889cccc6e57322f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->