### PR TITLE
Clarify generalized JSD endpoint definition

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -58,13 +58,19 @@ At each training step, the student generates a batch of completions for the samp
 
 ### Computing the loss
 
-The loss is the **generalized Jensen-Shannon divergence (JSD)** between the student distribution  \\( p_S \\)  and the teacher distribution  \\( p_T \\)  over the generated completion tokens, interpolated by `beta` and defined as:
+The loss interpolates between the forward KL, the **generalized Jensen-Shannon divergence (JSD)**, and the reverse KL for the student distribution  \\( p_S \\)  and teacher distribution  \\( p_T \\)  over the generated completion tokens:
 
 $$
-\mathcal{L}_\beta = \beta \, \mathbb{D}_{\mathrm{KL}}\!\left[ p_T \| p_M \right] + (1 - \beta) \, \mathbb{D}_{\mathrm{KL}}\!\left[ p_S \| p_M \right], \qquad p_M = (1 - \beta) \, p_S + \beta \, p_T,
+\mathcal{L}_\beta =
+\begin{cases}
+\mathbb{D}_{\mathrm{KL}}\!\left[ p_T \| p_S \right], & \beta = 0, \\
+\beta \, \mathbb{D}_{\mathrm{KL}}\!\left[ p_T \| p_M \right] + (1 - \beta) \, \mathbb{D}_{\mathrm{KL}}\!\left[ p_S \| p_M \right], & 0 < \beta < 1, \\
+\mathbb{D}_{\mathrm{KL}}\!\left[ p_S \| p_T \right], & \beta = 1,
+\end{cases}
+\qquad p_M = (1 - \beta) \, p_S + \beta \, p_T.
 $$
 
-where  \\( p_M \\)  is the  \\( \beta \\) -mixture of the two distributions. The endpoints reduce to the pure divergences:  `beta=0.0`  gives the forward KL  \\( \mathbb{D}_{\mathrm{KL}}\!\left[ p_T \| p_S \right] \\)  and  `beta=1.0`  the reverse KL  \\( \mathbb{D}_{\mathrm{KL}}\!\left[ p_S \| p_T \right] \\).
+For  \\( 0 < \beta < 1 \\),  \\( p_M \\)  is the  \\( \beta \\)-mixture of the two distributions. The endpoints are defined explicitly rather than obtained by substituting into the mixture formula: `beta=0.0` gives the forward KL and `beta=1.0` gives the reverse KL.
 
 In practice, the projection to vocabulary logits and the divergence are computed in chunks, so peak activation memory does not scale with the full vocabulary × sequence-length logits tensor. See [Reducing Memory Usage](reducing_memory_usage).
 


### PR DESCRIPTION
# What does this PR do?

Clarifies the piecewise loss used by `DistillationTrainer`: the generalized JSD expression applies for `0 < beta < 1`, while `beta=0.0` and `beta=1.0` are explicitly handled as forward and reverse KL.

This resolves the apparent contradiction in the documentation without swapping the interior JSD coefficients, which already match the implementation and its mixture definition.

Fixes #6780

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? (No new tests needed; this documents the existing tested behavior.)

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Validation

- `python -m pytest tests/test_distillation_trainer.py::TestChunkedDivergenceLoss -q` — 27 passed
- `git diff --check`

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only clarification; no runtime or API changes.
> 
> **Overview**
> **Documentation-only** update to `distillation_trainer.md` so the `DistillationTrainer` loss matches how the code treats `beta`.
> 
> The **Computing the loss** section now states the objective as a **piecewise** definition: forward KL at `beta=0`, generalized JSD (mixture formula) for `0 < beta < 1`, and reverse KL at `beta=1`. It clarifies that the endpoints are **explicit** cases, not limits of the interior mixture—addressing the contradiction called out in #6780 without changing the interior JSD coefficients (which already align with tests/implementation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e793dd7ac0432c955b78e387a39d8459390b5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->