### PR TITLE
Drop vLLM 0.17 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.17.0` to `0.26.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.18.0` to `0.26.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.17.0,<=0.26.0",
+    "vllm>=0.18.0,<=0.26.0",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -17,7 +17,6 @@ import subprocess
 from types import SimpleNamespace
 
 import pytest
-from packaging.version import Version
 from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
 from transformers.testing_utils import torch_device
 
@@ -37,12 +36,7 @@ from .testing_utils import (
 
 
 if is_vllm_available():
-    import vllm
     from vllm import LLM, SamplingParams
-
-    _is_vllm_ge_014 = Version(vllm.__version__) >= Version("0.14.0")
-else:
-    _is_vllm_ge_014 = False
 
 
 class TestChunkList(TrlTestCase):
@@ -548,176 +542,6 @@ class TestVLLMClientServerTP(TrlTestCase):
         # Start the server process
         cls.server_process = subprocess.Popen(
             ["trl", "vllm-serve", "--model", cls.model_id, "--tensor_parallel_size", "2"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env,
-        )
-
-        # Initialize the client
-        cls.client = VLLMClient(connection_timeout=240, host="localhost")
-        cls.client.init_communicator()
-
-    def test_generate(self):
-        prompts = ["Hello, AI!", "Tell me a joke"]
-        outputs = self.client.generate(prompts)
-        prompt_ids = outputs["prompt_ids"]
-        completion_ids = outputs["completion_ids"]
-
-        # Check that the outputs are lists
-        assert isinstance(prompt_ids, list)
-        assert isinstance(completion_ids, list)
-
-        # Check that the number of sequences are equal to the number of prompts
-        assert len(prompt_ids) == len(prompts)
-        assert len(completion_ids) == len(prompts)
-
-        # Check that the sequences are lists of integers
-        for seq in prompt_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-        for seq in completion_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-
-    def test_generate_with_logprobs_none(self):
-        outputs = self.client.generate(["Hello, AI!"], logprobs=None)
-
-        assert isinstance(outputs["prompt_ids"], list)
-        assert isinstance(outputs["completion_ids"], list)
-        assert outputs["logprobs"] is None
-        assert outputs["logprob_token_ids"] is None
-
-    def test_chat(self):
-        messages = [[{"role": "user", "content": "Hello, AI!"}], [{"role": "user", "content": "Tell me a joke"}]]
-        outputs = self.client.chat(messages)
-        prompt_ids = outputs["prompt_ids"]
-        completion_ids = outputs["completion_ids"]
-
-        # Check that the outputs are lists
-        assert isinstance(prompt_ids, list)
-        assert isinstance(completion_ids, list)
-
-        # Check that the number of sequences are equal to the number of messages
-        assert len(prompt_ids) == len(messages)
-        assert len(completion_ids) == len(messages)
-
-        # Check that the sequences are lists of integers
-        for seq in prompt_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-        for seq in completion_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-
-    def test_chat_with_logprobs_none(self):
-        outputs = self.client.chat([[{"role": "user", "content": "Hello, AI!"}]], logprobs=None)
-
-        assert isinstance(outputs["prompt_ids"], list)
-        assert isinstance(outputs["completion_ids"], list)
-        assert outputs["logprobs"] is None
-        assert outputs["logprob_token_ids"] is None
-
-    def test_chat_with_tools(self):
-        def multiply(a: int, b: int) -> int:
-            """
-            Multiplies two integers.
-
-            Args:
-                a: The first integer.
-                b: The second integer.
-
-            Returns:
-                The product of the two integers.
-            """
-            return a * b
-
-        messages = [[{"role": "user", "content": "What is 3 multiplied by 4?"}]]
-        outputs = self.client.chat(messages, tools=[multiply])
-
-        # Decode prompt and check that "Multiplies two integers." is in the prompt.
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        decoded_prompt = tokenizer.decode(outputs["prompt_ids"][0])
-        assert "Multiplies two integers." in decoded_prompt
-
-    def test_generate_with_token_ids(self):
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        prompts = ["Hello, AI!", "Tell me a joke"]
-        prompt_token_ids = tokenizer(prompts)["input_ids"]
-        outputs = self.client.generate(prompt_token_ids)
-        prompt_ids = outputs["prompt_ids"]
-        completion_ids = outputs["completion_ids"]
-
-        # Check that the outputs are lists
-        assert isinstance(prompt_ids, list)
-        assert isinstance(completion_ids, list)
-
-        # Check that the number of sequences are equal to the number of prompts
-        assert len(prompt_ids) == len(prompts)
-        assert len(completion_ids) == len(prompts)
-
-        # Check that prompt_ids match the input token IDs
-        assert prompt_ids == prompt_token_ids
-
-        # Check that the sequences are lists of integers
-        for seq in prompt_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-        for seq in completion_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-
-    def test_generate_with_params(self):
-        prompts = ["Hello, AI!", "Tell me a joke"]
-        completion_ids = self.client.generate(prompts, n=2, repetition_penalty=0.9, temperature=0.8, max_tokens=32)[
-            "completion_ids"
-        ]
-
-        # Check that the output is a list
-        assert isinstance(completion_ids, list)
-
-        # Check that the number of generated sequences is 2 times the number of prompts
-        assert len(completion_ids) == 2 * len(prompts)
-
-        # Check that the generated sequences are lists of integers
-        for seq in completion_ids:
-            assert all(isinstance(tok, int) for tok in seq)
-
-        # Check that the length of the generated sequences is less than or equal to 32
-        for seq in completion_ids:
-            assert len(seq) <= 32
-
-    def test_update_model_params(self):
-        model = AutoModelForCausalLM.from_pretrained(self.model_id, device_map=torch_device)
-        self.client.update_model_params(model)
-
-    def test_reset_prefix_cache(self):
-        # Test resetting the prefix cache
-        self.client.reset_prefix_cache()
-
-    @classmethod
-    def teardown_class(cls):
-        # Close the client
-        cls.client.close_communicator()
-
-        # vLLM x pytest (or Popen) seems not to handle process termination well. To avoid zombie processes, we need to
-        # kill the server process and its children explicitly.
-        kill_process(cls.server_process)
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(
-    _is_vllm_ge_014,
-    reason="Skipping DP server test for vLLM>=0.14.0 (PR vllm#30739: DP for non-MoE/dense models no longer supported).",
-)
-@require_3_accelerators
-@require_vllm
-class TestVLLMClientServerDP(TrlTestCase):
-    model_id = "Qwen/Qwen2.5-1.5B"
-
-    @classmethod
-    def setup_class(cls):
-        # We want the server to run on accelerator 1 and 2, so we set VISIBLE_DEVICES to "1,2"
-        env = os.environ.copy()
-        VISIBLE_DEVICES = "ZE_AFFINITY_MASK" if torch_device == "xpu" else "CUDA_VISIBLE_DEVICES"
-        env[VISIBLE_DEVICES] = "1,2"  # Restrict to accelerator 1 and 2
-
-        # Start the server process
-        cls.server_process = subprocess.Popen(
-            ["trl", "vllm-serve", "--model", cls.model_id, "--data_parallel_size", "2"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -950,10 +950,8 @@ class AsyncRolloutWorker:
         child_ready_timeout: int = 300,
         **loop_kwargs: Any,
     ):
-        if not is_vllm_available(min_version="0.17.1"):
-            raise ImportError(
-                "vLLM >= 0.17.1 is required to use AsyncRolloutWorker. Install it with: pip install 'vllm>=0.17.1'"
-            )
+        if not is_vllm_available():
+            raise ImportError("vLLM is required to use AsyncRolloutWorker. Install it with: pip install vllm")
         ctx = mp.get_context("spawn")
         self._mp_ctx = ctx
         self.rollout_buffer = ctx.Queue(maxsize=queue_maxsize)

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -116,9 +116,9 @@ def is_vllm_available(min_version: str | None = None) -> bool:
         # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
         # above the plain release and would otherwise fail the upper-bound check.
         _vllm_base_version = Version(Version(_vllm_version).base_version)
-        if not (Version("0.17.0") <= _vllm_base_version <= Version("0.26.0")):
+        if not (Version("0.18.0") <= _vllm_base_version <= Version("0.26.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.17.0 to 0.26.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.18.0 to 0.26.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION


As per the plan, and following #6404 (which dropped 0.16), this raises the minimum supported vLLM version from `0.17.0` to `0.18.0`. The upper bound stays `0.26.0`.

vLLM 0.17.0 was released on 7 Mar 2026 and 0.17.1 on 11 Mar 2026, so both reached the 5-month support window on **7 Aug 2026** and **11 Aug 2026** respectively. Both dates have passed, so this is ready to merge now.

<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/2c6ff46d-8594-4686-a76f-dd84786c4ea6" />

## Changes

The supported range is updated in the same three places as #6404:

- `docs/source/vllm_integration.md` — the vLLM integration doc warning
- `pyproject.toml` — the `trl[vllm]` optional dependency (`vllm>=0.18.0,<=0.26.0`)
- `trl/import_utils.py` — the version check and warning text in `is_vllm_available()`

One version gate becomes dead and is removed: `AsyncRolloutWorker` required `>=0.17.1`, which now sits below the floor, so its check collapses to a plain `is_vllm_available()`. The only remaining gate is `>=0.22.0` in `trl/experimental/async_grpo/weight_transfer.py`, still above the floor.

Users on vLLM 0.17.x will see the compatibility warning, and `pip install "trl[vllm]"` will no longer resolve to 0.17.

## Drive-by cleanup

`TestVLLMClientServerDP` in `tests/test_vllm_client_server.py` is removed, along with the `_is_vllm_ge_014` flag that gated it. That flag has been unconditionally `True` since #6209 raised the floor to 0.15.0, so the class (9 tests) has been skipped on every supported vLLM for three releases. It should have gone with #6209.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor and docs-only alignment; users on vLLM 0.17.x get warnings and pip no longer resolves that range via trl[vllm].
> 
> **Overview**
> Raises TRL’s **minimum supported vLLM** from `0.17.0` to **`0.18.0`** (upper bound remains `0.26.0`). The range is updated in **`pyproject.toml`** (`trl[vllm]`), **`trl/import_utils.is_vllm_available()`** (check + warning text), and **`docs/source/vllm_integration.md`**.
> 
> **`AsyncRolloutWorker`** no longer requires `vllm>=0.17.1`; it uses the global supported-range check via plain `is_vllm_available()`.
> 
> **Test cleanup:** **`TestVLLMClientServerDP`** and the **`_is_vllm_ge_014`** skip flag are removed from `tests/test_vllm_client_server.py` (DP server tests were permanently skipped on current vLLM).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45fdb23c8e76889005c896c49f40a979e8a0f954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->