### PR TITLE
Unpin liger-kernel 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.
     "transformers[hub-kernels]",  # transformers < 5.1.0
 ]
 liger = [
-    "liger-kernel>=0.8.0,!=0.8.1"  # upstream PR https://github.com/linkedin/Liger-Kernel/pull/1316
+    "liger-kernel>=0.8.0"
 ]
 peft = [
     "peft>=0.8.0"
@@ -111,7 +111,7 @@ dev = [
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
     # liger
-    "liger-kernel>=0.8.0,!=0.8.1",  # upstream PR https://github.com/linkedin/Liger-Kernel/pull/1316
+    "liger-kernel>=0.8.0",
     # openreward (requires Python 3.11+)
     "openreward>=0.1.109; python_version >= '3.11'",
     # peft
@@ -207,14 +207,6 @@ filterwarnings = [
     # Remove once: no supported torch version emits it
     "ignore:The argument 'device' of Tensor.pin_memory:DeprecationWarning",
     "ignore:The argument 'device' of Tensor.is_pinned:DeprecationWarning",
-
-    # Liger SAPO loss torch.compile anomaly-mode warning (upstream, not actionable in TRL)
-    # Liger's SAPO branch assigns per-token loss with boolean-mask indexing, which graph-breaks under
-    # torch.compile and is traced by AOTAutograd under anomaly mode
-    # Tracking issue: https://github.com/huggingface/trl/issues/6435
-    # Upstream fix released in liger-kernel 0.8.1: https://github.com/linkedin/Liger-Kernel/pull/1274
-    # Remove once: liger-kernel >= 0.8.2 is required (0.8.1 has the fix but is excluded, see GH-6517)
-    "ignore:Error detected in IndexPutBackward0:UserWarning",
 
     # bitsandbytes calls the deprecated torch._check_is_size in its CUDA quant ops (upstream, not actionable in TRL)
     # Triggered indirectly by loading bitsandbytes-quantized models in the PEFT + quantization tests


### PR DESCRIPTION
Requires #6741 (GPU CI on L40S).

0.8.1 was excluded because it needs bf16 gemm (compute capability >= 8.0) and our T4 runner is sm_75 see #6516. The L40S runner is sm_89, so the constraint is gone.

- `liger-kernel>=0.8.0,!=0.8.1` → `liger-kernel>=0.8.0` (`liger` + `dev` extras)
- Drop the SAPO `IndexPutBackward0` warning filter, fixed upstream in 0.8.1 (linkedin/Liger-Kernel#1274)


EDIT: after second thought, we shouldn't merge this now: `trl[liger]` is published, so unpinning breaks users on pre-Ampere GPUs (#6516) even though our CI moved to an L40S. PEP 508 markers can't scope a dependency by GPU arch. The upstream guard (linkedin/Liger-Kernel#1316) merged ~24h *after* 0.8.1 shipped, so it lands in 0.8.2 (not to be confused with #1274 (SAPO fix), which is in 0.8.1.)
When 0.8.2 ships: bump both extras to `liger-kernel>=0.8.2`, drop the SAPO `IndexPutBackward0` filterwarnings entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-warning cleanup only; no runtime training logic changes.
> 
> **Overview**
> **Allows `liger-kernel` 0.8.1** again by changing `liger-kernel>=0.8.0,!=0.8.1` to `liger-kernel>=0.8.0` in the **`liger`** and **`dev`** optional dependencies. That exclusion existed because 0.8.1 needs bf16 GEMM (compute capability ≥ 8.0), which the old T4 CI runner could not satisfy; GPU CI on L40S removes that constraint.
> 
> **Removes** the pytest `filterwarnings` entry that ignored Liger SAPO `IndexPutBackward0` under `torch.compile`, since that behavior was fixed upstream in 0.8.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545bf8f0defb7ceb6c7449656e6937340f4230a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->