### PR TITLE
Add Weighted Instruction Tuning loss to SFTTrainer

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1230,6 +1230,22 @@ trainer.train()
 
 Papers relating to the [`SFTTrainer`]
 
+### On the Effect of Instruction Tuning Loss on Generalization
+
+**📜 Paper**: https://huggingface.co/papers/2507.07817
+
+Weighted Instruction Tuning (WIT) assigns separate weights to prompt and response token losses and normalizes their weighted sum by the number of tokens with non-zero weight. The paper shows that conventional completion-only instruction tuning is often suboptimal and that low-to-moderate prompt weights combined with moderate-to-high response weights improve generalization across the studied models, datasets, and benchmarks. To use WIT with the [`SFTTrainer`], pass a prompt-completion dataset and configure:
+
+```python
+from trl import SFTConfig
+
+training_args = SFTConfig(
+    loss_type="wit",
+    prompt_loss_weight=0.2,
+    completion_loss_weight=0.8,
+)
+```
+
 ### EMA Without the Lag: Bias-Corrected Iterate Averaging Schemes
 
 **📜 Paper**: https://huggingface.co/papers/2508.00180

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1232,7 +1232,7 @@ Papers relating to the [`SFTTrainer`]
 
 ### On the Effect of Instruction Tuning Loss on Generalization
 
-**📜 Paper**: https://huggingface.co/papers/2507.07817
+**📜 Paper**: https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798
 
 Weighted Instruction Tuning (WIT) assigns separate weights to prompt and response token losses and normalizes their weighted sum by the number of tokens with non-zero weight. The paper shows that conventional completion-only instruction tuning is often suboptimal and that low-to-moderate prompt weights combined with moderate-to-high response weights improve generalization across the studied models, datasets, and benchmarks. To use WIT with the [`SFTTrainer`], pass a prompt-completion dataset and configure:
 

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1232,7 +1232,7 @@ Papers relating to the [`SFTTrainer`]
 
 ### On the Effect of Instruction Tuning Loss on Generalization
 
-**📜 Paper**: https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798
+**📜 Paper**: https://huggingface.co/papers/2507.07817
 
 Weighted Instruction Tuning (WIT) assigns separate weights to prompt and response token losses and normalizes their weighted sum by the number of tokens with non-zero weight. The paper shows that conventional completion-only instruction tuning is often suboptimal and that low-to-moderate prompt weights combined with moderate-to-high response weights improve generalization across the studied models, datasets, and benchmarks. To use WIT with the [`SFTTrainer`], pass a prompt-completion dataset and configure:
 

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -111,7 +111,7 @@ where  \\( y_t \\) is the target token at timestep  \\( t \\), and the model is 
 > The paper [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification](https://huggingface.co/papers/2508.05629) proposes an alternative loss function, called **Dynamic Fine-Tuning (DFT)**, which aims to improve generalization by rectifying the reward signal. This method can be enabled by setting `loss_type="dft"` in the [`SFTConfig`]. For more details, see [Paper Index - Dynamic Fine-Tuning](paper_index#on-the-generalization-of-sft-a-reinforcement-learning-perspective-with-reward-rectification).
 
 > [!TIP]
-> [Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) assigns independent weights to prompt and completion token losses. Enable it with `loss_type="wit"` and configure `prompt_loss_weight` and `completion_loss_weight`. WIT requires a text [prompt-completion](dataset_formats#prompt-completion) dataset. For more details, see [Paper Index - Weighted Instruction Tuning](paper_index#on-the-effect-of-instruction-tuning-loss-on-generalization).
+> [Weighted Instruction Tuning (WIT)](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798) assigns independent weights to prompt and completion token losses. Enable it with `loss_type="wit"` and configure `prompt_loss_weight` and `completion_loss_weight`. WIT requires a text [prompt-completion](dataset_formats#prompt-completion) dataset. For more details, see [Paper Index - Weighted Instruction Tuning](paper_index#on-the-effect-of-instruction-tuning-loss-on-generalization).
 
 > [!TIP]
 > By default, [`SFTTrainer`] uses `loss_type="chunked_nll"`: same math as `"nll"`, but the `lm_head` projection skips ignored-label tokens and the cross-entropy is processed in chunks, so peak activation memory does not scale with the full vocab × seq_len logits tensor. To fall back to the standard path, set `loss_type="nll"`. When `use_liger_kernel=True`, the default automatically resolves to `"nll"` (the two paths are not compatible). See [Chunked cross-entropy for reducing peak memory usage](reducing_memory_usage#chunked-cross-entropy-for-reducing-peak-memory-usage).
@@ -205,7 +205,7 @@ trainer.train()
 
 ### Weighted instruction tuning
 
-[Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) generalizes completion-only SFT by assigning separate loss weights to prompt and completion tokens. The weighted token losses are normalized by the number of tokens whose weight is non-zero, rather than by the sum of the weights.
+[Weighted Instruction Tuning (WIT)](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798) generalizes completion-only SFT by assigning separate loss weights to prompt and completion tokens. The weighted token losses are normalized by the number of tokens whose weight is non-zero, rather than by the sum of the weights.
 
 ```python
 from trl import SFTConfig

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -111,7 +111,7 @@ where  \\( y_t \\) is the target token at timestep  \\( t \\), and the model is 
 > The paper [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification](https://huggingface.co/papers/2508.05629) proposes an alternative loss function, called **Dynamic Fine-Tuning (DFT)**, which aims to improve generalization by rectifying the reward signal. This method can be enabled by setting `loss_type="dft"` in the [`SFTConfig`]. For more details, see [Paper Index - Dynamic Fine-Tuning](paper_index#on-the-generalization-of-sft-a-reinforcement-learning-perspective-with-reward-rectification).
 
 > [!TIP]
-> [Weighted Instruction Tuning (WIT)](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798) assigns independent weights to prompt and completion token losses. Enable it with `loss_type="wit"` and configure `prompt_loss_weight` and `completion_loss_weight`. WIT requires a text [prompt-completion](dataset_formats#prompt-completion) dataset. For more details, see [Paper Index - Weighted Instruction Tuning](paper_index#on-the-effect-of-instruction-tuning-loss-on-generalization).
+> [Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) assigns independent weights to prompt and completion token losses. Enable it with `loss_type="wit"` and configure `prompt_loss_weight` and `completion_loss_weight`. WIT requires a text [prompt-completion](dataset_formats#prompt-completion) dataset. For more details, see [Paper Index - Weighted Instruction Tuning](paper_index#on-the-effect-of-instruction-tuning-loss-on-generalization).
 
 > [!TIP]
 > By default, [`SFTTrainer`] uses `loss_type="chunked_nll"`: same math as `"nll"`, but the `lm_head` projection skips ignored-label tokens and the cross-entropy is processed in chunks, so peak activation memory does not scale with the full vocab × seq_len logits tensor. To fall back to the standard path, set `loss_type="nll"`. When `use_liger_kernel=True`, the default automatically resolves to `"nll"` (the two paths are not compatible). See [Chunked cross-entropy for reducing peak memory usage](reducing_memory_usage#chunked-cross-entropy-for-reducing-peak-memory-usage).
@@ -205,7 +205,7 @@ trainer.train()
 
 ### Weighted instruction tuning
 
-[Weighted Instruction Tuning (WIT)](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798) generalizes completion-only SFT by assigning separate loss weights to prompt and completion tokens. The weighted token losses are normalized by the number of tokens whose weight is non-zero, rather than by the sum of the weights.
+[Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) generalizes completion-only SFT by assigning separate loss weights to prompt and completion tokens. The weighted token losses are normalized by the number of tokens whose weight is non-zero, rather than by the sum of the weights.
 
 ```python
 from trl import SFTConfig

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -111,6 +111,9 @@ where  \\( y_t \\) is the target token at timestep  \\( t \\), and the model is 
 > The paper [On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification](https://huggingface.co/papers/2508.05629) proposes an alternative loss function, called **Dynamic Fine-Tuning (DFT)**, which aims to improve generalization by rectifying the reward signal. This method can be enabled by setting `loss_type="dft"` in the [`SFTConfig`]. For more details, see [Paper Index - Dynamic Fine-Tuning](paper_index#on-the-generalization-of-sft-a-reinforcement-learning-perspective-with-reward-rectification).
 
 > [!TIP]
+> [Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) assigns independent weights to prompt and completion token losses. Enable it with `loss_type="wit"` and configure `prompt_loss_weight` and `completion_loss_weight`. WIT requires a text [prompt-completion](dataset_formats#prompt-completion) dataset. For more details, see [Paper Index - Weighted Instruction Tuning](paper_index#on-the-effect-of-instruction-tuning-loss-on-generalization).
+
+> [!TIP]
 > By default, [`SFTTrainer`] uses `loss_type="chunked_nll"`: same math as `"nll"`, but the `lm_head` projection skips ignored-label tokens and the cross-entropy is processed in chunks, so peak activation memory does not scale with the full vocab × seq_len logits tensor. To fall back to the standard path, set `loss_type="nll"`. When `use_liger_kernel=True`, the default automatically resolves to `"nll"` (the two paths are not compatible). See [Chunked cross-entropy for reducing peak memory usage](reducing_memory_usage#chunked-cross-entropy-for-reducing-peak-memory-usage).
 
 ### Label shifting and masking
@@ -199,6 +202,24 @@ trainer.train()
 
 > [!TIP]
 > Training on completion only is compatible with training on assistant messages only. In this case, use a [conversational](dataset_formats#conversational) [prompt-completion](dataset_formats#prompt-completion) dataset and set `assistant_only_loss=True` in the [`SFTConfig`].
+
+### Weighted instruction tuning
+
+[Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) generalizes completion-only SFT by assigning separate loss weights to prompt and completion tokens. The weighted token losses are normalized by the number of tokens whose weight is non-zero, rather than by the sum of the weights.
+
+```python
+from trl import SFTConfig
+
+training_args = SFTConfig(
+    loss_type="wit",
+    prompt_loss_weight=0.2,
+    completion_loss_weight=0.8,
+)
+```
+
+Setting `(prompt_loss_weight, completion_loss_weight)` to `(0.0, 1.0)` recovers conventional completion-only SFT, while `(1.0, 1.0)` recovers full-sequence language modeling. WIT is supported for standard and conversational text prompt-completion datasets, including packing and padding-free training. It is not compatible with `assistant_only_loss`, vision-language datasets, Liger kernels, custom loss functions, or context/sequence parallelism.
+
+When `loss_type="wit"`, `prompt_loss_weight` and `completion_loss_weight` determine which tokens contribute to the loss; `completion_only_loss` does not alter the WIT objective.
 
 ### Train adapters with PEFT
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -42,6 +42,7 @@ from trl.trainer.sft_trainer import (
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
+    wit_loss,
 )
 
 from .testing_utils import (
@@ -94,6 +95,65 @@ class TestDFTLoss(TrlTestCase):
         torch.testing.assert_close(ce_loss / 2.0, predicted_dft_loss, atol=1e-4, rtol=1e-4)
 
 
+class TestWITLoss(TrlTestCase):
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"prompt_loss_weight": -0.1}, "prompt_loss_weight"),
+            ({"completion_loss_weight": 1.1}, "completion_loss_weight"),
+            (
+                {"loss_type": "wit", "prompt_loss_weight": 0.0, "completion_loss_weight": 0.0},
+                "must be non-zero",
+            ),
+        ],
+    )
+    def test_invalid_config(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            SFTConfig(output_dir=self.tmp_dir, **kwargs)
+
+    def test_wit_loss(self):
+        logits = torch.zeros(2, 3, 2)
+        outputs = MagicMock(logits=logits)
+        labels = torch.tensor([[1, 0, 0], [0, 1, -100]])
+        token_weights = torch.tensor([[0.2, 0.4, 0.8], [0.2, 0.4, 0.0]])
+
+        loss = wit_loss(outputs, labels, token_weights)
+
+        expected = torch.log(torch.tensor(2.0)) * (0.4 + 0.8 + 0.4) / 3
+        torch.testing.assert_close(loss, expected)
+
+    def test_zero_weight_tokens_are_excluded_from_normalization(self):
+        logits = torch.zeros(1, 4, 2)
+        outputs = MagicMock(logits=logits)
+        labels = torch.tensor([[1, 0, 1, 0]])
+        token_weights = torch.tensor([[1.0, 0.0, 0.5, 1.0]])
+
+        loss = wit_loss(outputs, labels, token_weights)
+
+        expected = torch.log(torch.tensor(2.0)) * (0.5 + 1.0) / 2
+        torch.testing.assert_close(loss, expected)
+
+    def test_gradient_accumulation_normalization(self):
+        torch.manual_seed(0)
+        logits = torch.randn(4, 5, 7)
+        labels = torch.randint(0, 7, (4, 5))
+        token_weights = torch.tensor([[0.2, 0.2, 1.0, 1.0, 1.0]] * 4)
+        num_items_in_batch = labels[..., 1:].numel()
+
+        full_loss = wit_loss(MagicMock(logits=logits), labels, token_weights, num_items_in_batch)
+        accumulated_loss = sum(
+            wit_loss(
+                MagicMock(logits=logits[start : start + 2]),
+                labels[start : start + 2],
+                token_weights[start : start + 2],
+                num_items_in_batch,
+            )
+            for start in (0, 2)
+        )
+
+        torch.testing.assert_close(accumulated_loss, full_loss)
+
+
 class TestDataCollatorForLanguageModeling(TrlTestCase):
     def test_basic_padding(self):
         """Test basic padding."""
@@ -118,6 +178,29 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
         torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
         torch.testing.assert_close(result["attention_mask"], torch.tensor([[1, 1, 1], [1, 1, 0]]))
         torch.testing.assert_close(result["labels"], torch.tensor([[1, 2, 3], [4, 5, -100]]))
+
+    def test_token_weights(self):
+        collator = DataCollatorForLanguageModeling(pad_token_id=0)
+        examples = [
+            {"input_ids": [1, 2, 3], "labels": [-100, 2, 3], "token_weights": [0.0, 0.2, 1.0]},
+            {"input_ids": [4, 5], "labels": [-100, 5], "token_weights": [0.0, 1.0]},
+        ]
+
+        result = collator(examples)
+
+        assert set(result.keys()) == {"input_ids", "attention_mask", "labels", "token_weights"}
+        torch.testing.assert_close(result["token_weights"], torch.tensor([[0.0, 0.2, 1.0], [0.0, 1.0, 0.0]]))
+
+    def test_token_weights_padding_free(self):
+        collator = DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True)
+        examples = [
+            {"input_ids": [1, 2, 3], "labels": [1, 2, 3], "token_weights": [0.2, 0.2, 1.0]},
+            {"input_ids": [4, 5], "labels": [4, 5], "token_weights": [0.2, 1.0]},
+        ]
+
+        result = collator(examples)
+
+        torch.testing.assert_close(result["token_weights"], torch.tensor([[0.0, 0.2, 1.0, 0.0, 1.0]]))
 
     def test_provided_labels_not_reconstructed_from_masks(self):
         """Provided labels are used as is, never rebuilt from the mask columns. Here the labels match the input IDs
@@ -438,6 +521,36 @@ class TestSFTTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
         # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_train_wit_loss(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_completion")
+
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="wit",
+            prompt_loss_weight=0.2,
+            completion_loss_weight=0.8,
+            gradient_accumulation_steps=2,
+            report_to="none",
+            eval_strategy="steps",
+            eval_steps=3,
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+            eval_dataset=dataset["test"],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        assert trainer.model_accepts_loss_kwargs
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
@@ -1301,6 +1414,33 @@ class TestSFTTrainer(TrlTestCase):
             assert any(label != -100 for label in labels)  # completion tokens contribute to the loss
             assert any(label == -100 for label in labels)  # prompt tokens are masked
 
+    @pytest.mark.parametrize("dataset_config", ["standard_prompt_completion", "conversational_prompt_completion"])
+    @pytest.mark.parametrize(("prompt_loss_weight", "completion_loss_weight"), [(0.2, 0.8), (0.0, 1.0), (1.0, 0.0)])
+    def test_dataset_preparation_builds_wit_loss_columns(
+        self, dataset_config, prompt_loss_weight, completion_loss_weight
+    ):
+        dataset = load_dataset("trl-internal-testing/zen", dataset_config, split="train")
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="wit",
+            prompt_loss_weight=prompt_loss_weight,
+            completion_loss_weight=completion_loss_weight,
+            report_to="none",
+        )
+
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        assert {"input_ids", "labels", "token_weights"}.issubset(trainer.train_dataset.column_names)
+        assert "completion_mask" not in trainer.train_dataset.column_names
+        expected_weights = {prompt_loss_weight, completion_loss_weight}
+        for example in trainer.train_dataset:
+            assert len(example["input_ids"]) == len(example["labels"]) == len(example["token_weights"])
+            assert set(example["token_weights"]) == expected_weights
+            for label, weight in zip(example["labels"], example["token_weights"], strict=True):
+                assert (label == -100) == (weight == 0.0)
+
     def test_dataset_preparation_respects_existing_labels(self):
         """A user-provided labels column must be taken as is, even when mask columns are also present."""
         dataset = Dataset.from_list(
@@ -1350,6 +1490,35 @@ class TestSFTTrainer(TrlTestCase):
         # The packed dataset must still contain trainable (non -100) labels
         assert any(label != -100 for example in trainer.train_dataset for label in example["labels"])
 
+    def test_packing_carries_wit_token_weights(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_completion", split="train")
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="wit",
+            prompt_loss_weight=0.2,
+            completion_loss_weight=0.8,
+            packing=True,
+            max_length=64,
+            report_to="none",
+        )
+
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        assert "token_weights" in trainer.train_dataset.column_names
+        for example in trainer.train_dataset:
+            assert len(example["input_ids"]) == len(example["labels"]) == len(example["token_weights"])
+
+    def test_wit_requires_prompt_completion_dataset(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+        training_args = SFTConfig(output_dir=self.tmp_dir, loss_type="wit", report_to="none")
+
+        with pytest.raises(ValueError, match="requires a prompt-completion dataset"):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+            )
+
     def test_skip_prepare_dataset_with_masks_but_no_labels_raises(self):
         """With `skip_prepare_dataset=True`, labels are not built at preparation time and the collator doesn't
         consume the mask columns; such datasets must be rejected instead of silently training on the full sequence."""
@@ -1359,6 +1528,22 @@ class TestSFTTrainer(TrlTestCase):
             output_dir=self.tmp_dir, dataset_kwargs={"skip_prepare_dataset": True}, report_to="none"
         )
         with pytest.raises(ValueError, match="Add a 'labels' column"):
+            SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+            )
+
+    def test_wit_skip_prepare_dataset_requires_loss_columns(self):
+        dataset = Dataset.from_list(
+            [{"input_ids": [1, 2, 3, 4], "labels": [1, 2, 3, 4], "completion_mask": [0, 0, 1, 1]}]
+        )
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="wit",
+            dataset_kwargs={"skip_prepare_dataset": True},
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="must contain 'labels' and 'token_weights'"):
             SFTTrainer(
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
             )

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -112,7 +112,7 @@ class SFTConfig(_BaseConfig):
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
             - `"wit"`: Weighted Instruction Tuning, as described in
-              [this paper](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798).
+              [this paper](https://huggingface.co/papers/2507.07817).
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.
@@ -292,7 +292,7 @@ class SFTConfig(_BaseConfig):
             "`use_liger_kernel=True`, in which case it defaults to `'nll'`. Possible values are `'nll'` (standard "
             "negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), "
             "`'wit'` (Weighted Instruction Tuning, "
-            "https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798), and "
+            "https://huggingface.co/papers/2507.07817), and "
             "`'chunked_nll'` (same math as `'nll'`, but the `lm_head` projection is computed on non-ignored tokens "
             "only — positions with `labels == -100` are dropped before the matmul — and the cross-entropy is "
             "processed in chunks of tokens to reduce peak activation memory; not compatible with `use_liger_kernel`; "

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -111,9 +111,15 @@ class SFTConfig(_BaseConfig):
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
+            - `"wit"`: Weighted Instruction Tuning, as described in
+              [this paper](https://huggingface.co/papers/2507.07817).
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.
+        prompt_loss_weight (`float`, *optional*, defaults to `0.0`):
+            Weight assigned to prompt-token losses when `loss_type="wit"`. Must be between `0.0` and `1.0`.
+        completion_loss_weight (`float`, *optional*, defaults to `1.0`):
+            Weight assigned to completion-token losses when `loss_type="wit"`. Must be between `0.0` and `1.0`.
 
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
@@ -284,13 +290,22 @@ class SFTConfig(_BaseConfig):
         metadata={
             "help": "Type of loss to use. When left unset, it defaults to `'chunked_nll'`, except when "
             "`use_liger_kernel=True`, in which case it defaults to `'nll'`. Possible values are `'nll'` (standard "
-            "negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), and "
+            "negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), "
+            "`'wit'` (Weighted Instruction Tuning, https://huggingface.co/papers/2507.07817), and "
             "`'chunked_nll'` (same math as `'nll'`, but the `lm_head` projection is computed on non-ignored tokens "
             "only — positions with `labels == -100` are dropped before the matmul — and the cross-entropy is "
             "processed in chunks of tokens to reduce peak activation memory; not compatible with `use_liger_kernel`; "
             "the patched `lm_head` path covers standard causal LMs and VLMs whose language model exposes a top-level "
             "`lm_head`, architectures with a non-standard head are not supported)."
         },
+    )
+    prompt_loss_weight: float = field(
+        default=0.0,
+        metadata={"help": "Weight assigned to prompt-token losses when `loss_type='wit'`."},
+    )
+    completion_loss_weight: float = field(
+        default=1.0,
+        metadata={"help": "Weight assigned to completion-token losses when `loss_type='wit'`."},
     )
     activation_offloading: bool = field(
         default=False,
@@ -333,3 +348,9 @@ class SFTConfig(_BaseConfig):
         # When unset, default to "chunked_nll" unless `use_liger_kernel=True`, in which case default to "nll".
         if self.loss_type is None:
             self.loss_type = "nll" if self.use_liger_kernel else "chunked_nll"
+        if not 0.0 <= self.prompt_loss_weight <= 1.0:
+            raise ValueError("`prompt_loss_weight` must be between 0.0 and 1.0.")
+        if not 0.0 <= self.completion_loss_weight <= 1.0:
+            raise ValueError("`completion_loss_weight` must be between 0.0 and 1.0.")
+        if self.loss_type == "wit" and self.prompt_loss_weight == 0.0 and self.completion_loss_weight == 0.0:
+            raise ValueError("At least one of `prompt_loss_weight` and `completion_loss_weight` must be non-zero.")

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -112,7 +112,7 @@ class SFTConfig(_BaseConfig):
             - `"dft"`: Dynamic Fine-Tuning, as described in
               [this paper](https://huggingface.co/papers/2508.05629).
             - `"wit"`: Weighted Instruction Tuning, as described in
-              [this paper](https://huggingface.co/papers/2507.07817).
+              [this paper](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798).
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.
@@ -291,7 +291,8 @@ class SFTConfig(_BaseConfig):
             "help": "Type of loss to use. When left unset, it defaults to `'chunked_nll'`, except when "
             "`use_liger_kernel=True`, in which case it defaults to `'nll'`. Possible values are `'nll'` (standard "
             "negative log-likelihood), `'dft'` (Dynamic Fine-Tuning, https://huggingface.co/papers/2508.05629), "
-            "`'wit'` (Weighted Instruction Tuning, https://huggingface.co/papers/2507.07817), and "
+            "`'wit'` (Weighted Instruction Tuning, "
+            "https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798), and "
             "`'chunked_nll'` (same math as `'nll'`, but the `lm_head` projection is computed on non-ignored tokens "
             "only — positions with `labels == -100` are dropped before the matmul — and the cross-entropy is "
             "processed in chunks of tokens to reduce peak activation memory; not compatible with `use_liger_kernel`; "

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -401,12 +401,13 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
     the [`SFTTrainer`] takes care of this during dataset preparation. The collator returns a dictionary containing the
     following keys:
     - `"input_ids"`: Tensor of input IDs, padded to the maximum length of the batch.
-    - `"labels"`: Tensor of labels, padded with `-100` to the maximum length of the batch. If `padding_free` is set
-    to `False`, the following key is also returned. If the input contains `"token_weights"`, they are padded with `0.0`
-    and returned under the same key.
-    - `"attention_mask"`: Tensor of attention masks, padded to the maximum length of the batch.
-    If `padding_free` is set to `True`, the following key is also returned:
-    - `"position_ids"`: Tensor of position IDs, padded to the maximum length of the batch.
+    - `"labels"`: Tensor of labels, padded with `-100` to the maximum length of the batch.
+    - `"token_weights"`: Tensor of token weights, padded with `0.0` to the maximum length of the batch. Returned only
+    when the input contains `"token_weights"`.
+    - `"attention_mask"`: Tensor of attention masks, padded to the maximum length of the batch. Returned only when
+    `padding_free=False`.
+    - `"position_ids"`: Tensor of position IDs, padded to the maximum length of the batch. Returned only when
+    `padding_free=True`.
 
     Args:
         pad_token_id (`int`):
@@ -802,7 +803,7 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
 def wit_loss(outputs, labels, token_weights, num_items_in_batch=None, num_virtual_tokens=0):
     """
     Weighted Instruction Tuning loss, as presented in [On the Effect of Instruction Tuning Loss on
-    Generalization](https://huggingface.co/papers/2507.07817).
+    Generalization](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798).
     """
     logits = outputs.logits[:, num_virtual_tokens:]
     labels = nn.functional.pad(labels, (0, 1), value=-100)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -402,7 +402,8 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
     following keys:
     - `"input_ids"`: Tensor of input IDs, padded to the maximum length of the batch.
     - `"labels"`: Tensor of labels, padded with `-100` to the maximum length of the batch. If `padding_free` is set
-    to `False`, the following key is also returned:
+    to `False`, the following key is also returned. If the input contains `"token_weights"`, they are padded with `0.0`
+    and returned under the same key.
     - `"attention_mask"`: Tensor of attention masks, padded to the maximum length of the batch.
     If `padding_free` is set to `True`, the following key is also returned:
     - `"position_ids"`: Tensor of position IDs, padded to the maximum length of the batch.
@@ -463,10 +464,13 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         input_ids = [example["input_ids"] for example in examples]
         batch_seq_lengths = [example["seq_lengths"] for example in examples] if "seq_lengths" in examples[0] else None
         labels = [example.get("labels", example["input_ids"]) for example in examples]
+        token_weights = [example["token_weights"] for example in examples] if "token_weights" in examples[0] else None
 
         # Convert to tensor
         input_ids = [torch.tensor(ids) for ids in input_ids]
         labels = [torch.tensor(lbl) for lbl in labels]
+        if token_weights is not None:
+            token_weights = [torch.tensor(weights, dtype=torch.float32) for weights in token_weights]
 
         # For padding-free, we should NOT create attention_mask as it causes FlashAttention to ignore position_ids and
         # compute wrong cu_seq_lens from the all-1s mask
@@ -483,6 +487,8 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         if self.padding_free:
             input_ids = [torch.cat(input_ids, dim=0)]
             labels = [torch.cat(labels, dim=0)]
+            if token_weights is not None:
+                token_weights = [torch.cat(token_weights, dim=0)]
             position_ids = [torch.cat(position_ids, dim=0)]
 
         # Pad
@@ -495,11 +501,17 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         output["labels"] = pad(
             labels, padding_value=-100, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
         )
+        if token_weights is not None:
+            output["token_weights"] = pad(
+                token_weights, padding_value=0.0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
+            )
         if self.padding_free:
             output["position_ids"] = pad(
                 position_ids, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
             )
             output["labels"][output["position_ids"] == 0] = -100
+            if token_weights is not None:
+                output["token_weights"][output["position_ids"] == 0] = 0.0
         else:
             output["attention_mask"] = pad(
                 attention_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
@@ -787,6 +799,25 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
     return loss
 
 
+def wit_loss(outputs, labels, token_weights, num_items_in_batch=None, num_virtual_tokens=0):
+    """
+    Weighted Instruction Tuning loss, as presented in [On the Effect of Instruction Tuning Loss on
+    Generalization](https://huggingface.co/papers/2507.07817).
+    """
+    logits = outputs.logits[:, num_virtual_tokens:]
+    labels = nn.functional.pad(labels, (0, 1), value=-100)
+    token_weights = nn.functional.pad(token_weights, (0, 1), value=0.0)
+    shift_labels = labels[..., 1:]
+    shift_token_weights = token_weights[..., 1:]
+    loss_mask = (shift_labels != -100) & (shift_token_weights != 0.0)
+    shift_labels[~loss_mask] = 0
+    logprobs = selective_log_softmax(logits, shift_labels)
+    if num_items_in_batch is None:
+        num_items_in_batch = loss_mask.sum()
+    loss = -(logprobs * shift_token_weights * loss_mask).sum() / num_items_in_batch
+    return loss
+
+
 class SFTTrainer(_BaseTrainer):
     """
     Trainer for Supervised Fine-Tuning (SFT) method.
@@ -932,6 +963,7 @@ class SFTTrainer(_BaseTrainer):
             if Version(transformers.__version__) < Version("5.0.0"):
                 dict_args.pop("push_to_hub_token")
             args = SFTConfig(**dict_args)
+        self._use_wit = args.loss_type == "wit"
 
         if train_dataset is None:
             raise ValueError("`train_dataset` is required")
@@ -1046,6 +1078,28 @@ class SFTTrainer(_BaseTrainer):
                 "drop them, causing pixel_values to be forwarded to the model with no corresponding visual "
                 "tokens in input_ids. Use truncation_mode='keep_start' (the default) or set max_length=None."
             )
+        if args.loss_type == "wit":
+            if self._is_vision_dataset:
+                raise ValueError("`loss_type='wit'` is not supported for vision-language datasets.")
+            if not (
+                "prompt" in dataset_sample
+                and "completion" in dataset_sample
+                or "completion_mask" in dataset_sample
+                or "token_weights" in dataset_sample
+            ):
+                raise ValueError("`loss_type='wit'` requires a prompt-completion dataset.")
+            if args.assistant_only_loss:
+                raise ValueError("`loss_type='wit'` is not compatible with `assistant_only_loss=True`.")
+            if formatting_func is not None:
+                raise ValueError("`loss_type='wit'` is not compatible with a formatting function.")
+            if args.use_liger_kernel:
+                raise ValueError("`loss_type='wit'` is not compatible with `use_liger_kernel=True`.")
+            if compute_loss_func is not None:
+                raise ValueError(
+                    "You passed a `compute_loss_func` together with `loss_type='wit'` to the `SFTTrainer`. "
+                    "When using `loss_type='wit'`, the loss function is internally set to the WIT loss, so "
+                    "passing a `compute_loss_func` is not allowed."
+                )
 
         # PEFT
         if peft_config is not None:
@@ -1299,6 +1353,8 @@ class SFTTrainer(_BaseTrainer):
                         "passing a `compute_loss_func` is not allowed."
                     )
                 compute_loss_func = dft_loss
+            elif args.loss_type == "wit":
+                pass  # handled in `compute_loss`, which also receives the per-token weights
             elif args.loss_type == "chunked_nll":
                 # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
                 # chunks of tokens. Implemented by patching the model's forward before `super().__init__` so accelerate
@@ -1323,7 +1379,7 @@ class SFTTrainer(_BaseTrainer):
                 _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', 'wit', and "
                     "'chunked_nll'."
                 )
         elif args.loss_type == "chunked_nll":
@@ -1351,6 +1407,10 @@ class SFTTrainer(_BaseTrainer):
             optimizer_cls_and_kwargs=optimizer_cls_and_kwargs,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
+        if args.loss_type == "wit":
+            # WIT consumes `num_items_in_batch` in `compute_loss`; ensure Trainer counts it even for models whose
+            # forward signature does not accept loss kwargs, and does not divide the loss by gradient accumulation.
+            self.model_accepts_loss_kwargs = True
 
         # Initialize activation offloading context
         if self.args.activation_offloading:
@@ -1543,12 +1603,45 @@ class SFTTrainer(_BaseTrainer):
                     **map_kwargs,
                 )
 
-            # Build a "labels" column, setting tokens that shouldn't contribute to the loss to -100 based on the
-            # available masks: "assistant_masks" always applies, "completion_mask" only when completion_only_loss
-            # is enabled. With no applicable mask, every token contributes (labels == input_ids). A dataset that
-            # already provides a "labels" column is left as is.
+            # Build the loss columns. WIT keeps the prompt/completion boundary as per-token weights and masks only
+            # tokens whose configured weight is zero. Other losses set tokens excluded by the applicable masks to
+            # -100. A dataset that already provides a "labels" column is left as is outside the WIT path.
             column_names = get_dataset_column_names(dataset)
-            if "labels" not in column_names:
+            if args.loss_type == "wit":
+                if "token_weights" not in column_names and "completion_mask" not in column_names:
+                    raise ValueError(
+                        "`loss_type='wit'` requires either a prompt-completion dataset or a pretokenized dataset "
+                        "with a 'completion_mask' or 'token_weights' column."
+                    )
+                if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
+                    map_kwargs["desc"] = f"Building WIT loss columns for {dataset_name} dataset"
+
+                def build_wit_loss_columns(example, prompt_loss_weight, completion_loss_weight):
+                    if "token_weights" in example:
+                        token_weights = example["token_weights"]
+                    else:
+                        token_weights = [
+                            completion_loss_weight if is_completion else prompt_loss_weight
+                            for is_completion in example["completion_mask"]
+                        ]
+                    labels = example.get("labels", example["input_ids"])
+                    labels = [
+                        label if label != -100 and weight != 0.0 else -100
+                        for label, weight in zip(labels, token_weights, strict=True)
+                    ]
+                    return {"labels": labels, "token_weights": token_weights}
+
+                mask_columns = [column for column in ("completion_mask", "assistant_masks") if column in column_names]
+                dataset = dataset.map(
+                    build_wit_loss_columns,
+                    fn_kwargs={
+                        "prompt_loss_weight": args.prompt_loss_weight,
+                        "completion_loss_weight": args.completion_loss_weight,
+                    },
+                    remove_columns=mask_columns,
+                    **map_kwargs,
+                )
+            elif "labels" not in column_names:
                 mask_columns = []
                 if self.completion_only_loss and "completion_mask" in column_names:
                     mask_columns.append("completion_mask")
@@ -1587,10 +1680,13 @@ class SFTTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Truncating {dataset_name} dataset"
 
-                def truncate(example, sl):
-                    return {"input_ids": example["input_ids"][sl], "labels": example["labels"][sl]}
+                def truncate(example, sl, use_wit):
+                    output = {"input_ids": example["input_ids"][sl], "labels": example["labels"][sl]}
+                    if use_wit:
+                        output["token_weights"] = example["token_weights"][sl]
+                    return output
 
-                dataset = dataset.map(truncate, fn_kwargs={"sl": sl}, **map_kwargs)
+                dataset = dataset.map(truncate, fn_kwargs={"sl": sl, "use_wit": args.loss_type == "wit"}, **map_kwargs)
 
                 # Drop examples left fully masked by truncation (e.g. a prompt alone filling `max_length` with
                 # `truncation_mode="keep_start"`), since they contribute no loss.
@@ -1608,7 +1704,10 @@ class SFTTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Packing {dataset_name} dataset"
 
-                dataset = dataset.select_columns(["input_ids", "labels"])
+                columns = ["input_ids", "labels"]
+                if args.loss_type == "wit":
+                    columns.append("token_weights")
+                dataset = dataset.select_columns(columns)
 
                 # Shuffle the dataset before packing. When using wrapped packing, it's important to shuffle before
                 # packing as well to avoid correlations between sequences packed together.
@@ -1638,6 +1737,8 @@ class SFTTrainer(_BaseTrainer):
                 self._signature_columns = ["messages", "prompt", "completion", "image", "images"]
             else:
                 self._signature_columns = ["input_ids", "labels", "seq_lengths"]
+                if self.args.loss_type == "wit":
+                    self._signature_columns.append("token_weights")
 
     def _reject_skip_prepare_without_labels(self, datasets: dict[str, Dataset], data_collator) -> None:
         # This guard may look defensive, but it covers a behavior change introduced when label building moved from
@@ -1654,6 +1755,11 @@ class SFTTrainer(_BaseTrainer):
             return
         for name, dataset in datasets.items():
             cols = get_dataset_column_names(dataset)
+            if self._use_wit and not {"labels", "token_weights"}.issubset(cols):
+                raise ValueError(
+                    f"The {name} dataset must contain 'labels' and 'token_weights' when using `loss_type='wit'` "
+                    "with `skip_prepare_dataset=True`."
+                )
             if "labels" not in cols and ("completion_mask" in cols or "assistant_masks" in cols):
                 raise ValueError(
                     f"The {name} dataset has mask columns but no 'labels', and `skip_prepare_dataset=True` skips "
@@ -1704,6 +1810,7 @@ class SFTTrainer(_BaseTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         mode = "train" if self.model.training else "eval"
         prediction_loss_only = inputs.pop("_prediction_loss_only", None)
+        token_weights = inputs.pop("token_weights", None)
 
         # Set aside labels as it will be dropped by super().compute_loss() if a custom `compute_loss_func` is used.
         # This can be removed when this issue is fixed.
@@ -1741,9 +1848,31 @@ class SFTTrainer(_BaseTrainer):
             inputs["use_token_scaling"] = self.args.loss_type == "dft"
 
         try:
-            (loss, outputs) = super().compute_loss(
-                model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
-            )
+            if self.args.loss_type == "wit":
+                if "shift_labels" in inputs:
+                    raise ValueError("`loss_type='wit'` is not supported with context or sequence parallelism.")
+                if token_weights is None:
+                    raise ValueError("`loss_type='wit'` requires a 'token_weights' tensor in every batch.")
+                labels = inputs.pop("labels")
+                outputs = model(**inputs)
+                num_virtual_tokens = 0
+                if (
+                    self.num_virtual_tokens > 0
+                    and model.peft_config[model.active_adapter].peft_type != PeftType.PREFIX_TUNING
+                ):
+                    num_virtual_tokens = self.num_virtual_tokens
+                loss = wit_loss(outputs, labels, token_weights, num_items_in_batch, num_virtual_tokens)
+                if self.aux_loss_enabled:
+                    loss = loss + self.args.router_aux_loss_coef * outputs.aux_loss
+                if self.args.average_tokens_across_devices and num_items_in_batch is not None:
+                    loss_scale = self.accelerator.num_processes
+                    if (pc := getattr(self.accelerator, "parallelism_config", None)) is not None:
+                        loss_scale //= pc.tp_size
+                    loss *= loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
+            else:
+                (loss, outputs) = super().compute_loss(
+                    model, inputs, return_outputs=True, num_items_in_batch=num_items_in_batch
+                )
         except ValueError as e:
             if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:
                 raise ValueError(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -803,7 +803,7 @@ def dft_loss(outputs, labels, num_items_in_batch=None):
 def wit_loss(outputs, labels, token_weights, num_items_in_batch=None, num_virtual_tokens=0):
     """
     Weighted Instruction Tuning loss, as presented in [On the Effect of Instruction Tuning Loss on
-    Generalization](https://direct.mit.edu/tacl/article/doi/10.1162/TACL.a.42/133798).
+    Generalization](https://huggingface.co/papers/2507.07817).
     """
     logits = outputs.logits[:, num_virtual_tokens:]
     labels = nn.functional.pad(labels, (0, 1), value=-100)


### PR DESCRIPTION
# What does this PR do?

Adds [Weighted Instruction Tuning (WIT)](https://huggingface.co/papers/2507.07817) as an opt-in `SFTTrainer` loss for text prompt-completion datasets:

```python
training_args = SFTConfig(
    loss_type="wit",
    prompt_loss_weight=0.2,
    completion_loss_weight=0.8,
)
```

WIT assigns independent weights to prompt and completion token losses. The weighted loss is normalized by the number of tokens whose weight is non-zero, rather than by the sum of weights. Consequently, `(0.0, 1.0)` recovers completion-only SFT and `(1.0, 1.0)` recovers full-sequence language modeling.

The implementation:

- preserves prompt/completion boundaries as per-token weights through preprocessing, truncation, packing, padding, and padding-free collation;
- masks zero-weight tokens in `labels`, allowing current Transformers to compute the exact nonzero-token denominator across gradient-accumulation microbatches;
- consumes `num_items_in_batch` in the custom loss so Trainer does not apply an additional gradient-accumulation division;
- supports standard and conversational text prompt-completion datasets;
- rejects unsupported combinations explicitly (language-modeling or vision datasets, assistant-only loss, formatting functions, Liger kernels, custom loss functions, and context/sequence parallelism);
- documents the API and adds the paper to TRL's paper index; and
- adds unit, preprocessing, collation, packing, gradient-accumulation, validation, and end-to-end training tests.

Validation performed locally on the current `main` branch:

- `make precommit`
- `python -m pytest -p no:rerunfailures tests/test_sft_trainer.py` — 116 passed, 166 skipped
- focused WIT selection — 18 passed

Fixes #6746

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #6746.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.
