### PR TITLE
Add support for vLLM 0.27.0 and 0.27.1

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.18.0` to `0.26.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.18.0` to `0.27.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ test = [
     "pytest"
 ]
 vllm = [
-    "vllm>=0.18.0,<=0.26.0",
+    "vllm>=0.18.0,<=0.27.1",
     "fastapi",
     "pydantic",
     "aiohttp>=3.13.3",

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -116,9 +116,9 @@ def is_vllm_available(min_version: str | None = None) -> bool:
         # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
         # above the plain release and would otherwise fail the upper-bound check.
         _vllm_base_version = Version(Version(_vllm_version).base_version)
-        if not (Version("0.18.0") <= _vllm_base_version <= Version("0.26.0")):
+        if not (Version("0.18.0") <= _vllm_base_version <= Version("0.27.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.18.0 to 0.26.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.18.0 to 0.27.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
Checked the v0.27.0 release notes against the vLLM surface TRL actually uses: **No breaking changes for TRL.** (v0.27.1 is a patch release with a single change, irrelevant to TRL.)

### Relevant

* **RL: stateful trainer-send IPC (vllm-project/vllm#48981) and weight version tagging for RL rollouts (vllm-project/vllm#49040)**: touch `vllm.distributed.weight_transfer`, which the experimental async GRPO weight transfer imports — the `[2/N]` step of the migration tracked in #6732. Nothing breaks: 0.27.1 ships the new stateful `factory.py` *alongside* the static functions TRL uses, which still resolve unchanged. The deletion step (`[4/N]`) is unwritten upstream, so this bump doesn't force the migration.
* **`vllm config` set during weight reload (vllm-project/vllm#45989)**: internal to the reload path, no API change.
* **PyTorch 2.13.0 / torchvision 0.28.0 / Triton 3.7.1 (vllm-project/vllm#48155)**: a breaking *environment* change on vLLM's side, but TRL doesn't pin torch, so nothing to do here beyond noting that installing `trl[vllm]` at 0.27.x pulls torch 2.13.
* **Removed `max_num_partial_prefills` / `max_long_partial_prefills` (vllm-project/vllm#49244)**: TRL never sets either;`trl vllm-serve` doesn't expose them.
* **400 instead of 500 for non-numeric logprobs (vllm-project/vllm#49144)**: OpenAI-server-side only; TRL's `/generate` endpoint and `extract_logprobs` are unaffected.

also:

* Transformers 5.14.1 bump (vllm-project/vllm#49223): TRL is already v5-aligned (`transformers>=4.56.2`).
* Every other vLLM symbol TRL imports still resolves at v0.27.1. All `LLM(...)` kwargs `trl vllm-serve` passes are still valid engine args.

## Support window

<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/16e70fe2-f9ec-4370-b395-c9ca6dc7bba9" />

vLLM 0.27.0 was released on 10 Aug 2026 and 0.27.1 on 11 Aug 2026, so on the rolling 5-month window they age out around 10 and 11 Jan 2027. Next scheduled drop is 0.18.0 (released 20 Mar 2026 → out on **20 Aug 2026**).

### Test results

Run against vLLM 0.27.1 (torch 2.13.0, transformers 5.15.0.dev0), 4×H100:

```
$ pytest -v tests/test_vllm_client_server.py
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /fsx/qgallouedec/miniconda3/envs/trl/bin/python
cachedir: .pytest_cache
rootdir: /fsx/qgallouedec/trl
configfile: pyproject.toml
plugins: anyio-4.14.2, xdist-3.8.0
collecting ... collected 42 items

tests/test_vllm_client_server.py::TestChunkList::test_even_split PASSED  [  2%]
tests/test_vllm_client_server.py::TestChunkList::test_uneven_split PASSED [  4%]
tests/test_vllm_client_server.py::TestChunkList::test_more_chunks_than_elements PASSED [  7%]
tests/test_vllm_client_server.py::TestChunkList::test_n_equals_len PASSED [  9%]
tests/test_vllm_client_server.py::TestChunkList::test_n_is_1 PASSED      [ 11%]
tests/test_vllm_client_server.py::TestChunkList::test_single_element_list PASSED [ 14%]
tests/test_vllm_client_server.py::TestChunkList::test_any_dtype PASSED   [ 16%]
tests/test_vllm_client_server.py::TestExtractLogprobs::test_extract_logprobs_sorts_by_rank_and_replaces_nan PASSED [ 19%]
tests/test_vllm_client_server.py::TestExtractLogprobs::test_extract_logprobs_returns_none_token_ids_when_logprobs_missing PASSED [ 21%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate PASSED [ 23%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_logprobs_none PASSED [ 26%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat PASSED [ 28%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat_with_logprobs_none PASSED [ 30%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat_with_tools PASSED [ 33%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_token_ids PASSED [ 35%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_params PASSED [ 38%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_update_model_params PASSED [ 40%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_reset_prefix_cache PASSED [ 42%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_logprobs_match_with_non_default_sampling XFAIL [ 45%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate PASSED [ 47%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_logprobs_none PASSED [ 50%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat PASSED [ 52%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat_with_logprobs_none PASSED [ 54%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat_with_tools PASSED [ 57%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_token_ids PASSED [ 59%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_params PASSED [ 61%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_update_model_params PASSED [ 64%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_reset_prefix_cache PASSED [ 66%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate PASSED [ 69%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_logprobs_none PASSED [ 71%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat PASSED [ 73%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat_with_logprobs_none PASSED [ 76%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat_with_tools PASSED [ 78%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_token_ids PASSED [ 80%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_params PASSED [ 83%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_update_model_params PASSED [ 85%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_reset_prefix_cache PASSED [ 88%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_int PASSED [ 90%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_string PASSED [ 92%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_torch_device PASSED [ 95%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_with_token_ids_and_image PASSED [ 97%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_with_token_ids_mixed_images PASSED [100%]

================== 41 passed, 1 xfailed in 1018.52s (0:16:58) ==================
```

No warnings: the version-range check passes on 0.27.1 with this change applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-cap and documentation-only changes; no logic changes to vLLM training or serving beyond allowing 0.27.x installs.
> 
> **Overview**
> **Extends the supported vLLM range** from `0.26.0` to **`0.27.1`** so TRL users can install and run recent vLLM releases without compatibility warnings.
> 
> The upper bound is updated consistently in **`docs/source/vllm_integration.md`**, the **`trl[vllm]`** extra in `pyproject.toml` (`vllm>=0.18.0,<=0.27.1`), and **`is_vllm_available()`** in `trl/import_utils.py`, including the warning text when an installed version falls outside the window. No TRL integration code paths change beyond these version gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9a0c900cf7024bc6f75e7bb62462a6b008c37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
