### PR TITLE
⚡️ Guard the RLOO completions table against prompts with no image

### DIFF
--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -17,9 +17,9 @@ from unittest.mock import patch
 import pytest
 import torch
 import transformers
-from PIL import Image
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
+from PIL import Image
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
@@ -2141,8 +2141,9 @@ class TestRLOOTrainerVLM(TrlTestCase):
         trainer._logs["images"] = [[Image.new("RGB", (4, 4))], None]  # second prompt has no image
 
         with (
-            patch.object(type(trainer.args), "report_to", ["wandb"]),
-            patch("trl.trainer.rloo_trainer.wandb", _Backend),
+            patch.object(trainer.args, "report_to", ["wandb"]),
+            # wandb is imported only when it is installed, so the name may not exist
+            patch("trl.trainer.rloo_trainer.wandb", _Backend, create=True),
             patch("trl.trainer.rloo_trainer.is_rich_available", return_value=False),
         ):
             _Backend.run = object()

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 import torch
 import transformers
+from PIL import Image
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import (
@@ -2090,6 +2091,65 @@ class TestRLOOTrainerVLM(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_log_completions_with_some_prompts_missing_images(self):
+        """A batch may mix multimodal and text-only prompts, in which case the per-sample entry
+        in `_logs["images"]` is None rather than an empty list, because `_generate_and_score_completions`
+        builds it as `[example.get("image")] if example.get("image") is not None else None`.
+        Building the completions table has to survive that. GRPOTrainer already guards it."""
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            report_to="none",
+            log_completions=True,
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        class _Backend:
+            """Stands in for wandb / trackio: only Image, Table and log are used."""
+
+            logged = None
+
+            class Image:
+                def __init__(self, image):
+                    self.image = image
+
+            class Table:
+                def __init__(self, dataframe):
+                    self.dataframe = dataframe
+
+            @classmethod
+            def log(cls, payload):
+                cls.logged = payload
+
+        trainer._logs["prompt"] = ["a", "b"]
+        trainer._logs["completion"] = ["x", "y"]
+        trainer._logs["rewards"] = {"reward": [1.0, 2.0]}
+        trainer._logs["advantages"] = [0.5, -0.5]
+        trainer._logs["images"] = [[Image.new("RGB", (4, 4))], None]  # second prompt has no image
+
+        with (
+            patch.object(type(trainer.args), "report_to", ["wandb"]),
+            patch("trl.trainer.rloo_trainer.wandb", _Backend),
+            patch("trl.trainer.rloo_trainer.is_rich_available", return_value=False),
+        ):
+            _Backend.run = object()
+            trainer.log({})
+
+        table = _Backend.logged["completions"].dataframe
+        assert list(table["image"].map(len)) == [1, 0]
 
     def test_train_vlm_log_multimodal_false(self):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1808,7 +1808,10 @@ class RLOOTrainer(_BaseTrainer):
                 if images_raw:
                     images = []
                     for image_list in self._logs["images"]:
-                        images.append([logging_backend.Image(image) for image in image_list])
+                        if image_list:
+                            images.append([logging_backend.Image(image) for image in image_list])
+                        else:
+                            images.append([])
                     df = pd.concat(
                         [df_base, pd.Series(images, name="image")],
                         axis=1,


### PR DESCRIPTION
# What does this PR do?

`RLOOTrainer._generate_and_score_completions` builds the per-sample image entry as

```python
images = [[example.get("image")] if example.get("image") is not None else None for example in inputs]
```

so a batch that mixes multimodal and text-only prompts puts `None` into `_logs["images"]`. `RLOOTrainer.log` then iterates it unguarded while building the completions table:

```python
for image_list in self._logs["images"]:
    images.append([logging_backend.Image(image) for image in image_list])
```

```
TypeError: 'NoneType' object is not iterable
```

`GRPOTrainer.log` already handles it and appends an empty list. The two blocks are otherwise identical, so this is the same fix propagated; they are byte identical after this change.

Reached whenever `log_completions=True` and `wandb` or `trackio` is in `report_to`, on any RLOO run whose dataset does not give every prompt an image.

`AGENTS.md` names this exact class: "A fix in GRPO often implies the same fix in RLOO, and vice versa. Not propagating a change is a bug."

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Tests

`test_log_completions_with_some_prompts_missing_images` in `tests/test_rloo_trainer.py` builds a trainer the same way the neighbouring VLM logging tests do, sets `_logs["images"]` to one real image and one `None`, stands in a fake backend for wandb, and asserts the table comes out with image counts `[1, 0]`.

Being straight about what I could and could not run: I do not have a machine that can run TRL's trainer tests, so the new test has not been executed and CI is the check. What I did verify locally is the failure itself, by running both blocks over `[["img"], None, ["img", "img"], None]`: RLOO's raises `TypeError: 'NoneType' object is not iterable`, GRPO's returns lengths `[1, 0, 2, 0]`. I also confirmed by AST-comparison that `grpo_trainer.py` and `rloo_trainer.py` are the only two files carrying this block, that only RLOO's is unguarded, and that after this change the two are identical. All of that was against `main` at 24db2a8.

If you would rather have the test exercise a real mixed dataset end to end than stand in a backend, say so and I will rewrite it that way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow logging-path fix aligned with existing GRPO behavior; no training or reward logic changes.
> 
> **Overview**
> Fixes a crash in **`RLOOTrainer.log`** when **`log_completions=True`** and wandb/trackio logging is enabled on batches that mix image and text-only prompts.
> 
> Per-sample entries in **`_logs["images"]`** can be **`None`** for prompts without an image; the completions table builder now skips those like **`GRPOTrainer`** already does, appending an empty image list instead of iterating **`None`**.
> 
> Adds **`test_log_completions_with_some_prompts_missing_images`** to assert the logged table gets image counts **`[1, 0]`** for one image and one **`None`** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18edfa4dcbd1fdb46df3f45a043ca1f8c86c9339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->