### PR TITLE
Exclude formatting/template tokens from the per-token KL penalty (#2933)

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1709,13 +1709,15 @@ class TestGRPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     def test_kl_ignores_special_tokens(self):
-        # The per-token KL penalty drops formatting/template tokens (EOS, chat delimiters); their KL otherwise
-        # dominates the term and spikes the metric (issue #2933). Verify the ignored-id cache is built from the
-        # tokenizer's special tokens and that a KL-on run (beta != 0) trains through the masked KL path.
+        # With `exclude_special_tokens_kl=True` the per-token KL penalty drops formatting/template tokens (EOS,
+        # chat delimiters); their KL otherwise dominates the term and spikes the metric (issue #2933). Verify the
+        # ignored-id cache is built from the tokenizer's special tokens and that a KL-on run (beta != 0) trains
+        # through the masked KL path.
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
             beta=0.1,  # KL term on so per_token_kl and its special-token masking are exercised
+            exclude_special_tokens_kl=True,
             learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
             per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
             num_generations=3,  # reduce the number of generations to reduce memory usage
@@ -1743,6 +1745,29 @@ class TestGRPOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_exclude_special_tokens_kl_rejects_liger(self):
+        # The Liger fused GRPO loss computes the KL penalty internally from `ref_per_token_logps`, so the
+        # special-token mask applied in `_compute_loss` would be silently skipped on that path. Guard at init
+        # rather than letting the two paths diverge.
+        assert GRPOConfig(output_dir=self.tmp_dir, use_cpu=True).exclude_special_tokens_kl is False
+        assert GRPOConfig(output_dir=self.tmp_dir, use_cpu=True, exclude_special_tokens_kl=True)
+
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            beta=0.1,  # the mask only applies when the KL term is on
+            exclude_special_tokens_kl=True,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        with pytest.raises(NotImplementedError, match="exclude_special_tokens_kl"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
 
     def test_reward_func_wrong_number_of_rewards(self):
         # A reward function that returns the wrong number of rewards should raise a clear error instead of silently

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1708,6 +1708,42 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_kl_ignores_special_tokens(self):
+        # The per-token KL penalty drops formatting/template tokens (EOS, chat delimiters); their KL otherwise
+        # dominates the term and spikes the metric (issue #2933). Verify the ignored-id cache is built from the
+        # tokenizer's special tokens and that a KL-on run (beta != 0) trains through the masked KL path.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            beta=0.1,  # KL term on so per_token_kl and its special-token masking are exercised
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # The ignored-id cache mirrors the tokenizer's special tokens (EOS at least), which are dropped from the KL.
+        assert trainer._tokenizer.eos_token_id in trainer._kl_ignored_token_ids.tolist()
+        assert set(trainer._kl_ignored_token_ids.tolist()) == set(trainer._tokenizer.all_special_ids)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # The masked KL path still produces gradients: params changed.
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
     def test_reward_func_wrong_number_of_rewards(self):
         # A reward function that returns the wrong number of rewards should raise a clear error instead of silently
         # broadcasting (when it returns a single value) or failing later with an opaque shape error.

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -111,6 +111,12 @@ class GMPOTrainer(GRPOTrainer):
             per_token_kl = (
                 torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
             )
+            # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
+            # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
+            # deterministic. They still receive the policy-gradient update below.
+            per_token_kl = per_token_kl.masked_fill(
+                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+            )
             seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
             per_sequence_loss = per_sequence_loss + self.beta * seq_kl
 

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -114,9 +114,10 @@ class GMPOTrainer(GRPOTrainer):
             # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
             # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
             # deterministic. They still receive the policy-gradient update below.
-            per_token_kl = per_token_kl.masked_fill(
-                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
-            )
+            if self.exclude_special_tokens_kl:
+                per_token_kl = per_token_kl.masked_fill(
+                    torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+                )
             seq_kl = (per_token_kl * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)  # (B,)
             per_sequence_loss = per_sequence_loss + self.beta * seq_kl
 

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -54,6 +54,12 @@ class GRPOTrainer(_GRPOTrainer):
             per_token_kl = (
                 torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
             )
+            # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
+            # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
+            # deterministic. They still receive the policy-gradient update below.
+            per_token_kl = per_token_kl.masked_fill(
+                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+            )
 
         # Compute the loss
         advantages = inputs["advantages"]

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -57,9 +57,10 @@ class GRPOTrainer(_GRPOTrainer):
             # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
             # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
             # deterministic. They still receive the policy-gradient update below.
-            per_token_kl = per_token_kl.masked_fill(
-                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
-            )
+            if self.exclude_special_tokens_kl:
+                per_token_kl = per_token_kl.masked_fill(
+                    torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+                )
 
         # Compute the loss
         advantages = inputs["advantages"]

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -363,6 +363,11 @@ class GRPOConfig(_BaseConfig):
             `beta != 0`, including on-policy: the ratio is differentiable, so it affects the gradient even where its
             value is exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level="token"`; with
             `"sequence"` a sequence-level weight is broadcast onto the per-token KL.
+        exclude_special_tokens_kl (`bool`, *optional*, defaults to `False`):
+            Whether to exclude the tokenizer's special tokens (EOS, pad, chat template delimiters) from the per-token
+            KL penalty. These formatting tokens are the ones the policy should be free to make deterministic, but
+            their KL otherwise dominates the term and spikes the logged `kl` metric. They still receive the policy
+            gradient update. Only has an effect when `beta != 0`, and is not supported with `use_liger_kernel=True`.
 
         > Parameters that control the logging
 
@@ -971,6 +976,16 @@ class GRPOConfig(_BaseConfig):
             "including on-policy: the ratio is differentiable, so it affects the gradient even where its value is "
             "exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level='token'`; with "
             "'sequence' a sequence-level weight is broadcast onto the per-token KL."
+        },
+    )
+    exclude_special_tokens_kl: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to exclude the tokenizer's special tokens (EOS, pad, chat template delimiters) from the "
+            "per-token KL penalty. These formatting tokens are the ones the policy should be free to make "
+            "deterministic, but their KL otherwise dominates the term and spikes the logged `kl` metric. They still "
+            "receive the policy gradient update. Only has an effect when `beta != 0`, and is not supported with "
+            "`use_liger_kernel=True`."
         },
     )
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -392,9 +392,10 @@ class GRPOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Cache the tokenizer's special-token ids (EOS, pad, chat delimiters). These formatting tokens are
-        # dropped from the per-token KL penalty in the loss (issue #2933): the policy should be free to make
-        # them deterministic, but their KL otherwise dominates the term and spikes the metric.
+        # Cache the tokenizer's special-token ids (EOS, pad, chat delimiters). When `exclude_special_tokens_kl`
+        # is set, these formatting tokens are dropped from the per-token KL penalty in the loss (issue #2933):
+        # the policy should be free to make them deterministic, but their KL otherwise dominates the term and
+        # spikes the metric.
         self._kl_ignored_token_ids = torch.tensor(sorted(set(self._tokenizer.all_special_ids)), dtype=torch.long)
 
         # Resolve vision placeholder token IDs once. Used by the forward pass to rebuild mm_token_type_ids
@@ -848,6 +849,13 @@ class GRPOTrainer(_BaseTrainer):
         self._entropy_window_stats = None
         if self.use_liger_kernel and self._entropy_bonus_enabled:
             raise NotImplementedError("Entropy bonus is not supported with Liger kernel.")
+        self.exclude_special_tokens_kl = args.exclude_special_tokens_kl
+        if self.use_liger_kernel and self.exclude_special_tokens_kl:
+            raise NotImplementedError(
+                "`exclude_special_tokens_kl=True` is not supported with `use_liger_kernel=True`: the Liger fused "
+                "GRPO loss computes the KL penalty internally from `ref_per_token_logps`, so the special-token "
+                "mask would be silently ignored. Set `use_liger_kernel=False` to use `exclude_special_tokens_kl`."
+            )
 
         # Datasets
         self.shuffle_dataset = args.shuffle_dataset
@@ -3107,9 +3115,10 @@ class GRPOTrainer(_BaseTrainer):
             # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
             # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
             # deterministic. They still receive the policy-gradient update below.
-            per_token_kl = per_token_kl.masked_fill(
-                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
-            )
+            if self.exclude_special_tokens_kl:
+                per_token_kl = per_token_kl.masked_fill(
+                    torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+                )
 
         # From here, log_importance_weights (and all subsequent tensors, coef_1, coef_2, etc.) shape depends on
         # importance_sampling_level: "token" level: (B, T); "sequence" level: (B, 1)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -392,6 +392,11 @@ class GRPOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
+        # Cache the tokenizer's special-token ids (EOS, pad, chat delimiters). These formatting tokens are
+        # dropped from the per-token KL penalty in the loss (issue #2933): the policy should be free to make
+        # them deterministic, but their KL otherwise dominates the term and spikes the metric.
+        self._kl_ignored_token_ids = torch.tensor(sorted(set(self._tokenizer.all_special_ids)), dtype=torch.long)
+
         # Resolve vision placeholder token IDs once. Used by the forward pass to rebuild mm_token_type_ids
         # when tool responses inject images into the completion (see _generate forward_kwargs block).
         self._image_pad_token_id = None
@@ -3099,6 +3104,12 @@ class GRPOTrainer(_BaseTrainer):
             # Importance sampling correction for the KL divergence
             if self.args.use_bias_correction_kl:
                 per_token_kl = per_token_kl * coef_1
+            # Exclude formatting/template tokens (EOS, chat delimiters) from the KL penalty: their per-token KL
+            # dominates the term and spikes the metric (issue #2933), and we want these tokens to become
+            # deterministic. They still receive the policy-gradient update below.
+            per_token_kl = per_token_kl.masked_fill(
+                torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
+            )
 
         # From here, log_importance_weights (and all subsequent tensors, coef_1, coef_2, etc.) shape depends on
         # importance_sampling_level: "token" level: (B, T); "sequence" level: (B, 1)


### PR DESCRIPTION
### Problem

With `beta != 0` (KL regularization on), formatting/template tokens (most notably the EOS/EOT token, and chat delimiters like `<|im_end|>`) can have a per-token KL 1-2 orders of magnitude higher than the semantic tokens. This spikes the KL metric and over-regularizes tokens we actually want the policy to make deterministic. See #2933 (thanks @kalomaze for the diagnosis).

### Change

Drop the tokenizer's special tokens from `per_token_kl` before it enters the loss and the metric, using `all_special_ids` (no new public config field, per @albertvillanova's note in #2933):

```python
per_token_kl = per_token_kl.masked_fill(
    torch.isin(completion_ids, self._kl_ignored_token_ids.to(completion_ids.device)), 0.0
)
```

The special-token ids are cached once in `__init__` from `self._tokenizer.all_special_ids`. These tokens still receive the policy-gradient update; only the KL pull toward the reference is removed. Applied consistently to the three duplicated K3 blocks (`grpo`, `gspo_token`, `gmpo`).

### Validation

- New test `test_kl_ignores_special_tokens`: a `beta=0.1` run trains through the masked KL path; it asserts the ignored-id cache equals the tokenizer's special ids and that params update.
- Existing `test_train_bias_correction_kl` still passes (the mask sits right after the bias-correction step).
- ruff + doc-builder clean.

### Open questions (draft, for your steer @albertvillanova)

1. **Automatic for all `beta != 0`**: this is unconditional (no config field, as you preferred). Do you want it as the default, or gated somehow?
2. **Token set**: I mask all `all_special_ids` (EOS + chat delimiters). Should it be narrower (just EOS), or is all-special the right definition of "formatting tokens"?
3. The **KL metric** now also excludes special tokens (I mask before both the loss and the logged metric). Intended, since the metric should not spike either, but flagging it.

Addresses #2933

cc @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KL regularization and logged metrics for GRPO-family trainers when enabled; behavior is gated behind a default-off flag and blocked on the Liger path.
> 
> **Overview**
> Adds opt-in **`exclude_special_tokens_kl`** on `GRPOConfig` (default `False`) so EOS, pad, and chat-template delimiter tokens can be zeroed out in the per-token KL term when `beta != 0`, addressing inflated KL metrics and over-regularization on formatting tokens (#2933). Policy gradients on those positions are unchanged.
> 
> `GRPOTrainer` caches `_kl_ignored_token_ids` from `tokenizer.all_special_ids` at init and applies the mask in `_compute_loss` (after bias-correction KL when enabled), which also affects the logged `kl` metric. The same masking is applied in **GMPO** and **GSPO-token** loss paths.
> 
> **`use_liger_kernel=True`** with this flag raises `NotImplementedError` at trainer init because the fused Liger loss would skip the mask.
> 
> Tests cover training with the flag on, cache alignment with special ids, and the Liger incompatibility guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7606cc2ba46bee306d84ef96f455549b0b5e1f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->