### PR TITLE
Declare the test report dependencies in the test extra

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -45,7 +45,6 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install ".[dev]"
-          uv pip install pytest-reportlog
 
       - name: Run slow tests on single GPU
         run: |
@@ -56,7 +55,6 @@ jobs:
         if: always()
         run: |
           source .venv/bin/activate
-          uv pip install tabulate
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
       - name: Post to Slack
@@ -100,7 +98,6 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install ".[dev]"
-          uv pip install pytest-reportlog
 
       - name: Run slow tests on Multi GPU
         run: |
@@ -111,7 +108,6 @@ jobs:
         if: always()
         run: |
           source .venv/bin/activate
-          uv pip install tabulate
           python scripts/log_reports.py >> $GITHUB_STEP_SUMMARY
 
       - name: Post to Slack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,11 @@ scikit = [
 test = [
     "pytest-cov",
     "pytest-datadir>=1.7.0",  # lazy datadirs
+    "pytest-reportlog",  # test report consumed by scripts/log_reports.py
     "pytest-rerunfailures==15.1",
     "pytest-xdist",
-    "pytest"
+    "pytest",
+    "tabulate"  # test report rendering in scripts/log_reports.py
 ]
 vllm = [
     "vllm>=0.18.0,<=0.27.1",
@@ -125,9 +127,11 @@ dev = [
     # test
     "pytest-cov",
     "pytest-datadir>=1.7.0",  # lazy datadirs
+    "pytest-reportlog",  # test report consumed by scripts/log_reports.py
     "pytest-rerunfailures==15.1",
     "pytest-xdist",
     "pytest",
+    "tabulate",  # test report rendering in scripts/log_reports.py
     # vllm: not included in dev by default due to CUDA error; see GH-4228
     # vlm
     "Pillow",


### PR DESCRIPTION
Stacked on top of #6754.

This PR declares `pytest-reportlog` and `tabulate` in the `test` extra, instead of installing them from the slow tests workflow.

### Motivation

Both jobs of the slow tests workflow install these two dependencies with their own `uv pip install` commands, while every other test dependency is declared in the `test` extra. As a consequence, they are missing from a local `.[dev]` install, so running `make slow_tests` with the report log flag locally fails on an unrecognized option, and the workflow has to know which dependencies the report needs.

### Changes

- Declare `pytest-reportlog` and `tabulate` in the `test` and `dev` extras
- Stop installing them from the slow tests jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI-only dependency wiring with no runtime or security impact.
> 
> **Overview**
> Moves **`pytest-reportlog`** and **`tabulate`** from ad-hoc `uv pip install` steps in the slow-tests workflow into the **`test`** and **`dev`** optional dependencies in `pyproject.toml`.
> 
> Both single- and multi-GPU slow test jobs now rely on `uv pip install ".[dev]"` alone for report generation (`scripts/log_reports.py`), so local `make slow_tests` with report logging matches CI without extra packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2deee62ce6e2afb247e2175b4098d0519662402f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->