### PR TITLE
Remove unused RUN_SLOW env variable from slow tests workflow

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -8,7 +8,6 @@ on:
       - "trl/**.py"
       - "examples/**.py"
 env:
-  RUN_SLOW: "yes"
   IS_GITHUB_CI: "1"
   SLACK_API_TOKEN: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
   HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
This PR removes the unused `RUN_SLOW` environment variable from the slow tests workflow.

### Motivation

`RUN_SLOW` is never read anywhere in the codebase, and it never was: it was introduced in #1223 as a copy of the `transformers` / `peft` / `accelerate` convention, where `testing_utils.py` reads it to build a `require_slow` decorator. TRL instead selects slow tests with the `slow` pytest marker declared in `pyproject.toml` and passed as `-m "slow"` by the `slow_tests` Make target, so the variable has no effect.

### Changes

- Drop the `RUN_SLOW` environment variable from the slow tests workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only removal of an env var that was never consumed; test selection behavior is unchanged.
> 
> **Overview**
> Removes the **`RUN_SLOW: "yes"`** workflow-level env var from **`.github/workflows/slow-tests.yml`**.
> 
> Slow CI still runs via **`make slow_tests`**, which selects tests with pytest’s **`slow`** marker (`-m "slow"`). Nothing in TRL reads **`RUN_SLOW`**, so dropping it only cleans up dead config copied from other Hugging Face repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826f553466e1d9590d6e0fd242448ff249f0d86a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->