### PR TITLE
Do not run slow tests when the setup steps failed

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -50,7 +50,6 @@ jobs:
           uv pip install pytest-reportlog
 
       - name: Run slow tests on single GPU
-        if: always()
         run: |
           source .venv/bin/activate
           make slow_tests
@@ -97,7 +96,6 @@ jobs:
           uv pip install pytest-reportlog
 
       - name: Run slow tests on Multi GPU
-        if: always()
         run: |
           source .venv/bin/activate
           make slow_tests


### PR DESCRIPTION
This PR removes `if: always()` from the steps that run the slow tests.

### Motivation

With `if: always()`, both jobs run the slow tests even when checkout, the virtual environment creation, or the dependency installation failed. The tests then fail for a reason that has nothing to do with the tests themselves, which is reported as a test failure and hides the actual setup error. Removing the condition makes the job stop at the step that broke.

The reporting steps keep `if: always()`, since they are meant to run whether the tests passed or failed.

### Changes

- Remove `if: always()` from the slow tests steps of the single GPU and multi GPU jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application or runtime impact; improves failure signal clarity.
> 
> **Overview**
> **Slow tests no longer run after a failed setup** in the single-GPU and multi-GPU jobs of `.github/workflows/slow-tests.yml`.
> 
> Those jobs previously used `if: always()` on the **Run slow tests** steps, so checkout, venv, or dependency install failures still triggered `make slow_tests`, producing misleading test failures. That condition is removed so the job stops at the first failing setup step. **Generate Report** steps still use `if: always()` so summaries can run when tests fail for real test reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b136b17492fd3c45119b04a203f0721f26e3b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->