### PR TITLE
Use built-in GITHUB_ACTIONS variable instead of custom IS_GITHUB_CI

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -8,7 +8,6 @@ on:
       - "trl/**.py"
       - "examples/**.py"
 env:
-  IS_GITHUB_CI: "1"
   SLACK_API_TOKEN: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   TRL_EXPERIMENTAL_SILENCE: 1

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ precommit:
 	pre-commit run --all-files
 
 slow_tests:
-	pytest -m "slow" tests/ $(if $(IS_GITHUB_CI),--report-log "slow_tests.log",)
+	pytest -m "slow" tests/ $(if $(GITHUB_ACTIONS),--report-log "slow_tests.log",)
 
 test_experimental:
 	pytest -n auto -s -v tests/experimental


### PR DESCRIPTION
This PR replaces the custom `IS_GITHUB_CI` environment variable with the `GITHUB_ACTIONS` variable that GitHub Actions sets automatically.

### Motivation

The `slow_tests` Make target only writes a pytest report log when running in CI, and this was signalled by an `IS_GITHUB_CI` variable declared in the slow tests workflow. GitHub Actions already exports `GITHUB_ACTIONS=true` on every runner, so the custom variable is redundant.

### Changes

- Use `GITHUB_ACTIONS` instead of `IS_GITHUB_CI` to enable the pytest report log in the `slow_tests` Make target
- Drop the `IS_GITHUB_CI` environment variable from the slow tests workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI/Makefile change with no application or security impact; report logging still only runs when GitHub Actions sets `GITHUB_ACTIONS`.
> 
> **Overview**
> The **slow tests** workflow no longer sets a custom **`IS_GITHUB_CI`** env var. The **`slow_tests`** Make target now gates **`pytest --report-log slow_tests.log`** on GitHub’s built-in **`GITHUB_ACTIONS`** variable instead.
> 
> Behavior in Actions should stay the same (report log only in CI); local **`make slow_tests`** still skips the report log when **`GITHUB_ACTIONS`** is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd400f5b028acfc581e79b01970bd478ba55511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->