### PR TITLE
Fix opencode.py proxy trace/log paths after OpenEnv moved them to functions

### DIFF
--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -417,8 +417,8 @@ class FreePortOpenCodeSessionFactory(OpenCodeSessionFactory):
 
     def _start_proxy(self, sandbox):
         port = _free_port()
-        trace_path = oc_harness._PROXY_TRACE_PATH
-        log_path = oc_harness._PROXY_LOG_PATH
+        trace_path = oc_harness.proxy_trace_path(self._config)
+        log_path = oc_harness.proxy_log_path(self._config)
         if not sandbox.exists("/home/user/proxy/interception.py"):
             self._exec_with_retry(
                 sandbox,


### PR DESCRIPTION
## What does this PR do?

`FreePortOpenCodeSessionFactory._start_proxy` in `examples/scripts/openenv/opencode.py` referenced `oc_harness._PROXY_TRACE_PATH` and `oc_harness._PROXY_LOG_PATH`. OpenEnv replaced those module constants with the config-dependent functions `proxy_trace_path(config)` / `proxy_log_path(config)`, so the subclass now raises `AttributeError` at rollout time against current OpenEnv `main` (which the example pins via git).

This swaps the two references to the functions. The subclass only exists to bind the in-sandbox proxy to a free port instead of the hardcoded `_PROXY_PORT = 7000`; `_start_proxy` should otherwise mirror OpenEnv's exactly. `_PROXY_SOURCE_PATH` is unchanged (still a module constant in OpenEnv).

Side note for OpenEnv: this whole subclass exists only because `_start_proxy` hardcodes `_PROXY_PORT = 7000`, so several local opencode sandboxes on one node collide. Accepting a port argument in OpenEnv's `_start_proxy` would remove the need for consumers to re-implement it (and drift like this).

## AI writing disclosure

- [x] AI-assisted

cc @AmineDiro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line API alignment in an example script; no auth, data, or training logic changes.
> 
> **Overview**
> Updates **`FreePortOpenCodeSessionFactory._start_proxy`** in `examples/scripts/openenv/opencode.py` so proxy trace and log locations come from OpenEnv’s **`proxy_trace_path(self._config)`** and **`proxy_log_path(self._config)`** instead of the removed **`_PROXY_TRACE_PATH`** / **`_PROXY_LOG_PATH`** module constants.
> 
> This restores rollout startup against current OpenEnv `main` (which the example pins via git), where those paths are config-driven. The free-port proxy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c7d66a4be0ee4c0e3e48c571cbf5b4bdeac113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->