### PR TITLE
feat: add Mistral training chat template with generation markers

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/mistral_for_causal_lm_0_3.py
+++ b/scripts/generate_tiny_models/for_causal_lm/mistral_for_causal_lm_0_3.py
@@ -1,0 +1,47 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import AutoTokenizer, GenerationConfig, MistralConfig, MistralForCausalLM
+
+from .._common import (
+    check_dtype_pattern,
+    check_transformers_version,
+    init_weights_tiny_model,
+    print_config_diff,
+    push_to_hub,
+    smoke_test,
+)
+
+
+check_transformers_version()
+
+MODEL_ID = "mistralai/Mistral-7B-Instruct-v0.3"
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+config = MistralConfig(
+    vocab_size=len(tokenizer.vocab),
+    hidden_size=8,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    num_hidden_layers=2,
+    intermediate_size=32,
+)
+model = MistralForCausalLM(config).to(dtype=torch.bfloat16)
+init_weights_tiny_model(model)
+smoke_test(model, tokenizer)
+check_dtype_pattern(MODEL_ID, model)
+print_config_diff(MODEL_ID, model)
+push_to_hub(model, tokenizer, generation_config, "tiny", "0.3")

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -589,6 +589,8 @@ llama3_2_chat_template = (_CHAT_TEMPLATES_DIR / "llama3_2.jinja").read_text(enco
 
 llava_next_chat_template = (_CHAT_TEMPLATES_DIR / "llava_next.jinja").read_text(encoding="utf-8")
 
+mistral_chat_template = (_CHAT_TEMPLATES_DIR / "mistral.jinja").read_text(encoding="utf-8")
+
 nemotron_3_nano_chat_template = (_CHAT_TEMPLATES_DIR / "nemotron_3_nano.jinja").read_text(encoding="utf-8")
 
 nemotron_3_super_chat_template = (_CHAT_TEMPLATES_DIR / "nemotron_3_super.jinja").read_text(encoding="utf-8")
@@ -939,6 +941,8 @@ llama3_training_chat_template = (_CHAT_TEMPLATES_DIR / "llama3_training.jinja").
 
 llava_next_training_chat_template = (_CHAT_TEMPLATES_DIR / "llava_next_training.jinja").read_text(encoding="utf-8")
 
+mistral_training_chat_template = (_CHAT_TEMPLATES_DIR / "mistral_training.jinja").read_text(encoding="utf-8")
+
 nemotron_3_nano_training_chat_template = (_CHAT_TEMPLATES_DIR / "nemotron_3_nano_training.jinja").read_text(
     encoding="utf-8"
 )
@@ -988,8 +992,8 @@ def get_training_chat_template(
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
     Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LFM2, LLaMA 3,
-    Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and
-    Qwen3.6 are supported.
+    Mistral, Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL,
+    Qwen3.5, and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -1090,6 +1094,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == llava_next_chat_template:
         return llava_next_training_chat_template
+
+    if processing_class.chat_template == mistral_chat_template:
+        return mistral_training_chat_template
 
     if processing_class.chat_template == nemotron_3_nano_chat_template:
         return nemotron_3_nano_training_chat_template

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -69,6 +69,10 @@ Original Llama 3.1 / 3.2 chat templates. Both render tool calls as a single bare
 
 Original Llava-Next chat template (as shipped by `llava-hf/llava-v1.6-mistral-7b-hf`). Renders multimodal `content` blocks in the LLaVA / Mistral `[INST] ... [/INST]` format. Does not support tool calling.
 
+### `mistral.jinja`
+
+Original Mistral chat template (as shipped by `mistralai/Mistral-7B-Instruct-v0.3` and related checkpoints). Renders `[AVAILABLE_TOOLS]` / `[TOOL_CALLS]` / `[TOOL_RESULTS]` blocks for tool calling, gated on a strict requirement that every `tool_call.id` (and `tool_call_id`) be a 9-character alphanumeric string — a conversation missing this raises. Because TRL's `supports_tool_calling()` probe uses a generic tool call with no `id`, it triggers that raise and is correctly classified as *not* supporting tool calling, so no prefix-preservation fix is needed for the training variant below.
+
 ### `nemotron_3_nano.jinja`
 
 Original Nemotron Nano chat template (as shipped by `nvidia/NVIDIA-Nemotron-3-Nano-*` checkpoints). Renders tool calls in the same Hermes-style `<function=...>` / `<parameter=...>` format as Qwen3.5, so it reuses `qwen3_5_schema` for response parsing.
@@ -191,6 +195,12 @@ Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so
 Patched Llava-Next template. Diff vs `llava_next.jinja`:
 
 Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
+
+### `mistral_training.jinja`
+
+Patched Mistral template. Diff vs `mistral.jinja`:
+
+Wrap both assistant branches (the `[TOOL_CALLS] ...` branch and the plain content branch) with `{% generation %}` / `{% endgeneration %}` so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss. No prefix-preservation fix is needed (see `mistral.jinja` above).
 
 ### `nemotron_3_nano_training.jinja`
 

--- a/trl/chat_templates/mistral.jinja
+++ b/trl/chat_templates/mistral.jinja
@@ -1,0 +1,87 @@
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+{%- set user_messages = loop_messages | selectattr("role", "equalto", "user") | list %}
+
+{#- This block checks for alternating user/assistant messages, skipping tool calling messages #}
+{%- set ns = namespace() %}
+{%- set ns.index = 0 %}
+{%- for message in loop_messages %}
+    {%- if not (message.role == "tool" or message.role == "tool_results" or (message.tool_calls is defined and message.tool_calls is not none)) %}
+        {%- if (message["role"] == "user") != (ns.index % 2 == 0) %}
+            {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
+        {%- endif %}
+        {%- set ns.index = ns.index + 1 %}
+    {%- endif %}
+{%- endfor %}
+
+{{- bos_token }}
+{%- for message in loop_messages %}
+    {%- if message["role"] == "user" %}
+        {%- if tools is not none and (message == user_messages[-1]) %}
+            {{- "[AVAILABLE_TOOLS] [" }}
+            {%- for tool in tools %}
+                {%- set tool = tool.function %}
+                {{- '{"type": "function", "function": {' }}
+                {%- for key, val in tool.items() if key != "return" %}
+                    {%- if val is string %}
+                        {{- '"' + key + '": "' + val + '"' }}
+                    {%- else %}
+                        {{- '"' + key + '": ' + val|tojson }}
+                    {%- endif %}
+                    {%- if not loop.last %}
+                        {{- ", " }}
+                    {%- endif %}
+                {%- endfor %}
+                {{- "}}" }}
+                {%- if not loop.last %}
+                    {{- ", " }}
+                {%- else %}
+                    {{- "]" }}
+                {%- endif %}
+            {%- endfor %}
+            {{- "[/AVAILABLE_TOOLS]" }}
+            {%- endif %}
+        {%- if loop.last and system_message is defined %}
+            {{- "[INST] " + system_message + "\n\n" + message["content"] + "[/INST]" }}
+        {%- else %}
+            {{- "[INST] " + message["content"] + "[/INST]" }}
+        {%- endif %}
+    {%- elif message.tool_calls is defined and message.tool_calls is not none %}
+        {{- "[TOOL_CALLS] [" }}
+        {%- for tool_call in message.tool_calls %}
+            {%- set out = tool_call.function|tojson %}
+            {{- out[:-1] }}
+            {%- if not tool_call.id is defined or tool_call.id|length != 9 %}
+                {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+            {%- endif %}
+            {{- ', "id": "' + tool_call.id + '"}' }}
+            {%- if not loop.last %}
+                {{- ", " }}
+            {%- else %}
+                {{- "]" + eos_token }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif message["role"] == "assistant" %}
+        {{- " " + message["content"]|trim + eos_token}}
+    {%- elif message["role"] == "tool_results" or message["role"] == "tool" %}
+        {%- if message.content is defined and message.content.content is defined %}
+            {%- set content = message.content.content %}
+        {%- else %}
+            {%- set content = message.content %}
+        {%- endif %}
+        {{- '[TOOL_RESULTS] {"content": ' + content|string + ", " }}
+        {%- if not message.tool_call_id is defined or message.tool_call_id|length != 9 %}
+            {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+        {%- endif %}
+        {{- '"call_id": "' + message.tool_call_id + '"}[/TOOL_RESULTS]' }}
+    {%- else %}
+        {{- raise_exception("Only user and assistant roles are supported, with the exception of an initial optional system message!") }}
+    {%- endif %}
+{%- endfor %}

--- a/trl/chat_templates/mistral_training.jinja
+++ b/trl/chat_templates/mistral_training.jinja
@@ -1,0 +1,100 @@
+{#- Training variant of the Mistral chat template (see mistral.jinja for the original).
+    Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around assistant message output (both the
+      `tool_calls` branch and the plain content branch) so that `return_assistant_tokens_mask=True`
+      produces correct masks for SFT assistant-only loss.
+    No prefix-preservation fix is needed: `supports_tool_calling()` already treats this template as
+    not supporting tool calling, because the generic tool-calling probe omits `tool_call.id`, and
+    this template raises on any tool call without a 9-character alphanumeric `id`.
+-#}
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+{%- set user_messages = loop_messages | selectattr("role", "equalto", "user") | list %}
+
+{#- This block checks for alternating user/assistant messages, skipping tool calling messages #}
+{%- set ns = namespace() %}
+{%- set ns.index = 0 %}
+{%- for message in loop_messages %}
+    {%- if not (message.role == "tool" or message.role == "tool_results" or (message.tool_calls is defined and message.tool_calls is not none)) %}
+        {%- if (message["role"] == "user") != (ns.index % 2 == 0) %}
+            {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
+        {%- endif %}
+        {%- set ns.index = ns.index + 1 %}
+    {%- endif %}
+{%- endfor %}
+
+{{- bos_token }}
+{%- for message in loop_messages %}
+    {%- if message["role"] == "user" %}
+        {%- if tools is not none and (message == user_messages[-1]) %}
+            {{- "[AVAILABLE_TOOLS] [" }}
+            {%- for tool in tools %}
+                {%- set tool = tool.function %}
+                {{- '{"type": "function", "function": {' }}
+                {%- for key, val in tool.items() if key != "return" %}
+                    {%- if val is string %}
+                        {{- '"' + key + '": "' + val + '"' }}
+                    {%- else %}
+                        {{- '"' + key + '": ' + val|tojson }}
+                    {%- endif %}
+                    {%- if not loop.last %}
+                        {{- ", " }}
+                    {%- endif %}
+                {%- endfor %}
+                {{- "}}" }}
+                {%- if not loop.last %}
+                    {{- ", " }}
+                {%- else %}
+                    {{- "]" }}
+                {%- endif %}
+            {%- endfor %}
+            {{- "[/AVAILABLE_TOOLS]" }}
+            {%- endif %}
+        {%- if loop.last and system_message is defined %}
+            {{- "[INST] " + system_message + "\n\n" + message["content"] + "[/INST]" }}
+        {%- else %}
+            {{- "[INST] " + message["content"] + "[/INST]" }}
+        {%- endif %}
+    {%- elif message.tool_calls is defined and message.tool_calls is not none %}
+        {%- generation %}
+        {{- "[TOOL_CALLS] [" }}
+        {%- for tool_call in message.tool_calls %}
+            {%- set out = tool_call.function|tojson %}
+            {{- out[:-1] }}
+            {%- if not tool_call.id is defined or tool_call.id|length != 9 %}
+                {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+            {%- endif %}
+            {{- ', "id": "' + tool_call.id + '"}' }}
+            {%- if not loop.last %}
+                {{- ", " }}
+            {%- else %}
+                {{- "]" + eos_token }}
+            {%- endif %}
+        {%- endfor %}
+        {%- endgeneration %}
+    {%- elif message["role"] == "assistant" %}
+        {%- generation %}
+        {{- " " + message["content"]|trim + eos_token}}
+        {%- endgeneration %}
+    {%- elif message["role"] == "tool_results" or message["role"] == "tool" %}
+        {%- if message.content is defined and message.content.content is defined %}
+            {%- set content = message.content.content %}
+        {%- else %}
+            {%- set content = message.content %}
+        {%- endif %}
+        {{- '[TOOL_RESULTS] {"content": ' + content|string + ", " }}
+        {%- if not message.tool_call_id is defined or message.tool_call_id|length != 9 %}
+            {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+        {%- endif %}
+        {{- '"call_id": "' + message.tool_call_id + '"}[/TOOL_RESULTS]' }}
+    {%- else %}
+        {{- raise_exception("Only user and assistant roles are supported, with the exception of an initial optional system message!") }}
+    {%- endif %}
+{%- endfor %}


### PR DESCRIPTION
# What does this PR do?

Adds a training-compatible variant of the Mistral chat template (as shipped by `mistralai/Mistral-7B-Instruct-v0.3` and related checkpoints) with `{% generation %}` / `{% endgeneration %}` markers, enabling `return_assistant_tokens_mask=True` for assistant-only loss masking in SFT training.

Contributes to #5471 (Tracking: add `{% generation %}` chat templates for common model families).

**Files changed:**
- `trl/chat_templates/mistral.jinja` — original Mistral chat template (source of truth for the exact-match comparison in `get_training_chat_template()`); verified byte-identical to the live `mistralai/Mistral-7B-Instruct-v0.3` tokenizer's `chat_template`
- `trl/chat_templates/mistral_training.jinja` — training variant: same text output as the original, with `{% generation %}` / `{% endgeneration %}` wrapping both assistant branches (the `[TOOL_CALLS] ...` branch and the plain-content branch)
- `trl/chat_template_utils.py` — loads both templates; adds a Mistral branch (alphabetically between LLaMA 3 and Phi-3) in `get_training_chat_template()`; updates the docstring's supported-model list
- `scripts/generate_tiny_models/for_causal_lm/mistral_for_causal_lm_0_3.py` — generator script for a `trl-internal-testing/tiny-MistralForCausalLM-0.3` fixture, following the existing `mistral_for_causal_lm_0_1.py` / `_0_2.py` pattern

**Template design:** Mistral's v0.3 template supports tool calling (`[AVAILABLE_TOOLS]` / `[TOOL_CALLS]` / `[TOOL_RESULTS]`), but every `tool_call.id` (and `tool_call_id`) must be a 9-character alphanumeric string or the template raises. TRL's `supports_tool_calling()` probe uses a generic tool call with no `id`, so it hits that raise and correctly classifies this template as **not** supporting tool calling — which means `get_training_chat_template()`'s `prefix_ok` check short-circuits to `True` and no prefix-preservation fix is required, only the generation markers.

**Testing note:** No `trl-internal-testing/tiny-Mistral*` fixture currently carries the v0.3-era tool-calling template (the existing `tiny-MistralForCausalLM-0.1` / `-0.2` fixtures carry the older, simpler `v0.1`/`v0.2` template, which has no tool-calling support at all and predates this one). I've included the generator script above so a maintainer can push `trl-internal-testing/tiny-MistralForCausalLM-0.3` (same flow as noted earlier in #5471 for other new-model fixtures); happy to add the `TestGetTrainingChatTemplate` / `TestSupportsToolCalling` parametrize entries in a follow-up once it's live.

In the meantime, I validated the new template directly against the real `mistralai/Mistral-7B-Instruct-v0.3` tokenizer, mirroring the existing test suite's own checks:
- `mistral.jinja` is byte-identical to the live `chat_template`
- `supports_tool_calling()` is `False` (as expected, see above)
- `get_training_chat_template()` returns the new patched template, which carries `{% generation %}` markers
- Rendered text is unchanged before/after patching for: single user turn (with/without generation prompt), multi-turn plain-content conversations, assistant turns with `tool_calls`, and system-message + tools conversations
- `is_chat_template_stop_token_trained()` passes
- `return_assistant_tokens_mask=True` produces masks that decode to exactly the assistant-authored spans, for both plain-content and tool-call turns

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — #5471
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? — no fixture exists yet for this template (see testing note below); happy to add the parametrize entries once `trl-internal-testing/tiny-MistralForCausalLM-0.3` is pushed

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec (opened #5471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to chat-template assets, routing in `chat_template_utils.py`, and a dev-only tiny model script; no runtime training or auth paths are modified.
> 
> **Overview**
> Adds **Mistral Instruct v0.3** chat templates so TRL can patch SFT training the same way as other model families (#5471).
> 
> **`mistral.jinja`** mirrors the upstream `mistralai/Mistral-7B-Instruct-v0.3` template (`[INST]`, `[AVAILABLE_TOOLS]`, `[TOOL_CALLS]`, `[TOOL_RESULTS]`). **`mistral_training.jinja`** is identical for rendered text but wraps both assistant paths (plain content and `tool_calls`) in `{% generation %}` / `{% endgeneration %}` for `return_assistant_tokens_mask=True`. No prefix-preservation patch is added because `supports_tool_calling()` fails on the stock probe (missing 9-char `tool_call.id`).
> 
> **`get_training_chat_template()`** in `chat_template_utils.py` loads both templates and returns the training variant when the tokenizer template matches `mistral.jinja`; docs in `trl/chat_templates/README.md` are updated accordingly.
> 
> A **`mistral_for_causal_lm_0_3.py`** tiny-model generator script is added for a future `trl-internal-testing/tiny-MistralForCausalLM-0.3` fixture; automated test parametrization is not in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c0895a2d5539afc068ef6a4f1e73cb2cb0b858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->