### PR TITLE
Fix uninstalling symlinked skills

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -299,6 +299,26 @@ class TestUninstallSkill:
         assert not (target_dir / "skill1").exists()
         assert (target_dir / "skill2").exists()
 
+    @pytest.mark.parametrize("broken", [False, True])
+    def test_uninstall_symlink(self, tmp_path, broken):
+        """Test that uninstall removes valid and broken symlinks without touching their targets."""
+        source_skill = tmp_path / "source" / "test-skill"
+        if not broken:
+            source_skill.mkdir(parents=True)
+            (source_skill / "SKILL.md").write_text("# Test")
+
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        target_skill = target_dir / "test-skill"
+        target_skill.symlink_to(source_skill, target_is_directory=True)
+
+        result = uninstall_skill("test-skill", target_dir)
+
+        assert result is True
+        assert not target_skill.is_symlink()
+        if not broken:
+            assert (source_skill / "SKILL.md").exists()
+
 
 class TestIntegration:
     """Integration tests for skills functions."""

--- a/trl/skills/skills.py
+++ b/trl/skills/skills.py
@@ -305,12 +305,15 @@ def _uninstall_skill_from_dir(skill_name: str, target_dir: Path) -> bool:
     """
     target_skill = target_dir / skill_name
 
-    if not target_skill.exists():
+    if not target_skill.exists() and not target_skill.is_symlink():
         raise FileNotFoundError(f"Skill '{skill_name}' not installed at {target_dir}")
 
     # Remove symlink or directory
     try:
-        shutil.rmtree(target_skill)
+        if target_skill.is_symlink():
+            target_skill.unlink()
+        else:
+            shutil.rmtree(target_skill)
     except PermissionError as e:
         raise PermissionError(f"Cannot remove skill: {e}") from e
     except OSError as e:


### PR DESCRIPTION
# What does this PR do?

`uninstall_skill` currently calls `shutil.rmtree` for every installed skill. That works for copied directories but fails for directory symlinks. Broken symlinks are also reported as not installed because `Path.exists()` follows the missing target.

This change:

- treats a symlink itself as an installed entry, even when its target is missing;
- removes symlinks with `Path.unlink()`;
- keeps recursive removal unchanged for real skill directories.

The symlink target is never followed or deleted.

Fixes #6657

## Verification

The parameterized regression test covers valid and broken directory symlinks and verifies that a valid target remains intact.

Before the fix:

```text
2 failed in 7.12s
```

After the fix:

```text
2 passed in 3.22s
74 passed in 5.68s
```

Commands:

```bash
pytest -q tests/test_skills.py::TestUninstallSkill::test_uninstall_symlink
pytest -q tests/test_skills.py tests/test_skills_cli.py
pre-commit run --files trl/skills/skills.py tests/test_skills.py
git diff --check
```

The pre-commit run passed Ruff check, Ruff format, and doc-builder style.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6657.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this bug fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with the skills installer or filesystem handling can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized filesystem fix in the skills installer with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **`uninstall_skill`** no longer treats every install entry as a directory tree. Symlinked skills are recognized as installed even when the target is missing, removed with **`unlink()`**, and real copied directories still use **`shutil.rmtree`**.
> 
> A parameterized test covers valid and broken directory symlinks and asserts the source skill directory is left intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0131387332fe98c95c67c194e14714d7bc3128f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->