### PR TITLE
Fix Qwen3.5 multimodal inputs in Liger GRPO

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3970,6 +3970,63 @@ class TestGRPOTrainerVLM(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+    )
+    @require_liger_kernel
+    @require_peft
+    def test_train_qwen3_5_vlm_with_liger_and_peft(self):
+        model_id = "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink"
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            max_steps=1,
+            report_to="none",
+        )
+        peft_config = LoraConfig(
+            r=8,
+            lora_alpha=32,
+            target_modules=["q_proj", "v_proj"],
+        )
+        trainer = GRPOTrainer(
+            model=model_id,
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            peft_config=peft_config,
+        )
+
+        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
+
+        assert isinstance(trainer.model, PeftModel)
+        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
+
+        previous_trainable_params = {
+            name: param.clone() for name, param in trainer.model.named_parameters() if param.requires_grad
+        }
+        assert previous_trainable_params
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        changed_params = [
+            name
+            for name, param in previous_trainable_params.items()
+            if not torch.equal(param, trainer.model.get_parameter(name))
+        ]
+        assert changed_params, "No trainable PEFT parameters have changed."
+
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1352,6 +1352,7 @@ class GRPOTrainer(_BaseTrainer):
         input_ids,
         attention_mask,
         logits_to_keep,
+        mm_token_type_ids,
         pixel_values=None,
         image_grid_thw=None,
         pixel_attention_mask=None,
@@ -1368,6 +1369,8 @@ class GRPOTrainer(_BaseTrainer):
         # For Qwen models:
         if image_grid_thw is not None and pixel_values is not None:
             model_inputs["image_grid_thw"] = image_grid_thw
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         # For Gemma, SmolVLM2, LLaVa-Next etc.:
         if pixel_values is not None:
             model_inputs["pixel_values"] = pixel_values
@@ -2891,6 +2894,7 @@ class GRPOTrainer(_BaseTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
+            inputs.get("mm_token_type_ids"),
             inputs.get("pixel_values"),
             inputs.get("image_grid_thw"),
             inputs.get("pixel_attention_mask"),


### PR DESCRIPTION
## What This Changes

- Adds `mm_token_type_ids` to the model inputs assembled by the Liger hidden-state path.
- Makes the field an explicit required internal argument, while allowing its value to be `None` for models that do not use it.
- Adds a one-step actual-image Qwen3.5 VLM + LoRA + Liger GRPO regression test.

## Why

Qwen3.5 processors return `mm_token_type_ids` for multimodal RoPE. The regular GRPO forward path preserves this field, but the Liger path manually calls the model backbone through `_get_last_hidden_state()` and omitted it. Actual-image Qwen3.5 training therefore failed before the fused GRPO loss with a missing multimodal token-type error.

## Before And After

| Case | Before | After |
| --- | --- | --- |
| Qwen3.5 VLM, actual image, LoRA, Liger GRPO | `ValueError`: `mm_token_type_ids` missing | one training step passes |
| Text GRPO Liger controls | pass | unchanged |
| Qwen3.5 VLM without the server compatibility wrapper | server-local cuDNN `conv3d` crash | unchanged; outside this PR |

## Validation

- [x] Same new test fails before the source fix with the expected `mm_token_type_ids` error.
- [x] Same new test passes after the source fix: 1 passed in 24.16 s.
- [x] Qwen3.5 conditional model + LoRA + ZeRO-3 + Liger control passes.
- [x] Existing seven GRPO loss types with Liger on/off pass.
- [x] Existing Qwen2.5 VLM actual-image Liger controls pass.
- [x] Compile and `git diff --check` pass.

## Environment Note

This server requires its existing Qwen vision patch-embedding compatibility wrapper to bypass a local cuDNN `conv3d` crash. The wrapper was applied only to the local test command and is not part of this PR. Once that independent server issue is bypassed, the TRL-owned missing-field failure is deterministic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional change on the Liger VLM code path; `mm_token_type_ids` is optional and only forwarded when set.
> 
> **Overview**
> Fixes **Qwen3.5 vision-language GRPO** when `use_liger_kernel=True`: the Liger path builds backbone inputs in `_get_last_hidden_state()` and was missing **`mm_token_type_ids`**, which Qwen3.5 needs for multimodal RoPE (the standard forward path already had it).
> 
> The trainer now threads `mm_token_type_ids` from batch `inputs` into that helper (only added to `model_inputs` when present, so text-only models are unchanged).
> 
> Adds a **one-step regression test** for tiny Qwen3.5 VLM + LoRA + Liger on real images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80304867cd921f0d21c8e05e9fda17a9ae27608e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->