### PR TITLE
[GRPO] Apply the completion mask elementwise in the luspo loss aggregation

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1873,17 +1873,28 @@ class TestGRPOTrainer(TrlTestCase):
         # Every loss type regularizes the mean per-token entropy, so contrib == entropy_coef * entropy.
         assert ratio == pytest.approx(entropy_coef, rel=0.3)
 
-    def test_luspo_loss_ignores_padding(self):
+    @pytest.mark.parametrize(
+        ("importance_sampling_level", "beta"),
+        [
+            ("sequence", 0.1),  # per_token_loss is (B, T) via the KL term
+            ("token", 0.0),  # per_token_loss is (B, T) via importance_sampling_level itself, the config default
+        ],
+    )
+    def test_luspo_loss_ignores_padding(self, importance_sampling_level, beta):
         # Regression test: the luspo branch assumes per_token_loss is (B, 1) and uses `mask` only as a per-sequence
-        # length, not as an elementwise mask. That assumption breaks once beta != 0, since the KL term broadcasts
-        # per_token_loss to (B, T), letting padded positions leak into the loss. The loss must not depend on padded
-        # positions.
+        # length, not as an elementwise mask. That assumption breaks once per_token_loss is actually (B, T),
+        # letting padded positions leak into the loss. The loss must not depend on padded positions.
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             loss_type="luspo",
-            beta=0.1,
-            importance_sampling_level="sequence",
+            beta=beta,
+            importance_sampling_level=importance_sampling_level,
+            # Wide open on purpose: old_per_token_logps below is random and unrelated to per_token_logps, so the
+            # importance-sampling ratio can easily land outside the default clip range. PPO-style clipping would
+            # then saturate and mask the exact signal this test perturbs, independently of whether the padding fix
+            # under test is correct. This test isolates masking, not clipping, so clipping is disabled here.
+            epsilon=1e6,
             report_to="none",
         )
         trainer = GRPOTrainer(
@@ -1893,29 +1904,57 @@ class TestGRPOTrainer(TrlTestCase):
             train_dataset=dataset,
         )
         trainer.model.eval()
-        trainer.current_gradient_accumulation_steps = 1
 
-        # Build inputs on whatever device the model actually loaded onto, rather than forcing CPU: some CI
-        # environments bind Qwen2's RMSNorm to a Triton kernel that assumes CUDA and rejects CPU tensors outright.
+        # Trainer.__init__ moves the model to args.device, so on a GPU runner the inputs have to be built there too.
         device = next(trainer.model.parameters()).device
         batch_size, prompt_len, completion_len = 2, 3, 6
+        # This is the first test in this file to call _compute_loss with hand-built inputs; there is no other way
+        # to isolate padded positions directly, so a future refactor of _compute_loss's input contract should keep
+        # this pinned.
+        prompt_ids = torch.randint(1, 1000, (batch_size, prompt_len), device=device)
+        prompt_mask = torch.ones(batch_size, prompt_len, dtype=torch.long, device=device)
+        completion_ids = torch.randint(1, 1000, (batch_size, completion_len), device=device)
+        # trailing positions are padding for every sequence
+        completion_mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]], device=device)
+
+        # old_per_token_logps/ref_per_token_logps must be close in scale to the model's actual per-token log-probs,
+        # not arbitrary noise: for this tiny, near-uniform model log-probs sit around -log(vocab_size) (~-11), so
+        # plain torch.randn() (mean 0) either makes the importance-sampling ratio astronomically small or the KL
+        # term astronomically large, and the resulting difference can fall below torch.testing.assert_close's
+        # tolerance regardless of whether the padding fix under test is correct. A small fixed offset from the
+        # model's real log-probs keeps both signals in a comparable, well-scaled range.
+        with torch.no_grad():
+            baseline_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+                trainer.model,
+                torch.cat([prompt_ids, completion_ids], dim=1),
+                torch.cat([prompt_mask, completion_mask], dim=1),
+                completion_len,
+            )
         inputs = {
-            "prompt_ids": torch.randint(1, 1000, (batch_size, prompt_len), device=device),
-            "prompt_mask": torch.ones(batch_size, prompt_len, dtype=torch.long, device=device),
-            "completion_ids": torch.randint(1, 1000, (batch_size, completion_len), device=device),
-            # trailing positions are padding for every sequence
-            "completion_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]], device=device),
+            "prompt_ids": prompt_ids,
+            "prompt_mask": prompt_mask,
+            "completion_ids": completion_ids,
+            "completion_mask": completion_mask,
             "advantages": torch.tensor([1.0, -1.0], device=device),
-            "ref_per_token_logps": torch.randn(batch_size, completion_len, device=device),
+            # old_per_token_logps must be given explicitly: left unset, it falls back to per_token_logps.detach(),
+            # which makes the token-level importance-sampling ratio exactly 1 everywhere and defeats this test for
+            # importance_sampling_level="token" (per_token_loss would be (B, T) in shape but constant-valued, so
+            # masked vs. unmasked aggregation would coincidentally agree regardless of the bug).
+            "old_per_token_logps": baseline_logps + 0.05,
+            "ref_per_token_logps": baseline_logps + 0.05,
         }
 
         loss_before = trainer._compute_loss(trainer.model, inputs)
 
-        # Perturb ref_per_token_logps only at padded positions; the loss must be unaffected.
+        # Perturb both ref_per_token_logps (feeds the beta > 0 KL term) and old_per_token_logps (feeds the
+        # importance_sampling_level="token" ratio) at padded positions only. Whichever one the current
+        # parametrization doesn't route through padding is an unaffected no-op; the loss must be unaffected either
+        # way.
         perturbed_inputs = dict(inputs)
-        perturbed_ref = inputs["ref_per_token_logps"].clone()
-        perturbed_ref[inputs["completion_mask"] == 0] += 1.0
-        perturbed_inputs["ref_per_token_logps"] = perturbed_ref
+        for key in ("ref_per_token_logps", "old_per_token_logps"):
+            perturbed = inputs[key].clone()
+            perturbed[inputs["completion_mask"] == 0] += 1.0
+            perturbed_inputs[key] = perturbed
 
         loss_after = trainer._compute_loss(trainer.model, perturbed_inputs)
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1885,7 +1885,6 @@ class TestGRPOTrainer(TrlTestCase):
             beta=0.1,
             importance_sampling_level="sequence",
             report_to="none",
-            use_cpu=True,
         )
         trainer = GRPOTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
@@ -1896,15 +1895,18 @@ class TestGRPOTrainer(TrlTestCase):
         trainer.model.eval()
         trainer.current_gradient_accumulation_steps = 1
 
+        # Build inputs on whatever device the model actually loaded onto, rather than forcing CPU: some CI
+        # environments bind Qwen2's RMSNorm to a Triton kernel that assumes CUDA and rejects CPU tensors outright.
+        device = next(trainer.model.parameters()).device
         batch_size, prompt_len, completion_len = 2, 3, 6
         inputs = {
-            "prompt_ids": torch.randint(1, 1000, (batch_size, prompt_len)),
-            "prompt_mask": torch.ones(batch_size, prompt_len, dtype=torch.long),
-            "completion_ids": torch.randint(1, 1000, (batch_size, completion_len)),
+            "prompt_ids": torch.randint(1, 1000, (batch_size, prompt_len), device=device),
+            "prompt_mask": torch.ones(batch_size, prompt_len, dtype=torch.long, device=device),
+            "completion_ids": torch.randint(1, 1000, (batch_size, completion_len), device=device),
             # trailing positions are padding for every sequence
-            "completion_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]]),
-            "advantages": torch.tensor([1.0, -1.0]),
-            "ref_per_token_logps": torch.randn(batch_size, completion_len),
+            "completion_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]], device=device),
+            "advantages": torch.tensor([1.0, -1.0], device=device),
+            "ref_per_token_logps": torch.randn(batch_size, completion_len, device=device),
         }
 
         loss_before = trainer._compute_loss(trainer.model, inputs)

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1890,11 +1890,6 @@ class TestGRPOTrainer(TrlTestCase):
             loss_type="luspo",
             beta=beta,
             importance_sampling_level=importance_sampling_level,
-            # Wide open on purpose: old_per_token_logps below is random and unrelated to per_token_logps, so the
-            # importance-sampling ratio can easily land outside the default clip range. PPO-style clipping would
-            # then saturate and mask the exact signal this test perturbs, independently of whether the padding fix
-            # under test is correct. This test isolates masking, not clipping, so clipping is disabled here.
-            epsilon=1e6,
             report_to="none",
         )
         trainer = GRPOTrainer(

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1873,6 +1873,52 @@ class TestGRPOTrainer(TrlTestCase):
         # Every loss type regularizes the mean per-token entropy, so contrib == entropy_coef * entropy.
         assert ratio == pytest.approx(entropy_coef, rel=0.3)
 
+    def test_luspo_loss_ignores_padding(self):
+        # Regression test: the luspo branch assumes per_token_loss is (B, 1) and uses `mask` only as a per-sequence
+        # length, not as an elementwise mask. That assumption breaks once beta != 0, since the KL term broadcasts
+        # per_token_loss to (B, T), letting padded positions leak into the loss. The loss must not depend on padded
+        # positions.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            loss_type="luspo",
+            beta=0.1,
+            importance_sampling_level="sequence",
+            report_to="none",
+            use_cpu=True,
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.model.train()
+        trainer.current_gradient_accumulation_steps = 1
+
+        batch_size, prompt_len, completion_len = 2, 3, 6
+        inputs = {
+            "prompt_ids": torch.randint(1, 1000, (batch_size, prompt_len)),
+            "prompt_mask": torch.ones(batch_size, prompt_len, dtype=torch.long),
+            "completion_ids": torch.randint(1, 1000, (batch_size, completion_len)),
+            # trailing positions are padding for every sequence
+            "completion_mask": torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]]),
+            "advantages": torch.tensor([1.0, -1.0]),
+            "ref_per_token_logps": torch.randn(batch_size, completion_len),
+        }
+
+        loss_before = trainer._compute_loss(trainer.model, inputs)
+
+        # Perturb ref_per_token_logps only at padded positions; the loss must be unaffected.
+        perturbed_inputs = dict(inputs)
+        perturbed_ref = inputs["ref_per_token_logps"].clone()
+        perturbed_ref[inputs["completion_mask"] == 0] += 1.0
+        perturbed_inputs["ref_per_token_logps"] = perturbed_ref
+
+        loss_after = trainer._compute_loss(trainer.model, perturbed_inputs)
+
+        torch.testing.assert_close(loss_before, loss_after)
+
     def test_train_with_adaptive_entropy_gradient_accumulation(self):
         # Adaptive entropy must behave correctly under gradient accumulation: the coefficient and gating are
         # frozen across an accumulation window and the controller updates once per optimizer step (not once

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1893,7 +1893,7 @@ class TestGRPOTrainer(TrlTestCase):
             args=training_args,
             train_dataset=dataset,
         )
-        trainer.model.train()
+        trainer.model.eval()
         trainer.current_gradient_accumulation_steps = 1
 
         batch_size, prompt_len, completion_len = 2, 3, 6

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3169,8 +3169,10 @@ class GRPOTrainer(_BaseTrainer):
             loss = (per_token_loss * mask).sum() / normalizer
             policy_loss = loss.detach()
         elif self.loss_type == "luspo":
-            # Unless importance_sampling_level="token" (not recommended here), per_token_loss is expected to be (B, 1)
-            loss = (per_token_loss * mask.sum(1, keepdim=True)).mean()
+            # `per_token_loss` is (B, 1) only in the recommended sequence-level setup; the KL term, token-level
+            # vLLM IS ratios and the entropy mask all broadcast it to (B, T), so mask before aggregating.
+            seq_loss = (per_token_loss * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
+            loss = (seq_loss * mask.sum(-1)).mean()
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
             policy_loss = loss.detach()
             loss = loss / normalizer

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3171,8 +3171,7 @@ class GRPOTrainer(_BaseTrainer):
         elif self.loss_type == "luspo":
             # `per_token_loss` is (B, 1) only in the recommended sequence-level setup; the KL term, token-level
             # vLLM IS ratios and the entropy mask all broadcast it to (B, T), so mask before aggregating.
-            seq_loss = (per_token_loss * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
-            loss = (seq_loss * mask.sum(-1)).mean()
+            loss = (per_token_loss * mask).sum(-1).mean()
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
             policy_loss = loss.detach()
             loss = loss / normalizer

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3169,8 +3169,9 @@ class GRPOTrainer(_BaseTrainer):
             loss = (per_token_loss * mask).sum() / normalizer
             policy_loss = loss.detach()
         elif self.loss_type == "luspo":
-            # `per_token_loss` is (B, 1) only in the recommended sequence-level setup; the KL term, token-level
-            # vLLM IS ratios and the entropy mask all broadcast it to (B, T), so mask before aggregating.
+            # `per_token_loss` is (B, 1) only in the recommended sequence-level setup; importance_sampling_level=
+            # "token" (the config default), the KL term, token-level vLLM IS ratios, and the entropy mask all
+            # broadcast it to (B, T), so mask before aggregating.
             loss = (per_token_loss * mask).sum(-1).mean()
             normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
             policy_loss = loss.detach()


### PR DESCRIPTION
## Description

**Current behavior:** the `luspo` branch in `GRPOTrainer._compute_loss` is the only loss
type that never multiplies `per_token_loss` by `mask` elementwise. It uses `mask` purely
as a per-sequence length:

```python
elif self.loss_type == "luspo":
    loss = (per_token_loss * mask.sum(1, keepdim=True)).mean()
```

That is only safe while `per_token_loss` has shape `(B, 1)`. Four reachable code paths
broaden it to `(B, T)` before this line: `beta != 0.0` (the KL term is `(B, T)`),
`use_vllm` with a token-level importance sampling mode, `top_entropy_quantile < 1.0`
(the entropy mask), and `importance_sampling_level="token"`, which is the config
default and, for `luspo`, only ever produces a `logger.warning`, never an error.

The more serious consequence, not just padding leaking into the loss: once
`per_token_loss` is `(B, T)`, the old formula quietly changes what's being weighted.
Writing `x` for `per_token_loss`, `L_b` for the completion length, and `T` for the
padded width:

```
old: (x * mask.sum(1, keepdim=True)).mean() = mean_b( L_b * mean_over_T(x_b) )
new: (x * mask).sum(-1).mean()               = mean_b( L_b * mean_over_valid(x_b) )
```

so the old form weights each sequence by `L_b^2 / T` instead of `L_b`, a quadratic
length bias, which is exactly the length bias LUSPO exists to remove. With `beta > 0`
the KL penalty also ends up dominated by padding noise, and its strength varies with
the batch's padding fraction instead of being a stable regularizer.

**Changes:** mask elementwise before aggregating:

```python
elif self.loss_type == "luspo":
    # `per_token_loss` is (B, 1) only in the recommended sequence-level setup;
    # importance_sampling_level="token" (the config default), the KL term, token-level
    # vLLM IS ratios, and the entropy mask all broadcast it to (B, T), so mask before
    # aggregating.
    loss = (per_token_loss * mask).sum(-1).mean()
```

This is numerically equivalent, not bit-identical, to the previous formula in the
recommended `(B, 1)` setup: the reduction order differs, so on a random `(B, 1)` input
in fp32 the old formula and the new one can land a few ULPs apart (e.g.
`-5.6097946167` vs `-5.6097936630` on one such input). It's also only unaffected in
that setup while `beta == 0` (the default). With the paper's recommended
`importance_sampling_level="sequence"` and `beta > 0`, `per_token_loss` is already
`(B, T)` before this line, so the KL term's effective scale moves too: from a mean
over all `T` slots including padding, to a mean over only the valid ones. That's the
point of the fix, but it means training runs using LUSPO with a KL penalty will see a
real (intended) change in the loss's magnitude, not just its correctness.

## Test plan

### Before

No test constructed `_compute_loss` inputs directly for `luspo`, so there was no way
to isolate padded positions and confirm the loss doesn't depend on them.

### After

Added `test_luspo_loss_ignores_padding`, parametrized over two configurations that
each broadcast `per_token_loss` to `(B, T)` by a different path:
`importance_sampling_level="sequence"` with `beta=0.1` (the KL term), and
`importance_sampling_level="token"` with `beta=0.0` (the config default, and the case
with the `L^2/T` weighting bug, previously uncovered). Both build `_compute_loss`
inputs directly, perturb `ref_per_token_logps`/`old_per_token_logps` only at padded
(`mask == 0`) positions, and assert the loss is unchanged. `old_per_token_logps` and
`ref_per_token_logps` are anchored to the model's real per-token log-probs (plus a
small fixed offset) rather than arbitrary noise: for this tiny, near-uniform model,
unrelated noise either makes the importance-sampling ratio astronomically small or the
KL term astronomically large, and PPO-style clipping (widened here since it isn't what
this test is exercising) or `assert_close`'s tolerance can then mask the exact
regression being tested for regardless of whether the fix is correct. Both
parametrized cases fail on unmodified code and pass after the fix; verified by
temporarily reverting just the trainer hunk and confirming both fail.

Existing `luspo` coverage (`test_train_loss_types[luspo]`,
`test_entropy_bonus_scale[luspo-*]`) still passes locally in the recommended
`(B, 1)`, `beta=0` setup, consistent with the fix being a no-op there.

**Merge note:** please land this before #6648, not after. That PR adds
`top_entropy_quantile=0.2` to `test_entropy_bonus_scale[luspo-*]`, which is precisely
one of the broadcast paths this PR's fix covers, so that new case would otherwise run
against the broken aggregation. There's also a textual conflict: both PRs insert new
code right after `test_entropy_bonus_scale` in `tests/test_grpo_trainer.py`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GRPO training objective math for LUSPO whenever per-token loss is broadcast to (B, T), so loss magnitude and gradients can shift (especially with KL); fix is correctness-focused but affects live training runs.
> 
> **Overview**
> Fixes **LUSPO** loss aggregation in `GRPOTrainer._compute_loss` so the completion mask is applied **elementwise** over tokens, matching other loss types. The old path multiplied `per_token_loss` by `mask.sum(1, keepdim=True)` (sequence length only), which is wrong when `per_token_loss` is `(B, T)`—e.g. default `importance_sampling_level="token"`, `beta > 0` KL, token-level vLLM IS, or entropy masking. That let **padding affect the loss** and introduced an unintended **\(L^2/T\)** length weighting instead of averaging over valid tokens.
> 
> Aggregation is now `(per_token_loss * mask).sum(-1).mean()` (still divided by the existing gradient-accumulation normalizer). Adds **`test_luspo_loss_ignores_padding`**, which perturbs log-probs only on padded positions and asserts the scalar loss is unchanged, for both KL-driven and token-level IS setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ccc31245e137b771ddc2da51797bcfbeda340a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


