### PR TITLE
Remove symlink support from skills installation

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -163,22 +163,6 @@ class TestInstallSkill:
         assert (target_dir / "trl-training").exists()
         assert not marker_file.exists()  # Marker should be gone
 
-    def test_force_overwrites_symlink(self, tmp_path):
-        """Test that install_skill with force=True can overwrite a symlink."""
-        target_dir = tmp_path / "target"
-        target_dir.mkdir()
-
-        # Create a symlink
-        symlink = target_dir / "trl-training"
-        symlink.symlink_to(_get_trl_skills_dir() / "trl-training")
-
-        # Install with force should replace symlink with copy
-        result = install_skill("trl-training", target_dir, force=True)
-
-        assert result is True
-        assert (target_dir / "trl-training").exists()
-        assert not (target_dir / "trl-training").is_symlink()
-
     def test_skill_not_directory(self, tmp_path):
         """Test that install_skill raises ValueError if skill is not a directory."""
         source_dir = tmp_path / "source"
@@ -425,24 +409,6 @@ class TestEdgeCases:
 
         assert (target_dir / "test-skill" / ".hidden").exists()
         assert (target_dir / "test-skill" / ".hidden").read_text() == "hidden content"
-
-    def test_list_skills_with_symlinks(self, tmp_path):
-        """Test that list_skills handles symlinked skill directories."""
-        source_dir = tmp_path / "source"
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
-
-        # Create a real skill
-        skill_dir = source_dir / "real-skill"
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Real")
-
-        # Create symlink to it
-        (skills_dir / "linked-skill").symlink_to(skill_dir)
-
-        # list_skills should include symlinked skills if they have SKILL.md
-        skills = list_skills(target=skills_dir)
-        assert "linked-skill" in skills
 
 
 class TestListAgentNames:

--- a/trl/skills/skills.py
+++ b/trl/skills/skills.py
@@ -223,10 +223,7 @@ def _install_skill_to_dir(
 
     # Remove existing if force
     if target_skill.exists() and force:
-        if target_skill.is_symlink():
-            target_skill.unlink()
-        else:
-            shutil.rmtree(target_skill)
+        shutil.rmtree(target_skill)
 
     # Install
     try:
@@ -308,7 +305,7 @@ def _uninstall_skill_from_dir(skill_name: str, target_dir: Path) -> bool:
     if not target_skill.exists():
         raise FileNotFoundError(f"Skill '{skill_name}' not installed at {target_dir}")
 
-    # Remove symlink or directory
+    # Remove directory
     try:
         shutil.rmtree(target_skill)
     except PermissionError as e:


### PR DESCRIPTION
This PR removes the remaining symlink-specific handling from the skills module, so installed skills are always plain copied directories.

Related to #6657.

### Motivation

TRL never creates symlinked skills: the `--method {copy,symlink}` option was dropped before Agent Skills shipped, and installation only copies files. The leftover symlink branches therefore handled a state that TRL cannot produce, and they suggested a level of support that the module does not actually provide. Symlinked skills are also fragile by nature, since a link pointing into the package directory breaks silently when TRL is upgraded, moved, or uninstalled.

This is also where `huggingface_hub` converged. `hf skills add` initially installed skills to a central directory and symlinked them into every agent directory (huggingface/huggingface_hub#3755), but two months later the symlinks for Codex, Cursor, and OpenCode were removed (huggingface/huggingface_hub#3956), leaving a single link for Claude's legacy directory. The one link that remains still forces the update path to be symlink aware, because installed skills now have to be deduplicated by resolved path to avoid updating the same skill twice. The same repository also moved file downloads away from symlinks: `local_dir_use_symlinks` is deprecated and ignored, and the symlink-based cache needed a degraded fallback, per-directory support checks, a `HF_HUB_DISABLE_SYMLINKS` escape hatch, and Windows developer mode instructions. Skills are a few kilobytes of Markdown, so there is no benefit that would justify paying that cost here.

### Solution

Make the module symlink agnostic: installation and uninstallation operate on copied directories only. Symlinks created by hand in a skills directory are left to the user to remove.

### Changes

- Remove the symlink branch from the forced installation path, which now always removes the existing skill directory
- Update the outdated comment in the uninstallation path that mentioned symlinks
- Drop the two tests covering symlinked skills

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small simplification in non-critical filesystem helpers; behavior change only if users manually symlinked skills into agent directories.
> 
> **Overview**
> **Removes symlink-specific behavior** from the skills install/uninstall path so TRL treats installed skills as **copied directories only**, matching how installation actually works after the old `copy`/`symlink` option was dropped.
> 
> Forced reinstall now always clears the existing target with `shutil.rmtree` instead of branching on `is_symlink()` vs directory. Uninstall is documented and implemented as directory removal only (still via `rmtree`). **Two tests** that covered symlink overwrite on force-install and symlink discovery in `list_skills` are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f3647d36c8a4574ec9a66508ba159f877dc32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->