### PR TITLE
Fix wrapped packing duplicating data when the input table is sliced

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1218,6 +1218,21 @@ class TestPackDatasetWrapped(TrlTestCase):
         assert next(iter(dataset.with_format(None).batch(batch_size=num_examples))) == expected_output
         assert formatting == dataset._formatting
 
+    def test_with_multiple_map_batches(self):
+        # `map` passes each batch as a slice, so every batch but the first starts at a non-zero offset
+        examples = {
+            "input_ids": [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]],
+            "attention_mask": [[0, 1], [1, 0], [0, 1], [1, 0], [0, 1], [1, 0]],
+        }
+        dataset = Dataset.from_dict(examples)
+        seq_length = 4
+        expected_output = {
+            "input_ids": [[1, 2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]],
+            "attention_mask": [[0, 1, 1, 0], [0, 1], [1, 0, 0, 1], [1, 0]],
+        }
+        dataset = pack_dataset(dataset, seq_length, strategy="wrapped", map_kwargs={"batch_size": 3})
+        assert dataset.to_dict() == expected_output
+
 
 class TestPackDatasetBfd(TrlTestCase):
     def test_with_dataset(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -830,14 +830,15 @@ def _pack_wrapped(examples: pa.Table, seq_length: int) -> pa.Table:
     """Pack sequences in a pyarrow Table using a wrapped strategy."""
     columns = [column.chunks[0] for column in examples.combine_chunks().columns]
     _check_if_columns_can_be_packed(columns)
-    offsets, values = columns[0].offsets, columns[0].values
-    values = values[offsets[0].as_py() : offsets[-1].as_py()]
-    num_elements = len(values)
+    # Use `flatten()` and not `values`, which returns the whole child buffer and ignores the array's own offset. That
+    # offset is non-zero whenever the table is a slice, as it is for every batch but the first in a batched `map`.
+    values = [column.flatten() for column in columns]
+    num_elements = len(values[0])
     offsets = np.arange(0, num_elements, seq_length, dtype=columns[0].offsets.type.to_pandas_dtype())
     offsets = np.concatenate((offsets, [num_elements]))
     columns = [
-        type(column).from_arrays(offsets.astype(column.offsets.type.to_pandas_dtype()), column.values)
-        for column in columns
+        type(column).from_arrays(offsets.astype(column.offsets.type.to_pandas_dtype()), column_values)
+        for column, column_values in zip(columns, values, strict=True)
     ]
     return pa.Table.from_arrays(columns, names=examples.column_names)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #6669

`_pack_wrapped` sizes the output from the array's sliced view but reads from the raw child buffer, so when the input table is a slice it re-reads from the start of the buffer instead of from the slice. `datasets.map(batched=True)` passes each
batch as a slice, so every batch after the first can come back holding data from the beginning of the dataset. Row and token counts are unchanged, so nothing errors.

```python
ds = Dataset.from_dict({"input_ids": [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]})
pack_dataset(ds, seq_length=4, strategy="wrapped", map_kwargs={"batch_size": 3})["input_ids"]
# before: [[1, 2, 3, 4], [5, 6], [1, 2, 3, 4], [5, 6]]
# after:  [[1, 2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]]
```

The correction was already computed into a local, but #5189 rewrote the loop as a list comprehension over all columns and passed `column.values`, which left that local unused. This switches to `column.flatten()`, which respects the list array's own offset, per column so each keeps its own offsets.

Only `wrapped` is affected. `bfd` and `bfd_split` hit the same pattern but are protected by the `pc.filter` and `pc.take` that run before it.

Output is byte-identical to current behavior when the table is not sliced, so no existing correct result changes. Also checked on `large_list` with int64 offsets.

## Tests

Added `TestPackDatasetWrapped::test_with_multiple_map_batches`, which packs across two `map` batches. It fails on main with the duplication above and passes here. The two existing `wrapped` tests use 3-row datasets, so they only ever exercise a single batch, which is why this was not caught.

```
pytest tests/test_data_utils.py -k "Pack"
10 passed, 548 deselected
```

Beyond the added test, I checked `_pack_wrapped` against an independent reference (concatenate each column's rows in order, then re-chunk) over 600 randomized shapes plus targeted edge cases: slices at every offset, `seq_length` of 1 and
equal to and greater than the total, ragged and empty rows, zero-row tables, multi-chunk tables, 1 to 3 columns, `list` and `large_list`, int32 and int64 offsets. All pass with the fix and 127 of them fail without it. `pack_dataset` also round-trips end to end across batch sizes 1 to 777, `num_proc` 2 and 4, and all three strategies, with `input_ids` / `attention_mask` / `labels` staying aligned.

Since #5189 was a performance PR, I benchmarked this too. `flatten()` is metadata work like `values`, so throughput is unchanged (at 500k rows x 16 tokens the median of 7 runs is 0.08 ms before and 0.09 ms after, which is within noise).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change alters training preprocessing for wrapped packing on multi-batch maps (silent wrong tokens before); unsliced inputs should stay byte-identical per the PR.
> 
> **Overview**
> Fixes **wrapped** sequence packing when `pack_dataset` runs through batched `Dataset.map`: batches after the first arrive as PyArrow table slices, and `_pack_wrapped` was sizing output from the slice but reading token data from `column.values` (the full child buffer), so later batches could repeat tokens from the start of the dataset instead of the current batch.
> 
> The implementation now uses **`column.flatten()`** per column so list data honors each array’s offset, then rebuilds packed list columns from those flattened values. **`bfd`** / **`bfd_split`** are unchanged in this diff.
> 
> Adds **`test_with_multiple_map_batches`** to pack with `map_kwargs={"batch_size": 3}` across two map batches and assert `input_ids` / `attention_mask` stay correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ad2adbb06f92367de1d8e0721adc35d4afa715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->