### PR TITLE
feat: add Falcon3 training chat template with generation markers

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_falcon3.py
+++ b/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_falcon3.py
@@ -1,0 +1,49 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import AutoTokenizer, GenerationConfig, LlamaConfig, LlamaForCausalLM
+
+from .._common import (
+    check_dtype_pattern,
+    check_transformers_version,
+    init_weights_tiny_model,
+    print_config_diff,
+    push_to_hub,
+    smoke_test,
+)
+
+
+check_transformers_version()
+
+# Falcon3 is a LlamaForCausalLM under the hood (config.json: architectures=["LlamaForCausalLM"]), so this reuses the
+# same tiny-model recipe as the Llama 3.x generators, only pointed at Falcon3's tokenizer/chat template.
+MODEL_ID = "tiiuae/Falcon3-7B-Instruct"
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+config = LlamaConfig(
+    vocab_size=len(tokenizer.vocab),
+    hidden_size=8,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    num_hidden_layers=2,
+    intermediate_size=32,
+)
+model = LlamaForCausalLM(config).to(dtype=torch.bfloat16)
+init_weights_tiny_model(model)
+smoke_test(model, tokenizer)
+check_dtype_pattern(MODEL_ID, model)
+print_config_diff(MODEL_ID, model)
+push_to_hub(model, tokenizer, generation_config, "tiny", "Falcon3")

--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -363,6 +363,10 @@ class TestSupportsToolCalling:
             pytest.param("trl-internal-testing/tiny-SmolVLMForConditionalGeneration", id="smolvlm"),
             # Silently drops both tool_calls and tool messages
             pytest.param("trl-internal-testing/tiny-Cohere2ForCausalLM", id="cohere2"),
+            # Falcon3's default (no `tools=`) branch never reads `message.tool_calls` for the assistant role and has
+            # no `elif message['role'] == 'tool'` clause at all, so both the tool call and the tool response are
+            # silently dropped when tools aren't explicitly passed.
+            pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-Falcon3", id="falcon3"),
             pytest.param("trl-internal-testing/tiny-LlavaForConditionalGeneration", id="llava"),
             # Olmo3 uses a bespoke function-calling schema (a `functions`/`function_calls` string on the
             # message plus an `environment` role) instead of the standard `tools`/`tool_calls`/`tool`
@@ -614,6 +618,7 @@ class TestIsChatTemplateStopTokenTrained:
                 ),
             ],
         ),
+        pytest.param("trl-internal-testing/tiny-LlamaForCausalLM-Falcon3", id="falcon3"),
         pytest.param("trl-internal-testing/tiny-GemmaForCausalLM", id="gemma"),
         pytest.param("trl-internal-testing/tiny-Gemma2ForCausalLM", id="gemma2"),
         pytest.param("trl-internal-testing/tiny-Gemma3ForConditionalGeneration", id="gemma3", marks=require_vision),

--- a/trl/chat_template_utils.py
+++ b/trl/chat_template_utils.py
@@ -565,6 +565,8 @@ deepseekv3_chat_template = (_CHAT_TEMPLATES_DIR / "deepseekv3.jinja").read_text(
 
 diffusion_gemma_chat_template = (_CHAT_TEMPLATES_DIR / "diffusion_gemma.jinja").read_text(encoding="utf-8")
 
+falcon3_chat_template = (_CHAT_TEMPLATES_DIR / "falcon3.jinja").read_text(encoding="utf-8")
+
 gemma_chat_template = (_CHAT_TEMPLATES_DIR / "gemma.jinja").read_text(encoding="utf-8")
 
 gemma3_chat_template = (_CHAT_TEMPLATES_DIR / "gemma3.jinja").read_text(encoding="utf-8")
@@ -923,6 +925,8 @@ diffusion_gemma_training_chat_template = (_CHAT_TEMPLATES_DIR / "diffusion_gemma
     encoding="utf-8"
 )
 
+falcon3_training_chat_template = (_CHAT_TEMPLATES_DIR / "falcon3_training.jinja").read_text(encoding="utf-8")
+
 gemma_training_chat_template = (_CHAT_TEMPLATES_DIR / "gemma_training.jinja").read_text(encoding="utf-8")
 
 gemma3_training_chat_template = (_CHAT_TEMPLATES_DIR / "gemma3_training.jinja").read_text(encoding="utf-8")
@@ -987,9 +991,9 @@ def get_training_chat_template(
 
     Returns a patched chat template that is prefix-preserving and includes `{%% generation %%}` / `{%% endgeneration
     %%}` markers for assistant-only loss masking. Returns `None` if the template already satisfies both requirements.
-    Currently Cohere, Cohere 2, DeepSeek-V3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LFM2, LLaMA 3,
-    Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL, Qwen3.5, and
-    Qwen3.6 are supported.
+    Currently Cohere, Cohere 2, DeepSeek-V3, Falcon3, Gemma, Gemma 2, Gemma 3, GLM-4-MoE, GPT-OSS, Idefics3, LFM2,
+    LLaMA 3, Phi-3, Phi-3.5, Qwen2-VL, Qwen2.5, Qwen2.5-VL, Qwen3 (including the Instruct-2507 variant), Qwen3-VL,
+    Qwen3.5, and Qwen3.6 are supported.
 
     Args:
         processing_class (`PreTrainedTokenizerBase` or `ProcessorMixin`):
@@ -1066,6 +1070,9 @@ def get_training_chat_template(
 
     if processing_class.chat_template == diffusion_gemma_chat_template:
         return diffusion_gemma_training_chat_template
+
+    if processing_class.chat_template == falcon3_chat_template:
+        return falcon3_training_chat_template
 
     if processing_class.chat_template == gemma_chat_template:
         return gemma_training_chat_template

--- a/trl/chat_templates/README.md
+++ b/trl/chat_templates/README.md
@@ -25,6 +25,10 @@ Original Cohere2 chat template (as shipped by `CohereLabs/c4ai-command-r7b-12-20
 
 Original DeepSeek-V3 chat template.
 
+### `falcon3.jinja`
+
+Original Falcon3 chat template (as shipped by `tiiuae/Falcon3-*-Instruct` checkpoints). Branches on whether `tools` is set: the tools branch renders assistant `tool_calls` as a JSON block and tool responses under an `<|assistant|>` tag; the plain branch has no `tool` role clause at all, so tool calls and tool responses are both silently dropped when `tools` isn't passed.
+
 ### `gemma.jinja`
 
 Original Gemma chat template. Used by both Gemma (v1) and Gemma2, which ship identical templates.
@@ -138,6 +142,12 @@ Patched DeepSeek-V3 template. Diff vs `deepseekv3.jinja`:
 
 - Uses `| tojson` on `tool['function']['arguments']` so that `arguments` can be passed as a `dict` (the documented format per [transformers docs](https://huggingface.co/docs/transformers/en/chat_extras#tool-calling-example)). The original template uses raw string concatenation, which crashes on dict inputs.
 - Wraps assistant message output with `{% generation %}` / `{% endgeneration %}` markers for SFT assistant-only loss.
+
+### `falcon3_training.jinja`
+
+Patched Falcon3 template. Diff vs `falcon3.jinja`:
+
+Wrap assistant message output with `{% generation %}` / `{% endgeneration %}` in both the tools and no-tools branches so that `return_assistant_tokens_mask=True` produces correct masks for SFT assistant-only loss.
 
 ### `gemma_training.jinja`
 

--- a/trl/chat_templates/falcon3.jinja
+++ b/trl/chat_templates/falcon3.jinja
@@ -1,0 +1,45 @@
+{%- if tools %}
+{{- '<|system|>\n' }}
+{%- if messages[0]['role'] == 'system' %}
+{{- messages[0]['content'] }}
+{%- set remaining_messages = messages[1:] %}
+{%- else %}
+{%- set remaining_messages = messages %}
+{%- endif %}
+{{- 'You are a Falcon assistant skilled in function calling. You are helpful, respectful, and concise.\n\n# Tools\n\nYou have access to the following functions. You MUST use them to answer questions when needed. For each function call, you MUST return a JSON object inside <tool_call></tool_call> tags.\n\n<tools>' + tools|tojson(indent=2) + '</tools>\n\n# Output Format\n\nYour response MUST follow this format when making function calls:\n<tool_call>\n[\n  {"name": "function_name", "arguments": {"arg1": "value1", "arg2": "value2"}},\n  {"name": "another_function", "arguments": {"arg": "value"}}\n]\n</tool_call>\nIf no function calls are needed, respond normally without the tool_call tags.\n' }}
+{%- for message in remaining_messages %}
+{%- if message['role'] == 'user' %}
+{{- '<|user|>\n' + message['content'] + '\n' }}
+{%- elif message['role'] == 'assistant' %}
+{%- if message.content %}
+{{- '<|assistant|>\n' + message['content'] }}
+{%- endif %}
+{%- if message.tool_calls %}
+{{- '\n<tool_call>\n' }}
+{{- message.tool_calls|tojson(indent=2) }}
+{{- '\n</tool_call>' }}
+{%- endif %}
+{{- eos_token + '\n' }}
+{%- elif message['role'] == 'tool' %}
+{{- '<|assistant|>\n<tool_response>\n' + message['content'] + '\n</tool_response>\n' }}
+{%- endif %}
+{%- endfor %}
+{{- '<|assistant|>\n' if add_generation_prompt }}
+{%- else %}
+{%- for message in messages %}
+{%- if message['role'] == 'system' %}
+{{- '<|system|>\n' + message['content'] + '\n' }}
+{%- elif message['role'] == 'user' %}
+{{- '<|user|>\n' + message['content'] + '\n' }}
+{%- elif message['role'] == 'assistant' %}
+{%- if not loop.last %}
+{{- '<|assistant|>\n' + message['content'] + eos_token + '\n' }}
+{%- else %}
+{{- '<|assistant|>\n' + message['content'] + eos_token }}
+{%- endif %}
+{%- endif %}
+{%- if loop.last and add_generation_prompt %}
+{{- '<|assistant|>\n' }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}

--- a/trl/chat_templates/falcon3_training.jinja
+++ b/trl/chat_templates/falcon3_training.jinja
@@ -1,0 +1,65 @@
+{#- Training variant of the Falcon3 chat template (see falcon3.jinja for the original).
+    Modifications vs the original:
+    - Added {% generation %} / {% endgeneration %} around assistant message output (both the
+      tools and no-tools branches) to support assistant-only loss masking in SFT training.
+-#}
+{%- if tools %}
+    {{- '<|system|>\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+        {%- set remaining_messages = messages[1:] %}
+    {%- else %}
+        {%- set remaining_messages = messages %}
+    {%- endif %}
+    {{- 'You are a Falcon assistant skilled in function calling. You are helpful, respectful, and concise.\n\n# Tools\n\nYou have access to the following functions. You MUST use them to answer questions when needed. For each function call, you MUST return a JSON object inside <tool_call></tool_call> tags.\n\n<tools>' + tools|tojson(indent=2) + '</tools>\n\n# Output Format\n\nYour response MUST follow this format when making function calls:\n<tool_call>\n[\n  {"name": "function_name", "arguments": {"arg1": "value1", "arg2": "value2"}},\n  {"name": "another_function", "arguments": {"arg": "value"}}\n]\n</tool_call>\nIf no function calls are needed, respond normally without the tool_call tags.\n' }}
+    {%- for message in remaining_messages %}
+        {%- if message['role'] == 'user' %}
+            {{- '<|user|>\n' + message['content'] + '\n' }}
+        {%- elif message['role'] == 'assistant' %}
+            {%- if message.content %}
+                {{- '<|assistant|>\n' }}
+                {%- generation %}
+                {{- message['content'] }}
+                {%- if message.tool_calls %}
+                    {{- '\n<tool_call>\n' }}
+                    {{- message.tool_calls|tojson(indent=2) }}
+                    {{- '\n</tool_call>' }}
+                {%- endif %}
+                {{- eos_token + '\n' }}
+                {%- endgeneration %}
+            {%- else %}
+                {%- generation %}
+                {%- if message.tool_calls %}
+                    {{- '\n<tool_call>\n' }}
+                    {{- message.tool_calls|tojson(indent=2) }}
+                    {{- '\n</tool_call>' }}
+                {%- endif %}
+                {{- eos_token + '\n' }}
+                {%- endgeneration %}
+            {%- endif %}
+        {%- elif message['role'] == 'tool' %}
+            {{- '<|assistant|>\n<tool_response>\n' + message['content'] + '\n</tool_response>\n' }}
+        {%- endif %}
+    {%- endfor %}
+    {{- '<|assistant|>\n' if add_generation_prompt }}
+{%- else %}
+    {%- for message in messages %}
+        {%- if message['role'] == 'system' %}
+            {{- '<|system|>\n' + message['content'] + '\n' }}
+        {%- elif message['role'] == 'user' %}
+            {{- '<|user|>\n' + message['content'] + '\n' }}
+        {%- elif message['role'] == 'assistant' %}
+            {{- '<|assistant|>\n' }}
+            {%- generation %}
+            {%- if not loop.last %}
+                {{- message['content'] + eos_token + '\n' }}
+            {%- else %}
+                {{- message['content'] + eos_token }}
+            {%- endif %}
+            {%- endgeneration %}
+        {%- endif %}
+        {%- if loop.last and add_generation_prompt %}
+            {{- '<|assistant|>\n' }}
+        {%- endif %}
+    {%- endfor %}
+{%- endif %}


### PR DESCRIPTION
# What does this PR do?

Adds a training-compatible chat template for **Falcon3** (e.g. `tiiuae/Falcon3-7B-Instruct`), following the same pattern as the other model families added in #5471: Llama 3 (#5493), Qwen2.5 (#5522), Phi-3 (#5526), and DeepSeek-V3 (#5527).

**Files added:**
- `trl/chat_templates/falcon3.jinja` — exact copy of the official Falcon3 tokenizer template (sourced from `tiiuae/Falcon3-7B-Instruct`)
- `trl/chat_templates/falcon3_training.jinja` — training variant with `{% generation %}` / `{% endgeneration %}` markers wrapping assistant output for assistant-only loss masking in SFT. Falcon3's template branches on whether `tools` is set (two separate loops), so the markers are added in both the tools branch and the plain branch.
- `scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_falcon3.py` — tiny-model generator script (see note below)

**Changes to existing files:**
- `trl/chat_template_utils.py`: loads both templates, registers Falcon3 in `get_training_chat_template()`, updates docstring
- `trl/chat_templates/README.md`: documents `falcon3.jinja` / `falcon3_training.jinja`
- `tests/test_chat_template_utils.py`: adds a Falcon3 tokenizer to `TestGetTrainingChatTemplate`, and to `TestSupportsToolCalling::test_does_not_support_tool_calling` (Falcon3's default, no-`tools=` branch has no `elif message['role'] == 'tool'` clause at all and never reads `message.tool_calls`, so both are silently dropped — same category as Cohere2/Llava)

**Prefix preservation:** Not needed. `supports_tool_calling()` returns `False` for Falcon3's original template (verified locally against the real `tiiuae/Falcon3-7B-Instruct` tokenizer — the default render path drops tool content, same as the basic Llama 3 / Phi-3 / Cohere2 cases already in the codebase), so the prefix-preservation check is skipped, matching the "no structural fix needed" precedent from #5493 and #5526.

**⚠️ Test fixture note:** Falcon3 is a `LlamaForCausalLM` under the hood (`config.json`: `architectures: ["LlamaForCausalLM"]`), but there's no existing `trl-internal-testing` tiny-model fixture with Falcon3's tokenizer/chat template (only `tiny-FalconMambaForCausalLM`, a different architecture, exists for "Falcon"). I wrote `llama_for_causal_lm_falcon3.py` following the exact recipe of `llama_for_causal_lm_3.py`, and referenced the resulting fixture (`trl-internal-testing/tiny-LlamaForCausalLM-Falcon3`) in the new test parametrize entries — same approach used for other new-model fixtures in #5471 (e.g. the Qwen3.5 discussion). I don't have push access to the `trl-internal-testing` org, so those 14 parametrized tests will 404 until a maintainer runs the script and pushes the fixture; everything else (ruff, full test collection, and the rest of the existing suite) is green.

I validated the template correctness directly against the real `tiiuae/Falcon3-7B-Instruct` tokenizer (not the tiny fixture) locally: exact-match dispatch, byte-identical rendering before/after patching across all the scenarios covered by `TestGetTrainingChatTemplate` (single-turn, multi-turn, tool calls, tools with/without system message, `enable_thinking=False`), and correct assistant-token masks (stop token trained, multi-turn mask transitions == 3).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — #5471
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI (Claude Code), but the PR was written and reviewed by a human.

## Who can review?

@qgallouedec (opened #5471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Jinja templates, docs, and test parametrization; no core training or auth paths are modified. CI may fail until the Hub tiny fixture is published.
> 
> **Overview**
> Adds **Falcon3** (`tiiuae/Falcon3-*-Instruct`) to TRL’s training chat-template pipeline, matching other families in #5471.
> 
> **New assets:** `falcon3.jinja` (official template copy) and `falcon3_training.jinja`, which wraps assistant output in `{% generation %}` / `{% endgeneration %}` in both the `tools` and no-tools branches so SFT assistant-only masking works. `get_training_chat_template()` dispatches on the Falcon3 template; the README documents behavior (plain path drops tool calls/responses unless `tools` is passed).
> 
> **Tests & fixture:** `trl-internal-testing/tiny-LlamaForCausalLM-Falcon3` is wired into `TestGetTrainingChatTemplate` and `TestSupportsToolCalling::test_does_not_support_tool_calling` (no-`tools` branch silently drops tools, like Cohere2/Llava). A `llama_for_causal_lm_falcon3.py` script generates that tiny Llama-backed fixture from Falcon3’s tokenizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64ea19d81b1ee01e9a5f452bb6b0805387c0171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->