### PR TITLE
Align the chunked-loss config access between SFT and Distillation

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -256,15 +256,17 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
         is_vlm (`bool`):
-            Set to `True` for VLMs. Only used to read `logit_scale` / `final_logit_softcapping` /
-            `output_router_logits` from `model.config.text_config` instead of the top-level config.
+            Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set
+            `base_model_prefix = ""` there (so the backbone must be read off `model.model`), and they take the
+            config-level MoE aux-loss parameters rather than the model-level ones.
     """
-    # VLM scaling configs (`logit_scale`, `final_logit_softcapping`, MoE `output_router_logits`) live on `text_config`;
-    # text-only models keep them on the top-level config.
-    text_config = model.config.text_config if is_vlm else model.config
+    # On VLMs the logit post-processing (`logit_scale`, `final_logit_softcapping`) and the MoE
+    # `output_router_logits` flag live on `text_config`, so read them through `get_text_config()`.
+    text_config = model.config.get_text_config()
     final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
-    # Muse Glimmer applies the same pre-softcap multiplier as Cohere's `logit_scale`, under the name
-    # `output_multiplier`. A real `logit_scale` of 0.0 is kept as-is and applied faithfully.
+    # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept
+    # as-is and applied faithfully. Muse Glimmer applies the same pre-softcap multiplier under the name
+    # `output_multiplier`.
     logit_scale = getattr(text_config, "logit_scale", None)
     if logit_scale is None:
         logit_scale = getattr(text_config, "output_multiplier", None)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -260,8 +260,8 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             `base_model_prefix = ""` there (so the backbone must be read off `model.model`), and they take the
             config-level MoE aux-loss parameters rather than the model-level ones.
     """
-    # On VLMs the logit post-processing (`logit_scale`, `final_logit_softcapping`) and the MoE
-    # `output_router_logits` flag live on `text_config`, so read them through `get_text_config()`.
+    # On VLMs the logit post-processing lives on `text_config`, so read it through `get_text_config()`. The MoE
+    # `output_router_logits` flag lives there too, and is read off the same config below.
     text_config = model.config.get_text_config()
     final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
     # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -256,9 +256,9 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
         is_vlm (`bool`):
-            Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set
-            `base_model_prefix = ""` there (so the backbone must be read off `model.model`), and they take the
-            config-level MoE aux-loss parameters rather than the model-level ones.
+            Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
+            there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss
+            parameters rather than the model-level ones.
     """
     # On VLMs the logit post-processing lives on `text_config`, so read it through `get_text_config()`. The MoE
     # `output_router_logits` flag lives there too, and is read off the same config below.


### PR DESCRIPTION
Both trainers resolve the same per-model logit post-processing (`logit_scale` / `output_multiplier` / `final_logit_softcapping`) for their chunked loss, but reached it two different ways. `DistillationTrainer` uses `config.get_text_config()`; SFT branched on an `is_vlm` flag.

- `_patch_chunked_ce_lm_head` now reads `model.config.get_text_config()`, so the resolution block is word-for-word identical to the one in `distillation_trainer.py`.
- `is_vlm` stays — it still gates two transformers < 5.0.0 fallbacks (VLMs set `base_model_prefix = ""`, and take config-level MoE aux-loss parameters) — but its docstring no longer claims a config-reading role it no longer has.
- `TestPatchChunkedCELMHead` + `TestChunkedCrossEntropyLoss`: 79 passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow refactor of config resolution for chunked NLL training; behavior should improve consistency for VLMs without touching auth or data paths.
> 
> **Overview**
> **SFT chunked-loss patching** now resolves logit post-processing (`logit_scale` / `output_multiplier`, `final_logit_softcapping`, and MoE `output_router_logits`) via `model.config.get_text_config()` instead of choosing between top-level `model.config` and `model.config.text_config` when `is_vlm` is true. That matches **`DistillationTrainer`**’s chunked-loss path so both trainers read the same config surface for VLMs and text-only models.
> 
> The **`is_vlm`** argument is unchanged for behavior: it still only drives transformers **&lt; 5.0.0** fallbacks (VLM backbone via `self.model` and config-level MoE aux-loss fields). Its docstring no longer describes config selection, since that is handled uniformly by `get_text_config()`. Inline comments were updated to document the `logit_scale` / `output_multiplier` fallback semantics in line with distillation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fe9e51b0ac1085dad9eb63905aa13a9ddc905a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->