### PR TITLE
Fix Nemotron 3 SFT example: add Mamba modules to LoRA targets

### DIFF
--- a/examples/scripts/sft_nemotron_3.py
+++ b/examples/scripts/sft_nemotron_3.py
@@ -25,6 +25,13 @@
 """
 Fine-tune NVIDIA Nemotron 3 models with SFT.
 
+Nemotron 3 uses a hybrid Mamba-Attention architecture. The LoRA target modules
+must cover both Mamba layers (in_proj, out_proj) and Attention/MLP layers
+(q_proj, k_proj, v_proj, o_proj, up_proj, down_proj). Using only attention
+modules (q/k/v/o_proj) would leave the Mamba layers frozen, which are the
+majority of layers in NemotronH models. See
+https://github.com/huggingface/peft/issues/3554 for details.
+
 Prerequisites:
 
     pip install "transformers>=5.7.0"
@@ -52,7 +59,7 @@ accelerate launch \
     --use_peft \
     --lora_r 8 \
     --lora_alpha 16 \
-    --lora_target_modules q_proj k_proj v_proj o_proj gate_proj up_proj down_proj
+    --lora_target_modules q_proj k_proj v_proj o_proj in_proj out_proj up_proj down_proj
 """
 
 from datasets import load_dataset


### PR DESCRIPTION
# What does this PR do?

Fixes the Nemotron 3 SFT example (`examples/scripts/sft_nemotron_3.py`) which had incorrect LoRA target modules for the hybrid Mamba-Attention architecture.

Fixes #6773

## Problem

NemotronH is a hybrid Mamba-Attention architecture. The previous `--lora_target_modules` in the example docstring were:

```
q_proj k_proj v_proj o_proj gate_proj up_proj down_proj
```

Two issues:

1. **`gate_proj` does not exist** in NemotronH. The MLP layers use `up_proj`/`down_proj`, not `gate_proj`.
2. **Mamba layers were missing entirely.** NemotronH models have Mamba SSM layers with `in_proj`/`out_proj` modules. In Nemotron-Nano-9B-v2, 52 of 56 layers are Mamba. Omitting these from LoRA targets means 93% of the model is frozen during fine-tuning, resulting in zero learning (DPO loss stays at ln(2), HumanEval drops to 0%).

See https://github.com/huggingface/peft/issues/3554 for the full analysis.

## Fix

Changed `--lora_target_modules` from `q_proj k_proj v_proj o_proj gate_proj up_proj down_proj` to `q_proj k_proj v_proj o_proj in_proj out_proj up_proj down_proj`, and added an explanatory comment about the hybrid architecture.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (Issue #6773)
- [x] Did you make sure to update the documentation with your changes? (Added explanatory comment in the docstring)
- [ ] Did you write any new necessary tests? (N/A — this is an example script fix)

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone familiar with NemotronH or LoRA fine-tuning examples.
