### PR TITLE
Fix Embed and lm_head FLOPS accounting

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1510,7 +1510,7 @@ class TestComputeFlopsPerToken(TrlTestCase):
         f_tied = compute_flops_per_token(cfg, 16384)
         cfg.tie_word_embeddings = False
         f_untied = compute_flops_per_token(cfg, 16384)
-        expected_delta = 3 * 2 * cfg.vocab_size * cfg.hidden_size
+        expected_delta = 0
         assert f_untied - f_tied == expected_delta
 
     def test_moe_active_vs_total_experts(self):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1573,10 +1573,8 @@ def compute_flops_per_token(config: PretrainedConfig, seq_len: int) -> int:
             attn_flops + (moe_mlp_flops if layer_idx % sparse_step == 0 else dense_mlp_flops) for layer_idx in range(L)
         )
 
-    embed_flops = 2 * V * h
-    lm_head_flops = 0 if config.tie_word_embeddings else 2 * V * h
-
-    forward_flops = total_layer_flops + embed_flops + lm_head_flops
+    lm_head_flops = 2 * V * h
+    forward_flops = total_layer_flops + lm_head_flops
     return 3 * forward_flops
 
 


### PR DESCRIPTION

# What does this PR do? 
Fixes #6708 

Input embedding is a lookup rather than a matrix multiplication, so it should count as 0 FLOPs. The LM head costs 2 * V * h FLOPs regardless of whether the embedding weights are tied.

embed_flops = 0
lm_head_flops = 2 * V * h

This PR removes the unnecessary tie_word_embeddings conditional logic and prevents double-counting when the embeddings are untied.

For a detailed explanation, see [this discussion](https://github.com/huggingface/trl/pull/5698/changes#r3733919945).

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [x] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

@AmineDiro @qgallouedec 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to MFU/FLOP estimation helpers and one unit test; no training, auth, or runtime model behavior changes.
> 
> **Overview**
> **`compute_flops_per_token`** no longer counts input embeddings as `2×V×h` matmul FLOPs (treated as **0** because embedding is a lookup). The **LM head** is always counted as **`2×V×h`** forward FLOPs, and the **`tie_word_embeddings`** branch is removed so tied weights are not double-counted as separate embed + head matmuls.
> 
> The **`test_tied_vs_untied_lm_head`** expectation is updated: tied vs untied configs should report the **same** total FLOPs (`expected_delta = 0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594b62df5f2b0cace80030ca1fff7be5fccfdd0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->