### PR TITLE
fix(rewards): use rightmost delimiter in reasoning_accuracy_reward

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -293,6 +293,15 @@ class TestReasoningAccuracyReward:
         assert rewards[1] == 0.0
 
     @require_math_latex
+    def test_multiple_delimiters_uses_last_occurrence_in_text(self):
+        completions = [
+            [{"content": (r"<think> reasoning </think> \boxed{\frac{64}{400}} <answer> \boxed{\frac{63}{400}}")}],
+        ]
+        solutions = [r"\frac{63}{400}"]
+        rewards = reasoning_accuracy_reward(completions, solutions, reasoning_delimiters=["</think>", "<answer>"])
+        assert rewards[0] == 1.0
+
+    @require_math_latex
     def test_unparsable_gold_solution_yields_none_reward(self):
         completions = [
             [{"content": r"<think> Reasoning content </think> \boxed{42}"}],

--- a/trl/rewards/accuracy_rewards.py
+++ b/trl/rewards/accuracy_rewards.py
@@ -301,14 +301,19 @@ def reasoning_accuracy_reward(
         logging.getLogger("math_verify.grader").setLevel(logging.ERROR)
 
     for content, sol in zip(contents, solution, strict=True):
-        # Split final answer from reasoning content
-        is_reasoning_complete = False
+        # Split final answer from reasoning content. The final answer starts after the last occurrence of
+        # whichever delimiter appears furthest right in the text, not whichever is listed first in
+        # `reasoning_delimiters`.
+        split_pos = -1
         for delim in reasoning_delimiters:
-            if delim in content:
-                content = content.split(delim)[-1]
-                is_reasoning_complete = True
-                break
-        if not is_reasoning_complete:
+            pos = content.rfind(delim)
+            if pos > split_pos:
+                split_pos = pos
+                content_after_delim = content[pos + len(delim) :]
+        is_reasoning_complete = split_pos != -1
+        if is_reasoning_complete:
+            content = content_after_delim
+        else:
             # We assign zero reward instead of `None` to penalize incomplete reasoning
             rewards.append(0.0)
             gold_parsed_strs.append("[incomplete reasoning]")


### PR DESCRIPTION
## What does this PR do?

Fixes #6661.

`reasoning_accuracy_reward` picks the final-answer span using the
*first* delimiter (from `reasoning_delimiters`) that appears anywhere
in the text, rather than whichever delimiter's last occurrence is
furthest right. When a completion contains multiple delimiter types,
e.g. `... </think> stale answer </analysis> final`, this can split
off a stale intermediate answer instead of the actual final one.

This PR changes the delimiter search to find, across all configured
delimiters, the one whose last occurrence is furthest right in the
text, and splits there instead.

## Before submitting

- [x] Added a regression test (`test_multiple_delimiters_uses_last_occurrence_in_text`) reproducing the issue's example.
- [x] Ran `ruff check` / `ruff format` on the changed files.
- [x] Existing `TestReasoningAccuracyReward` cases still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how RL/math rewards are computed for reasoning completions when multiple delimiters appear, which can shift training signals but matches the documented delimiter semantics.
> 
> **Overview**
> **`reasoning_accuracy_reward`** now strips reasoning using the **rightmost** match among all `reasoning_delimiters`, instead of splitting on the first delimiter type that appears anywhere in the completion. That way a stale answer after `</think>` is ignored when a later `<answer>` block holds the real final answer.
> 
> A regression test covers completions with both `</think>` and `<answer>` and expects grading on the text after the furthest-right delimiter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e047c88cda3822bdb6d7896ce037616276aedd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->