### PR TITLE
ci: exclude the buggy TruffleHog lob detector

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -14,5 +14,7 @@ jobs:
     - name: Secret Scanning
       uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55  # v3.95.9
       with:
-        # exclude buggy postgres detector that is causing false positives and not relevant to our codebase
-        extra_args: --results=verified,unknown --exclude-detectors=postgres
+        # exclude buggy detectors that cause false positives and are not relevant to our codebase.
+        # lob matches `(live|test)_[a-zA-Z0-9_]{35}`, which any pytest name of exactly 35 characters after
+        # `test_` satisfies (e.g. `test_reward_func_wrong_number_of_rewards`).
+        extra_args: --results=verified,unknown --exclude-detectors=postgres,lob


### PR DESCRIPTION
## What this fixes

The `Secret Leaks` workflow fails on branches whose push range contains a pytest function name of exactly 35 characters after `test_`. TruffleHog's Lob detector matches `\b((live|test)_[a-zA-Z0-9_]{35})\b`, which such a name satisfies exactly.

Eight names currently on `main` match, all of them ordinary tests:

```
test_applies_logit_scale_and_softcapping
test_history_rewrite_forks_into_two_rows
test_iw_opd_uses_cached_rollout_logprobs
test_length_exceeding_max_len_is_clamped
test_reward_func_wrong_number_of_rewards
test_train_runs_with_prompt_only_dataset
test_train_with_environment_owned_reward
test_vlm_uld_cross_arch_train_step_smoke
```

## Why they are reported as "verified"

The Lob detector treats two HTTP statuses as proof a key is live:

```go
switch res.StatusCode {
case http.StatusForbidden, http.StatusUnprocessableEntity:
    // 403 indicates key is active but no billing method on file
    // 422 indicates key is active but request body is invalid
    return true, nil
case http.StatusUnauthorized:
    return false, nil
```

The 403 is the one that fires here. Credit to @albertvillanova for pinning the actual trigger: Lob sits behind Cloudflare, which blocks TruffleHog's hardcoded `User-Agent: TruffleHog` and answers 403, while the same request from an ordinary client gets the correct 401:

```
UA='curl/8.0'           -> 401
UA='Go-http-client/2.0' -> 401
UA='TruffleHog'         -> 403   # Cloudflare "Attention Required!" HTML page
```

So the detector reads a WAF block as a verified credential. This also explains the timing, which nothing on either side accounts for otherwise: the detector is byte-identical in v3.95.9 and v3.96.0, and the symptom appeared on 2026-08-06 with no code change. It further explains why only new-branch pushes fail: with no base commit the action scans full history, while incremental pushes cover too few chunks to hit a match.

An earlier revision of this description attributed the 403/422 to the detector's empty request body producing a 422. That was wrong: Lob returns 401 for a bogus key from a normal client. The correction is @albertvillanova's, tested directly.

Upstream: trufflesecurity/trufflehog#5184. Related: trufflesecurity/trufflehog#5187 and trufflesecurity/trufflehog#5188, which tightens `keyPat` to exclude underscores and would fix this symptom but not the underlying "403 means verified" behavior.

## The change

Adds `lob` to the existing exclusion list, mirroring what the file already does for `postgres` and for the same reason. TRL has no Lob dependency; Lob is a direct-mail API, so the detector can only ever produce false positives here and there is no need to revert once upstream is fixed.

No credential was found, and nothing in the repository needs rotating.

cc @qgallouedec @kashif
