### PR TITLE
fix(models): restore state in _unwrap_model_for_generation on error

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -16,10 +16,11 @@ import types
 from unittest.mock import patch
 
 import pytest
+from accelerate import Accelerator
 from transformers import AutoModelForCausalLM
 
 from trl.import_utils import is_deepspeed_available
-from trl.models.utils import disable_gradient_checkpointing, prepare_deepspeed
+from trl.models.utils import _unwrap_model_for_generation, disable_gradient_checkpointing, prepare_deepspeed
 
 
 @pytest.mark.skipif(not is_deepspeed_available(), reason="deepspeed is not installed")
@@ -72,4 +73,19 @@ class TestDisableGradientCheckpointing:
         assert model.is_gradient_checkpointing is True
         with disable_gradient_checkpointing(model):
             assert model.is_gradient_checkpointing is False
+        assert model.is_gradient_checkpointing is True
+
+
+class TestUnwrapModelForGeneration:
+    def test_restores_gradient_checkpointing_after_exception(self):
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        model.gradient_checkpointing_enable()
+        assert model.is_gradient_checkpointing is True
+        accelerator = Accelerator()
+
+        with pytest.raises(RuntimeError, match="boom"), _unwrap_model_for_generation(model, accelerator):
+            raise RuntimeError("boom")
+
+        # The context manager must restore gradient checkpointing even though generation raised, so the model isn't
+        # left in an inconsistent state for the training steps that follow.
         assert model.is_gradient_checkpointing is True

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -136,20 +136,26 @@ def _unwrap_model_for_generation(
         unwrapped_model.gradient_checkpointing_disable()
     from ..distributed import DistributedBackend
 
-    if DistributedBackend(accelerator).is_zero3:
-        if not gather_deepspeed3_params:
-            yield accelerator.unwrap_model(model)
-        else:
-            import deepspeed
-
-            with deepspeed.zero.GatheredParameters(model.parameters()):
-                remove_hooks(model)
+    try:
+        if DistributedBackend(accelerator).is_zero3:
+            if not gather_deepspeed3_params:
                 yield accelerator.unwrap_model(model)
-                add_hooks(model)
-    else:
-        yield unwrapped_model
-    if is_gradient_checkpointing:
-        unwrapped_model.gradient_checkpointing_enable()
+            else:
+                import deepspeed
+
+                with deepspeed.zero.GatheredParameters(model.parameters()):
+                    remove_hooks(model)
+                    try:
+                        yield accelerator.unwrap_model(model)
+                    finally:
+                        add_hooks(model)
+        else:
+            yield unwrapped_model
+    finally:
+        # Restore generation-time state whether generation succeeded or raised, so an exception mid-generation
+        # doesn't leave the model with checkpointing disabled or ZeRO-3 hooks missing.
+        if is_gradient_checkpointing:
+            unwrapped_model.gradient_checkpointing_enable()
 
 
 @contextmanager


### PR DESCRIPTION
## What does this PR do?

Fixes #6659.

`_unwrap_model_for_generation`'s cleanup (re-enabling gradient
checkpointing, restoring DeepSpeed ZeRO-3 optimizer hooks via
`add_hooks`) ran after the generator's `yield`, with no
`try`/`finally`. If generation raises inside the `with` block, Python
re-raises at the `yield` point and both cleanup statements are
skipped entirely, leaving the model with gradient checkpointing
disabled and/or ZeRO-3 hooks missing for every subsequent step.

This PR wraps the yield points in `try`/`finally` so cleanup always
runs regardless of whether generation succeeds or raises, while the
original exception still propagates normally. The pattern mirrors
`disable_gradient_checkpointing` already in the same file
(`trl/models/utils.py`), which does this correctly.

## Before submitting

- [x] Added a regression test (`TestUnwrapModelForGeneration::test_restores_gradient_checkpointing_after_exception`) that fails against the pre-fix code and passes against the fix.
- [x] Ran `ruff check` / `ruff format` on the changed files.
- [x] Existing `TestDisableGradientCheckpointing` tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed generation teardown used during RL training; behavior change is limited to error paths but affects ZeRO-3 hook lifecycle.
> 
> **Overview**
> **`_unwrap_model_for_generation`** now always restores training state when generation fails inside the context manager. Previously, cleanup ran only after a successful `yield`, so an exception during `generate()` could leave gradient checkpointing off and, on ZeRO-3 with gathered params, optimizer hooks unrestored.
> 
> The yield path is wrapped in **`try`/`finally`**: gradient checkpointing is re-enabled in the outer `finally`, and ZeRO-3 **`add_hooks`** runs in an inner `finally` after `remove_hooks`/`GatheredParameters`. Exceptions still propagate unchanged.
> 
> A regression test asserts gradient checkpointing is restored after a **`RuntimeError`** raised inside the context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692c1027fe6eb1d06baf86c8bc57d579e503355f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->