### PR TITLE
Honor model_init_kwargs dtype in AsyncGRPOTrainer

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -17,6 +17,7 @@ import itertools
 import math
 import multiprocessing as mp
 import queue
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -135,6 +136,38 @@ class _StubWeightTransfer:
 
     def destroy(self):
         pass
+
+
+class TestAsyncGRPOTrainerModelLoading(TrlTestCase):
+    @pytest.mark.parametrize(
+        ("model_init_kwargs", "expected_dtype"),
+        [(None, torch.float32), ({"dtype": "bfloat16"}, "bfloat16")],
+    )
+    def test_model_init_dtype(self, model_init_kwargs, expected_dtype):
+        expected_model_init_kwargs = model_init_kwargs.copy() if model_init_kwargs is not None else None
+        args = AsyncGRPOConfig(
+            output_dir=self.tmp_dir,
+            use_cpu=True,
+            bf16=False,
+            report_to="none",
+            model_init_kwargs=model_init_kwargs,
+        )
+
+        with patch(
+            "trl.experimental.async_grpo.async_grpo_trainer.AutoModelForCausalLM.from_pretrained",
+            side_effect=RuntimeError("model loader called"),
+        ) as model_loader:
+            with pytest.raises(RuntimeError, match="model loader called"):
+                AsyncGRPOTrainer(model="dummy-model", args=args)
+
+        model_loader.assert_called_once_with(
+            "dummy-model",
+            device_map=None,
+            attn_implementation="kernels-community/flash-attn3",
+            dtype=expected_dtype,
+            trust_remote_code=False,
+        )
+        assert args.model_init_kwargs == expected_model_init_kwargs
 
 
 @pytest.mark.skipif(

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -539,8 +539,9 @@ class AsyncGRPOTrainer(_BaseTrainer):
             Model to be trained. Must be a string, being the *model id* of a pretrained model hosted inside a model
             repo on huggingface.co, or a path to a *directory* containing model weights saved using
             [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
-            using [`~transformers.AutoModelForCausalLM.from_pretrained`]. The model name is also used to identify the
-            model on the vLLM server used for generation.
+            using [`~transformers.AutoModelForCausalLM.from_pretrained`] with the keyword arguments in
+            `args.model_init_kwargs`. If `dtype` is not specified in `args.model_init_kwargs`, it defaults to
+            `float32`. The model name is also used to identify the model on the vLLM server used for generation.
         reward_funcs (`RewardFunc | list[RewardFunc]`, *optional*):
             Reward functions to be used for computing the rewards. To compute the rewards, we call all the reward
             functions with the prompts and completions and sum the rewards. May be omitted when the reward is supplied
@@ -664,14 +665,14 @@ class AsyncGRPOTrainer(_BaseTrainer):
         self.temperature = args.temperature
 
         # Model
-        model_init_kwargs = args.model_init_kwargs or {}
+        model_init_kwargs = dict(args.model_init_kwargs or {})  # copy to avoid mutating model_init_kwargs
+        model_init_kwargs.setdefault("dtype", torch.float32)
         model_init_kwargs.setdefault("trust_remote_code", args.trust_remote_code)
         # FlashAttention is required: training runs in padding-free mode, where sequences are concatenated into a
         # single row and `cu_seq_lens` are derived from `position_ids` resets. SDPA/eager can't handle this.
         model = AutoModelForCausalLM.from_pretrained(
             model,
             device_map=None,
-            dtype=torch.float32,
             attn_implementation="kernels-community/flash-attn3",
             **model_init_kwargs,
         )


### PR DESCRIPTION
  # What does this PR do?

  Allows `AsyncGRPOTrainer` to honor `args.model_init_kwargs["dtype"]`
  while preserving `torch.float32` as the default.

  Previously, passing a dtype through `model_init_kwargs` collided with the
  trainer's explicit `dtype=torch.float32` argument and raised a duplicate
  keyword `TypeError`.

  This also copies `model_init_kwargs` before adding defaults so the user's
  configuration dictionary is not mutated. CPU-level regression tests cover
  both the default and explicit bfloat16 paths.

  Fixes #6684

  ## Testing

  - Focused AsyncGRPO model-loading tests
  - Ruff check and format
  - Documentation style check

  ## AI writing disclosure

  - [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized model-construction change with regression tests; affects load dtype only, not training logic or security paths.
> 
> **Overview**
> **`AsyncGRPOTrainer`** no longer passes a fixed `dtype=torch.float32` into `AutoModelForCausalLM.from_pretrained` alongside `args.model_init_kwargs`, which previously caused a duplicate-keyword `TypeError` when callers set `dtype` in config. Loading now merges a **copy** of `model_init_kwargs`, applies `setdefault("dtype", torch.float32)` when omitted, and forwards the rest unchanged; user-supplied `dtype` (e.g. `bfloat16`) is respected.
> 
> Docs note that `model_init_kwargs` controls load kwargs and that default dtype is `float32`. CPU tests mock the loader to assert default vs explicit dtype and that the original `model_init_kwargs` dict is not mutated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae30a13025a5027f55072745002d845bd2703097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->