### PR TITLE
Close daemon event loops on shutdown

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,8 +49,10 @@ from trl.trainer.utils import (
     repeat_iterable_dataset,
     selective_log_softmax,
     shuffle_sequence_dict,
+    shutdown_event_loop_in_daemon,
     split_pixel_values_by_grid,
     split_tensor_dict,
+    start_event_loop_in_daemon,
     unsplit_pixel_values_by_grid,
     use_adapter,
 )
@@ -60,6 +62,16 @@ from .testing_utils import TrlTestCase, require_peft, require_rich, require_torc
 
 if is_peft_available():
     from peft import AutoPeftModelForCausalLM, LoraConfig
+
+
+def test_shutdown_event_loop_in_daemon_closes_loop():
+    thread, loop, loop_ready_event = start_event_loop_in_daemon()
+    assert loop_ready_event.wait(timeout=1)
+
+    shutdown_event_loop_in_daemon(thread, loop)
+
+    assert not thread.is_alive()
+    assert loop.is_closed()
 
 
 @require_peft

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1265,7 +1265,10 @@ def start_event_loop_in_daemon(
     def run_loop():
         asyncio.set_event_loop(loop)
         loop_ready_event.set()
-        loop.run_forever()
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
 
     thread = threading.Thread(target=run_loop, name=name, daemon=True)
     thread.start()


### PR DESCRIPTION
# What does this PR do?

`start_event_loop_in_daemon` creates an asyncio event loop for asynchronous reward functions, but the shutdown helper only stops the loop and joins its thread. The stopped loop remains open, leaving its resources allocated until interpreter teardown.

This change closes the event loop in the daemon thread after `run_forever()` exits. Keeping creation and closure in the same thread also makes the lifecycle explicit without changing task scheduling or trainer behavior.

The regression test verifies that shutdown both terminates the thread and closes the loop.

## Verification

```text
pytest -q tests/test_utils.py
130 passed, 97 skipped

pytest -q tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_sync_and_async_reward_funcs
1 passed

pytest -q tests/test_rloo_trainer.py::TestRLOOTrainer::test_train_sync_and_async_reward_funcs
1 passed

pre-commit run --files trl/trainer/utils.py tests/test_utils.py
ruff check: passed
ruff format: passed
doc-builder style: passed
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? No issue was opened for this focused lifecycle fix.
- [x] Did you make sure to update the documentation with your changes? No public API or documented behavior changes.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with the asynchronous reward lifecycle in GRPO or RLOO can review this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in trainer utilities with no API or scheduling changes; risk is low aside from ensuring loop.close() on the owning thread behaves as expected on all Python versions.
> 
> **Overview**
> Daemon asyncio loops used for async reward functions in GRPO/RLOO were stopped and joined on shutdown but **never closed**, so loop resources could linger until process exit.
> 
> **`start_event_loop_in_daemon`** now calls **`loop.close()`** in a **`finally`** block after **`run_forever()`** returns, so teardown runs on the same thread that owns the loop. Scheduling and trainer behavior are unchanged.
> 
> A regression test asserts that **`shutdown_event_loop_in_daemon`** leaves the thread dead and the loop closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf4de75bf24b8e8004812a741b19719f11a8718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->