### PR TITLE
Honor model_init_kwargs dtype in AsyncGRPOTrainer

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -17,6 +17,7 @@ import itertools
 import math
 import multiprocessing as mp
 import queue
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -135,6 +136,38 @@ class _StubWeightTransfer:
 
     def destroy(self):
         pass
+
+
+class TestAsyncGRPOTrainerModelLoading(TrlTestCase):
+    @pytest.mark.parametrize(
+        ("model_init_kwargs", "expected_dtype"),
+        [(None, torch.float32), ({"dtype": "bfloat16"}, "bfloat16")],
+    )
+    def test_model_init_dtype(self, model_init_kwargs, expected_dtype):
+        expected_model_init_kwargs = model_init_kwargs.copy() if model_init_kwargs is not None else None
+        args = AsyncGRPOConfig(
+            output_dir=self.tmp_dir,
+            use_cpu=True,
+            bf16=False,
+            report_to="none",
+            model_init_kwargs=model_init_kwargs,
+        )
+
+        with patch(
+            "trl.experimental.async_grpo.async_grpo_trainer.AutoModelForCausalLM.from_pretrained",
+            side_effect=RuntimeError("model loader called"),
+        ) as model_loader:
+            with pytest.raises(RuntimeError, match="model loader called"):
+                AsyncGRPOTrainer(model="dummy-model", args=args)
+
+        model_loader.assert_called_once_with(
+            "dummy-model",
+            device_map=None,
+            attn_implementation="kernels-community/flash-attn3",
+            dtype=expected_dtype,
+            trust_remote_code=False,
+        )
+        assert args.model_init_kwargs == expected_model_init_kwargs
 
 
 @pytest.mark.skipif(

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -539,8 +539,9 @@ class AsyncGRPOTrainer(_BaseTrainer):
             Model to be trained. Must be a string, being the *model id* of a pretrained model hosted inside a model
             repo on huggingface.co, or a path to a *directory* containing model weights saved using
             [`~transformers.PreTrainedModel.save_pretrained`], e.g., `'./my_model_directory/'`. The model is loaded
-            using [`~transformers.AutoModelForCausalLM.from_pretrained`]. The model name is also used to identify the
-            model on the vLLM server used for generation.
+            using [`~transformers.AutoModelForCausalLM.from_pretrained`] with the keyword arguments in
+            `args.model_init_kwargs`. If `dtype` is not specified in `args.model_init_kwargs`, it defaults to
+            `float32`. The model name is also used to identify the model on the vLLM server used for generation.
         reward_funcs (`RewardFunc | list[RewardFunc]`, *optional*):
             Reward functions to be used for computing the rewards. To compute the rewards, we call all the reward
             functions with the prompts and completions and sum the rewards. May be omitted when the reward is supplied
@@ -664,14 +665,14 @@ class AsyncGRPOTrainer(_BaseTrainer):
         self.temperature = args.temperature
 
         # Model
-        model_init_kwargs = args.model_init_kwargs or {}
+        model_init_kwargs = dict(args.model_init_kwargs or {})  # copy to avoid mutating model_init_kwargs
+        model_init_kwargs.setdefault("dtype", torch.float32)
         model_init_kwargs.setdefault("trust_remote_code", args.trust_remote_code)
         # FlashAttention is required: training runs in padding-free mode, where sequences are concatenated into a
         # single row and `cu_seq_lens` are derived from `position_ids` resets. SDPA/eager can't handle this.
         model = AutoModelForCausalLM.from_pretrained(
             model,
             device_map=None,
-            dtype=torch.float32,
             attn_implementation="kernels-community/flash-attn3",
             **model_init_kwargs,
         )


### PR DESCRIPTION
  # What does this PR do?

  This PR allows `AsyncGRPOTrainer` to honor
  `args.model_init_kwargs["dtype"]` while preserving `torch.float32` as
  the default.

  Previously, `AsyncGRPOTrainer` passed `dtype=torch.float32` explicitly
  while also forwarding `model_init_kwargs`. Passing a documented dtype
  override through `model_init_kwargs` therefore supplied `dtype` twice
  and raised a `TypeError`.

  The trainer now copies `model_init_kwargs`, applies
  `model_init_kwargs.setdefault("dtype", torch.float32)`, and forwards
  the resulting arguments once. This preserves existing behavior when
  no dtype is supplied while permitting explicit overrides such as
  `"bfloat16"`.

  CPU-level regression tests verify:

  - `torch.float32` remains the default.
  - An explicit `"bfloat16"` value reaches the model loader.
  - Required AsyncGRPO loader arguments remain unchanged.
  - The supplied `model_init_kwargs` dictionary is not mutated.

  The scope was discussed in #6684 and confirmed by the issue author.

  This supersedes #6692, which was closed because its description did
  not retain the required PR template.

  Fixes #6684

  ## Before submitting

  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
  - [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
  - [x] Did you make sure to update the documentation with your changes?
  - [x] Did you write any new necessary tests?

  ## AI writing disclosure

  We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in
  this PR.

  - [ ] No AI usage: the PR was written entirely by a human.
  - [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
  - [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

  ## Who can review?

  Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow initialization fix with regression tests; no changes to training, weight sync, or rollout logic.
> 
> **Overview**
> **`AsyncGRPOTrainer` no longer passes `dtype` twice** to `AutoModelForCausalLM.from_pretrained`. It copies `args.model_init_kwargs`, applies `setdefault("dtype", torch.float32)`, and forwards a single kwargs dict—so documented overrides like `"bfloat16"` work and the default stays float32 when omitted.
> 
> The trainer docstring now describes this behavior. **CPU tests** mock the model loader to assert default vs explicit dtype, unchanged loader args, and that the original `model_init_kwargs` dict is not mutated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d856a5a11403fdf05ef32a368e4ed5ac6b8cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->