### PR TITLE
Fix extract_prompt boundary cases

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1169,6 +1169,26 @@ class TestExtractPrompt(TrlTestCase):
             "The prompt is not correctly extracted from the dataset."
         )
 
+    @pytest.mark.parametrize(
+        ("example", "expected"),
+        [
+            (
+                {"chosen": "same", "rejected": "same"},
+                {"prompt": "same", "chosen": "", "rejected": ""},
+            ),
+            (
+                {"chosen": "", "rejected": ""},
+                {"prompt": "", "chosen": "", "rejected": ""},
+            ),
+            (
+                {"chosen": "a ", "rejected": "b"},
+                {"prompt": "", "chosen": "a ", "rejected": "b"},
+            ),
+        ],
+    )
+    def test_extract_prompt_boundary_cases(self, example, expected):
+        assert extract_prompt(example) == expected
+
     def test_maybe_extract_prompt_standard(self):
         # Test that the prompt is correctly extracted from the dataset with maybe_extract_prompt
         example_extracted_prompt = maybe_extract_prompt(self.example_implicit_prompt_standard)

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -629,15 +629,17 @@ def extract_prompt(example: dict[str, Sequence]) -> dict[str, Sequence]:
      'rejected': [{'role': 'assistant', 'content': 'It is green.'}]}
     ```
     """
-    for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
+    common_length = min(len(example["chosen"]), len(example["rejected"]))
+    for idx in range(common_length):
         if example["chosen"][idx] != example["rejected"][idx]:
-            if example["chosen"][idx - 1] == " ":  # remove space before the prompt
-                idx -= 1
+            common_length = idx
+            if idx > 0 and example["chosen"][idx - 1] == " ":  # remove space before the prompt
+                common_length -= 1
             break
     return {
-        "prompt": example["chosen"][:idx],
-        "chosen": example["chosen"][idx:],
-        "rejected": example["rejected"][idx:],
+        "prompt": example["chosen"][:common_length],
+        "chosen": example["chosen"][common_length:],
+        "rejected": example["rejected"][common_length:],
     }
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes `extract_prompt` boundary handling when the chosen and rejected sequences are identical, empty, or differ at the first element.

The previous loop used its iteration index as the common-prefix length. This left the index undefined for empty inputs, omitted the final shared element for identical inputs, and could inspect index `-1` when the first elements differed. The updated implementation tracks the common-prefix length explicitly and only trims a separating space after at least one shared character.

No issue is linked because this was found while auditing the existing data utility and no matching open or closed issue/PR was found.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed because the documented longest-common-prefix behavior is unchanged.
- [x] Did you write any new necessary tests?

## Verification

- Regression test before the fix: 3 failed
- Regression test after the fix: 3 passed
- `python -m pytest tests/test_data_utils.py -q`: 547 passed, 13 skipped
- `pre-commit run --files trl/data_utils.py tests/test_data_utils.py`: passed

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix in preference dataset preprocessing with regression tests; normal-prefix behavior is unchanged.
> 
> **Overview**
> **`extract_prompt`** now tracks an explicit **`common_length`** for the shared prefix instead of reusing the loop index as the split point.
> 
> That fixes wrong splits when **chosen** and **rejected** are **identical** (full string should become the prompt with empty completions), **both empty**, or **differ on the first character** (no invalid `-1` access or bogus space trimming). Trimming a separating space before the divergence only runs when **`idx > 0`**.
> 
> Parametrized tests in **`test_extract_prompt_boundary_cases`** lock in those three scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c2b1a12a53e4b50735fa3608a05461ee1f33fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->