### PR TITLE
Fix misaligned headers in the failed tests report table

### DIFF
--- a/scripts/log_reports.py
+++ b/scripts/log_reports.py
@@ -104,7 +104,7 @@ def main(slack_channel_name):
                 ]
                 message += (
                     "\n```\n"
-                    + tabulate(failed_table, headers=["Test Location", "Test Name"], tablefmt="grid")
+                    + tabulate(failed_table, headers=["File", "Class", "Test Name"], tablefmt="grid")
                     + "\n```\n"
                 )
 


### PR DESCRIPTION
This PR fixes the headers of the failed tests table reported by the slow tests workflow.

### Motivation

Each row of the table holds three fields, the test file, the test class and the truncated test name, but only two headers are passed to `tabulate`. As a result the header row is padded on the left and every column ends up with the wrong label, the file being reported under `Test Location` and the class under `Test Name`.

Before:

```
+-----------------+-----------------+----------------------------------+
|                 | Test Location   | Test Name                        |
+=================+=================+==================================+
| tests/test_b.py | TestBaz         | test_qux_with_a_very_long_name.. |
+-----------------+-----------------+----------------------------------+
```

After:

```
+-----------------+---------+-----------------------------+
| File            | Class   | Test Name                   |
+=================+=========+=============================+
| tests/test_b.py | TestBaz | test_qux_with_a_long_name.. |
+-----------------+---------+-----------------------------+
```

### Changes

- Name the three columns of the failed tests table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change in CI log formatting with no runtime or security impact.
> 
> **Overview**
> Fixes mislabeled columns in the **failed tests** grid that `log_reports.py` prints for CI/Slack when pytest failures are reported.
> 
> Each row already splits `nodeid` into **file**, **class**, and a truncated **test name**, but `tabulate` was only given two headers (`Test Location`, `Test Name`), so labels shifted across columns. The change passes three headers—`File`, `Class`, `Test Name`—so the grid matches the data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5473d14950761ef30611e77618f99668c3490b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->