### PR TITLE
Bump doc-builder pre-commit revision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
         name: Check style with doc-builder
         language: python
         entry: doc-builder style trl tests docs/source --max_len 119
-        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@2430c1ec91d04667414e2fa31ecfc36c153ea391", ruff]  # See GH-5633
+        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@6dd1bdab58a8564730f633d70e76bb1ef57ec627", ruff]  # See GH-5633
         pass_filenames: false
         types_or: [python, markdown, rst]


### PR DESCRIPTION
This PR bumps the pinned `doc-builder` commit used by the pre-commit style check.

### Changes

- Update the `doc-builder` dependency revision in `.pre-commit-config.yaml` from `2430c1e` to `6dd1bda`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tooling pin update with no application or CI workflow changes in this diff.
> 
> **Overview**
> Updates the **pinned `doc-builder` git commit** for the local `doc-builder-style` pre-commit hook in `.pre-commit-config.yaml`, moving from `2430c1e` to `6dd1bda`.
> 
> The hook command and scope (`doc-builder style trl tests docs/source --max_len 119`) are unchanged; only the dependency revision used when pre-commit installs the hook is bumped (still referenced via GH-5633).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c55954bbac1c565d4640cafb239ec788d1ff78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->