### PR TITLE
Use spawn context for vLLM server workers

### DIFF
--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -15,6 +15,7 @@
 import os
 import subprocess
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from packaging.version import Version
@@ -24,6 +25,7 @@ from transformers.testing_utils import torch_device
 from trl.generation.vllm_client import VLLMClient
 from trl.generation.vllm_generation import extract_logprobs
 from trl.import_utils import is_vllm_available
+from trl.scripts import vllm_serve
 from trl.scripts.vllm_serve import chunk_list
 
 from .testing_utils import (
@@ -43,6 +45,31 @@ if is_vllm_available():
     _is_vllm_ge_014 = Version(vllm.__version__) >= Version("0.14.0")
 else:
     _is_vllm_ge_014 = False
+
+
+@require_vllm
+class TestVLLMServerMultiprocessing(TrlTestCase):
+    def test_workers_use_spawn_context(self):
+        multiprocessing_context = MagicMock()
+        parent_connection, child_connection = MagicMock(), MagicMock()
+        process = MagicMock()
+        multiprocessing_context.Pipe.return_value = parent_connection, child_connection
+        multiprocessing_context.Process.return_value = process
+        script_args = vllm_serve.ScriptArguments(model="test-model")
+
+        with (
+            patch("trl.scripts.vllm_serve.get_context", return_value=multiprocessing_context) as get_context,
+            patch("vllm.utils.network_utils.get_open_port", return_value=12345),
+            patch("uvicorn.run"),
+        ):
+            vllm_serve.main(script_args)
+
+        get_context.assert_called_once_with("spawn")
+        multiprocessing_context.Pipe.assert_called_once_with()
+        multiprocessing_context.Process.assert_called_once_with(
+            target=vllm_serve.llm_worker, args=(script_args, 0, 12345, child_connection)
+        )
+        process.start.assert_called_once_with()
 
 
 class TestChunkList(TrlTestCase):

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -23,7 +23,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from io import BytesIO
 from itertools import chain
-from multiprocessing import Pipe, Process
+from multiprocessing import get_context
 from multiprocessing.connection import Connection
 
 
@@ -450,11 +450,14 @@ def main(script_args: ScriptArguments):
 
     # Spawn dp workers, and setup pipes for communication
     master_port = get_open_port()
+    multiprocessing_context = get_context("spawn")
     connections = []
     processes = []
     for data_parallel_rank in range(script_args.data_parallel_size):
-        parent_connection, child_connection = Pipe()
-        process = Process(target=llm_worker, args=(script_args, data_parallel_rank, master_port, child_connection))
+        parent_connection, child_connection = multiprocessing_context.Pipe()
+        process = multiprocessing_context.Process(
+            target=llm_worker, args=(script_args, data_parallel_rank, master_port, child_connection)
+        )
         process.start()
         connections.append(parent_connection)
         processes.append(process)


### PR DESCRIPTION
# What does this PR do?

`trl vllm-serve` currently creates its outer data-parallel workers with Python's default multiprocessing context. On systems where the parent process initializes CUDA before starting these workers, the default `fork` context leaves the children with an unusable inherited CUDA state and vLLM fails with `Cannot re-initialize CUDA in forked subprocess`.

This PR uses a local `spawn` context for the pipes and processes created by the TRL vLLM server. It does not change the global multiprocessing start method, and it keeps `VLLM_WORKER_MULTIPROC_METHOD=spawn` for vLLM's own internal workers.

A regression test verifies that the server requests a `spawn` context and uses that same context to create and start its worker process.

Fixes #6679

## Validation

- `python -m pytest -q tests/test_vllm_client_server.py -m "not slow"` (10 passed, 42 deselected)
- `python -m pytest -q tests/test_cli.py -k vllm_serve` (1 passed, 15 deselected)
- `pre-commit run --files trl/scripts/vllm_serve.py tests/test_vllm_client_server.py`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6679.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed because this does not change the public API.
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: AI tools assisted with codebase navigation, drafting, and test execution. I reproduced the failure mechanism described in the issue, reviewed the multiprocessing behavior, selected the scoped `spawn` approach, and reviewed the final implementation and regression test.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to how worker processes are created; behavior is intended to match spawn-only CUDA-safe startup with no public API changes.
> 
> **Overview**
> Fixes **`trl vllm-serve`** failing with *Cannot re-initialize CUDA in forked subprocess* when the parent has already touched CUDA and the default **`fork`** start method is used for TRL’s outer data-parallel workers.
> 
> **`vllm_serve.main`** now calls **`get_context("spawn")`** and creates **`Pipe`** / **`Process`** from that context instead of the module-level defaults. **`VLLM_WORKER_MULTIPROC_METHOD=spawn`** is unchanged for vLLM’s own workers; the global multiprocessing start method is not modified.
> 
> Adds **`TestVLLMServerMultiprocessing.test_workers_use_spawn_context`**, which mocks **`get_context`**, **`uvicorn.run`**, and port selection to assert **`spawn`** is requested and workers are started via the spawn context’s **`Pipe`** / **`Process`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcb128cdf5335927b0234c7c464540c89977a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->