### PR TITLE
Restrict token access in the secret scanning workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -3,6 +3,9 @@ on:
 
 name: Secret Leaks
 
+permissions:
+  contents: read
+
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
@@ -11,6 +14,8 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         fetch-depth: 0
+        # the scan step mounts this directory, `.git/config` included, into a third-party container
+        persist-credentials: false
     - name: Secret Scanning
       uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11  # v3.96.0
       with:


### PR DESCRIPTION
This PR restricts the token access granted to the secret scanning job.

### Motivation

The workflow declares no `permissions` block, so the job takes the repository default, and the checkout keeps the job's token in `.git/config` because `persist-credentials` defaults to `true`.

That matters here more than in a normal job: the scan step runs the scanner as a container with the working directory bind-mounted (`docker run -v .:/tmp`), so `.git/config` and the token in it are visible to a third-party image.

The scanner only reads the repository, and the checkout only needs the token for its own fetch, so neither the write scopes nor the persisted credential is used.

### Solution

Declare the single scope the job needs, and stop persisting the credential into the mounted directory. Both settings match the same workflow in `huggingface/transformers`.

### Changes

- Add a `permissions` block granting `contents: read`
- Set `persist-credentials: false` on the checkout, with a comment recording why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only hardening with no runtime or application behavior changes; reduces accidental token leakage to the scanner container.
> 
> **Overview**
> **Tightens secret-scanning CI** so the job no longer inherits broad default token permissions or leaves credentials on disk where the TruffleHog container can read them.
> 
> Adds `permissions: contents: read` at workflow scope and sets `persist-credentials: false` on checkout, with a comment that the scan bind-mounts the workspace (including `.git/config`) into a third-party image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2b861824fe2a7e2da84c0676a7a9f257b53924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->