### PR TITLE
Use the last reasoning delimiter

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -14,9 +14,11 @@
 
 import pickle
 import threading
+from unittest.mock import Mock, patch
 
 import pytest
 
+import trl.rewards.accuracy_rewards as accuracy_rewards_module
 from trl.rewards import (
     accuracy_reward,
     get_cosine_scaled_reward,
@@ -241,6 +243,30 @@ class TestAccuracyReward:
 
 
 class TestReasoningAccuracyReward:
+    def test_uses_last_matching_reasoning_delimiter(self):
+        def fake_parse(value, **kwargs):
+            return ["gold"] if value == "solution" else [value.strip()]
+
+        def fake_verify(gold, answer, **kwargs):
+            return gold == ["gold"] and answer == ["final"]
+
+        with patch.multiple(
+            accuracy_rewards_module,
+            is_math_verify_available=Mock(return_value=True),
+            parse=Mock(side_effect=fake_parse),
+            verify=Mock(side_effect=fake_verify),
+            LatexExtractionConfig=Mock(return_value=object()),
+            NormalizationConfig=Mock(return_value=object()),
+            create=True,
+        ):
+            rewards = reasoning_accuracy_reward(
+                [[{"content": "reasoning </think> stale answer </analysis> final"}]],
+                ["solution"],
+                reasoning_delimiters=["</think>", "</analysis>"],
+            )
+
+        assert rewards == [1.0]
+
     @require_math_latex
     def test_correct_answer_yields_unit_reward(self):
         completions = [

--- a/trl/rewards/accuracy_rewards.py
+++ b/trl/rewards/accuracy_rewards.py
@@ -302,18 +302,17 @@ def reasoning_accuracy_reward(
 
     for content, sol in zip(contents, solution, strict=True):
         # Split final answer from reasoning content
-        is_reasoning_complete = False
-        for delim in reasoning_delimiters:
-            if delim in content:
-                content = content.split(delim)[-1]
-                is_reasoning_complete = True
-                break
-        if not is_reasoning_complete:
+        reasoning_end = max(
+            (content.rfind(delim) + len(delim) for delim in reasoning_delimiters if delim in content),
+            default=None,
+        )
+        if reasoning_end is None:
             # We assign zero reward instead of `None` to penalize incomplete reasoning
             rewards.append(0.0)
             gold_parsed_strs.append("[incomplete reasoning]")
             answer_parsed_strs.append("[incomplete reasoning]")
             continue
+        content = content[reasoning_end:]
 
         gold_parsed = parse(sol, parsing_timeout=parsing_timeout)
         if len(gold_parsed) != 0:


### PR DESCRIPTION
# What does this PR do?

`reasoning_accuracy_reward` documents the final answer as the text after the last occurrence of any configured reasoning delimiter. The current loop instead stops at the first delimiter type from `reasoning_delimiters` that appears anywhere, even if another configured delimiter occurs later in the completion.

This change computes the end positions of all matching delimiters and slices after the textually last one. It preserves the existing behavior for repeated occurrences of one delimiter and for completions with no matching delimiter.

Fixes #6661

PR #6222 also touches `accuracy_rewards.py`, but it adds separate reward factories and does not modify this delimiter-selection block.

## Verification

The regression test replaces only the optional math parser/verifier so it runs even when `math_verify` is not installed. It demonstrates that argument-list order no longer overrides completion order.

Before the fix:

```text
1 failed in 12.07s
```

After the fix:

```text
1 passed in 4.20s
19 passed, 20 skipped in 4.86s
```

Commands:

```bash
pytest -q tests/test_rewards.py::TestReasoningAccuracyReward::test_uses_last_matching_reasoning_delimiter
pytest -q tests/test_rewards.py
pre-commit run --files trl/rewards/accuracy_rewards.py tests/test_rewards.py
git diff --check
```

The 20 skipped tests are existing tests gated on optional math dependencies. The new regression test executed without that extra. Pre-commit passed Ruff check, Ruff format, and doc-builder style.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6661.
- [x] Did you make sure to update the documentation with your changes? Existing documentation already states the corrected behavior.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with the reward utilities can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to reward parsing logic with a targeted test; behavior only shifts for multi-delimiter completions where list order previously disagreed with text order.
> 
> **Overview**
> **`reasoning_accuracy_reward`** now takes the final answer from the text **after the latest matching delimiter in the completion**, not after the first delimiter type listed in `reasoning_delimiters`. Delimiter selection uses `rfind` across all configured delimiters and slices at the maximum end position; missing delimiters still yield a **0.0** incomplete-reasoning penalty.
> 
> A regression test mocks `math_verify` so it runs without optional deps and checks that when `</think>` appears before `</analysis>`, grading uses the text after `</analysis>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1771628ab0df21728e6940362c42c665ec084a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->