### PR TITLE
Remove unnecessary docstyle-ignore tag from docstrings

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -454,12 +454,11 @@ def _unpair_row(batch: dict[str, list[Any]]) -> dict[str, list[Any]]:
 def unpair_preference_dataset(
     dataset: DatasetType | IterableDatasetType, **map_kwargs
 ) -> DatasetType | IterableDatasetType:
-    # docstyle-ignore
     """
     Unpair a preference dataset.
 
-    The output contains `"prompt"`, `"completion"`, and `"label"` plus any extra columns, which are duplicated for
-    each chosen and rejected row.
+    The output contains `"prompt"`, `"completion"`, and `"label"` plus any extra columns, which are duplicated for each
+    chosen and rejected row.
 
     Args:
         dataset ([`~datasets.Dataset`] or [`~datasets.DatasetDict`] or [`~datasets.IterableDataset`] or [`~datasets.IterableDatasetDict`]):
@@ -469,7 +468,8 @@ def unpair_preference_dataset(
             Additional keyword arguments to pass to the dataset's map method when unpairing preferences.
 
     Returns:
-        [`~datasets.Dataset`] or [`~datasets.DatasetDict`] or [`~datasets.IterableDataset`] or [`~datasets.IterableDatasetDict`]:
+        [`~datasets.Dataset`] or [`~datasets.DatasetDict`] or [`~datasets.IterableDataset`] or
+        [`~datasets.IterableDatasetDict`]:
             The unpaired preference dataset.
 
     Example:

--- a/trl/experimental/a2po/a2po_config.py
+++ b/trl/experimental/a2po/a2po_config.py
@@ -19,7 +19,6 @@ from trl.trainer.base_config import _BaseConfig
 
 @dataclass
 class A2POConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`A2POTrainer`].
 

--- a/trl/experimental/a2po/a2po_trainer.py
+++ b/trl/experimental/a2po/a2po_trainer.py
@@ -46,7 +46,6 @@ RewardFunc = Callable[..., list[float]]
 
 
 class A2POTrainer(_BaseTrainer):
-    # docstyle-ignore
     """
     Trainer for the A*-PO (Optimal Advantage Regression) method, introduced in [Accelerating RL for LLM Reasoning with
     Optimal Advantage Regression](https://huggingface.co/papers/2505.20686).
@@ -54,8 +53,8 @@ class A2POTrainer(_BaseTrainer):
     A*-PO runs in two stages:
 
     1. **Offline value estimation.** Before training, `num_value_samples` completions are sampled from the reference
-       policy for every training prompt and scored with `reward_funcs`. The optimal value is estimated as
-       `V*(x) = beta1 * log(mean_i exp(r(x, y_i) / beta1))` and cached per prompt.
+       policy for every training prompt and scored with `reward_funcs`. The optimal value is estimated as `V*(x) =
+       beta1 * log(mean_i exp(r(x, y_i) / beta1))` and cached per prompt.
     2. **On-policy regression.** During training, a single completion is generated per prompt from the current policy.
        The loss is the squared error between the implicit reward `beta2 * log(pi(y|x) / pi_ref(y|x))` and the optimal
        advantage estimate `r(x, y) - V*(x)`.

--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class AsyncGRPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`AsyncGRPOTrainer`].
 
@@ -74,9 +73,9 @@ class AsyncGRPOConfig(_BaseConfig):
             and reconciling the result against the tokens held so far: a clean append stays one row, a rewrite (dropped
             reasoning, summarized history) forks a new row. When a turn's re-tokenized prompt drifts inside the last
             generated answer, the decision is made on the **drift size** — how many previously-trained tokens the
-            realign would mask to context. A drift smaller than this many tokens is treated as a re-tokenization
-            wobble (realigned as context); a larger drift — e.g. a long reasoning block dropped by the template —
-            forks a new row so those trained tokens keep their training signal instead of being silently masked.
+            realign would mask to context. A drift smaller than this many tokens is treated as a re-tokenization wobble
+            (realigned as context); a larger drift — e.g. a long reasoning block dropped by the template — forks a new
+            row so those trained tokens keep their training signal instead of being silently masked.
 
         > Parameters that control the vLLM server
 
@@ -95,22 +94,22 @@ class AsyncGRPOConfig(_BaseConfig):
             Upper-bound epsilon value for clipping. If not specified, it defaults to the same value as the lower-bound
             specified in argument `epsilon`. Paper [DAPO](https://huggingface.co/papers/2503.14476) recommends `0.28`.
         token_budget (`int`, *optional*):
-            Maximum number of real tokens packed into a single row (one DP rank's forward) for dynamic
-            token-budgeted micro-batching. When `> 0`, a `TokenBudgetBatcher` forms Σ Lᵢ²-balanced micro-batches
-            whose rows each stay within this budget, bounding peak memory independently of the sample count (the
-            number of samples per row becomes dynamic). If `None` (default), it is set to the vLLM server's
-            `max_model_len` (queried at train start) — the cap on prompt + completion length — so no rollout sample
-            can ever exceed the budget. A sample longer than `token_budget` fits in no row and is dropped with a
-            warning. Set `<= 0` to disable token budgeting and instead pack a fixed `per_device_train_batch_size ×
-            num_processes` samples per micro-batch, Σ Lᵢ²-balanced across the rows.
+            Maximum number of real tokens packed into a single row (one DP rank's forward) for dynamic token-budgeted
+            micro-batching. When `> 0`, a `TokenBudgetBatcher` forms Σ Lᵢ²-balanced micro-batches whose rows each stay
+            within this budget, bounding peak memory independently of the sample count (the number of samples per row
+            becomes dynamic). If `None` (default), it is set to the vLLM server's `max_model_len` (queried at train
+            start) — the cap on prompt + completion length — so no rollout sample can ever exceed the budget. A sample
+            longer than `token_budget` fits in no row and is dropped with a warning. Set `<= 0` to disable token
+            budgeting and instead pack a fixed `per_device_train_batch_size × num_processes` samples per micro-batch, Σ
+            Lᵢ²-balanced across the rows.
 
         > Parameters that control the async rollout pipeline
 
         max_inflight_tasks (`int`, *optional*, defaults to `-1`):
-            Maximum number of concurrent generation tasks sent to the vLLM server. Defaults to `-1` (auto), which
-            sets it to `max_staleness * per_device_train_batch_size * gradient_accumulation_steps * num_processes`.
-            If using tool-use environments, you may want to set this manually based on how many parallel environments
-            you can run.
+            Maximum number of concurrent generation tasks sent to the vLLM server. Defaults to `-1` (auto), which sets
+            it to `max_staleness * per_device_train_batch_size * gradient_accumulation_steps * num_processes`. If using
+            tool-use environments, you may want to set this manually based on how many parallel environments you can
+            run.
         max_staleness (`int`, *optional*, defaults to `4`):
             Maximum number of weight update steps a rollout sample can lag behind the current model version before
             being discarded.
@@ -119,8 +118,7 @@ class AsyncGRPOConfig(_BaseConfig):
         weight_sync_steps (`int`, *optional*, defaults to `1`):
             Number of training steps between weight synchronizations to the vLLM server.
         heartbeat_stale_after_s (`float`, *optional*, defaults to `300.0`):
-            Seconds since the rollout worker's last heartbeat after which the trainer treats it as
-            hung and aborts.
+            Seconds since the rollout worker's last heartbeat after which the trainer treats it as hung and aborts.
 
         > Parameters that control the logging
 

--- a/trl/experimental/bco/bco_config.py
+++ b/trl/experimental/bco/bco_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class BCOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.bco.BCOTrainer`].
 

--- a/trl/experimental/cpo/cpo_config.py
+++ b/trl/experimental/cpo/cpo_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class CPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.cpo.CPOTrainer`].
 

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -19,7 +19,6 @@ from ...trainer.grpo_config import GRPOConfig
 
 @dataclass
 class GMPOConfig(GRPOConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`GMPOTrainer`].
 

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -21,7 +21,6 @@ from ...trainer.sft_config import SFTConfig
 
 @dataclass
 class GOLDConfig(SFTConfig):
-    # docstyle-ignore
     r"""
     Configuration class for [`GOLDTrainer`].
 
@@ -75,8 +74,8 @@ class GOLDConfig(SFTConfig):
             Whether to use Universal Logit Distillation (ULD) loss instead of Generalized Jensen-Shannon Divergence
             loss.
         use_extended_uld (`bool`, *optional*, defaults to `True`):
-            Whether to enable extended ULD alignment that uses tokenizers to align and merge token probabilities
-            across student and teacher tokenizations. When `True`, the trainer will compute token mappings and merge
+            Whether to enable extended ULD alignment that uses tokenizers to align and merge token probabilities across
+            student and teacher tokenizations. When `True`, the trainer will compute token mappings and merge
             probabilities for split tokens; when `False`, ULD will use simple positional truncation like in the
             original ULD paper.
         uld_token_merge_strategy (`str`, *optional*, defaults to `"observed"`):

--- a/trl/experimental/iw_opd/iw_opd_config.py
+++ b/trl/experimental/iw_opd/iw_opd_config.py
@@ -21,7 +21,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class IWOPDConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`IWOPDTrainer`].
 
@@ -36,12 +35,12 @@ class IWOPDConfig(_BaseConfig):
         > Parameters that control the model
 
         model_init_kwargs (`dict[str, Any]`, *optional*):
-            Keyword arguments for `AutoModelForCausalLM.from_pretrained`, used when the `model` argument of the
-            trainer is provided as a string.
+            Keyword arguments for `AutoModelForCausalLM.from_pretrained`, used when the `model` argument of the trainer
+            is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoTokenizer.from_pretrained`], for both the student and teacher.
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoTokenizer.from_pretrained`],
+            for both the student and teacher.
         max_length (`int` or `None`, *optional*, defaults to `1024`):
             Maximum total sequence length (prompt + completion) for tokenization and truncation.
 
@@ -66,9 +65,9 @@ class IWOPDConfig(_BaseConfig):
             Stabilizer used when normalizing IW-OPD prefix weights.
         reverse_kl_top_1_mode (`str`, *optional*, defaults to `"sampled"`):
             Selection rule for the reverse-KL top-1 token when `beta > 0` and `loss_top_k == 1`. `"sampled"` uses the
-            actual completion token in the batch. `"argmax"` uses the student's highest-probability token. This
-            setting does not affect the forward-KL support, which always uses the teacher's top-1 token. Ignored when
-            `beta == 0` or `loss_top_k != 1`.
+            actual completion token in the batch. `"argmax"` uses the student's highest-probability token. This setting
+            does not affect the forward-KL support, which always uses the teacher's top-1 token. Ignored when `beta ==
+            0` or `loss_top_k != 1`.
         max_completion_length (`int`, *optional*, defaults to `512`):
             Maximum number of tokens to generate per completion during on-policy generation.
         max_prompt_length (`int` or `None`, *optional*):
@@ -90,11 +89,12 @@ class IWOPDConfig(_BaseConfig):
             Whether to use an external vLLM teacher server instead of a local teacher model.
         teacher_model_server_url (`str` or `None`, *optional*):
             Base URL of a vLLM server hosting the teacher model (e.g., `"http://localhost:8000"`). When set, teacher
-            logprobs are fetched from the server instead of running a local forward pass when `use_teacher_server=True`.
+            logprobs are fetched from the server instead of running a local forward pass when
+            `use_teacher_server=True`.
         loss_top_k (`int`, *optional*, defaults to `1`):
             Number of top tokens to use when computing the JSD/KL loss. Both student and teacher distributions are
-            restricted to these K tokens and re-normalized before computing divergence. If 0, the full vocabulary
-            is used. For local teachers, the general support rule is teacher top-k for forward KL, student top-k for
+            restricted to these K tokens and re-normalized before computing divergence. If 0, the full vocabulary is
+            used. For local teachers, the general support rule is teacher top-k for forward KL, student top-k for
             reverse KL, and the union for mixed JSD. When `beta > 0` and `loss_top_k == 1`, the forward support still
             uses the teacher's top-1 token, while the reverse top-1 token is controlled by `reverse_kl_top_1_mode`.
             When `use_teacher_server=True`, the pure forward path (`beta=0`) requires this to be positive and uses the

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -21,7 +21,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class OnlineDPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.online_dpo.OnlineDPOTrainer`].
 

--- a/trl/experimental/orpo/orpo_config.py
+++ b/trl/experimental/orpo/orpo_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class ORPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.orpo.ORPOTrainer`].
 

--- a/trl/experimental/ppo/ppo_config.py
+++ b/trl/experimental/ppo/ppo_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class PPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.ppo.PPOTrainer`].
 

--- a/trl/experimental/prm/prm_config.py
+++ b/trl/experimental/prm/prm_config.py
@@ -19,7 +19,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class PRMConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.prm.PRMTrainer`].
 

--- a/trl/experimental/tpo/tpo_config.py
+++ b/trl/experimental/tpo/tpo_config.py
@@ -20,7 +20,6 @@ from ...trainer.base_config import _BaseConfig
 
 @dataclass
 class TPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`experimental.tpo.TPOTrainer`].
 
@@ -40,8 +39,7 @@ class TPOConfig(_BaseConfig):
             argument of the [`experimental.tpo.TPOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`].
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
         disable_dropout (`bool`, *optional*, defaults to `True`):
             Whether to disable dropout in the model.
 
@@ -67,9 +65,8 @@ class TPOConfig(_BaseConfig):
                 - `"hinge"`: hinge loss on the normalized likelihood from the
                   [SLiC](https://huggingface.co/papers/2305.10425) paper.
                 - `"ipo"`: IPO loss from the [IPO](https://huggingface.co/papers/2310.12036) paper.
-                - `"tpo-l"`: length-normalized TPO variant from the
-                  [TPO](https://huggingface.co/papers/2405.16681) paper, which adds a target reward margin
-                  `tpo_l_gamma` to the Bradley-Terry objective.
+                - `"tpo-l"`: length-normalized TPO variant from the [TPO](https://huggingface.co/papers/2405.16681)
+                  paper, which adds a target reward margin `tpo_l_gamma` to the Bradley-Terry objective.
 
         beta (`float`, *optional*, defaults to `0.01`):
             Parameter controlling the temperature of the TPO loss. For the IPO loss (`loss_type="ipo"`), β is the

--- a/trl/trainer/distillation_config.py
+++ b/trl/trainer/distillation_config.py
@@ -20,7 +20,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class DistillationConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`DistillationTrainer`].
 
@@ -35,12 +34,12 @@ class DistillationConfig(_BaseConfig):
         > Parameters that control the model and the teacher model
 
         model_init_kwargs (`str` or `dict[str, Any]`, *optional*):
-            Keyword arguments for `AutoModelForCausalLM.from_pretrained`, used when the `model` argument of the
-            trainer is provided as a string.
+            Keyword arguments for `AutoModelForCausalLM.from_pretrained`, used when the `model` argument of the trainer
+            is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoTokenizer.from_pretrained`], for both the student and teacher.
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoTokenizer.from_pretrained`],
+            for both the student and teacher.
         teacher_model_name_or_path (`str`, *optional*):
             Model name or path for the teacher model. Used when the teacher is loaded locally.
         teacher_model_revision (`str`, *optional*):
@@ -140,9 +139,9 @@ class DistillationConfig(_BaseConfig):
         > Parameters that control the logging
 
         log_completions (`bool`, *optional*, defaults to `False`):
-            Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is
-            installed, it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb`
-            and/or `trackio`.
+            Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
+            it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
+            `trackio`.
         num_completions_to_print (`int`, *optional*):
             Number of completions to print with `rich`. If `None`, all completions are logged.
         log_unique_prompts (`bool`, *optional*, defaults to `False`):

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -21,7 +21,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class DPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`DPOTrainer`].
 
@@ -41,8 +40,7 @@ class DPOConfig(_BaseConfig):
             argument of the [`DPOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`].
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
@@ -58,8 +56,8 @@ class DPOConfig(_BaseConfig):
             Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left or
             right depending on the `truncation_mode`. If `None`, no truncation is applied.
         truncation_mode (`str`, *optional*, defaults to `"keep_start"`):
-            Truncation mode to use when the sequence exceeds `max_length`. The only supported value is
-            `"keep_start"`. The `"keep_end"` value is deprecated and will be removed in v2.0.0.
+            Truncation mode to use when the sequence exceeds `max_length`. The only supported value is `"keep_start"`.
+            The `"keep_end"` value is deprecated and will be removed in v2.0.0.
         padding_free (`bool`, *optional*, defaults to `False`):
             Whether to perform forward passes without padding by flattening all sequences in the batch into a single
             continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -21,7 +21,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class GRPOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`GRPOTrainer`].
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -40,8 +40,8 @@ class GRPOConfig(_BaseConfig):
             argument of the [`GRPOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`]. Also applied to reward-model and reward-tokenizer loads.
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
+            Also applied to reward-model and reward-tokenizer loads.
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
@@ -299,14 +299,14 @@ class GRPOConfig(_BaseConfig):
             encourages exploration by keeping the policy from collapsing to near-deterministic outputs. The bonus is
             always the mean per-token entropy regardless of `loss_type`; it is not rescaled to match a loss type's
             policy normalization, so `entropy_coef` has the same meaning for every loss type. When
-            `use_adaptive_entropy=True`, this serves as the initial coefficient and is updated each optimizer step.
-            Has no effect when set to `0.0` (default).
+            `use_adaptive_entropy=True`, this serves as the initial coefficient and is updated each optimizer step. Has
+            no effect when set to `0.0` (default).
         use_adaptive_entropy (`bool`, *optional*, defaults to `False`):
             Whether to use adaptive entropy control, introduced in
             [Skywork-OR1](https://huggingface.co/papers/2505.22312). When enabled, the entropy coefficient
-            `entropy_coef` is updated each optimizer step: incremented by `entropy_coef_delta` when the current
-            entropy is below `entropy_target`, and decremented otherwise. The coefficient is only applied when
-            entropy is at or below `entropy_target`.
+            `entropy_coef` is updated each optimizer step: incremented by `entropy_coef_delta` when the current entropy
+            is below `entropy_target`, and decremented otherwise. The coefficient is only applied when entropy is at or
+            below `entropy_target`.
         entropy_coef_min (`float`, *optional*, defaults to `0.0`):
             Lower bound for the entropy coefficient when using adaptive entropy control.
         entropy_coef_max (`float`, *optional*, defaults to `1.0`):
@@ -314,14 +314,13 @@ class GRPOConfig(_BaseConfig):
         entropy_coef_delta (`float`, *optional*, defaults to `0.005`):
             Step size for adjusting the entropy coefficient at each optimizer step during adaptive entropy control.
         entropy_target (`float`, *optional*, defaults to `0.2`):
-            Target mean per-token entropy (in nats) used by adaptive entropy control. The coefficient is only
-            applied when the current entropy falls at or below this value. Measured over the same token set as
-            the policy loss: all completion tokens by default, or only the high-entropy subset when
-            `top_entropy_quantile < 1.0`. Typical language models have per-token entropies in the range 2–10
-            nats, so the default of `0.2` almost never triggers regularization (only on near-complete entropy
-            collapse); set it close to the entropy you observe early in training (logged as the `entropy`
-            metric) so the bonus engages before the policy collapses (and account for the token subset when
-            using `top_entropy_quantile`).
+            Target mean per-token entropy (in nats) used by adaptive entropy control. The coefficient is only applied
+            when the current entropy falls at or below this value. Measured over the same token set as the policy loss:
+            all completion tokens by default, or only the high-entropy subset when `top_entropy_quantile < 1.0`.
+            Typical language models have per-token entropies in the range 2–10 nats, so the default of `0.2` almost
+            never triggers regularization (only on near-complete entropy collapse); set it close to the entropy you
+            observe early in training (logged as the `entropy` metric) so the bonus engages before the policy collapses
+            (and account for the token subset when using `top_entropy_quantile`).
         max_tool_calling_iterations (`int`, *optional*):
             Maximum number of tool-calling turns when training an agent. If `None`, there is no limit and generation
             stops when the model generates a response turn with no tool calls or when the total response length reaches
@@ -357,10 +356,10 @@ class GRPOConfig(_BaseConfig):
             paper](https://huggingface.co/papers/2512.02556). It expects a positive value (e.g., 0.5).
         use_bias_correction_kl (`bool`, *optional*, defaults to `True`):
             Whether to multiply the KL term by the importance sampling ratio, so that the KL gradient becomes the
-            unbiased reverse-KL gradient, as described in the
-            [DeepSeek-V3.2 paper](https://huggingface.co/papers/2512.02556). This changes the KL gradient whenever
-            `beta != 0`, including on-policy: the ratio is differentiable, so it affects the gradient even where its
-            value is exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level="token"`; with
+            unbiased reverse-KL gradient, as described in the [DeepSeek-V3.2
+            paper](https://huggingface.co/papers/2512.02556). This changes the KL gradient whenever `beta != 0`,
+            including on-policy: the ratio is differentiable, so it affects the gradient even where its value is
+            exactly 1. The unbiased reverse-KL property holds for `importance_sampling_level="token"`; with
             `"sequence"` a sequence-level weight is broadcast onto the per-token KL.
 
         > Parameters that control the logging

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -20,7 +20,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class KTOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`KTOTrainer`].
 
@@ -40,8 +39,7 @@ class KTOConfig(_BaseConfig):
             argument of the [`KTOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`].
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -21,7 +21,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class RewardConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`RewardTrainer`].
 

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -21,7 +21,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class RLOOConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`RLOOTrainer`].
 
@@ -41,8 +40,8 @@ class RLOOConfig(_BaseConfig):
             argument of the [`RLOOTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`]. Also applied to reward-model and reward-tokenizer loads.
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
+            Also applied to reward-model and reward-tokenizer loads.
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -21,7 +21,6 @@ from .base_config import _BaseConfig
 
 @dataclass
 class SFTConfig(_BaseConfig):
-    # docstyle-ignore
     r"""
     Configuration class for the [`SFTTrainer`].
 
@@ -41,8 +40,7 @@ class SFTConfig(_BaseConfig):
             argument of the [`SFTTrainer`] is provided as a string.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
-            [`~transformers.AutoModelForCausalLM.from_pretrained`] and
-            [`~transformers.AutoProcessor.from_pretrained`].
+            [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoProcessor.from_pretrained`].
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
@@ -67,12 +65,12 @@ class SFTConfig(_BaseConfig):
             Token used to indicate the end of a turn or sequence. If `None`, it defaults to
             `processing_class.eos_token`.
         max_length (`int` or `None`, *optional*, defaults to `1024`):
-            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left
-            or right depending on `truncation_mode`. If `None`, no truncation is applied. When packing is enabled,
-            this value sets the sequence length.
+            Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from the left or
+            right depending on `truncation_mode`. If `None`, no truncation is applied. When packing is enabled, this
+            value sets the sequence length.
         truncation_mode (`str`, *optional*, defaults to `"keep_start"`):
-            Truncation mode to use when the sequence exceeds `max_length`. The only supported value is
-            `"keep_start"`. The `"keep_end"` value is deprecated and will be removed in v2.0.0.
+            Truncation mode to use when the sequence exceeds `max_length`. The only supported value is `"keep_start"`.
+            The `"keep_end"` value is deprecated and will be removed in v2.0.0.
         shuffle_dataset (`bool`, *optional*, defaults to `False`):
             Whether to shuffle the dataset.
         packing (`bool`, *optional*, defaults to `False`):
@@ -109,8 +107,7 @@ class SFTConfig(_BaseConfig):
             in which case it defaults to `"nll"`. Possible values are:
 
             - `"nll"`: standard negative log-likelihood.
-            - `"dft"`: Dynamic Fine-Tuning, as described in
-              [this paper](https://huggingface.co/papers/2508.05629).
+            - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.


### PR DESCRIPTION
This PR removes unnecessary `docstyle-ignore` tag from docstrings and updates their style.

Follow-up to:
- #6784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only edits; no training logic, defaults, or APIs change.
> 
> **Overview**
> Follow-up to #6784: strips the `# docstyle-ignore` comment immediately above class docstrings across trainer/experimental **config** modules (A2PO, AsyncGRPO, BCO, CPO, GMPO, GOLD, IW-OPD, Online DPO, ORPO, PPO, PRM, TPO, and core `DistillationConfig`, `DPOConfig`, `GRPOConfig`, `KTOConfig`, `RewardConfig`, `RLOOConfig`, `SFTConfig`) and from `A2POTrainer`.
> 
> Docstring text is unchanged in meaning but **re-wrapped** so long lines (Hugging Face cross-refs, parameter descriptions, return types) fit docstyle rules without suppressing checks—e.g. `unpair_preference_dataset` in `data_utils.py`, `fork_threshold_tokens` / `token_budget` in `AsyncGRPOConfig`, entropy and KL docs in `GRPOConfig`.
> 
> `# docstyle-ignore` is **left in place** where still needed (e.g. multimodal examples in `data_utils.py`, BibTeX `citation` blocks in trainers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922bcc57ec46c9136c6e274321b89d156a6a8f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->