### PR TITLE
Restore Liger Kernel's global patches between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,13 @@
 
 import gc
 import logging
+import sys
 import traceback
 from functools import wraps
 
 import pytest
 import torch
-from transformers.utils import is_torch_xpu_available
+from transformers.utils import is_liger_kernel_available, is_torch_xpu_available
 
 
 # ============================================================================
@@ -200,3 +201,45 @@ def cleanup_vllm_dist_env():
         from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 
         cleanup_dist_env_and_memory()
+
+
+@pytest.fixture(autouse=True)
+def undo_liger_kernel_patching(monkeypatch):
+    """
+    Restore the transformers modeling modules that Liger Kernel patches process-wide.
+
+    `use_liger_kernel=True` makes transformers call `liger_kernel.transformers._apply_liger_kernel_to_instance`, which
+    patches the model instance but also rebinds module-level names in `transformers.models.<arch>.modeling_<arch>`
+    (`Qwen3RMSNorm` -> `LigerRMSNorm`, `Qwen3MLP` -> `LigerSwiGLUMLP`, `apply_rotary_pos_emb` ->
+    `liger_rotary_pos_emb`, ...). Liger never restores them, so every model of that architecture instantiated later in
+    the same process silently gets Triton kernels and fails on CPU tensors with `ValueError: Pointer argument cannot be
+    accessed from Triton (cpu tensor?)`. Which test trips over it depends on how pytest-xdist spreads tests across
+    workers, so the failure surfaces in an unrelated test (e.g. `TestUseAdapter`, whose PEFT model has a Qwen3 base)
+    and only in some runs. Snapshot the modeling modules when Liger patches, and restore them once the test is over.
+
+    Only the trigger is transformers-version dependent, not the leak itself: transformers < 5.3 applies the kernels in
+    `Trainer.__init__`, so a test that merely builds a trainer leaks, while transformers >= 5.3 applies them in
+    `Trainer.train()`. Either way they are never reverted, which is why only the minimum-versions CI job fails: the
+    Liger tests that use a Qwen3 model build a trainer but never train.
+    """
+    if not is_liger_kernel_available():
+        yield
+        return
+
+    import liger_kernel.transformers as liger_transformers
+
+    apply_to_instance = liger_transformers._apply_liger_kernel_to_instance
+    snapshots = {}
+
+    def apply_to_instance_and_snapshot(*args, **kwargs):
+        # Liger imports the modeling modules it patches inside the patch function, but a module can only be patched
+        # if the model being patched already uses it, so it is imported by now.
+        for name, module in list(sys.modules.items()):
+            if name.startswith("transformers.models.") and ".modeling_" in name:
+                snapshots.setdefault(name, (module, vars(module).copy()))
+        return apply_to_instance(*args, **kwargs)
+
+    monkeypatch.setattr(liger_transformers, "_apply_liger_kernel_to_instance", apply_to_instance_and_snapshot)
+    yield
+    for module, snapshot in snapshots.values():
+        vars(module).update(snapshot)


### PR DESCRIPTION
This PR makes the test suite revert Liger Kernel's process-wide patching of the transformers modeling modules, so enabling `use_liger_kernel` in one test can no longer break unrelated tests that run later in the same pytest-xdist worker.

Fix #6778.

Supersedes and closes #6779.

### Motivation

The `Tests with minimum versions` CI job fails on three tests that never ask for Liger Kernel:

```
FAILED tests/test_utils.py::TestUseAdapter::test_disables_on_none - ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
FAILED tests/test_utils.py::TestUseAdapter::test_restores_previous_adapter - ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
FAILED tests/test_utils.py::TestUseAdapter::test_with_multiple_adapters - ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
```

The traceback goes from `AutoPeftModelForCausalLM` through `modeling_qwen3.py` into `liger_kernel/transformers/rms_norm.py`, so a plain CPU PEFT model is running Liger Triton kernels.

**Leaked global state.** `use_liger_kernel=True` makes transformers call `liger_kernel.transformers._apply_liger_kernel_to_instance`, which dispatches to `apply_liger_kernel_to_<arch>(model=...)`. Besides patching the model instance, that function rebinds module-level names in the architecture's modeling module and never restores them:

```python
# liger_kernel/transformers/monkey_patch.py, in apply_liger_kernel_to_qwen3
if rope:     modeling_qwen3.apply_rotary_pos_emb = liger_rotary_pos_emb
if rms_norm: modeling_qwen3.Qwen3RMSNorm = LigerRMSNorm
if swiglu:   modeling_qwen3.Qwen3MLP = LigerSwiGLUMLP
```

Every Qwen3 model built afterwards in that process therefore gets `LigerRMSNorm`, and its first forward launches a Triton kernel on CPU tensors. Patching `apply_rotary_pos_emb` is worse still: it is looked up as a module global inside `Qwen3Attention.forward`, so it also changes models that already exist.

Here, the polluters are the Liger tests in `tests/test_distillation_trainer.py` that build a `DistillationTrainer` on a Qwen3 student, and the victim is `TestUseAdapter`, whose `trl-internal-testing/tiny-PeftModel` has a `tiny-Qwen3ForCausalLM` base.

**Why only the minimum-versions job.** transformers moved the Liger call from `Trainer.__init__` to `Trainer.train()` in 5.3.0. With `transformers==4.56.2` the distillation tests leak the Qwen3 patch simply by constructing a trainer, while with `transformers==5.15.0` they never train, so nothing is patched. The leak itself is not version specific: after a real `train()` on 5.15 the modules stay patched for the rest of the process.

**Why it started with #6764.** `make test` runs `pytest -n auto`, so xdist assigns tests to workers dynamically. #6764 changed the collected test set, and from then on the Qwen3 Liger tests and `TestUseAdapter` happened to share a worker. The failure is order dependent, not caused by that PR: in the failing runs both landed on `gw3`, and in the run that passed they landed on `gw1` and `gw2`.

### Solution

An autouse fixture wraps `_apply_liger_kernel_to_instance`, snapshots the imported transformers modeling modules whenever Liger actually patches, and restores them at the end of the test. It hooks the single point through which all Liger model patching flows (TRL never calls Liger's patchers itself), so it covers every architecture and works whether transformers patches at trainer init or at `train()`. It costs nothing for tests that do not use Liger.

Verified locally with a temporary reproducer: a test that applies Liger to a Qwen3 model, followed by a test that runs a CPU forward on a fresh Qwen3 model. The second test fails without the fixture and passes with it.

Note that the trainers themselves are deliberately left unchanged: they pass `use_liger_kernel` through to transformers on purpose, and a teardown at trainer level has no correct scope (the model must keep the kernels while it trains, and outlives the trainer), nor any way to revert the in-place instance patching without reimplementing Liger's per-architecture inverse, which upstream ships only in its own test suite. The user-facing sharp edge, that enabling Liger affects other models of the same architecture created later in the same process, is better addressed by documenting it here and fixing the unnecessary global rebinding upstream in Liger Kernel.

### Changes

- Add an autouse fixture in `tests/conftest.py` that snapshots and restores the transformers modeling modules patched by Liger Kernel

### Why #6779 is superseded

#6779 moves the `TestUseAdapter` model and inputs to `torch_device`. It makes this CI job green, but treats the victim rather than the leak, and I would rather not merge it:

- The leaked patch is still in place, so the next test that builds a model of a Liger-patched architecture on CPU fails the same way. Many tests do (`TestPatchChunkedLMHead`, among others), for any of the architectures Liger supports.
- On a machine without an accelerator, `torch_device` is `cpu`, so the flake remains for contributors running the suite locally and in any CPU-only job.
- It makes the assertions depend on scheduling. Once the model runs on the accelerator, `TestUseAdapter` silently compares logits computed with Liger kernels or with the reference implementation depending on whether a Liger test happened to run earlier in the same worker, while the tests are about adapter switching and use exact `torch.equal` comparisons.
- CPU placement in these tests is a reasonable choice for what they cover, so the change also removes coverage of the adapter logic on CPU.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only isolation in conftest; no production trainer or library behavior changes.
> 
> **Overview**
> Fixes flaky CI and local failures where unrelated tests (e.g. `TestUseAdapter` on CPU Qwen3 PEFT models) hit Triton kernels after another test used `use_liger_kernel=True`.
> 
> Adds an **autouse** fixture `undo_liger_kernel_patching` in `tests/conftest.py` that wraps `liger_kernel.transformers._apply_liger_kernel_to_instance`, snapshots `vars()` of affected `transformers.models.*.modeling_*` modules when patching runs, and restores them after each test. It is a no-op when Liger is not installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 034df2c92d9406c21b6cd6b530ecd36a717ab1c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->