### PR TITLE
Pin the TruffleHog scanner image by digest

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -12,8 +12,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55  # v3.95.9
+      uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11  # v3.96.0
       with:
+        # the action runs the scanner as a container and defaults to the mutable `:latest` tag, so the SHA above
+        # pins only the wrapper. pin the image by digest too, and bump it together with the action SHA.
+        version: 3.96.0@sha256:aa821cf4ace8861c7d096d83818cdf7bb9719028a52d37a52eaad44086a52577
         # exclude buggy detectors that cause false positives and are not relevant to our codebase.
         # lob matches `(live|test)_[a-zA-Z0-9_]{35}`, which any pytest name of exactly 35 characters after
         # `test_` satisfies (e.g. `test_reward_func_wrong_number_of_rewards`).


### PR DESCRIPTION
This PR pins the TruffleHog scanner container image by digest, so that the secret scanning job runs a fixed, immutable version.

### Motivation

The `trufflesecurity/trufflehog` action is pinned by commit SHA, but that pins only the composite action wrapper. Its final step runs the scanner as a container built from the `image` and `version` inputs, and `version` defaults to the mutable `:latest` tag. The job labelled `v3.95.9` was therefore running scanner `3.96.0`.

This leaves an unpinned mutable dependency executing in CI, and lets scanner behaviour change without any reviewable diff. That is exactly how the recent Lob false positives broke this workflow on every new branch push, with no change on our side. See:
- #6674

### Solution

The `version` input accepts a full `repo:tag@digest` reference, because the action builds the image reference by concatenating the two inputs. Passing the digest there pins the scanner image by content, which is the container equivalent of the commit SHA pin already applied to the action. The tag is kept alongside the digest so the version stays readable.

The pinned digest is the multi-arch index digest, covering `linux/amd64` and `linux/arm64`.

Note that Dependabot bumps the action SHA but has no visibility into action inputs, so the digest has to be bumped by hand alongside it. A comment in the workflow records that coupling.

### Changes

- Bump the TruffleHog action SHA from v3.95.9 to v3.96.0
- Pin the scanner container image by digest through the `version` input
- Document why the digest pin is needed and that it must be bumped together with the action SHA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application runtime impact; reduces supply-chain drift in secret scanning.
> 
> **Overview**
> **Hardens secret scanning** so CI runs a fixed TruffleHog scanner build instead of whatever `:latest` resolves to when only the action wrapper is SHA-pinned.
> 
> The workflow bumps `trufflesecurity/trufflehog` to **v3.96.0** and sets `version` to `3.96.0@sha256:…`, pinning the scanner container by digest. Comments note that the action SHA alone does not pin the scanner image and that the digest must be updated together with the action bump (Dependabot will not do that).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d734d69df590e8b51b35885276cb5f0bfc9ce83f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->