### PR TITLE
Run `TestUseAdapter` on the accelerator

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,8 +67,8 @@ class TestUseAdapter(TrlTestCase):
     def test_disables_on_none(self):
         model = AutoPeftModelForCausalLM.from_pretrained(
             "trl-internal-testing/tiny-PeftModel", adapter_name="my_adapter"
-        )
-        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        ).to(torch_device)
+        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], device=torch_device)
         with model.disable_adapter():
             expected = model(input_ids).logits
 
@@ -80,8 +80,8 @@ class TestUseAdapter(TrlTestCase):
     def test_restores_previous_adapter(self):
         model = AutoPeftModelForCausalLM.from_pretrained(
             "trl-internal-testing/tiny-PeftModel", adapter_name="my_adapter"
-        )
-        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        ).to(torch_device)
+        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], device=torch_device)
         expected = model(input_ids).logits
         with use_adapter(model, "my_adapter"):
             pass
@@ -96,9 +96,9 @@ class TestUseAdapter(TrlTestCase):
     def test_with_multiple_adapters(self):
         model = AutoPeftModelForCausalLM.from_pretrained(
             "trl-internal-testing/tiny-PeftModel", adapter_name="my_adapter_1"
-        )
+        ).to(torch_device)
         model.load_adapter("trl-internal-testing/tiny-PeftModel-2", "my_adapter_2")
-        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], device=torch_device)
 
         model.set_adapter("my_adapter_1")  # should be a no-op, but let's keep it for clarity
         expected_1 = model(input_ids).logits


### PR DESCRIPTION
- `TestUseAdapter` left the model and inputs on CPU, unlike the rest of the test suite.
- When a Liger test runs first in the same worker, it globally patches `modeling_qwen3.Qwen3RMSNorm = LigerRMSNorm`, so the CPU forward launches a Triton kernel on CPU tensors: `ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)`.
- Move the model and `input_ids` to `torch_device`.

Fixes the transient CI failures in https://github.com/huggingface/trl/actions/runs/32046322535/job/95434970188.

Closes #6778.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only device placement in `tests/test_utils.py`; no production or library API changes.
> 
> **Overview**
> **`TestUseAdapter`** now places the PEFT model and **`input_ids`** on **`torch_device`**, matching the rest of the TRL test suite instead of leaving them on CPU.
> 
> That avoids flaky CI when a Liger test runs earlier in the same worker and globally swaps in a Triton-backed norm: a CPU forward then errors with *Pointer argument cannot be accessed from Triton (cpu tensor?)*. Behavior under test is unchanged; only device placement is updated in all three adapter tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfc47464d5268a8a44a6356b3c8160926f09524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
