### PR TITLE
Restore generation context after errors

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import types
+from contextlib import nullcontext
 from unittest.mock import patch
 
 import pytest
 from transformers import AutoModelForCausalLM
 
 from trl.import_utils import is_deepspeed_available
-from trl.models.utils import disable_gradient_checkpointing, prepare_deepspeed
+from trl.models.utils import _unwrap_model_for_generation, disable_gradient_checkpointing, prepare_deepspeed
 
 
 @pytest.mark.skipif(not is_deepspeed_available(), reason="deepspeed is not installed")
@@ -56,6 +57,49 @@ def test_prepare_deepspeed_strips_optimizer_for_cpu_offload(stage):
     assert "optimizer" not in captured["config"]
     assert "scheduler" not in captured["config"]
     assert "offload_optimizer" not in captured["config"]["zero_optimization"]
+
+
+class TestUnwrapModelForGeneration:
+    def test_restores_gradient_checkpointing_after_error(self):
+        model = types.SimpleNamespace(is_gradient_checkpointing=True)
+
+        def disable():
+            model.is_gradient_checkpointing = False
+
+        def enable():
+            model.is_gradient_checkpointing = True
+
+        model.gradient_checkpointing_disable = disable
+        model.gradient_checkpointing_enable = enable
+        accelerator = types.SimpleNamespace(unwrap_model=lambda model: model)
+
+        with patch("trl.distributed.DistributedBackend", return_value=types.SimpleNamespace(is_zero3=False)):
+            with pytest.raises(RuntimeError, match="generation failed"):
+                with _unwrap_model_for_generation(model, accelerator):
+                    assert model.is_gradient_checkpointing is False
+                    raise RuntimeError("generation failed")
+
+        assert model.is_gradient_checkpointing is True
+
+    def test_restores_deepspeed_hooks_after_error(self):
+        model = types.SimpleNamespace(is_gradient_checkpointing=False, parameters=lambda: [])
+        accelerator = types.SimpleNamespace(unwrap_model=lambda model: model)
+        deepspeed = types.SimpleNamespace(
+            zero=types.SimpleNamespace(GatheredParameters=lambda parameters: nullcontext())
+        )
+
+        with (
+            patch.dict("sys.modules", {"deepspeed": deepspeed}),
+            patch("trl.distributed.DistributedBackend", return_value=types.SimpleNamespace(is_zero3=True)),
+            patch("trl.models.utils.remove_hooks") as remove_hooks,
+            patch("trl.models.utils.add_hooks") as add_hooks,
+        ):
+            with pytest.raises(RuntimeError, match="generation failed"):
+                with _unwrap_model_for_generation(model, accelerator):
+                    raise RuntimeError("generation failed")
+
+        remove_hooks.assert_called_once_with(model)
+        add_hooks.assert_called_once_with(model)
 
 
 class TestDisableGradientCheckpointing:

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -136,20 +136,24 @@ def _unwrap_model_for_generation(
         unwrapped_model.gradient_checkpointing_disable()
     from ..distributed import DistributedBackend
 
-    if DistributedBackend(accelerator).is_zero3:
-        if not gather_deepspeed3_params:
-            yield accelerator.unwrap_model(model)
-        else:
-            import deepspeed
-
-            with deepspeed.zero.GatheredParameters(model.parameters()):
-                remove_hooks(model)
+    try:
+        if DistributedBackend(accelerator).is_zero3:
+            if not gather_deepspeed3_params:
                 yield accelerator.unwrap_model(model)
-                add_hooks(model)
-    else:
-        yield unwrapped_model
-    if is_gradient_checkpointing:
-        unwrapped_model.gradient_checkpointing_enable()
+            else:
+                import deepspeed
+
+                with deepspeed.zero.GatheredParameters(model.parameters()):
+                    remove_hooks(model)
+                    try:
+                        yield accelerator.unwrap_model(model)
+                    finally:
+                        add_hooks(model)
+        else:
+            yield unwrapped_model
+    finally:
+        if is_gradient_checkpointing:
+            unwrapped_model.gradient_checkpointing_enable()
 
 
 @contextmanager


### PR DESCRIPTION
# What does this PR do?

`_unwrap_model_for_generation` temporarily disables gradient checkpointing and, for gathered DeepSpeed ZeRO-3 generation, removes optimizer hooks. Those cleanup operations currently appear after `yield`, so an exception raised by generation skips them and leaves the training model in a modified state.

This change adds scoped `try/finally` cleanup:

- gradient checkpointing is re-enabled whenever it was enabled on entry;
- ZeRO-3 hooks are re-added whenever they were removed;
- normal backend selection, yielded models, and exception propagation remain unchanged.

Fixes #6659

## Verification

Two lightweight regression tests cover the independent cleanup paths:

1. a non-ZeRO generation error restores gradient checkpointing;
2. a gathered ZeRO-3 generation error calls `add_hooks` after `remove_hooks`.

Before the fix:

```text
2 failed in 22.44s
```

After the fix:

```text
2 passed in 4.55s
4 passed, 3 skipped in 10.47s
```

Commands:

```bash
pytest -q tests/test_model_utils.py::TestUnwrapModelForGeneration
pytest -q tests/test_model_utils.py
pre-commit run --files trl/models/utils.py tests/test_model_utils.py
git diff --check
```

The three skipped full-file tests require DeepSpeed. The ZeRO-3 cleanup regression uses a lightweight `deepspeed.zero.GatheredParameters` module stub and mocks only hook registration, so no GPU or distributed runtime is claimed. The pre-commit run passed Ruff check, Ruff format, and doc-builder style.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6659.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this cleanup fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with model generation contexts or DeepSpeed hook handling can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped cleanup fix in a generation context manager with targeted regression tests; normal success paths and yielded models are unchanged.
> 
> **Overview**
> Fixes a bug where **`_unwrap_model_for_generation`** could leave the training model in a bad state if **`generate`** (or code inside the context) raised.
> 
> Cleanup used to run only after a normal **`yield`** exit, so failures skipped re-enabling gradient checkpointing and, for gathered DeepSpeed ZeRO-3, skipped calling **`add_hooks`** after **`remove_hooks`**. The context manager now uses **`try/finally`**: an outer **`finally`** restores gradient checkpointing when it was on at entry, and an inner **`finally`** around the ZeRO-3 yield re-adds hooks.
> 
> Adds **`TestUnwrapModelForGeneration`** with mocked models to assert both cleanup paths run when generation raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a332beff4c941120b29754c814f18af8f1c928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->