### PR TITLE
Fix Nemotron 3 SFT example: add Mamba modules to LoRA targets

### DIFF
--- a/examples/scripts/sft_nemotron_3.py
+++ b/examples/scripts/sft_nemotron_3.py
@@ -25,6 +25,13 @@
 """
 Fine-tune NVIDIA Nemotron 3 models with SFT.
 
+Nemotron 3 uses a hybrid Mamba-Attention architecture. The LoRA target modules
+must cover both Mamba layers (in_proj, out_proj) and Attention/MLP layers
+(q_proj, k_proj, v_proj, o_proj, up_proj, down_proj). Using only attention
+modules (q/k/v/o_proj) would leave the Mamba layers frozen, which are the
+majority of layers in NemotronH models. See
+https://github.com/huggingface/peft/issues/3554 for details.
+
 Prerequisites:
 
     pip install "transformers>=5.7.0"
@@ -52,7 +59,7 @@ accelerate launch \
     --use_peft \
     --lora_r 8 \
     --lora_alpha 16 \
-    --lora_target_modules q_proj k_proj v_proj o_proj gate_proj up_proj down_proj
+    --lora_target_modules q_proj k_proj v_proj o_proj in_proj out_proj up_proj down_proj
 """
 
 from datasets import load_dataset


### PR DESCRIPTION
## Summary

- Replaced `gate_proj` with `in_proj` and `out_proj` in the LoRA target modules for the Nemotron 3 SFT example
- Added explanatory comment about NemotronH's hybrid Mamba-Attention architecture

## Why

NemotronH is a hybrid Mamba-Attention architecture. The previous target modules (q_proj k_proj v_proj o_proj gate_proj up_proj down_proj) had two problems:

1. **gate_proj does not exist** in NemotronH. The MLP layers use up_proj/down_proj (standard MLP) or MoE variants, not gate_proj.
2. **Mamba layers were missing entirely.** NemotronH models have Mamba SSM layers with in_proj/out_proj modules. In Nemotron-Nano-9B-v2, 52 of 56 layers are Mamba. Omitting these from LoRA targets means 93% of the model is frozen during fine-tuning, resulting in zero learning (DPO loss stays at ln(2)).

See https://github.com/huggingface/peft/issues/3554 for the full analysis.

## What Changed

- examples/scripts/sft_nemotron_3.py: Changed --lora_target_modules from q_proj k_proj v_proj o_proj gate_proj up_proj down_proj to q_proj k_proj v_proj o_proj in_proj out_proj up_proj down_proj
- Added a comment block explaining the hybrid architecture and why Mamba modules must be included

## Test plan

- [ ] Example runs without errors on Nemotron-3-Nano-30B-A3B
- [ ] LoRA adapter targets both Mamba and Attention layers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example CLI defaults only; no library or training runtime code changes.
> 
> **Overview**
> Updates the Nemotron 3 SFT example so LoRA actually trains the hybrid model instead of mostly freezing it.
> 
> The sample **`accelerate`** command now uses **`in_proj`** and **`out_proj`** instead of **`gate_proj`**, and keeps attention/MLP targets (**`q_proj`**, **`k_proj`**, **`v_proj`**, **`o_proj`**, **`up_proj`**, **`down_proj`**). **`gate_proj`** is not part of NemotronH, and without the Mamba projections most layers stay frozen.
> 
> A short module docstring explains why NemotronH needs both Mamba and attention/MLP modules in **`--lora_target_modules`**, with a link to the PEFT issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e38dfdfe96777c3afc353185e0c8e41549bccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->