### PR TITLE
fix(data): fix _pack_wrapped corrupting data on sliced input tables

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1218,6 +1218,15 @@ class TestPackDatasetWrapped(TrlTestCase):
         assert next(iter(dataset.with_format(None).batch(batch_size=num_examples))) == expected_output
         assert formatting == dataset._formatting
 
+    def test_with_multiple_map_batches(self):
+        # Regression test: `_pack_wrapped` must not duplicate or drop rows when `map` splits the dataset into
+        # multiple batches, each handed to it as a table sliced from a larger underlying buffer.
+        dataset = Dataset.from_dict({"input_ids": [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]})
+        seq_length = 4
+        expected_output = {"input_ids": [[1, 2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]]}
+        dataset = pack_dataset(dataset, seq_length, strategy="wrapped", map_kwargs={"batch_size": 3})
+        assert dataset.to_dict() == expected_output
+
 
 class TestPackDatasetBfd(TrlTestCase):
     def test_with_dataset(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -836,7 +836,14 @@ def _pack_wrapped(examples: pa.Table, seq_length: int) -> pa.Table:
     offsets = np.arange(0, num_elements, seq_length, dtype=columns[0].offsets.type.to_pandas_dtype())
     offsets = np.concatenate((offsets, [num_elements]))
     columns = [
-        type(column).from_arrays(offsets.astype(column.offsets.type.to_pandas_dtype()), column.values)
+        type(column).from_arrays(
+            offsets.astype(column.offsets.type.to_pandas_dtype()),
+            # `column.values` is the child buffer of the *unsliced* array the table's column may be a view into, so
+            # it must be cut down to this table's own slice the same way `values` was above, before pairing it with
+            # the new 0-based offsets computed from `num_elements`. Reusing the raw, unsliced buffer here silently
+            # duplicated or dropped rows whenever the incoming table was itself a slice (e.g. a `map` batch).
+            column.values[column.offsets[0].as_py() : column.offsets[-1].as_py()],
+        )
         for column in columns
     ]
     return pa.Table.from_arrays(columns, names=examples.column_names)


### PR DESCRIPTION
## What does this PR do?

Fixes #6669.

`_pack_wrapped` (the `"wrapped"` strategy of `pack_dataset`) computes
a fresh set of 0-based offsets sized to `columns[0]`'s own slice of
its child buffer, then reuses those offsets against **every column's
raw, unsliced `.values` buffer**:

```python
offsets, values = columns[0].offsets, columns[0].values
values = values[offsets[0].as_py() : offsets[-1].as_py()]  # correctly sliced, but only used for num_elements
num_elements = len(values)
offsets = np.arange(0, num_elements, seq_length, ...)       # 0-based, relative to the *sliced* view
...
columns = [
    type(column).from_arrays(offsets..., column.values)      # `column.values` is the *raw, unsliced* buffer
    for column in columns
]
```

If the table handed to `_pack_wrapped` is itself a zero-copy slice of
a larger underlying buffer — which happens routinely, e.g. once
`dataset.map(..., batched=True)` moves past the first batch — each
column's real data starts at some non-zero offset into the raw
buffer. Pairing that raw buffer with 0-based offsets silently
duplicates earlier rows and drops the real ones, with no error or
warning:

```python
from datasets import Dataset
from trl import pack_dataset

ds = Dataset.from_dict({"input_ids": [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]})
packed = pack_dataset(ds, seq_length=4, strategy="wrapped", map_kwargs={"batch_size": 3})
print(packed.to_dict()["input_ids"])
# Actual:   [[1, 2, 3, 4], [5, 6], [1, 2, 3, 4], [5, 6]]   <- second batch duplicates the first
# Expected: [[1, 2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]]
```

This is a regression from #5189. Only `"wrapped"` is affected;
`"bfd"`/`"bfd_split"` build fresh arrays via `pc.take` and don't share
this issue.

## The fix

Slice each column's `.values` down to its own offset bounds before
pairing it with the new offsets, the same way it was already (only)
done for `columns[0]` to compute `num_elements`.

## Before submitting

- [x] Added a regression test reproducing the issue's repro (`pack_dataset(..., strategy="wrapped", map_kwargs={"batch_size": 3})`); confirmed it fails against the pre-fix code and passes against the fix.
- [x] Manually verified the issue's larger repro (2500 rows) no longer loses any tokens.
- [x] Ran `ruff check` / `ruff format` on the changed files.
- [x] Existing `TestPackDatasetWrapped` / `TestPackDatasetBfd` tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes incorrect training data for wrapped packing under multi-batch map; scope is narrow but wrong packed tokens could have affected downstream LM training.
> 
> **Overview**
> Fixes silent **data corruption** in `pack_dataset` when using the **`wrapped`** strategy on batched `map` input (e.g. `map_kwargs={"batch_size": 3}`). After the first batch, Hugging Face `datasets` often passes **zero-copy slices** of a larger Arrow buffer; `_pack_wrapped` built **0-based offsets** for that slice but still attached them to each column’s **full, unsliced** `.values` buffer, which **duplicated** earlier rows and **dropped** the real ones with no error.
> 
> The change **slices every column’s `.values`** to `[offsets[0]:offsets[-1]]` before `from_arrays`, matching what was already done for `columns[0]` when computing `num_elements`. **`bfd` / `bfd_split`** are unchanged.
> 
> Adds **`test_with_multiple_map_batches`** to lock in correct packing across multiple map batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff265d88a4b9b3d335600061fd25e91472170365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->