### PR TITLE
fix(examples): use OpenEnv's proxy path helpers in the opencode example

### DIFF
--- a/examples/scripts/openenv/opencode.py
+++ b/examples/scripts/openenv/opencode.py
@@ -78,6 +78,7 @@ from datasets import Dataset, load_dataset
 from opencode_env import harness as oc_harness
 from opencode_env.config import OpenCodeConfig
 from opencode_env.harness import OpenCodeSessionFactory
+from opencode_env.opencode_runtime import proxy_log_path, proxy_trace_path
 from opencode_env.sandbox.base import ExecResult, SandboxHandle
 from opencode_env.task import OpenCodeTask
 from openenv.core.harness import ResourceSession, ResourceSessionFactory, VerifyResult
@@ -417,8 +418,8 @@ class FreePortOpenCodeSessionFactory(OpenCodeSessionFactory):
 
     def _start_proxy(self, sandbox):
         port = _free_port()
-        trace_path = oc_harness._PROXY_TRACE_PATH
-        log_path = oc_harness._PROXY_LOG_PATH
+        trace_path = proxy_trace_path(self._config)
+        log_path = proxy_log_path(self._config)
         if not sandbox.exists("/home/user/proxy/interception.py"):
             self._exec_with_retry(
                 sandbox,


### PR DESCRIPTION
## What

`examples/scripts/openenv/opencode.py` fails at session creation against current `OpenEnv@main`, so every rollout is scored `unscorable` and the example cannot train:

```
[RANK 0] harness session create failed; scoring rollout as unscorable
  File "opencode.py", line 420, in _start_proxy
    trace_path = oc_harness._PROXY_TRACE_PATH
AttributeError: module 'opencode_env.harness' has no attribute '_PROXY_TRACE_PATH'
```

`FreePortOpenCodeSessionFactory._start_proxy` read two private module constants. OpenEnv removed both in `451480ab0` ("Honor config.sandbox_home for proxy/opencode paths", 2026-07-21) and replaced them with functions so the paths follow `config.sandbox_home`.

Pinning OpenEnv does not help, as @Mandark-droid points out in the issue: `451480ab0` removed the constants a week *before* `7a882b87a` added the `ResourceSessionFactory` this example subclasses, so no single revision satisfies both.

## The change

```python
from opencode_env.opencode_runtime import proxy_log_path, proxy_trace_path
...
        trace_path = proxy_trace_path(self._config)
        log_path = proxy_log_path(self._config)
```

Imported from `opencode_env.opencode_runtime`, where the helpers are defined, rather than through their re-export in `opencode_env.harness`. Both resolve, but depending on the re-export is the pattern that broke here, and OpenEnv's own `harness.py` imports them from `opencode_runtime`.

`_PROXY_SOURCE_PATH` (line 431) still exists upstream and is untouched. `self._config` was already in scope, so nothing is plumbed through.

## Behavior is unchanged

At `a5af5cb8`, the parent of the removing commit, the constants were:

```python
_PROXY_TRACE_PATH = "/home/user/logs/agent/proxy_trace.jsonl"
_PROXY_LOG_PATH = "/home/user/logs/agent/proxy.log"
```

`build_factory` sets `sandbox_home="/home/user"`, so the helpers return those same two strings. The fix restores the previous paths rather than changing them.

## Verification

`opencode_env` is not a TRL dependency, so CI cannot exercise this. I installed `OpenEnv@main` locally and ran the checks directly:

| check | result |
|---|---|
| `oc_harness._PROXY_TRACE_PATH` / `._PROXY_LOG_PATH` | `AttributeError`, reproducing the report |
| `oc_harness._PROXY_SOURCE_PATH` | still a `PosixPath`, exists, readable |
| `from opencode_env.opencode_runtime import proxy_log_path, proxy_trace_path` | imports |
| `proxy_trace_path(cfg)` with the example's config | `'/home/user/logs/agent/proxy_trace.jsonl'` (`str`) |
| `proxy_log_path(cfg)` with the example's config | `'/home/user/logs/agent/proxy.log'` (`str`) |
| `shlex.quote` on both, and `sandbox.read_text(log_path)` typing | valid, both are `str` as before |

Also `py_compile` clean, `ruff check` and `ruff format --check` clean at the pinned 0.13.3, and an AST pass confirming no `_PROXY_TRACE_PATH` or `_PROXY_LOG_PATH` reads remain.

Scope is one file. `examples/scripts/openenv/opencode_hf_sandbox.py` does not import the harness module and is unaffected.

Resolves #6683

cc @qgallouedec @kashif @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file example script change with no TRL core or training-path impact; behavior is intended to be path-equivalent for the default config.
> 
> **Overview**
> Fixes **session creation failures** against current OpenEnv `main`, where `FreePortOpenCodeSessionFactory._start_proxy` referenced removed private harness constants (`_PROXY_TRACE_PATH`, `_PROXY_LOG_PATH`) and raised `AttributeError`, leaving every rollout **unscorable**.
> 
> The example now imports **`proxy_trace_path`** and **`proxy_log_path`** from `opencode_env.opencode_runtime` and resolves paths via **`self._config`**, matching OpenEnv’s post-refactor API. With the example’s `sandbox_home="/home/user"`, the resolved trace and log paths stay the same as before; only the lookup mechanism changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2ad5aeaee28efe63e852b57968414a529b0455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->