### PR TITLE
Validate YAML config root type

### DIFF
--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -106,6 +106,16 @@ class TestTrlParser(TrlTestCase):
         with pytest.raises(ValueError, match="`env` field should be a dict in the YAML file."):
             parser.parse_args_and_config(args)
 
+    @pytest.mark.parametrize("config", [None, [], "value", 42])
+    @patch("builtins.open", mock_open())
+    @patch("yaml.safe_load")
+    def test_parse_args_and_config_with_non_mapping_config(self, mock_yaml_load, config):
+        mock_yaml_load.return_value = config
+        parser = TrlParser(dataclass_types=[MyDataclass])
+
+        with pytest.raises(ValueError, match="must contain a YAML mapping"):
+            parser.parse_args_and_config(["--config", "config.yaml"])
+
     def test_parse_args_and_config_without_config(self):
         """Test parse_args_and_config without the `--config` argument."""
         parser = TrlParser(dataclass_types=[MyDataclass])

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -325,6 +325,8 @@ class TrlParser(HfArgumentParser):
             config_path = args.pop(config_index)  # get the path to the config file
             with open(config_path) as yaml_file:
                 config = yaml.safe_load(yaml_file)
+            if not isinstance(config, dict):
+                raise ValueError(f"Config file {config_path} must contain a YAML mapping.")
 
             # Set the environment variables specified in the config file
             if "env" in config:


### PR DESCRIPTION
# What does this PR do?

`TrlParser.parse_args_and_config` currently assumes that `yaml.safe_load` returns a mapping. Empty YAML files return `None`, while YAML sequences and scalars return other root types. Those values reach either the `"env" in config` check or `**config` expansion and expose internal `TypeError` exceptions.

This change validates the YAML root immediately after loading it and raises one actionable `ValueError` when it is not a mapping. Valid mapping configs, environment variables, CLI overrides, and unknown-argument handling are unchanged.

Fixes #6655

## Verification

The new parameterized regression test covers an empty file, a sequence, a string, and an integer.

Before the fix:

```text
4 failed in 40.93s
```

After the fix:

```text
4 passed in 7.69s
30 passed in 107.92s
```

Commands:

```bash
pytest -q tests/test_cli_utils.py::TestTrlParser::test_parse_args_and_config_with_non_mapping_config
pytest -q tests/test_cli_utils.py
pre-commit run --files trl/scripts/utils.py tests/test_cli_utils.py
git diff --check
```

The pre-commit run passed Ruff check, Ruff format, and doc-builder style.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6655.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this error-handling change.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with `TrlParser` or the training CLI can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI error-handling change with no impact on valid configs; only invalid YAML roots get a different exception type.
> 
> **Overview**
> **`TrlParser.parse_args_and_config`** now checks that the loaded `--config` YAML root is a mapping (`dict`) right after `yaml.safe_load`. Empty files (`None`), lists, and scalars raise a clear **`ValueError`** instead of surfacing internal **`TypeError`**s from `"env" in config` or `**config` expansion.
> 
> Behavior for valid mapping configs (including `env`, CLI overrides, and unknown-arg handling) is unchanged. A parameterized test covers `None`, `[]`, a string, and an integer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f067628d463ad4c499e5495b31eea2c7d52a72fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->