### PR TITLE
Document the GRPO reward-function batch layout and group-relative rewards

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -431,6 +431,8 @@ Reward functions can be either synchronous Python callables or asynchronous `asy
 
 2. **Return value**: The function must return a list of floats. Each float represents the reward corresponding to a single completion.
 
+3. **Batch layout**: The function is called once per batch with every completion at once, not once per completion. The completions are grouped by prompt: the first `num_generations` entries are the generations of the first prompt, the next `num_generations` entries those of the second, and so on. A reward function can therefore score a completion relative to the other generations of the same prompt. See Example 7. Note that `num_generations` is not passed as an argument, so a group-aware reward function has to capture it.
+
 #### Example 1: Reward longer completions
 
 Below is an example of a reward function for a standard format that rewards longer completions:
@@ -625,6 +627,30 @@ def reward_func(completions, ground_truth, log_extra=None, log_metric=None, **kw
 
     return rewards
 ```
+
+#### Example 7: Group-relative rewards (LLM-as-a-judge rankings)
+
+Some judges score a completion only in comparison with the other completions of the same prompt, by ranking them against each other rather than grading each one on its own. Because the reward function receives the whole batch grouped by prompt (see Batch layout above), it can split the batch into groups of `num_generations` and rank within each group. The group size is not passed to the function, so capture it:
+
+```python
+def make_ranking_reward(num_generations):
+    def ranking_reward(prompts, completions, **kwargs):
+        rewards = [0.0] * len(completions)
+        for start in range(0, len(completions), num_generations):
+            group = completions[start : start + num_generations]
+            # Ask the judge to rank the group against itself, best first. It returns positions within
+            # the group, so offset them by `start` to index back into the full batch.
+            for rank, position in enumerate(judge_ranking(prompts[start], group)):
+                rewards[start + position] = 1.0 - rank / max(num_generations - 1, 1)
+        return rewards
+
+    return ranking_reward
+
+
+trainer = GRPOTrainer(..., reward_funcs=make_ranking_reward(training_args.num_generations))
+```
+
+Ranking spreads a group's rewards apart, so the group always has a non-zero reward standard deviation and contributes to the gradient. Grading each completion on its own can instead give every completion in a group the same reward, which zeroes the advantage of the whole group and is reported as `frac_reward_zero_std`.
 
 #### Passing the reward function to the trainer
 


### PR DESCRIPTION
## What this does

Documents two things about custom reward functions in GRPO that the docs did not state, and adds an example for the use case in #4707.

`docs/source/grpo_trainer.md` specified the reward-function contract (arguments, return value) but never the shape of the call. Reward functions are invoked **once per batch with every completion at once**, grouped by prompt as `num_generations` consecutive entries, and `num_generations` itself is not among the arguments.

Without that stated, a judge that ranks a prompt's completions against each other (the ART RULER style asked about in #4707) reads as unsupported. It works today: all six existing examples are pointwise, so nothing showed the group structure is already available.

## Verification

Ran a probe against current `main` rather than reasoning from the source:

| Question | Observed |
|---|---|
| Whole batch in one call | yes, 8 completions for `B=2, G=4` |
| Layout G-consecutive per prompt | yes, prompt run lengths `[4, 4]` over 2 distinct prompts |
| `num_generations` reachable from the signature | no, kwargs are `{log_extra, log_metric, trainer_state}` and `TrainerState` has no such field |
| Group-relative reward trains | yes, `reward_std 0.3984` and `frac_reward_zero_std 0`, against `0` and `1` for a constant reward |

The layout is an invariant in three places, not an accident of one run:

1. `RepeatSampler`'s docstring, where `mini_repeat_count=3` gives `[0, 0, 0, 1, 1, 1, 2, 2, 2, ...]`
2. `grpo_trainer.py:1102`, which passes `mini_repeat_count=self.num_generations`
3. `grpo_trainer.py:2417`, where `rewards.view(-1, num_generations)` depends on it to compute the advantage

The added snippet was executed against a stub judge for `num_generations` 1 through 4, and each group's best completion scores `1.0` independently of the other groups.

## Note for reviewers

Neither automated gate covers this file: the ruff hooks are `types_or: [python, pyi]`, and `doc-builder style trl tests docs/source` filters to `.mdx` and `.py` (`style_doc.py:537`) while `docs/source` holds 63 `.md` files and no `.mdx`. I confirmed that with a negative control, so this change was checked by parsing and executing the snippet instead.

Closes #4707

cc @qgallouedec, whose reply on the issue is the basis for the example, and @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation; no trainer or reward API behavior changes.
> 
> **Overview**
> **Documentation-only** update to `docs/source/grpo_trainer.md` for custom GRPO reward functions.
> 
> Adds a **Batch layout** contract item: the trainer calls each reward function **once per batch** with completions ordered as **`num_generations` consecutive entries per prompt**, and **`num_generations` is not passed** into the function (callers must close over it, e.g. from `training_args.num_generations`).
> 
> Adds **Example 7** for **group-relative / LLM-as-judge rankings**: split the batch into prompt groups, rank within each group, and map ranks to spread rewards so group advantage is non-zero—contrasted with pointwise grading that can drive **`frac_reward_zero_std`** when every completion in a group gets the same score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e934f46bd4a925c76ee79007ce41f521c75b25cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->