### PR TITLE
fix: surface NaN GRPO/RLOO steps in log_history

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -205,6 +205,7 @@ While training and evaluating, we record the following metrics:
 - `cispo_clip_ratio`: The ratio of token (or sequence, if `importance_sampling_level="sequence"`) importance sampling weights that were clipped at `epsilon_high` while having a positive advantage:  \\(r_{i,t}(\theta) > \epsilon_\mathrm{high}\\). Logged only when `loss_type="cispo"`.
 - `vespo/phi_seq_mean`: The average value of the VESPO Gamma weighting  \\(\varphi(w)\\)  applied to the sequence-level importance weights. Values below `1.0` mean sequences are being down-weighted. Logged only when `loss_type="vespo"`.
 - `clip_ratio`: The ratio of clipped tokens reported by the fused Liger GRPO loss. Logged only when `use_liger_kernel=True`, in which case it replaces the `clip_ratio/*` metrics above.
+- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
 
 ## Customization
 

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -205,7 +205,7 @@ While training and evaluating, we record the following metrics:
 - `cispo_clip_ratio`: The ratio of token (or sequence, if `importance_sampling_level="sequence"`) importance sampling weights that were clipped at `epsilon_high` while having a positive advantage:  \\(r_{i,t}(\theta) > \epsilon_\mathrm{high}\\). Logged only when `loss_type="cispo"`.
 - `vespo/phi_seq_mean`: The average value of the VESPO Gamma weighting  \\(\varphi(w)\\)  applied to the sequence-level importance weights. Values below `1.0` mean sequences are being down-weighted. Logged only when `loss_type="vespo"`.
 - `clip_ratio`: The ratio of clipped tokens reported by the fused Liger GRPO loss. Logged only when `use_liger_kernel=True`, in which case it replaces the `clip_ratio/*` metrics above.
-- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
+- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite on at least one process. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
 
 ## Customization
 

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -152,7 +152,7 @@ While training and evaluating, we record the following metrics:
 - `clip_ratio/low_min`: The smallest per-completion clip indicator on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
 - `clip_ratio/high_mean`: The average ratio of sequence probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
 - `clip_ratio/high_max`: The largest per-completion clip indicator on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
-- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
+- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite on at least one process. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
 
 ## Customization
 

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -152,6 +152,7 @@ While training and evaluating, we record the following metrics:
 - `clip_ratio/low_min`: The smallest per-completion clip indicator on the lower bound of the trust region:  \\(r_{i,t}(\theta) < 1 - \epsilon_\mathrm{low}\\).
 - `clip_ratio/high_mean`: The average ratio of sequence probabilities that were clipped on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
 - `clip_ratio/high_max`: The largest per-completion clip indicator on the upper bound of the trust region:  \\(r_{i,t}(\theta) > 1 + \epsilon_\mathrm{high}\\).
+- `frac_non_finite_loss`: The fraction of forward passes in the logging window whose loss was NaN or infinite. Such a loss is still backpropagated, but [`~transformers.Trainer`] hides it from the reported loss by replacing it with the average of the previous losses (`logging_nan_inf_filter`, enabled by default), so this metric is the only trace it leaves. Any nonzero value means the update was computed from a non-finite loss.
 
 ## Customization
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import math
 import os
 import warnings
 from collections.abc import Callable
@@ -1691,6 +1692,48 @@ class TestGRPOTrainer(TrlTestCase):
                 "an unscorable token caused sequences to be dropped by the off-policy mask, even though the "
                 "threshold is high enough to keep every sequence"
             )
+
+    def test_non_finite_loss_is_logged(self):
+        # Regression test for #6702: a step whose loss is NaN is still backpropagated, but `Trainer` replaces it in
+        # the reported loss with the average of the previous losses (`logging_nan_inf_filter`, on by default), so a
+        # run that is corrupting its weights logs a clean loss curve. `frac_non_finite_loss` is the only trace.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            logging_steps=1,  # one log entry per step, so the poisoned step has its own entry
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # Poison the first loss only. Adding a NaN constant makes the loss non-finite while leaving its gradients
+        # untouched, so the following steps stay healthy and the first step is the only one to report anything.
+        original_compute_loss = trainer._compute_loss
+
+        def compute_nan_loss_once(model, inputs):
+            trainer._compute_loss = original_compute_loss
+            return original_compute_loss(model, inputs) + float("nan")
+
+        trainer._compute_loss = compute_nan_loss_once
+
+        trainer.train()
+
+        logs = [log for log in trainer.state.log_history if "frac_non_finite_loss" in log]
+        assert logs, "no step reported whether its loss was finite, so nothing was verified"
+        assert logs[0]["frac_non_finite_loss"] > 0.0, "the NaN loss left no trace in the logs"
+        assert all(log["frac_non_finite_loss"] == 0.0 for log in logs[1:]), (
+            "a step with a finite loss was reported as non-finite"
+        )
+        # The reported loss of that same step is finite, which is what makes the metric necessary.
+        assert math.isfinite(logs[0]["loss"])
 
     def test_train_with_off_policy_mask(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from unittest.mock import patch
 
 import pytest
@@ -102,6 +103,48 @@ class TestRLOOTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_non_finite_loss_is_logged(self):
+        # Regression test for #6702: a step whose loss is NaN is still backpropagated, but `Trainer` replaces it in
+        # the reported loss with the average of the previous losses (`logging_nan_inf_filter`, on by default), so a
+        # run that is corrupting its weights logs a clean loss curve. `frac_non_finite_loss` is the only trace.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            logging_steps=1,  # one log entry per step, so the poisoned step has its own entry
+            report_to="none",
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        # Poison the first loss only. Adding a NaN constant makes the loss non-finite while leaving its gradients
+        # untouched, so the following steps stay healthy and the first step is the only one to report anything.
+        original_compute_loss = trainer._compute_loss
+
+        def compute_nan_loss_once(model, inputs):
+            trainer._compute_loss = original_compute_loss
+            return original_compute_loss(model, inputs) + float("nan")
+
+        trainer._compute_loss = compute_nan_loss_once
+
+        trainer.train()
+
+        logs = [log for log in trainer.state.log_history if "frac_non_finite_loss" in log]
+        assert logs, "no step reported whether its loss was finite, so nothing was verified"
+        assert logs[0]["frac_non_finite_loss"] > 0.0, "the NaN loss left no trace in the logs"
+        assert all(log["frac_non_finite_loss"] == 0.0 for log in logs[1:]), (
+            "a step with a finite loss was reported as non-finite"
+        )
+        # The reported loss of that same step is finite, which is what makes the metric necessary.
+        assert math.isfinite(logs[0]["loss"])
 
     def test_reward_func_wrong_number_of_rewards(self):
         # A reward function that returns the wrong number of rewards should raise a clear error instead of silently

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3000,8 +3000,17 @@ class GRPOTrainer(_BaseTrainer):
         if self.use_liger_kernel:
             # Compute the loss using the liger grpo loss
             unwrapped_model = self.accelerator.unwrap_model(model)
-            return self._forward_redirection(model, unwrapped_model, self.compute_liger_loss, unwrapped_model, inputs)
-        return self._compute_loss(model, inputs)
+            loss = self._forward_redirection(model, unwrapped_model, self.compute_liger_loss, unwrapped_model, inputs)
+        else:
+            loss = self._compute_loss(model, inputs)
+
+        # A non-finite loss is still backpropagated, but `Trainer` replaces it in the logged running loss with the
+        # average of the previous losses (`logging_nan_inf_filter`, enabled by default), so a run whose weights are
+        # being corrupted reports a clean loss curve. Log the fraction of non-finite losses to make it visible.
+        mode = "train" if self.model.training else "eval"
+        is_non_finite = (~torch.isfinite(loss)).float()
+        self._metrics[mode]["frac_non_finite_loss"].append(self.accelerator.gather(is_non_finite).max().item())
+        return loss
 
     @staticmethod
     def get_off_policy_mask(

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1678,7 +1678,15 @@ class RLOOTrainer(_BaseTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         if return_outputs:
             raise ValueError("The RLOOTrainer does not support returning outputs")
-        return self._compute_loss(model, inputs)
+        loss = self._compute_loss(model, inputs)
+
+        # A non-finite loss is still backpropagated, but `Trainer` replaces it in the logged running loss with the
+        # average of the previous losses (`logging_nan_inf_filter`, enabled by default), so a run whose weights are
+        # being corrupted reports a clean loss curve. Log the fraction of non-finite losses to make it visible.
+        mode = "train" if self.model.training else "eval"
+        is_non_finite = (~torch.isfinite(loss)).float()
+        self._metrics[mode]["frac_non_finite_loss"].append(self.accelerator.gather(is_non_finite).max().item())
+        return loss
 
     def _compute_loss(self, model, inputs):
         # Compute the per-token log probabilities for the model


### PR DESCRIPTION
# What does this PR do?

Trainer logging_nan_inf_filter replaces a NaN loss with the previous average, so a corrupted GRPO step looks clean in log_history. This logs frac_non_finite_loss on GRPO and RLOO so a non-finite step is visible.

Fixes #6702

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that is the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure
- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?
Anyone in the community is free to review the PR once the tests have passed.

GRPO tests: 157 passed. RLOO tests: 70 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small observability-only change in compute_loss with no change to loss computation or optimization logic; low risk aside from minor distributed logging overhead.
> 
> **Overview**
> **GRPO** and **RLOO** now record **`frac_non_finite_loss`** in training/eval metrics so corrupted steps are visible in `log_history` even when Hugging Face **`Trainer`**’s default **`logging_nan_inf_filter`** replaces NaN/Inf losses with a smoothed finite value in the reported **`loss`**.
> 
> Each **`compute_loss`** call flags non-finite losses (gathered across processes), appends to the existing metrics pipeline, and still returns the raw loss for backward. GRPO covers both the standard and Liger-kernel paths.
> 
> Docs for GRPO and RLOO logged metrics describe the new field; regression tests poison the first step with NaN and assert **`frac_non_finite_loss > 0`** on that step only while **`loss`** stays finite (fixes #6702).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497266229cdb75eac6e6e60ea17e01034f40e786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->