### PR TITLE
Fix ZeRO-3 chunk synchronization in chunked CE

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -39,6 +39,7 @@ from transformers.utils import is_peft_available
 from trl import SFTConfig, SFTTrainer
 from trl.trainer.sft_trainer import (
     DataCollatorForLanguageModeling,
+    _chunk,
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
@@ -2721,6 +2722,70 @@ class TestChunkedCrossEntropyLoss:
         assert hidden.grad is not None and hidden.grad.abs().sum().item() == 0.0
         assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
+
+    def test_zero3_synchronizes_chunk_count_across_ranks(self):
+        """ZeRO-3 ranks execute the global maximum chunk count when local valid-token counts differ."""
+        hidden, weight, labels = self._inputs(ignore_positions=slice(0, 6), requires_grad=True)
+        local_n_valid = (labels[..., 1:] != -100).sum()
+        global_n_padded = 2 * self.CHUNK_SIZE
+
+        def set_global_max(n_padded, op):
+            assert op == torch.distributed.ReduceOp.MAX
+            n_padded.fill_(global_n_padded)
+
+        with (
+            patch("trl.trainer.sft_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.all_reduce", side_effect=set_global_max) as all_reduce,
+            patch("trl.trainer.sft_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, _, _, n_valid = _chunked_cross_entropy_loss(
+                hidden,
+                weight,
+                self.CHUNK_SIZE,
+                labels,
+                num_items_in_batch=local_n_valid,
+            )
+
+        assert all_reduce.call_count == 1
+        assert chunk.call_count == global_n_padded // self.CHUNK_SIZE
+        assert n_valid.item() == local_n_valid.item()
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert hidden.grad is not None
+        assert weight.grad is not None
+
+    def test_zero3_all_ignored_rank_joins_chunk_loop(self):
+        """A fully masked ZeRO-3 rank still joins chunk gathers required by ranks with valid labels."""
+        hidden, weight, labels = self._inputs(requires_grad=True)
+        labels[:] = -100
+        global_n_padded = 2 * self.CHUNK_SIZE
+
+        def set_global_max(n_padded, op):
+            assert op == torch.distributed.ReduceOp.MAX
+            n_padded.fill_(global_n_padded)
+
+        with (
+            patch("trl.trainer.sft_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.all_reduce", side_effect=set_global_max),
+            patch("trl.trainer.sft_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, correct, entropy_sum, n_valid = _chunked_cross_entropy_loss(
+                hidden,
+                weight,
+                self.CHUNK_SIZE,
+                labels,
+            )
+
+        assert chunk.call_count == global_n_padded // self.CHUNK_SIZE
+        assert loss.item() == 0.0
+        assert correct.item() == 0.0
+        assert entropy_sum.item() == 0.0
+        assert n_valid.item() == 0
+        loss.backward()
+        assert hidden.grad is not None and hidden.grad.abs().sum().item() == 0.0
+        assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
 
     def test_shift_labels_matches_labels(self):
         """`shift_labels` path (CP/SP) must match the default `labels` path after external shifting."""

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -44,6 +44,7 @@ from transformers import (
     TrainingArguments,
 )
 from transformers.data.data_collator import DataCollatorMixin
+from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
@@ -185,9 +186,16 @@ def _chunked_cross_entropy_loss(
     valid = labels != -100
     n_valid_tensor = valid.sum()
 
+    # ZeRO-3 gathers the sharded lm_head inside each chunk. Every rank must therefore execute the same number of
+    # chunks, even when assistant-only masking leaves a different number of valid tokens on each rank. Otherwise the
+    # collective gather count diverges and distributed training stalls in the first step.
+    n_padded = (n_valid_tensor / chunk_size).ceil().to(torch.int64) * chunk_size
+    if is_deepspeed_zero3_enabled() and torch.distributed.is_initialized():
+        torch.distributed.all_reduce(n_padded, op=torch.distributed.ReduceOp.MAX)
+
     correct = hidden.new_zeros((), dtype=torch.float32)
     entropy_sum = hidden.new_zeros((), dtype=torch.float32)
-    if n_valid_tensor == 0:
+    if n_padded == 0:
         # Whole micro-batch masked (e.g. completion-only loss + truncation). Keep the loss connected
         # to the autograd graph through every trainable parameter so `.backward()` succeeds and DDP /
         # FSDP gradient sync doesn't hang on a missing param.
@@ -202,9 +210,6 @@ def _chunked_cross_entropy_loss(
     order = valid.to(torch.int8).argsort(descending=True, stable=True)
     hidden = hidden[order]
     labels = labels[order]
-
-    # Process only the whole chunks covering the valid prefix: bounds XLA recompiles and drops fully-masked chunks on GPU.
-    n_padded = (n_valid_tensor / chunk_size).ceil().to(torch.int64) * chunk_size
 
     loss = hidden.new_zeros((), dtype=torch.float32)
 
@@ -226,7 +231,7 @@ def _chunked_cross_entropy_loss(
         entropy_sum = entropy_sum + chunk_entropy
 
     if num_items_in_batch is None:
-        loss = loss / n_valid_tensor
+        loss = loss / n_valid_tensor.clamp_min(1)
     else:
         if isinstance(num_items_in_batch, torch.Tensor):
             num_items_in_batch = num_items_in_batch.to(loss.device)


### PR DESCRIPTION
## What This Changes

- Computes the local padded chunk span before the all-masked fast path.
- Under ZeRO-3, all-reduces that span with `MAX` so every rank executes the same number of `lm_head` gather collectives.
- Keeps fully masked ranks in the synchronized loop when another rank has valid targets.
- Uses a clamped local denominator only for the no-global-denominator fallback, preserving zero loss on a fully masked rank.

## Why

Assistant-only and completion-only masks naturally produce different valid-token counts per rank. The chunked CE path gathers the sharded `lm_head` inside every chunk. If ranks execute different chunk counts, their collective sequence diverges and training stalls in the first step.

## Before And After

| Reproducer | Before | After |
| --- | --- | --- |
| Qwen3 LLM, ZeRO-3, rank chunks 1/2 | timeout at 120 s | pass, 0.73 s |
| Qwen3.5 VLM, ZeRO-3, rank chunks 1/2 | over 5 min, no step | pass, 1.83 s |
| all-masked rank versus two chunks | collective mismatch risk | pass, masked loss 0 |

## Validation

- [x] Minimal distributed test fails before and passes after.
- [x] NLL control passes.
- [x] DDP chunked control passes without ZeRO-3.
- [x] Equal and uneven valid-token counts with equal chunk counts pass.
- [x] Qwen3 LLM and Qwen3.5 VLM distributed cases pass after patch.
- [x] Fully masked rank case passes after patch.
- [x] Representative official unit/VLM/PEFT regressions: 19 passed.
- [x] Upstream-native chunked CE unit class with two new ZeRO-3 synchronization cases: 12 passed.
- [x] `git diff --check` and compile validation pass.
- [x] Add focused unit regressions for unequal rank chunk counts and a fully masked rank.

## Notes

The full official chunked CE class has two independent numerical-tolerance failures under PyTorch 2.10.0 (Phi-3 and LLaVA backward parity). They reproduce before the patch and in isolation and are unrelated to this control-flow fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the distributed SFT loss path and ZeRO-3 collectives; a bug could still cause hangs or wrong scaling, but the change is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes distributed **SFT** stalls when **chunked cross-entropy** runs under **DeepSpeed ZeRO-3** and ranks see different numbers of valid labels (e.g. assistant-only or completion-only masking).
> 
> **`_chunked_cross_entropy_loss`** now computes the local padded chunk span before deciding the all-masked fast path. When ZeRO-3 is active and distributed is initialized, that span is **`all_reduce`d with `MAX`** so every rank runs the same number of **`lm_head` gather** steps inside the chunk loop. The zero-loss shortcut is keyed off **`n_padded == 0`** instead of local valid-token count, so a fully masked rank still participates in chunk work when another rank has targets. When there is no global **`num_items_in_batch`**, the local mean uses **`n_valid_tensor.clamp_min(1)`** so division stays safe without changing zero loss on an all-masked rank.
> 
> Adds two unit tests that mock ZeRO-3 and **`all_reduce`** for unequal per-rank chunk counts and for an all-ignored rank joining the synchronized loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efffbdb9f9a0cb7ebe816824dc78bf10b024816e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->