### PR TITLE
fix(trainer): make compute_flops_per_token invariant to embedding tying

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1474,14 +1474,14 @@ class TestComputeFlopsPerToken(TrlTestCase):
         assert f_32k - f_16k == 2 * (f_16k - f_8k)
 
     def test_tied_vs_untied_lm_head(self):
-        # Untied lm_head adds `2 * V * h` forward FLOPs, ×3 for fwd+bwd.
+        # Tying only shares parameters between the input embedding and the lm_head; the forward pass still runs
+        # the same lm_head matmul either way, so FLOPs must be identical.
         cfg = AutoConfig.from_pretrained(self.DENSE_MODEL_ID)
         cfg.tie_word_embeddings = True
         f_tied = compute_flops_per_token(cfg, 16384)
         cfg.tie_word_embeddings = False
         f_untied = compute_flops_per_token(cfg, 16384)
-        expected_delta = 3 * 2 * cfg.vocab_size * cfg.hidden_size
-        assert f_untied - f_tied == expected_delta
+        assert f_untied == f_tied
 
     def test_moe_active_vs_total_experts(self):
         # Doubling `num_experts_per_tok` (active experts) changes FLOPs by exactly the

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1568,10 +1568,12 @@ def compute_flops_per_token(config: PretrainedConfig, seq_len: int) -> int:
             attn_flops + (moe_mlp_flops if layer_idx % sparse_step == 0 else dense_mlp_flops) for layer_idx in range(L)
         )
 
-    embed_flops = 2 * V * h
-    lm_head_flops = 0 if config.tie_word_embeddings else 2 * V * h
+    # The input embedding is a lookup (gather), not a matmul, so it costs ~0 FLOPs regardless of vocab size. The
+    # output (lm_head) projection is a real matmul and always runs to produce logits, whether or not its weight is
+    # tied to the input embedding — tying only affects parameter count, not the forward computation.
+    lm_head_flops = 2 * V * h
 
-    forward_flops = total_layer_flops + embed_flops + lm_head_flops
+    forward_flops = total_layer_flops + lm_head_flops
     return 3 * forward_flops
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #6708.

`compute_flops_per_token` gave different FLOPs estimates for tied vs.
untied word embeddings, even though tying only shares *parameters*
between the input embedding and the `lm_head` — it doesn't change
what actually runs in the forward pass:

```python
embed_flops = 2 * V * h
lm_head_flops = 0 if config.tie_word_embeddings else 2 * V * h
```

- The input embedding is a lookup (gather), not a matmul, so modeling
  it as `2 * V * h` FLOPs overcounts it — it should cost ~0.
- The `lm_head` projection *is* a real matmul (hidden → vocab logits)
  and always runs, whether or not its weight matrix happens to be the
  same object as the input embedding. Zeroing it out when tied is
  incorrect.

This PR drops the embedding-lookup term entirely and makes the
`lm_head` matmul unconditional, so the FLOPs estimate no longer
depends on `tie_word_embeddings`, matching the repro in the issue
(`f_untied - f_tied == 0`).

Also updates the existing `test_tied_vs_untied_lm_head` test, which
had encoded the old (incorrect) non-zero delta as the expected
result.

## Before submitting

- [x] Updated the regression test to assert the correct invariant; confirmed it fails against the pre-fix code and passes against the fix.
- [x] Ran `ruff check` / `ruff format` on the changed files.
- [x] Other `TestComputeFlopsPerToken` / `TestComputeMfu` / `TestAdjustedMfu` tests still pass (`adjusted_mfu` calls `compute_flops_per_token` internally, so it picks up the fix automatically).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to an MFU estimation helper and its test; no training, auth, or runtime model behavior is affected, though reported MFU values will differ slightly from before.
> 
> **Overview**
> **`compute_flops_per_token`** no longer treats input embeddings as a `2×V×h` matmul or skips **`lm_head`** FLOPs when **`tie_word_embeddings`** is true. The estimate now always includes the **`lm_head`** logits matmul and omits embedding lookup cost (~0 FLOPs), so tied and untied configs return the same per-token FLOPs and MFU-style metrics shift slightly downward versus the old formula.
> 
> The **`test_tied_vs_untied_lm_head`** regression test now asserts **`f_untied == f_tied`** instead of expecting a vocab-sized delta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9009eedcd15d8384850b5e93633c20bcc457a044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->