### PR TITLE
Drop ruff workaround from doc-builder pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
         name: Check style with doc-builder
         language: python
         entry: doc-builder style trl tests docs/source --max_len 119
-        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@6dd1bdab58a8564730f633d70e76bb1ef57ec627", ruff]  # See GH-5633
+        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@ffa599793cc5ed7a7e880ba824b2ea6e75e1530e"]
         pass_filenames: false
         types_or: [python, markdown, rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
         name: Check style with doc-builder
         language: python
         entry: doc-builder style trl tests docs/source --max_len 119
-        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@ffa599793cc5ed7a7e880ba824b2ea6e75e1530e"]
+        additional_dependencies: ["git+https://github.com/huggingface/doc-builder@af49b8dc3859c3d80c7220c8c0ba146431132e49"]
         pass_filenames: false
         types_or: [python, markdown, rst]


### PR DESCRIPTION
This PR removes the explicit `ruff` dependency from the `doc-builder-style` pre-commit hook, now that the upstream fix is merged.

### Motivation

`doc-builder style` invokes `ruff` unconditionally but did not declare it as a dependency, so the hook failed in CI with `No such file or directory: 'ruff'` (it passed locally only because `ruff` happened to be present in the dev venv). This was reported in #5633 and hotfixed in #5634 by adding `ruff` explicitly to the hook's `additional_dependencies`.

That hotfix was always meant to be temporary. The upstream fix huggingface/doc-builder#785 has now been merged, which adds `ruff` to `doc-builder`'s `install_requires`, so the workaround is no longer needed.

### Solution

The pinned `doc-builder` revision is bumped to `ffa5997`, the merge commit of huggingface/doc-builder#785. At that revision `ruff` is pulled in transitively, so listing it in the hook is redundant and the hotfix from #5634 is reverted.

The `# See GH-5633` comment is dropped along with it, since it only documented the workaround.

Verified locally that `pre-commit run doc-builder-style --all-files` passes in a fresh hook environment.

### Changes

- Bump the pinned `doc-builder` revision from `6dd1bda` to `ffa5997`
- Remove the explicit `ruff` entry from the hook's `additional_dependencies`, reverting the #5634 hotfix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only pre-commit configuration; no runtime, auth, or application logic changes.
> 
> **Overview**
> Reverts the temporary **#5634** workaround for the `doc-builder-style` pre-commit hook now that **huggingface/doc-builder#785** declares `ruff` as a dependency.
> 
> The hook’s pinned `doc-builder` git revision is updated, and `additional_dependencies` no longer lists `ruff` or the `# See GH-5633` comment—`ruff` is expected to install transitively with `doc-builder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf5139abd53c89dcc1cf6a1a45cf76c5c4807d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->