### PR TITLE
Restore tokenizer padding after callback generation

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -14,14 +14,53 @@
 
 import json
 import os
-from unittest.mock import call, patch
+import types
+from contextlib import nullcontext
+from unittest.mock import Mock, call, patch
 
+import pytest
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig, Trainer, TrainingArguments
 
 from trl import BEMACallback, LogCompletionsCallback
+from trl.trainer.callbacks import _generate_completions
 
 from .testing_utils import TrlTestCase, require_comet, require_wandb
+
+
+class TokenizedBatch(dict):
+    @property
+    def input_ids(self):
+        return self["input_ids"]
+
+    def to(self, device):
+        return self
+
+
+class TestGenerateCompletions:
+    @pytest.mark.parametrize("raise_error", [False, True])
+    def test_temporarily_uses_left_padding(self, raise_error):
+        tokenizer = Mock(padding_side="right")
+        tokenizer.return_value = TokenizedBatch(input_ids=[[1]])
+        tokenizer.decode.return_value = "completion"
+        model = Mock(device="cpu")
+
+        def generate(**kwargs):
+            assert tokenizer.padding_side == "left"
+            if raise_error:
+                raise RuntimeError("generation failed")
+            return [[1, 2]]
+
+        model.generate.side_effect = generate
+
+        with patch("trl.trainer.callbacks.unwrap_model_for_generation", return_value=nullcontext(model)):
+            if raise_error:
+                with pytest.raises(RuntimeError, match="generation failed"):
+                    _generate_completions(["prompt"], model, tokenizer, Mock(), None)
+            else:
+                assert _generate_completions(["prompt"], model, tokenizer, Mock(), None) == ["completion"]
+
+        assert tokenizer.padding_side == "right"
 
 
 class TestLogCompletionsCallback(TrlTestCase):
@@ -40,6 +79,25 @@ class TestLogCompletionsCallback(TrlTestCase):
         self.dataset = dataset.map(tokenize_function, batched=True)
 
         self.generation_config = GenerationConfig(max_length=32)
+
+    def test_does_not_change_tokenizer_padding_side(self):
+        trainer = types.SimpleNamespace(
+            eval_dataset={"prompt": ["prompt"]},
+            accelerator=types.SimpleNamespace(
+                is_main_process=False,
+                split_between_processes=lambda prompts: nullcontext(prompts),
+            ),
+            model_wrapped=self.model,
+        )
+        callback = LogCompletionsCallback(trainer, freq=1)
+        args = types.SimpleNamespace(per_device_eval_batch_size=1, report_to=[])
+        state = types.SimpleNamespace(global_step=1, eval_steps=1)
+        self.tokenizer.padding_side = "right"
+
+        with patch("trl.trainer.callbacks._generate_completions", return_value=["completion"]):
+            callback.on_step_end(args, state, None, processing_class=self.tokenizer)
+
+        assert self.tokenizer.padding_side == "right"
 
     @require_wandb
     def test_basic_wandb(self):

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -85,19 +85,24 @@ def _generate_completions(
     """
     completions = []
     # TODO: Override model.generation_config with generation_kwargs
-    with unwrap_model_for_generation(model, accelerator) as unwrapped_model:
-        for idx in range(0, len(prompts), batch_size):
-            batch = prompts[idx : idx + batch_size]
-            tokenized_batch = tokenizer(batch, return_tensors="pt", padding=True, truncation=True).to(model.device)
-            generations = unwrapped_model.generate(
-                **tokenized_batch,
-                generation_config=generation_config,
-            )
-            for prompt, generation in zip(tokenized_batch.input_ids, generations, strict=True):
-                # Remove prompt from generation
-                generation = generation[len(prompt) :]
-                completion = tokenizer.decode(generation, skip_special_tokens=True)
-                completions.append(completion)
+    original_padding_side = tokenizer.padding_side
+    tokenizer.padding_side = "left"
+    try:
+        with unwrap_model_for_generation(model, accelerator) as unwrapped_model:
+            for idx in range(0, len(prompts), batch_size):
+                batch = prompts[idx : idx + batch_size]
+                tokenized_batch = tokenizer(batch, return_tensors="pt", padding=True, truncation=True).to(model.device)
+                generations = unwrapped_model.generate(
+                    **tokenized_batch,
+                    generation_config=generation_config,
+                )
+                for prompt, generation in zip(tokenized_batch.input_ids, generations, strict=True):
+                    # Remove prompt from generation
+                    generation = generation[len(prompt) :]
+                    completion = tokenizer.decode(generation, skip_special_tokens=True)
+                    completions.append(completion)
+    finally:
+        tokenizer.padding_side = original_padding_side
     return completions
 
 
@@ -309,7 +314,6 @@ class LogCompletionsCallback(TrainerCallback):
             return
 
         tokenizer = kwargs["processing_class"]
-        tokenizer.padding_side = "left"
         accelerator = self.trainer.accelerator
         model = self.trainer.model_wrapped
         with accelerator.split_between_processes(self.eval_dataset["prompt"]) as prompts:
@@ -491,7 +495,6 @@ class WeaveCallback(TrainerCallback):
             return
 
         tokenizer = kwargs["processing_class"]
-        tokenizer.padding_side = "left"
         accelerator = self.trainer.accelerator
         model = self.trainer.model_wrapped
 


### PR DESCRIPTION
# What does this PR do?

`LogCompletionsCallback` and `WeaveCallback` currently set their shared tokenizer's `padding_side` to `"left"` and leave it there after completion generation. The tokenizer belongs to the trainer rather than the callback, so this logging-side mutation silently changes padding behavior for later training and evaluation batches.

This change moves the temporary setting into `_generate_completions`, which is shared by both callbacks:

- generation still observes left padding;
- the previous padding side is restored after successful generation;
- the previous padding side is also restored when tokenization or generation raises;
- callback generation arguments and outputs are unchanged.

Fixes #6663

PR #5625 also touches callback generation, but it adds `generation_kwargs` support and does not address tokenizer state restoration.

## Verification

The regression coverage verifies three behaviors:

1. `_generate_completions` uses left padding during successful generation and restores the original value;
2. the original value is restored when generation raises;
3. `LogCompletionsCallback` no longer changes the trainer tokenizer after returning.

Before the fix:

```text
3 failed in 47.20s
```

After the fix:

```text
3 passed in 15.67s
9 passed, 2 skipped in 66.26s
```

Commands:

```bash
pytest -q tests/test_callbacks.py::TestGenerateCompletions tests/test_callbacks.py::TestLogCompletionsCallback::test_does_not_change_tokenizer_padding_side
pytest -q tests/test_callbacks.py
pre-commit run --files trl/trainer/callbacks.py tests/test_callbacks.py
git diff --check
```

These results were revalidated after rebasing onto current `main` at commit `58bed168` on 2026-08-12. The temporary state restoration is kept inline in `_generate_completions` to follow the repository simplicity guidelines. The two skipped full-file tests require optional W&B and Comet integrations. Six warnings report that pinned memory is unavailable on MPS and are unrelated. Pre-commit passed Ruff check, Ruff format, and doc-builder style.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? #6663 contains the reproducer, but no maintainer has confirmed the direction yet.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed for this state-restoration fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with trainer callbacks or generation padding can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared tokenizer state used during training and evaluation; incorrect padding can silently affect later batches, though the fix is small and covered by regression tests.
> 
> **Overview**
> Fixes a bug where `LogCompletionsCallback` and `WeaveCallback` permanently set the shared trainer tokenizer's `padding_side` to `"left"`, which could silently change padding for later training and eval batches.
> 
> Moves the temporary left-padding into `_generate_completions` and restores the original side in a `finally` block, including when generation fails. Removes the permanent mutation from both callbacks.
> 
> Adds regression tests covering successful generation, exception paths, and that `LogCompletionsCallback` no longer leaves the tokenizer mutated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58bed16884168297cb54fbe695186bcb22630de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->