### PR TITLE
Fix ZeRO-3 chunk synchronization in chunked losses

### DIFF
--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 from unittest.mock import patch
 
 import pytest
@@ -26,7 +27,7 @@ from transformers.utils import is_peft_available
 
 from trl import DistillationConfig, DistillationTrainer
 from trl.experimental.gkd.gkd_trainer import GKDTrainer
-from trl.trainer.distillation_trainer import _chunked_divergence_loss
+from trl.trainer.distillation_trainer import _chunk, _chunked_divergence_loss
 
 from .testing_utils import (
     TrlTestCase,
@@ -206,6 +207,11 @@ class TestChunkedDivergenceLoss(TrlTestCase):
         expected = per_token.sum() / mask.sum()
         torch.testing.assert_close(loss, expected)
 
+    @staticmethod
+    def _set_global_max(n_padded, op, global_n_padded):
+        assert op == torch.distributed.ReduceOp.MAX
+        n_padded.fill_(global_n_padded)
+
     @pytest.mark.parametrize("beta", [0.0, 0.5, 1.0])
     def test_parity_with_gkd(self, beta):
         # Identity lm_head so hidden states are the logits, then compare against GKD's full-vocab JSD (sum reduction).
@@ -275,6 +281,73 @@ class TestChunkedDivergenceLoss(TrlTestCase):
         assert torch.isfinite(loss)
         loss.backward()  # must not raise: the graph stays connected through the student hidden states + lm_head
         assert sh.grad is not None and sw.grad is not None and s_bias.grad is not None
+
+    def test_zero3_synchronizes_chunk_count_across_ranks(self):
+        """ZeRO-3 ranks execute the global maximum chunk count when local valid-token counts differ."""
+        sh, th, sw, tw, mask = self._inputs(n_masked=9)
+        sh, sw = sh.clone().requires_grad_(True), sw.clone().requires_grad_(True)
+        local_n_valid = mask.sum()
+        global_n_padded = 2 * 4
+
+        with (
+            patch("trl.trainer.distillation_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.all_reduce",
+                side_effect=partial(
+                    self._set_global_max,
+                    global_n_padded=global_n_padded,
+                ),
+            ) as all_reduce,
+            patch("trl.trainer.distillation_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, _, n_valid = _chunked_divergence_loss(
+                sh,
+                th,
+                sw,
+                tw,
+                mask,
+                beta=0.5,
+                chunk_size=4,
+                num_items_in_batch=local_n_valid,
+            )
+
+        assert all_reduce.call_count == 1
+        assert chunk.call_count == global_n_padded // 4
+        assert n_valid.item() == local_n_valid.item()
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert sh.grad is not None
+        assert sw.grad is not None
+
+    def test_zero3_all_masked_rank_joins_chunk_loop(self):
+        """A fully masked ZeRO-3 rank still joins chunk gathers required by ranks with valid tokens."""
+        sh, th, sw, tw, _ = self._inputs()
+        sh, sw = sh.clone().requires_grad_(True), sw.clone().requires_grad_(True)
+        mask = torch.zeros(sh.size(0), sh.size(1))
+        global_n_padded = 2 * 4
+
+        with (
+            patch("trl.trainer.distillation_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.all_reduce",
+                side_effect=partial(
+                    self._set_global_max,
+                    global_n_padded=global_n_padded,
+                ),
+            ),
+            patch("trl.trainer.distillation_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, entropy_sum, n_valid = _chunked_divergence_loss(sh, th, sw, tw, mask, beta=0.5, chunk_size=4)
+
+        assert chunk.call_count == global_n_padded // 4
+        assert loss.item() == 0.0
+        assert entropy_sum.item() == 0.0
+        assert n_valid.item() == 0
+        loss.backward()
+        assert sh.grad is not None and sh.grad.abs().sum().item() == 0.0
+        assert sw.grad is not None and sw.grad.abs().sum().item() == 0.0
 
 
 class TestDistillationTrainer(TrlTestCase):

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -17,6 +17,7 @@ import copy
 import gc
 import json
 import pathlib
+from functools import partial
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,6 +40,7 @@ from transformers.utils import is_peft_available
 from trl import SFTConfig, SFTTrainer
 from trl.trainer.sft_trainer import (
     DataCollatorForLanguageModeling,
+    _chunk,
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
@@ -2717,6 +2719,11 @@ class TestChunkedCrossEntropyLoss:
             entropy = torch.zeros((), dtype=torch.float32)
         return loss, accuracy, entropy
 
+    @staticmethod
+    def _set_global_max(n_padded, op, global_n_padded):
+        assert op == torch.distributed.ReduceOp.MAX
+        n_padded.fill_(global_n_padded)
+
     def test_forward_matches_cross_entropy(self):
         """With no ignored tokens, chunked loss equals standard mean cross-entropy."""
         hidden, weight, labels = self._inputs()
@@ -2802,6 +2809,74 @@ class TestChunkedCrossEntropyLoss:
         assert hidden.grad is not None and hidden.grad.abs().sum().item() == 0.0
         assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
+
+    def test_zero3_synchronizes_chunk_count_across_ranks(self):
+        """ZeRO-3 ranks execute the global maximum chunk count when local valid-token counts differ."""
+        hidden, weight, labels = self._inputs(ignore_positions=slice(0, 6), requires_grad=True)
+        local_n_valid = (labels[..., 1:] != -100).sum()
+        global_n_padded = 2 * self.CHUNK_SIZE
+
+        with (
+            patch("trl.trainer.sft_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.all_reduce",
+                side_effect=partial(
+                    self._set_global_max,
+                    global_n_padded=global_n_padded,
+                ),
+            ) as all_reduce,
+            patch("trl.trainer.sft_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, _, _, n_valid = _chunked_cross_entropy_loss(
+                hidden,
+                weight,
+                self.CHUNK_SIZE,
+                labels,
+                num_items_in_batch=local_n_valid,
+            )
+
+        assert all_reduce.call_count == 1
+        assert chunk.call_count == global_n_padded // self.CHUNK_SIZE
+        assert n_valid.item() == local_n_valid.item()
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert hidden.grad is not None
+        assert weight.grad is not None
+
+    def test_zero3_all_ignored_rank_joins_chunk_loop(self):
+        """A fully masked ZeRO-3 rank still joins chunk gathers required by ranks with valid labels."""
+        hidden, weight, labels = self._inputs(requires_grad=True)
+        labels[:] = -100
+        global_n_padded = 2 * self.CHUNK_SIZE
+
+        with (
+            patch("trl.trainer.sft_trainer.is_deepspeed_zero3_enabled", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.all_reduce",
+                side_effect=partial(
+                    self._set_global_max,
+                    global_n_padded=global_n_padded,
+                ),
+            ),
+            patch("trl.trainer.sft_trainer._chunk", wraps=_chunk) as chunk,
+        ):
+            loss, correct, entropy_sum, n_valid = _chunked_cross_entropy_loss(
+                hidden,
+                weight,
+                self.CHUNK_SIZE,
+                labels,
+            )
+
+        assert chunk.call_count == global_n_padded // self.CHUNK_SIZE
+        assert loss.item() == 0.0
+        assert correct.item() == 0.0
+        assert entropy_sum.item() == 0.0
+        assert n_valid.item() == 0
+        loss.backward()
+        assert hidden.grad is not None and hidden.grad.abs().sum().item() == 0.0
+        assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
 
     def test_shift_labels_matches_labels(self):
         """`shift_labels` path (CP/SP) must match the default `labels` path after external shifting."""

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -45,6 +45,7 @@ from transformers import (
     is_trackio_available,
     is_wandb_available,
 )
+from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.utils import is_peft_available, is_rich_available
 
 from ..chat_template_utils import (
@@ -259,6 +260,11 @@ def _chunked_divergence_loss(
     # GPU. At least one chunk always runs: under context parallelism a rank can hold only masked positions, and its
     # zero loss still has to reach every trainable parameter for `.backward()` and gradient sync to work.
     n_padded = (n_valid_tensor / chunk_size).ceil().clamp(min=1).to(torch.int64) * chunk_size
+    if is_deepspeed_zero3_enabled() and torch.distributed.is_initialized():
+        torch.distributed.all_reduce(
+            n_padded,
+            op=torch.distributed.ReduceOp.MAX,
+        )
 
     loss = h_s.new_zeros((), dtype=torch.float32)
     for start in range(0, n_padded, chunk_size):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -45,6 +45,7 @@ from transformers import (
     TrainingArguments,
 )
 from transformers.data.data_collator import DataCollatorMixin
+from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.trainer_utils import EvalPrediction
 from transformers.utils import is_peft_available
@@ -203,6 +204,11 @@ def _chunked_cross_entropy_loss(
     # GPU. At least one chunk always runs: under context parallelism a rank can hold only masked positions, and its
     # zero loss still has to reach every trainable parameter for `.backward()` and gradient sync to work.
     n_padded = (n_valid_tensor / chunk_size).ceil().clamp(min=1).to(torch.int64) * chunk_size
+    if is_deepspeed_zero3_enabled() and torch.distributed.is_initialized():
+        torch.distributed.all_reduce(
+            n_padded,
+            op=torch.distributed.ReduceOp.MAX,
+        )
 
     loss = hidden.new_zeros((), dtype=torch.float32)
 


### PR DESCRIPTION
# What does this PR do?

`SFTTrainer(loss_type="chunked_nll")` can stall under DeepSpeed ZeRO-3 when assistant-only or completion-only masking gives ranks different valid-token chunk counts. The same issue applies to the chunked divergence loss used by `DistillationTrainer`. Each local chunk gathers the sharded `lm_head`, so unequal loop counts desynchronize collectives.

This change synchronizes the padded chunk span with a rank-wise `MAX` in both chunked loss paths, keeps fully masked ranks in the shared loop, and safely clamps only the local fallback denominator. It adds regressions for unequal chunk counts and a fully masked rank in both trainers.

Validation: the minimal two-rank SFT reproducer times out before the fix and passes after it for Qwen3 LLM and Qwen3.5 VLM; the focused SFT and Distillation chunk-loss unit classes pass 41/41; Ruff format and diff checks pass.

<!-- Remove if not applicable -->

Fixes #6696

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed loss paths used by SFT and distillation training; incorrect sync logic could affect ZeRO-3 correctness or performance, but the change is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes training hangs under **DeepSpeed ZeRO-3** when ranks see different numbers of valid tokens (e.g. completion-only / assistant-only masking), which previously led to mismatched chunk-loop counts and desynchronized `lm_head` gathers.
> 
> In **`_chunked_cross_entropy_loss`** (`SFTTrainer` / `chunked_nll`) and **`_chunked_divergence_loss`** (`DistillationTrainer`), the padded chunk span `n_padded` is now **`all_reduce`d with `MAX`** when ZeRO-3 is enabled and distributed is initialized, so every rank executes the same number of chunk iterations while local loss normalization still uses each rank’s valid-token count.
> 
> Adds unit tests that mock ZeRO-3 and `all_reduce` for unequal valid-token counts and for a fully masked rank, asserting expected `_chunk` invocations and safe backward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d084f91755acecfc4f22fd4b40226f8fa932b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->