### PR TITLE
Hotfix CI: Skip transformers continuous batching test on pre-Ampere GPUs

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4445,6 +4445,11 @@ class TestGRPOTrainerSlow(TrlTestCase):
             "trl-internal-testing/tiny-MistralForCausalLM-0.2",
         ],
     )
+    @pytest.mark.skipif(
+        not is_ampere_or_newer() and torch_device != "xpu",
+        reason="transformers continuous batching switches attention to Flash Attention, which requires an Ampere or "
+        "newer GPU, or XPU (see https://github.com/huggingface/transformers/issues/47926)",
+    )
     def test_train_with_transformers_continuous_batching(self, model_name):
         """Test that training works with transformers continuous batching (requires GPU)."""
         if not Version(transformers.__version__) >= Version("5.8.0"):


### PR DESCRIPTION
This PR skips `test_train_with_transformers_continuous_batching` on pre-Ampere GPUs to keep the slow-tests CI green while the fix lands upstream.

Tracking issue:
- #6711

Upstream issue:
- huggingface/transformers#47926

### Motivation

The slow-tests CI job (single-GPU T4 runner) started failing `test_train_with_transformers_continuous_batching` for both `trl-internal-testing/tiny-LlamaForCausalLM-3.2` and `trl-internal-testing/tiny-MistralForCausalLM-0.2`:

> RuntimeError: min(): Expected reduction dim to be specified for input.numel() == 0. Specify the reduction dim with the 'dim' argument.

The root cause is upstream: with `transformers` 5.15.0, continuous batching auto-switches attention from `sdpa` to `flash_attention_3` (`kernels-community/vllm-flash-attn3`), which requires an Ampere or newer GPU and hard-fails on the T4 (Turing) runner:

> FlashAttention only supports Ampere GPUs or newer.

The generation thread then terminates and returns no completions, so the downstream metric logging (`agg_completion_lengths.float().min()`) raises on an empty tensor. The same test passed on `transformers` 5.14.1. See #6711 and huggingface/transformers#47926 for details.

### Solution

Short-term, TRL-side workaround to keep CI green while the fix lands upstream. No TRL runtime code is changed.

### Changes

- Skip `test_train_with_transformers_continuous_batching` on pre-Ampere GPUs (`not is_ampere_or_newer() and torch_device != "xpu"`), reusing the same Flash Attention skip condition already applied to other tests in this file, with a reason linking huggingface/transformers#47926.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI skip with no production or training code changes.
> 
> **Overview**
> Skips `test_train_with_transformers_continuous_batching` on pre-Ampere GPUs (except XPU) so slow-tests CI stays green on T4 runners.
> 
> Continuous batching in newer `transformers` auto-switches to Flash Attention, which fails on Turing GPUs. This reuses the existing `is_ampere_or_newer()` skip pattern already used elsewhere in the file. No runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc35c389755e66fa68285b64b7a39ad04500b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->