### PR TITLE
Add multimodal regression coverage for chunked GRPO log-probs

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4327,10 +4327,10 @@ class TestGRPOTrainerVLM(TrlTestCase):
             peft_config=peft_config,
         )
 
-        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
+        from trl.losses import FusedLinearGRPOLoss
 
-        assert isinstance(trainer.model, PeftModel)
-        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
+        assert isinstance(trainer.model, peft.PeftModel)
+        assert isinstance(trainer.liger_loss, FusedLinearGRPOLoss)
 
         previous_trainable_params = {
             name: param.clone() for name, param in trainer.model.named_parameters() if param.requires_grad

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4290,6 +4290,63 @@ class TestGRPOTrainerVLM(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.skipif(
+        Version(transformers.__version__) < Version("5.2.0"),
+        reason="Qwen3.5 models were introduced in transformers-5.2.0",
+    )
+    @require_liger_kernel
+    @require_peft
+    def test_train_qwen3_5_vlm_with_liger_and_peft(self):
+        model_id = "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink"
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            use_liger_kernel=True,
+            max_steps=1,
+            report_to="none",
+        )
+        peft_config = LoraConfig(
+            r=8,
+            lora_alpha=32,
+            target_modules=["q_proj", "v_proj"],
+        )
+        trainer = GRPOTrainer(
+            model=model_id,
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            peft_config=peft_config,
+        )
+
+        from liger_kernel.chunked_loss import LigerFusedLinearGRPOLoss
+
+        assert isinstance(trainer.model, PeftModel)
+        assert isinstance(trainer.liger_loss, LigerFusedLinearGRPOLoss)
+
+        previous_trainable_params = {
+            name: param.clone() for name, param in trainer.model.named_parameters() if param.requires_grad
+        }
+        assert previous_trainable_params
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        changed_params = [
+            name
+            for name, param in previous_trainable_params.items()
+            if not torch.equal(param, trainer.model.get_parameter(name))
+        ]
+        assert changed_params, "No trainable PEFT parameters have changed."
+
     @pytest.mark.parametrize(
         "model_id",
         [

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4244,6 +4244,7 @@ class TestGRPOTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",
         [
+            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
             pytest.param(
                 "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
                 marks=pytest.mark.xfail(
@@ -4281,9 +4282,13 @@ class TestGRPOTrainerVLM(TrlTestCase):
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
-        trainer.train()
+        with patch.object(trainer, "_get_last_hidden_state", wraps=trainer._get_last_hidden_state) as get_hidden_state:
+            trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
+        if model_id == "trl-internal-testing/tiny-Gemma3ForConditionalGeneration":
+            token_type_ids = get_hidden_state.call_args.kwargs.get("token_type_ids")
+            assert token_type_ids is not None
 
         # Check that the params have changed
         for n, param in previous_trainable_params.items():

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1349,6 +1349,7 @@ class GRPOTrainer(_BaseTrainer):
         input_ids,
         attention_mask,
         logits_to_keep,
+        mm_token_type_ids,
         pixel_values=None,
         image_grid_thw=None,
         pixel_attention_mask=None,
@@ -1365,6 +1366,8 @@ class GRPOTrainer(_BaseTrainer):
         # For Qwen models:
         if image_grid_thw is not None and pixel_values is not None:
             model_inputs["image_grid_thw"] = image_grid_thw
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         # For Gemma, SmolVLM2, LLaVa-Next etc.:
         if pixel_values is not None:
             model_inputs["pixel_values"] = pixel_values
@@ -2967,6 +2970,7 @@ class GRPOTrainer(_BaseTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
+            inputs.get("mm_token_type_ids"),
             inputs.get("pixel_values"),
             inputs.get("image_grid_thw"),
             inputs.get("pixel_attention_mask"),

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1349,12 +1349,13 @@ class GRPOTrainer(_BaseTrainer):
         input_ids,
         attention_mask,
         logits_to_keep,
-        mm_token_type_ids,
         pixel_values=None,
         image_grid_thw=None,
         pixel_attention_mask=None,
         spatial_shapes=None,
         image_sizes=None,
+        token_type_ids=None,
+        mm_token_type_ids=None,
         image_position_ids=None,
     ):
         if is_peft_model(unwrapped_model):
@@ -1366,8 +1367,6 @@ class GRPOTrainer(_BaseTrainer):
         # For Qwen models:
         if image_grid_thw is not None and pixel_values is not None:
             model_inputs["image_grid_thw"] = image_grid_thw
-        if mm_token_type_ids is not None:
-            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         # For Gemma, SmolVLM2, LLaVa-Next etc.:
         if pixel_values is not None:
             model_inputs["pixel_values"] = pixel_values
@@ -1380,6 +1379,10 @@ class GRPOTrainer(_BaseTrainer):
         # For LLaVa-Next
         if image_sizes is not None:
             model_inputs["image_sizes"] = image_sizes
+        if token_type_ids is not None:
+            model_inputs["token_type_ids"] = token_type_ids
+        if mm_token_type_ids is not None:
+            model_inputs["mm_token_type_ids"] = mm_token_type_ids
         if image_position_ids is not None:
             model_inputs["image_position_ids"] = image_position_ids
 
@@ -2970,13 +2973,14 @@ class GRPOTrainer(_BaseTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            inputs.get("mm_token_type_ids"),
-            inputs.get("pixel_values"),
-            inputs.get("image_grid_thw"),
-            inputs.get("pixel_attention_mask"),
-            inputs.get("spatial_shapes"),
-            inputs.get("image_sizes"),
-            inputs.get("image_position_ids"),
+            pixel_values=inputs.get("pixel_values"),
+            image_grid_thw=inputs.get("image_grid_thw"),
+            pixel_attention_mask=inputs.get("pixel_attention_mask"),
+            spatial_shapes=inputs.get("spatial_shapes"),
+            image_sizes=inputs.get("image_sizes"),
+            token_type_ids=inputs.get("token_type_ids"),
+            mm_token_type_ids=inputs.get("mm_token_type_ids"),
+            image_position_ids=inputs.get("image_position_ids"),
         )
 
         # Apply tool_mask (from env_mask) for loss computation in multi-turn training scenarios


### PR DESCRIPTION
# What does this PR do?

After #7077 replaced the fused GRPO loss path, main already forwards `token_type_ids` and `mm_token_type_ids` through `_chunked_logps()`. This PR now adds regression coverage for that path; it no longer changes production code.

The tests cover:

- Processor-provided token-type fields reaching the backbone unchanged, including the case where neither field is present.
- Log-probability and entropy parity with a full-logits calculation, plus finite gradients.
- Actual-image Gemma 3 and Qwen2.5-VL training through the chunked path, with finite loss and parameter updates.
- Qwen3.5 + PEFT training, checking `mm_token_type_ids` and trainable adapter updates.

The Gemma 3 coverage incorporates @vladbataev's contribution from DimensionSTP/trl#2.

Validation against main at `5bb945c3`:

- CPU: all three input-forwarding cases passed.
- CUDA suite: 8 passed, 0 skipped. This includes the three unit cases, three VLM training cases, and the existing full-logits parity and bf16 autocast tests.
- Local negative controls: dropping either token-type field caused the expected backbone-input assertion to fail.
- Ruff lint, formatting, and diff whitespace checks passed.

The CUDA run used tiny models with PyTorch 2.11.0+cu129, Transformers 5.14.1, PEFT 0.18.1, and Liger 0.8.2. cuDNN was disabled for the local Conv3d limitation. These environment settings and the negative-control harness are not part of the patch.

Gemma pan-and-scan preprocessing remains outside this PR's scope.

Related to #6697. The original production fix is superseded by #7077.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GRPO trainer tests; no production training logic is modified in this diff.
> 
> **Overview**
> **Expands GRPO test coverage** for the Liger hidden-state / `_chunked_logps` path with multimodal inputs, aligning with fixes that forward processor token-type fields (`token_type_ids`, `mm_token_type_ids`) into the backbone.
> 
> Adds **`TestGRPOChunkedMultimodalInputs`**, a focused unit test that mocks a VLM and checks `_chunked_logps` passes `pixel_values` and the right token-type kwargs, returns correct log-probs/entropies, and backprops without NaNs.
> 
> **Tightens the existing Liger VLM training test**: includes **tiny Gemma 3**, wraps `_chunked_logps` to assert it runs during training, requires a **finite** `train_loss`, and for Gemma 3 verifies **`token_type_ids`** were forwarded.
> 
> Adds **`test_train_qwen3_5_vlm_with_liger_and_peft`** (Transformers ≥ 5.2, Liger + PEFT) for **Qwen3.5** on an image conversational dataset, asserting **`mm_token_type_ids`** on the chunked logps call and that trainable LoRA weights update after one step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf481adbb8abaae1c916f3c5a2381291098acac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->