### PR TITLE
Handle empty legacy conversations

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -515,8 +515,8 @@ class TestIsConversationalFromValue(TrlTestCase):
         }
         assert not is_conversational_from_value(example)
 
-    def test_negative_2(self):
-        example = {"text": "The sky is blue."}
+    @pytest.mark.parametrize("example", [{"text": "The sky is blue."}, {"conversations": []}])
+    def test_negative_2(self, example):
         assert not is_conversational_from_value(example)
 
 

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -963,7 +963,7 @@ def is_conversational_from_value(example: dict[str, Any]) -> bool:
     """
     maybe_messages = example.get("conversations")
     # It must be a list of messages
-    if isinstance(maybe_messages, list):
+    if isinstance(maybe_messages, list) and maybe_messages:
         maybe_message = maybe_messages[0]
         # Each message must a list of dictionaries with keys "from" and "value"
         if isinstance(maybe_message, dict) and "from" in maybe_message and "value" in maybe_message:


### PR DESCRIPTION
# What does this PR do?

Makes `is_conversational_from_value` return `False` for an empty legacy `conversations` list instead of raising `IndexError` while inspecting its first element.

This keeps empty or malformed non-conversational examples on the same boolean detection path as missing and non-list values. The change is limited to a non-empty guard and a regression case in the existing negative-test parametrization.

No issue is linked because this was found while auditing the data compatibility utilities and no matching open or closed issue/PR was found.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? No documentation update is needed because the function already documents a boolean detector.
- [x] Did you write any new necessary tests?

## Verification

- Regression test before the fix: 1 failed, 3 passed
- Regression test after the fix: 4 passed
- `python -m pytest tests/test_data_utils.py -q`: 545 passed, 13 skipped
- `pre-commit run --files trl/data_utils.py tests/test_data_utils.py`: passed

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean guard in a data-format helper with a focused regression test; no API or training-path behavior change beyond avoiding crashes on malformed rows.
> 
> **Overview**
> **`is_conversational_from_value`** no longer raises when `conversations` is an empty list. The legacy from/value check now requires a **non-empty** list before reading the first message, so `{"conversations": []}` returns **`False`** like other non-conversational examples instead of hitting **`IndexError`**.
> 
> Tests extend the existing negative case with **`{"conversations": []}`** via parametrization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f6e88754169fd418f9f05089671b133d376b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->