### PR TITLE
Add Muse Glimmer support and testing

### DIFF
--- a/scripts/generate_tiny_models/for_conditional_generation/muse_glimmer_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/muse_glimmer_for_conditional_generation.py
@@ -1,0 +1,66 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import AutoConfig, AutoProcessor, GenerationConfig, MuseGlimmerForConditionalGeneration
+
+from .._common import (
+    check_dtype_pattern,
+    check_transformers_version,
+    init_weights_tiny_model,
+    print_config_diff,
+    push_to_hub,
+    smoke_test,
+)
+
+
+check_transformers_version("5.15.0")
+
+MODEL_ID = "meta-models/Muse-Glimmer-30B"
+
+processor = AutoProcessor.from_pretrained(MODEL_ID)
+generation_config = GenerationConfig.from_pretrained(MODEL_ID)
+
+text_config = {
+    "num_hidden_layers": 2,
+    "hidden_size": 16,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 8,
+    "intermediate_size": 32,
+    # The reference interleaves three sliding-attention layers with one full-attention layer, and the full-attention
+    # layers are the ones without rope (`layer_rope_theta` 0); keep one of each so both are exercised.
+    "layer_types": ["sliding_attention", "full_attention"],
+    "layer_rope_theta": [500000.0, 0],
+}
+vision_config = {
+    "num_hidden_layers": 2,
+    "hidden_size": 16,
+    "num_attention_heads": 4,
+    "intermediate_size": 32,
+    # Same idea on the vision side, where the window/full alternation plays the role of the sliding/full one.
+    "layer_types": ["window_attention", "full_attention"],
+}
+
+# The vision adapter consumes the pixel-shuffled vision output, so `out_hidden_size` must stay
+# `vision hidden_size * merge_size ** 2` (6144 = 1536 * 2 ** 2 in the reference).
+config = AutoConfig.from_pretrained(
+    MODEL_ID, text_config=text_config, vision_config=vision_config, out_hidden_size=64, projector_hidden_size=32
+)
+model = MuseGlimmerForConditionalGeneration(config).to(dtype=torch.bfloat16)
+init_weights_tiny_model(model)
+smoke_test(model, processor)
+check_dtype_pattern(MODEL_ID, model)
+print_config_diff(MODEL_ID, model)
+push_to_hub(model, processor, generation_config, "tiny")

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1484,6 +1484,13 @@ class TestDPOTrainerVLM(TrlTestCase):
             # "trl-internal-testing/tiny-Idefics3ForConditionalGeneration",  high memory peak, skipped for now
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.15.0"),
+                    reason="Muse Glimmer was introduced in transformers-5.15.0",
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -1410,6 +1410,13 @@ class TestKTOTrainerVLM(TrlTestCase):
             ),
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.15.0"),
+                    reason="Muse Glimmer was introduced in transformers-5.15.0",
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -505,6 +505,13 @@ class TestSFTTrainer(TrlTestCase):
             ),
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.15.0"),
+                    reason="Muse Glimmer was introduced in transformers-5.15.0",
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             pytest.param(
@@ -1847,6 +1854,13 @@ class TestSFTTrainer(TrlTestCase):
             # "trl-internal-testing/tiny-Idefics3ForConditionalGeneration",  high memory peak, skipped for now
             "trl-internal-testing/tiny-LlavaForConditionalGeneration",
             "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+            pytest.param(
+                "trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration",
+                marks=pytest.mark.skipif(
+                    Version(transformers.__version__) < Version("5.15.0"),
+                    reason="Muse Glimmer was introduced in transformers-5.15.0",
+                ),
+            ),
             "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
@@ -2584,6 +2598,13 @@ _CHUNKED_CE_VLM_MODEL_IDS = [
     ),
     "trl-internal-testing/tiny-LlavaForConditionalGeneration",
     "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
+    pytest.param(
+        "trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration",
+        marks=pytest.mark.skipif(
+            Version(transformers.__version__) < Version("5.15.0"),
+            reason="Muse Glimmer was introduced in transformers-5.15.0",
+        ),
+    ),
     "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
     "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
     pytest.param(

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -677,8 +677,14 @@ class DistillationTrainer(_BaseTrainer):
             # `logit_scale` or Gemma `final_logit_softcapping`. Refuse rather than silently optimize a different
             # objective than the model's real forward.
             if self.use_liger_kernel:
-                for name, config in [("student", self.model.config), ("teacher", teacher_model.config)]:
-                    scaled = getattr(config, "logit_scale", 1.0) not in (None, 1.0)
+                for name, model in [("student", self.model), ("teacher", teacher_model)]:
+                    # On VLMs the logit post-processing lives on `text_config`, so read it through
+                    # `get_text_config()`. Muse Glimmer names its pre-softcap multiplier `output_multiplier`.
+                    config = model.config.get_text_config()
+                    logit_scale = getattr(config, "logit_scale", None)
+                    if logit_scale is None:
+                        logit_scale = getattr(config, "output_multiplier", None)
+                    scaled = logit_scale not in (None, 1.0)
                     softcapped = getattr(config, "final_logit_softcapping", None) is not None
                     if scaled or softcapped:
                         raise ValueError(
@@ -1456,11 +1462,18 @@ class DistillationTrainer(_BaseTrainer):
             # The fused kernel produces no entropy; `compute_loss` logs none for the Liger path.
             return loss, None, None
 
-        student_config, teacher_config = unwrapped_student.config, unwrapped_teacher.config
+        # On VLMs the logit post-processing lives on `text_config`, so read it through `get_text_config()`.
+        student_config = unwrapped_student.config.get_text_config()
+        teacher_config = unwrapped_teacher.config.get_text_config()
         # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept
-        # as-is: the Liger guard rejects it, and the chunked path applies it faithfully.
-        student_logit_scale = getattr(student_config, "logit_scale", 1.0)
-        teacher_logit_scale = getattr(teacher_config, "logit_scale", 1.0)
+        # as-is: the Liger guard rejects it, and the chunked path applies it faithfully. Muse Glimmer applies the same
+        # pre-softcap multiplier under the name `output_multiplier`.
+        student_logit_scale = getattr(student_config, "logit_scale", None)
+        if student_logit_scale is None:
+            student_logit_scale = getattr(student_config, "output_multiplier", None)
+        teacher_logit_scale = getattr(teacher_config, "logit_scale", None)
+        if teacher_logit_scale is None:
+            teacher_logit_scale = getattr(teacher_config, "output_multiplier", None)
         student_logit_scale = 1.0 if student_logit_scale is None else student_logit_scale
         teacher_logit_scale = 1.0 if teacher_logit_scale is None else teacher_logit_scale
         loss, entropy_sum, n_valid = _chunked_divergence_loss(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -263,7 +263,9 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
     # text-only models keep them on the top-level config.
     text_config = model.config.text_config if is_vlm else model.config
     final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
-    logit_scale = getattr(text_config, "logit_scale", 1.0)
+    # Muse Glimmer applies the same pre-softcap multiplier as Cohere's `logit_scale`, under the name
+    # `output_multiplier`.
+    logit_scale = getattr(text_config, "logit_scale", None) or getattr(text_config, "output_multiplier", 1.0)
     original_forward = model.forward
     lm_head = model.get_output_embeddings()
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -264,8 +264,11 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
     text_config = model.config.text_config if is_vlm else model.config
     final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
     # Muse Glimmer applies the same pre-softcap multiplier as Cohere's `logit_scale`, under the name
-    # `output_multiplier`.
-    logit_scale = getattr(text_config, "logit_scale", None) or getattr(text_config, "output_multiplier", 1.0)
+    # `output_multiplier`. A real `logit_scale` of 0.0 is kept as-is and applied faithfully.
+    logit_scale = getattr(text_config, "logit_scale", None)
+    if logit_scale is None:
+        logit_scale = getattr(text_config, "output_multiplier", None)
+    logit_scale = 1.0 if logit_scale is None else logit_scale
     original_forward = model.forward
     lm_head = model.get_output_embeddings()
 


### PR DESCRIPTION
Released 2026-08-10: [meta-models/Muse-Glimmer-30B](https://huggingface.co/meta-models/Muse-Glimmer-30B) — Meta's Apache-2.0 agentic VLM (2B Perception Encoder + 28B dense text decoder), shipped in transformers 5.15.0.

- Tiny model script `muse_glimmer_for_conditional_generation.py` (`MuseGlimmerForConditionalGeneration`), pinned to `transformers==5.15.0`. Keeps one layer of each type on both towers (text: sliding / full-attention, where full-attention layers are the NoPE ones via `layer_rope_theta` 0; vision: window / full-attention), and scales `out_hidden_size` to `vision hidden_size * merge_size ** 2`, which the vision adapter requires. Config diff vs the reference is 14 entries, all scale-downs.
- Tests: VLM param lists in `test_sft_trainer.py` (3), `test_dpo_trainer.py`, `test_kto_trainer.py`.
- Tiny model pushed: `trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration`.

Not in this PR: the chat template. Muse Glimmer ships a native `response_template`, so parsing works out of the box, but the template has no `{% generation %}` markers — SFT `assistant_only_loss=True` needs a vendored training variant, and its `<atem:function_calls>` tool syntax is a new family. Follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly test coverage and small, targeted trainer config lookups for VLM logit scaling; no auth or data-path changes.
> 
> **Overview**
> Adds **Muse Glimmer** (transformers ≥5.15) to TRL via a new tiny-model generator script and wires `trl-internal-testing/tiny-MuseGlimmerForConditionalGeneration` into the existing VLM training tests for **SFT**, **DPO**, and **KTO**.
> 
> **SFT** chunked CE and **distillation** chunked/Liger paths now read logit post-processing from `get_text_config()` on VLMs and treat Muse Glimmer’s `output_multiplier` like Cohere’s `logit_scale`, so scaled logits match the model’s real forward instead of being skipped or mis-guarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441473ef025f23a63ba9f6744e0bc04db50604cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->