### PR TITLE
Add opt-in GLOO weight-sync backend for XPU

### DIFF
--- a/trl/generation/vllm_client.py
+++ b/trl/generation/vllm_client.py
@@ -16,6 +16,7 @@ import atexit
 import base64
 import copy
 import logging
+import os
 import socket
 import time
 from io import BytesIO
@@ -469,13 +470,19 @@ class VLLMClient:
                 host_name=self.host, port=self.group_port, world_size=world_size, is_master=(self.rank == 0)
             )
             prefixed_store = c10d.PrefixStore("client2server", store)
-            xccl_options = c10d.ProcessGroupXCCL.Options()
-            pg = c10d.ProcessGroupXCCL(
-                store=prefixed_store,
-                rank=self.rank,
-                size=world_size,
-                options=xccl_options,
-            )
+            if os.environ.get("TRL_XPU_WEIGHT_SYNC_BACKEND", "xccl") == "gloo":
+                # On some XPU stacks (e.g. multi-card Intel Arc), the cross-device XCCL weight-sync
+                # collective never completes. Setting TRL_XPU_WEIGHT_SYNC_BACKEND=gloo routes the sync
+                # through a host-staged GLOO group instead (weights go via CPU, see update_named_param).
+                pg = c10d.ProcessGroupGloo(prefixed_store, self.rank, world_size)
+            else:
+                xccl_options = c10d.ProcessGroupXCCL.Options()
+                pg = c10d.ProcessGroupXCCL(
+                    store=prefixed_store,
+                    rank=self.rank,
+                    size=world_size,
+                    options=xccl_options,
+                )
             self.communicator = pg
         else:
             pg = StatelessProcessGroup.create(
@@ -503,9 +510,17 @@ class VLLMClient:
             raise Exception(f"Request failed: {response.status_code}, {response.text}")
 
         if is_torch_xpu_available():
-            # Use XCCL to broadcast the updated weights from the client (src) to all workers.
-            self.communicator.broadcast(weights, root=self.rank)
-            self.communicator.barrier()
+            if os.environ.get("TRL_XPU_WEIGHT_SYNC_BACKEND", "xccl") == "gloo":
+                # GLOO is host-only: send the weights from CPU (see init_communicator).
+                weights_cpu = weights.detach().to("cpu").contiguous()
+                broadcast_options = c10d.BroadcastOptions()
+                broadcast_options.rootRank = self.rank
+                self.communicator.broadcast([weights_cpu], broadcast_options).wait()
+                self.communicator.barrier().wait()
+            else:
+                # Use XCCL to broadcast the updated weights from the client (src) to all workers.
+                self.communicator.broadcast(weights, root=self.rank)
+                self.communicator.barrier()
         else:
             # Use NCCL to broadcast the updated weights from the client (src) to all workers.
             self.communicator.broadcast(weights, src=self.rank)

--- a/trl/scripts/vllm_serve.py
+++ b/trl/scripts/vllm_serve.py
@@ -97,13 +97,19 @@ class WeightSyncWorkerExtension:
         if is_torch_xpu_available():
             store = torch.distributed.TCPStore(host_name=host, port=port, world_size=world_size, is_master=(rank == 0))
             prefixed_store = c10d.PrefixStore("client2server", store)
-            xccl_options = c10d.ProcessGroupXCCL.Options()
-            pg = c10d.ProcessGroupXCCL(
-                store=prefixed_store,
-                rank=rank,
-                size=world_size,
-                options=xccl_options,
-            )
+            if os.environ.get("TRL_XPU_WEIGHT_SYNC_BACKEND", "xccl") == "gloo":
+                # On some XPU stacks (e.g. multi-card Intel Arc), the cross-device XCCL weight-sync
+                # collective never completes. Setting TRL_XPU_WEIGHT_SYNC_BACKEND=gloo routes the sync
+                # through a host-staged GLOO group instead (weights go via CPU, see update_named_param).
+                pg = c10d.ProcessGroupGloo(prefixed_store, rank, world_size)
+            else:
+                xccl_options = c10d.ProcessGroupXCCL.Options()
+                pg = c10d.ProcessGroupXCCL(
+                    store=prefixed_store,
+                    rank=rank,
+                    size=world_size,
+                    options=xccl_options,
+                )
             self.communicator = pg
         else:
             # Create a stateless process group to manage communication between training processes and vLLM workers.
@@ -137,9 +143,20 @@ class WeightSyncWorkerExtension:
         weight = torch.empty(shape, dtype=dtype, device=self.device)
 
         if is_torch_xpu_available():
-            # Use XCCL to broadcast the updated weights from the client (src) to all workers.
-            self.communicator.broadcast(weight, root=self.client_rank)
-            self.communicator.barrier()
+            if os.environ.get("TRL_XPU_WEIGHT_SYNC_BACKEND", "xccl") == "gloo":
+                # GLOO is host-only: receive the weight on CPU, then move it to the XPU device.
+                import torch.distributed.distributed_c10d as c10d
+
+                weight_cpu = torch.empty(shape, dtype=dtype, device="cpu")
+                broadcast_options = c10d.BroadcastOptions()
+                broadcast_options.rootRank = self.client_rank
+                self.communicator.broadcast([weight_cpu], broadcast_options).wait()
+                self.communicator.barrier().wait()
+                weight = weight_cpu.to(self.device)
+            else:
+                # Use XCCL to broadcast the updated weights from the client (src) to all workers.
+                self.communicator.broadcast(weight, root=self.client_rank)
+                self.communicator.barrier()
         else:
             # Use NCCL to broadcast the updated weights from the client (src) to all workers.
             self.communicator.broadcast(weight, src=self.client_rank)


### PR DESCRIPTION
## What this does

Adds an **opt-in** weight-sync transport for XPU: setting the environment
variable `TRL_XPU_WEIGHT_SYNC_BACKEND=gloo` routes vLLM-server weight
synchronization through a host-staged **GLOO** process group instead of
`ProcessGroupXCCL`. The default is unchanged (`xccl`), so existing XPU setups
are unaffected.

## Why

On a multi-card **Intel Arc Pro B60** box, GRPO in `vllm_mode="server"` hangs.
The trainer connects fine — `init_communicator` and all `update_named_param`
calls return 200 — but the **first generation deadlocks**: the vLLM
`EngineCore` blocks forever in `torch.xpu.synchronize()`.

Root cause is not in TRL's code path (the XPU communicator is already ported),
but one level down: the **cross-device XCCL/oneCCL collective used for weight
sync never completes** when the two processes are each pinned to a single
different card via `ZE_AFFINITY_MASK` (oneCCL logs
`comm_dev_uuids size 2 vs node_dev_uuids size 1 ... narrow device affinity mask`).
The broadcast/barrier work is enqueued but never finishes on-device, so it
piles up until the first generation's device-wide `torch.xpu.synchronize()`
blocks on it. No affinity-mask combination made the XCCL collective complete
(single-card → collective never finishes; dual-card → hangs at PG init or trips
the "same device for two roles" guard).

## The change

`ProcessGroupGloo` (CPU/host transport) sidesteps XPU cross-card P2P entirely.
Weights are broadcast as CPU tensors and moved to the device on the server
side. Since gloo leaves no pending XPU collective, generation then runs
normally. Applied consistently to both sides:

- `trl/scripts/vllm_serve.py` — `WeightSyncWorkerExtension.init_communicator` + `update_named_param`
- `trl/generation/vllm_client.py` — `VLLMClient.init_communicator` + `update_named_param`

## Verification

End-to-end GRPO smoke test (`biomedical_QA` recipe, Llama-3.2-3B-Instruct),
server on card 1, trainer on card 0, `TRL_XPU_WEIGHT_SYNC_BACKEND=gloo`:

- 3/3 steps completed; all `/generate/` calls returned (previously hung on the first).
- All `update_named_param` synced each step; 0 engine errors; trainer exited cleanly.
- Weights numerically correct: `importance_sampling_ratio/mean ≈ 1.0`,
  `sampling_logp_difference/mean ≈ 0.01` (vLLM outputs match the trainer policy).

## Performance

The gloo path adds a CPU round-trip per weight (D2H → loopback broadcast → H2D)
vs. a direct device-to-device XCCL transfer. In practice both processes are on
the same host (loopback), and weight sync was a small fraction of GRPO step time
(~1.7 s of a ~15 s step). It is strictly a fallback for hardware where the XCCL
path does not work.

## Open questions for maintainers

- I opted for an **env-var opt-in** (default `xccl`) to keep existing behavior
  intact. Given the repo's preference against "just in case" config, I'm happy
  to instead make gloo the XPU default, or express it differently — guidance
  welcome. Draft for discussion.
- Whether this warrants a short note in the vLLM-integration docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
