### PR TITLE
fix(grpo): fail fast when continuing from a non-trainable PEFT adapter (silent no-op)

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3699,6 +3699,78 @@ class TestGRPOTrainer(TrlTestCase):
 
 
 @require_vision
+class TestGRPOTrainerPEFTContinuation(TrlTestCase):
+    """
+    Regression tests for the silent no-op when continuing GRPO from a PEFT
+    adapter loaded with ``PeftModel.from_pretrained`` (``is_trainable=False``).
+    """
+
+    def _make_sft_adapter(self, model_id):
+        model = AutoModelForCausalLM.from_pretrained(model_id)
+        lora = LoraConfig(
+            r=4,
+            lora_alpha=8,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            task_type="CAUSAL_LM",
+        )
+        sft = get_peft_model(model, lora)
+        path = os.path.join(self.tmp_dir, "sft_adapter")
+        sft.save_pretrained(path)
+        return path
+
+    @staticmethod
+    def _reward(completions, **kwargs):
+        return [1.0] * len(completions)
+
+    @require_peft
+    def test_raises_when_pretrained_adapter_is_not_trainable(self):
+        # GRPOTrainer must fail fast (instead of silently training nothing) when
+        # given a PeftModel loaded with is_trainable=False and beta != 0.
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        adapter_path = self._make_sft_adapter(model_id)
+        model = PeftModel.from_pretrained(
+            AutoModelForCausalLM.from_pretrained(model_id), adapter_path
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        args = GRPOConfig(output_dir=self.tmp_dir, beta=0.01, report_to="none")
+
+        with pytest.raises(ValueError, match="no trainable parameters"):
+            GRPOTrainer(
+                model=model,
+                processing_class=AutoTokenizer.from_pretrained(model_id),
+                reward_funcs=[self._reward],
+                args=args,
+                train_dataset=dataset,
+            )
+
+    @require_peft
+    def test_trains_when_pretrained_adapter_is_trainable(self):
+        # The same setup with is_trainable=True must keep working.
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        adapter_path = self._make_sft_adapter(model_id)
+        model = PeftModel.from_pretrained(
+            AutoModelForCausalLM.from_pretrained(model_id), adapter_path, is_trainable=True
+        )
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            beta=0.01,
+            learning_rate=0.1,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model=model,
+            processing_class=AutoTokenizer.from_pretrained(model_id),
+            reward_funcs=[self._reward],
+            args=args,
+            train_dataset=dataset,
+        )
+        assert any(p.requires_grad for p in trainer.model.parameters())
+
+
 class TestGRPOTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3698,7 +3698,6 @@ class TestGRPOTrainer(TrlTestCase):
         assert trainer.reward_processing_classes[0] == single_processing_class
 
 
-@require_vision
 class TestGRPOTrainerPEFTContinuation(TrlTestCase):
     """
     Regression tests for the silent no-op when continuing GRPO from a PEFT
@@ -3771,6 +3770,7 @@ class TestGRPOTrainerPEFTContinuation(TrlTestCase):
         assert any(p.requires_grad for p in trainer.model.parameters())
 
 
+@require_vision
 class TestGRPOTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
         "model_id",

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -679,6 +679,27 @@ class DPOTrainer(_BaseTrainer):
                         ref_name = name.replace(".default.", ".ref.")
                         ref_param = model.get_parameter(ref_name)
                         ref_param.data.copy_(param.data)
+                # The reference adapter must never be trained. `add_adapter`
+                # inherits `inference_mode` from the default adapter's config:
+                # when the model was loaded with `is_trainable=False` (the
+                # default of `PeftModel.from_pretrained`), PEFT also freezes the
+                # active "default" adapter here, so the optimizer would be
+                # created empty and the trainer would silently train nothing.
+                # Freeze the reference explicitly (defensive: PEFT 0.20.0
+                # housekeeping already freezes it) and rely on the
+                # trainability check below to catch the empty-optimizer case.
+                if Version(peft.__version__) >= Version("0.18.0") and not model.peft_config["ref"].is_prompt_learning:
+                    model.set_requires_grad("ref", requires_grad=False)
+
+        if is_peft_model(model) and peft_config is None and not any(
+            p.requires_grad for p in model.parameters()
+        ):
+            raise ValueError(
+                "DPOTrainer found no trainable parameters in the PEFT model. "
+                "If you loaded an existing adapter with `PeftModel.from_pretrained`, "
+                "pass `is_trainable=True`, or `merge_and_unload()` it and pass a "
+                "`peft_config` to the trainer instead."
+            )
 
         # PEFT + DeepSpeed ZeRO-3 requires reentrant checkpointing. For more details, see
         # https://github.com/huggingface/trl/issues/2514#issuecomment-2692152703.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -474,6 +474,27 @@ class GRPOTrainer(_BaseTrainer):
                         ref_name = name.replace(".default.", ".ref.")
                         ref_param = model.get_parameter(ref_name)
                         ref_param.data.copy_(param.data)
+                # The reference adapter must never be trained. `add_adapter`
+                # inherits `inference_mode` from the default adapter's config:
+                # when the model was loaded with `is_trainable=False` (the
+                # default of `PeftModel.from_pretrained`), PEFT also freezes the
+                # active "default" adapter here, so the optimizer would be
+                # created empty and GRPO would silently train nothing. Freeze
+                # the reference explicitly (defensive: PEFT 0.20.0 housekeeping
+                # already freezes it) and rely on the trainability check below
+                # to catch the empty-optimizer case.
+                if not model.peft_config["ref"].is_prompt_learning:
+                    model.set_requires_grad("ref", requires_grad=False)
+
+        if is_peft_model(model) and peft_config is None and not any(
+            p.requires_grad for p in model.parameters()
+        ):
+            raise ValueError(
+                "GRPOTrainer found no trainable parameters in the PEFT model. "
+                "If you loaded an existing adapter with `PeftModel.from_pretrained`, "
+                "pass `is_trainable=True`, or `merge_and_unload()` it and pass a "
+                "`peft_config` to the trainer instead."
+            )
 
         # PEFT + DeepSpeed ZeRO-3 requires reentrant checkpointing. For more details, see
         # https://github.com/huggingface/trl/issues/2514#issuecomment-2692152703.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -483,7 +483,7 @@ class GRPOTrainer(_BaseTrainer):
                 # the reference explicitly (defensive: PEFT 0.20.0 housekeeping
                 # already freezes it) and rely on the trainability check below
                 # to catch the empty-optimizer case.
-                if not model.peft_config["ref"].is_prompt_learning:
+                if Version(peft.__version__) >= Version("0.18.0") and not model.peft_config["ref"].is_prompt_learning:
                     model.set_requires_grad("ref", requires_grad=False)
 
         if is_peft_model(model) and peft_config is None and not any(

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -727,6 +727,27 @@ class KTOTrainer(_BaseTrainer):
                         ref_name = name.replace(".default.", ".ref.")
                         ref_param = model.get_parameter(ref_name)
                         ref_param.data.copy_(param.data)
+                # The reference adapter must never be trained. `add_adapter`
+                # inherits `inference_mode` from the default adapter's config:
+                # when the model was loaded with `is_trainable=False` (the
+                # default of `PeftModel.from_pretrained`), PEFT also freezes the
+                # active "default" adapter here, so the optimizer would be
+                # created empty and the trainer would silently train nothing.
+                # Freeze the reference explicitly (defensive: PEFT 0.20.0
+                # housekeeping already freezes it) and rely on the
+                # trainability check below to catch the empty-optimizer case.
+                if Version(peft.__version__) >= Version("0.18.0") and not model.peft_config["ref"].is_prompt_learning:
+                    model.set_requires_grad("ref", requires_grad=False)
+
+        if is_peft_model(model) and peft_config is None and not any(
+            p.requires_grad for p in model.parameters()
+        ):
+            raise ValueError(
+                "KTOTrainer found no trainable parameters in the PEFT model. "
+                "If you loaded an existing adapter with `PeftModel.from_pretrained`, "
+                "pass `is_trainable=True`, or `merge_and_unload()` it and pass a "
+                "`peft_config` to the trainer instead."
+            )
 
         # PEFT + DeepSpeed ZeRO-3 requires reentrant checkpointing. For more details, see
         # https://github.com/huggingface/trl/issues/2514#issuecomment-2692152703.

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -387,6 +387,27 @@ class RLOOTrainer(_BaseTrainer):
                         ref_name = name.replace(".default.", ".ref.")
                         ref_param = model.get_parameter(ref_name)
                         ref_param.data.copy_(param.data)
+                # The reference adapter must never be trained. `add_adapter`
+                # inherits `inference_mode` from the default adapter's config:
+                # when the model was loaded with `is_trainable=False` (the
+                # default of `PeftModel.from_pretrained`), PEFT also freezes the
+                # active "default" adapter here, so the optimizer would be
+                # created empty and the trainer would silently train nothing.
+                # Freeze the reference explicitly (defensive: PEFT 0.20.0
+                # housekeeping already freezes it) and rely on the
+                # trainability check below to catch the empty-optimizer case.
+                if Version(peft.__version__) >= Version("0.18.0") and not model.peft_config["ref"].is_prompt_learning:
+                    model.set_requires_grad("ref", requires_grad=False)
+
+        if is_peft_model(model) and peft_config is None and not any(
+            p.requires_grad for p in model.parameters()
+        ):
+            raise ValueError(
+                "RLOOTrainer found no trainable parameters in the PEFT model. "
+                "If you loaded an existing adapter with `PeftModel.from_pretrained`, "
+                "pass `is_trainable=True`, or `merge_and_unload()` it and pass a "
+                "`peft_config` to the trainer instead."
+            )
 
         # PEFT + DeepSpeed ZeRO-3 requires reentrant checkpointing. For more details, see
         # https://github.com/huggingface/trl/issues/2514#issuecomment-2692152703.


### PR DESCRIPTION
> [!NOTE]
> **Clarified scope:** The `ref` adapter is not the root cause, and changing PEFT trainability is not the goal. This PR is about preventing a misleading no-op: after accepting a model with zero trainable parameters, the trainer can complete with apparently normal gradients and metrics while the optimizer updates nothing and the saved adapter remains unchanged. The useful change is the diagnostic fail-fast; the ref-specific explanation and defensive freeze can be removed.

# What does this PR do?

`GRPOTrainer` currently **silently no-ops** when it is given a `PeftModel` that was loaded with `PeftModel.from_pretrained(..., is_trainable=False)` and `beta != 0`:

- The auto-created `ref` adapter (KL reference) inherits `inference_mode=True` from the default adapter's config, and PEFT's `inject_adapter` then freezes the active ("default") adapter too, so the optimizer is created with **zero parameters**.
- During each step, `use_adapter()` temporarily flips `requires_grad`, so loss / reward / grad_norm all look alive; the training completes without any warning and the saved adapter is **byte-identical** to the initial adapter.

This PR:

1. explicitly freezes the auto-created `ref` adapter (`set_requires_grad("ref", False)`) so the reference policy can never drift (defensive; PEFT 0.20.0 housekeeping already freezes it today);
2. adds a fail-fast check after the PEFT setup: if the model has no trainable parameters, raise a clear `ValueError` telling the user to load the adapter with `is_trainable=True` or to `merge_and_unload()` it and pass a `peft_config` — instead of silently training nothing;
3. adds regression tests for both the error path and the working `is_trainable=True` path.

The trainability check also covers the `beta == 0` case, which silently no-ops in the same way (that path never enters the `ref`-adapter branch).

Fixes #6700

## Verification

- Minimal CPU reproduction (public notebook): https://www.kaggle.com/code/meredith10pi/trl-1-9-2-ref-adapter-silent-no-op-repro
- With the fix applied (trl 1.9.2 + peft 0.20.0): `is_trainable=False + beta!=0` raises `ValueError`; `is_trainable=True + beta!=0` trains normally (optimizer non-empty, saved weights change); `is_trainable=False + beta==0` also raises; `merge_and_unload + peft_config` and `is_trainable=True + beta==0` are unaffected.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — https://github.com/huggingface/trl/issues/6700
- [x] Did you make sure to update the documentation with your changes? — Inline comments updated; behavior change documented in the error message.
- [x] Did you write any new necessary tests? — `TestGRPOTrainerPEFTContinuation` in `tests/test_grpo_trainer.py`.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. `albertvillanova` has been the maintainer most involved in the PEFT/ref-adapter code paths (see #3031, #5222, #5673) and may be interested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trainer initialization for all PEFT continuation paths across four trainers; previously broken setups now error instead of silently not training, which is safer but may break scripts that relied on the old behavior.
> 
> **Overview**
> Fixes a **silent no-op** when continuing RLHF-style training from a `PeftModel` loaded via `PeftModel.from_pretrained` with the default `is_trainable=False`: PEFT can leave the active adapter frozen and the optimizer empty while metrics still look healthy.
> 
> **DPO**, **GRPO**, **KTO**, and **RLOO** trainers now explicitly freeze the auto-created `ref` adapter (`set_requires_grad("ref", False)` on PEFT ≥ 0.18.0) and **raise `ValueError`** during init if the model has no trainable parameters and no new `peft_config` was passed, with guidance to use `is_trainable=True` or `merge_and_unload()` plus `peft_config`.
> 
> Adds **`TestGRPOTrainerPEFTContinuation`** regression tests: expect failure when the adapter is non-trainable (with `beta != 0`), and assert trainable parameters exist when `is_trainable=True`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ad59a11d606f9f52b92fa5d9c2114fad25f28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->