### PR TITLE
fix(sft): warn when all labels are masked instead of silent 0.0 loss

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -40,6 +40,7 @@ from trl import SFTConfig, SFTTrainer
 from trl.trainer.sft_trainer import (
     DataCollatorForLanguageModeling,
     _chunked_cross_entropy_loss,
+    _labels_are_all_masked,
     _patch_chunked_ce_lm_head,
     dft_loss,
 )
@@ -69,6 +70,30 @@ if is_peft_available():
         TaskType,
         get_peft_model,
     )
+
+
+class TestAllLabelsMaskedHelpers(TrlTestCase):
+    """Regression for https://github.com/huggingface/trl/issues/6668."""
+
+    def test_labels_are_all_masked(self):
+        assert _labels_are_all_masked(None) is False
+        assert _labels_are_all_masked(torch.tensor([[-100, -100], [-100, -100]])) is True
+        assert _labels_are_all_masked(torch.tensor([[-100, 1], [-100, -100]])) is False
+
+    def test_dft_loss_all_masked_returns_zero_not_nan(self):
+        import trl.trainer.sft_trainer as sft_mod
+
+        batch_size, seq_len, vocab_size = 2, 3, 5
+        logits = torch.randn(batch_size, seq_len, vocab_size, requires_grad=True)
+        labels = torch.full((batch_size, seq_len), -100)
+        outputs = type("O", (), {"logits": logits})()
+        sft_mod._ALL_LABELS_MASKED_WARNED = False
+        with pytest.warns(UserWarning, match="no unmasked labels"):
+            loss = dft_loss(outputs, labels)
+        assert loss.item() == 0.0
+        assert not torch.isnan(loss)
+        loss.backward()
+        assert logits.grad is not None
 
 
 class TestDFTLoss(TrlTestCase):
@@ -2703,13 +2728,18 @@ class TestChunkedCrossEntropyLoss:
 
         Every trainable parameter of the chunked path (hidden_states, lm_head_weight, and lm_head_bias when present)
         must receive a gradient — otherwise DDP / FSDP synchronization hangs or errors at the all-reduce step.
+        Also warns once so a silent 0.0 is not mistaken for a healthy run (#6668).
         """
         hidden, weight, labels = self._inputs(requires_grad=True)
         bias = torch.zeros(self.V, dtype=torch.float32, requires_grad=True)
         labels[:] = -100
-        loss, correct, ent_sum, n_valid = _chunked_cross_entropy_loss(
-            hidden, weight, self.CHUNK_SIZE, labels, lm_head_bias=bias
-        )
+        import trl.trainer.sft_trainer as sft_mod
+
+        sft_mod._ALL_LABELS_MASKED_WARNED = False
+        with pytest.warns(UserWarning, match="no unmasked labels"):
+            loss, correct, ent_sum, n_valid = _chunked_cross_entropy_loss(
+                hidden, weight, self.CHUNK_SIZE, labels, lm_head_bias=bias
+            )
         assert loss.item() == 0.0
         assert correct.item() == 0.0
         assert ent_sum.item() == 0.0

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -190,7 +190,9 @@ def _chunked_cross_entropy_loss(
     if n_valid_tensor == 0:
         # Whole micro-batch masked (e.g. completion-only loss + truncation). Keep the loss connected
         # to the autograd graph through every trainable parameter so `.backward()` succeeds and DDP /
-        # FSDP gradient sync doesn't hang on a missing param.
+        # FSDP gradient sync doesn't hang on a missing param. Warn once so a reported 0.0 loss is
+        # not mistaken for a healthy run (#6668).
+        _warn_all_labels_masked()
         with maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
             loss = (hidden_states.float().sum() + lm_head_weight.float().sum()) * 0.0
             if lm_head_bias is not None:
@@ -379,6 +381,45 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
 
 
 logger = get_logger(__name__)
+
+
+_ALL_LABELS_MASKED_WARNED = False
+
+
+def _warn_all_labels_masked() -> None:
+    """Warn once when a batch has no tokens contributing to the loss.
+
+    All-``-100`` labels yield NaN from standard CE (empty reduction) or an intentional
+    zero from the chunked path; either way reporting silent ``0.0`` hides misconfig
+    (e.g. ``completion_only_loss`` + ``max_length`` truncating every completion).
+    See https://github.com/huggingface/trl/issues/6668.
+
+    Uses a module-level flag rather than ``logger.warning_once`` so the warning still
+    fires in unit tests / scripts that have not initialized Accelerate's ``PartialState``.
+    """
+    global _ALL_LABELS_MASKED_WARNED
+    if _ALL_LABELS_MASKED_WARNED:
+        return
+    _ALL_LABELS_MASKED_WARNED = True
+    msg = (
+        "SFTTrainer: a batch has no unmasked labels (all labels are -100). "
+        "This often means completion tokens were fully truncated (e.g. completion_only_loss "
+        "with a too-small max_length) or the chat template never marks assistant turns. "
+        "Loss is treated as 0.0 so training can continue; increase max_length or fix the "
+        "dataset if this is unexpected."
+    )
+    try:
+        logger.warning(msg)
+    except RuntimeError:
+        # Accelerate logging requires PartialState; fall back outside training loops.
+        warnings.warn(msg, UserWarning, stacklevel=2)
+
+
+def _labels_are_all_masked(labels: torch.Tensor | None) -> bool:
+    """Return True if `labels` is non-None and every entry is ignore_index (-100)."""
+    if labels is None:
+        return False
+    return not bool((labels != -100).any().item())
 
 
 FLASH_ATTENTION_VARIANTS = {
@@ -783,6 +824,14 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
     per_token_loss = -logprobs.exp().detach() * logprobs
     if num_items_in_batch is None:
         num_items_in_batch = loss_mask.sum()
+    if isinstance(num_items_in_batch, torch.Tensor):
+        empty = bool((num_items_in_batch == 0).all().item())
+    else:
+        empty = num_items_in_batch == 0
+    if empty:
+        # Avoid 0/0 → NaN; keep a graph-connected zero for backward / DDP (same idea as chunked CE).
+        _warn_all_labels_masked()
+        return (outputs.logits * 0.0).sum()
     loss = (per_token_loss * loss_mask).sum() / num_items_in_batch
     return loss
 
@@ -1709,6 +1758,11 @@ class SFTTrainer(_BaseTrainer):
         # This can be removed when this issue is fixed.
         # When using CP or SP, labels are pre-shifted, we must use shift_labels instead.
         labels = inputs["labels"] if "shift_labels" not in inputs else None
+        # Prefer shift_labels for the all-masked check under CP/SP; otherwise use labels.
+        labels_for_mask_check = inputs.get("shift_labels", inputs.get("labels"))
+        all_masked = _labels_are_all_masked(labels_for_mask_check)
+        if all_masked:
+            _warn_all_labels_masked()
 
         # If not set, defaults from model config and may warn since cache isn't compatible with gradient checkpointing
         inputs["use_cache"] = False
@@ -1752,6 +1806,14 @@ class SFTTrainer(_BaseTrainer):
                     f"Please increase `max_length` or set it to `None` to disable truncation."
                 ) from e
             raise
+
+        # Default HF CE on a fully ignored batch returns NaN; replace with a graph-safe 0.0 so logs are
+        # not NaN and DDP still works. Chunked CE already returns 0.0 in that case (#6668).
+        if all_masked and torch.isnan(loss):
+            if getattr(outputs, "logits", None) is not None:
+                loss = (outputs.logits * 0.0).sum()
+            else:
+                loss = torch.nan_to_num(loss, nan=0.0)
 
         # Compute entropy
         if self.args.loss_type == "chunked_nll":

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -408,11 +408,13 @@ def _warn_all_labels_masked() -> None:
         "Loss is treated as 0.0 so training can continue; increase max_length or fix the "
         "dataset if this is unexpected."
     )
+    # Always emit UserWarning so tests are order-independent; also log when Accelerate is ready.
+    warnings.warn(msg, UserWarning, stacklevel=2)
     try:
         logger.warning(msg)
     except RuntimeError:
-        # Accelerate logging requires PartialState; fall back outside training loops.
-        warnings.warn(msg, UserWarning, stacklevel=2)
+        # Accelerate logging requires PartialState outside training loops.
+        pass
 
 
 def _labels_are_all_masked(labels: torch.Tensor | None) -> bool:
@@ -1810,7 +1812,7 @@ class SFTTrainer(_BaseTrainer):
         # Default HF CE on a fully ignored batch returns NaN; replace with a graph-safe 0.0 so logs are
         # not NaN and DDP still works. Chunked CE already returns 0.0 in that case (#6668).
         if all_masked and torch.isnan(loss):
-            if getattr(outputs, "logits", None) is not None:
+            if outputs.logits is not None:
                 loss = (outputs.logits * 0.0).sum()
             else:
                 loss = torch.nan_to_num(loss, nan=0.0)


### PR DESCRIPTION
# What does this PR do?

Fixes #6668

When every label in a batch is masked (`-100`) — e.g. `completion_only_loss=True` and a small `max_length` cuts off all completion tokens — the real loss can be NaN while training reports `0.0` and looks successful.

This PR:
- Warns **once** when a batch has no unmasked labels (with guidance to increase `max_length` / fix data)
- Keeps a graph-safe `0.0` so backward/DDP still work
- Replaces NaN from the default CE path when all labels are masked
- Guards DFT loss against 0/0
- Adds unit tests

Chose **warn** (not hard fail) so runs continue but misconfiguration is visible.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
      https://github.com/huggingface/trl/issues/6668
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SFT loss paths (`compute_loss`, `dft_loss`, chunked CE) and changes reported loss when all labels are masked; behavior is intentional but affects training metrics and distributed runs.
> 
> **Overview**
> Fixes **#6668**: batches where every label is `-100` could show **0.0** (or **NaN** on the default CE path) while training looked fine—common with `completion_only_loss` and a too-small `max_length`.
> 
> Adds **`_warn_all_labels_masked()`** (once per process) with actionable guidance, plus **`_labels_are_all_masked()`** for detection (including `shift_labels` under CP/SP). Warnings fire from chunked CE, **`dft_loss`**, and **`compute_loss`** when a batch is fully masked.
> 
> **Loss handling** stays graph-safe for backward/DDP: chunked CE unchanged; **`dft_loss`** avoids `0/0` NaN; **`compute_loss`** swaps NaN from default HF CE for a logits-connected **0.0**. Training continues (warn, not fail).
> 
> Regression tests cover the helper, DFT all-masked path, and chunked CE warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1d5609baca64f226544329211e0dae4ef326ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->