### PR TITLE
Use the vLLM base image for TRL Docker images

### DIFF
--- a/docker/trl-dev/Dockerfile
+++ b/docker/trl-dev/Dockerfile
@@ -1,5 +1,7 @@
-FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+FROM vllm/vllm-openai:v0.26.0
+ENTRYPOINT []
+WORKDIR /workspace
+RUN apt-get update && apt-get install -y git build-essential python-is-python3 && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip uv
 RUN uv pip install --system --no-cache "git+https://github.com/huggingface/trl.git#egg=trl[liger,peft,vlm]"
 RUN uv pip install --system kernels liger_kernel peft trackio

--- a/docker/trl/Dockerfile
+++ b/docker/trl/Dockerfile
@@ -1,4 +1,6 @@
-FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+FROM vllm/vllm-openai:v0.26.0
+ENTRYPOINT []
+WORKDIR /workspace
+RUN apt-get update && apt-get install -y git build-essential python-is-python3 && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip uv
 RUN uv pip install --system trl[liger,peft,vlm] kernels trackio


### PR DESCRIPTION
# What does this PR do?

This switches both TRL Docker images to `vllm/vllm-openai:v0.26.0`.

It clears the default `vllm serve` entrypoint so `trl`, `python`, `uv run`, and Hugging Face Jobs commands work normally.

It also:

- keeps `git` and adds `build-essential`;
- restores the `python` command with `python-is-python3`;
- keeps `/workspace` as the default working directory.

Fixes #4523

## Testing

- Built both Docker images and verified the cleared entrypoint, `/workspace` working directory, `python` command, CLI/toolchain availability, and key package imports.
- On native Linux with a Tesla T4, ran GPU-backed vLLM generation with `Qwen/Qwen3-0.6B` in both images.
- Ran a custom two-step colocated GRPO + LoRA smoke test in both images, covering vLLM generation, weight synchronization, and LoRA parameter updates.

## Notes

- On the T4 host, `trl vllm-serve` reproduced the CUDA/fork startup error reported in #6679. A diagnostic run using `spawn` for the outer process started successfully and passed a `VLLMClient` request. The fix is being handled separately in #6682.
- The release image emits an outdated vLLM 0.26.0 compatibility warning because TRL 1.9.2 predates #6569. The tested inference and training paths passed, and the development image does not emit this warning.
- `pip check` reports two dependency issues inherited from the vLLM 0.26.0 base image (`pygobject`/`pycairo` and `nixl`/`nixl-cu13`); both are present before TRL is installed.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #4523.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed because the existing user-facing commands and paths remain compatible.
- [x] Did you write any new necessary tests? No new automated test is needed for this Dockerfile-only change.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image base and CUDA/Python stack shift can affect downstream jobs that assumed the old PyTorch image; behavior was manually smoke-tested but there is no automated Dockerfile test in this PR.
> 
> **Overview**
> Both **`docker/trl`** and **`docker/trl-dev`** images now build from **`vllm/vllm-openai:v0.26.0`** instead of **`pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel`**, aligning the published TRL containers with vLLM for inference/training workflows (fixes #4523).
> 
> The default vLLM **`serve`** entrypoint is cleared with **`ENTRYPOINT []`**, **`WORKDIR /workspace`** is set, and the apt layer adds **`build-essential`** and **`python-is-python3`** alongside **`git`**. Existing TRL install steps (`pip`/`uv`, extras, dev vs release packages) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c050f0bac8fc632d404794f4358cf325e74ebbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->