### PR TITLE
Fix misleading SFT step names in slow tests CI workflow

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -49,7 +49,7 @@ jobs:
           uv pip install ".[dev]"
           uv pip install pytest-reportlog
 
-      - name: Run slow SFT tests on single GPU
+      - name: Run slow tests on single GPU
         if: always()
         run: |
           source .venv/bin/activate
@@ -96,7 +96,7 @@ jobs:
           uv pip install ".[dev]"
           uv pip install pytest-reportlog
 
-      - name: Run slow SFT tests on Multi GPU
+      - name: Run slow tests on Multi GPU
         if: always()
         run: |
           source .venv/bin/activate


### PR DESCRIPTION
The two slow-tests steps are named "Run slow SFT tests on ... GPU", but both run the full slow test suite (`make slow_tests`), not only SFT tests. This renames them to "Run slow tests on ... GPU" to avoid confusion (e.g. GRPO failures showing up under an "SFT tests" step).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label-only CI workflow change; no test selection or runtime behavior changes.
> 
> **Overview**
> Renames two GitHub Actions step titles in `.github/workflows/slow-tests.yml` so they match what actually runs.
> 
> **Single GPU:** "Run slow SFT tests on single GPU" → **"Run slow tests on single GPU"**. **Multi GPU:** "Run slow SFT tests on Multi GPU" → **"Run slow tests on Multi GPU"**. Commands are unchanged (`make slow_tests`, which runs all `pytest -m "slow"` tests).
> 
> This avoids misreading CI when non-SFT slow tests (e.g. GRPO) fail under a step labeled SFT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e403f91ea40f161af61c3ead609456249898148e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->