### PR TITLE
Fix AsyncGRPO weight-transfer deadlock with more than 2 trainer ranks

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -1313,12 +1313,24 @@ class AsyncGRPOTrainer(_BaseTrainer):
     def _streaming_iter(self):
         # Iterate parameters one at a time. For FSDP2 (DTensor), full_tensor() all-gathers just this parameter across
         # FSDP ranks, then frees it once the generator advances — avoiding materializing the full model in memory.
+        #
+        # The gather must run on the default stream and complete before we yield: on rank 0 this generator is consumed
+        # from inside vLLM's packed transfer loop, i.e. under `torch.cuda.stream(<side stream>)`, so a lazy
+        # full_tensor() would enqueue the training-group collective behind pending transfer-group broadcasts on that
+        # side stream, while ranks 1+ enqueue the same collective on their default stream with nothing ahead of it.
+        # With more than 2 trainer ranks this inconsistent ordering across the two NCCL groups deadlocks (rank 0 waits
+        # on the transfer group, everyone else waits on rank 0's gather; the watchdog reports the training-group
+        # collective as enqueued but never started). Completing each gather on the default stream before the transfer
+        # sees the tensor keeps the two groups strictly ordered.
         device = self.accelerator.device
+        default_stream = torch.cuda.default_stream(device)
         for name, param in self.model.named_parameters():
             name = name.removeprefix("module.")  # DDP/FSDP1 wrapping
-            full = param.full_tensor() if isinstance(param, DTensor) else param.detach()
-            if full.device != device:
-                full = full.to(device)
+            with torch.cuda.stream(default_stream):
+                full = param.full_tensor() if isinstance(param, DTensor) else param.detach()
+                if full.device != device:
+                    full = full.to(device)
+            default_stream.synchronize()
             yield name, full
 
     def _sync_weight(self):


### PR DESCRIPTION
Fixes the deadlock variant of #6797.

AsyncGRPO's weight sync deadlocks whenever the trainer has more than 2 FSDP ranks, independent of server tp. The cause is stream ordering across the two NCCL groups: rank 0's `_streaming_iter` is consumed lazily from inside vLLM's packed transfer loop, so its `full_tensor()` all-gathers (training group) get enqueued on the transfer's side streams behind pending transfer-group broadcasts, while ranks 1+ enqueue the same collectives on their default stream with nothing ahead of them. With more than one non-zero rank this inconsistent ordering deadlocks, and the NCCL watchdog kills the job after 30 min reporting the training-group collective as enqueued but never started.

The fix runs each gather on the default stream and completes it before yielding, so the transfer loop only ever sees finished tensors and the two groups stay strictly ordered. Costs one stream sync per parameter, a few ms total per weight sync.

Before and after (Qwen3-0.6B, tp2 server + 4 FSDP trainer ranks, sync every step):

| | initial weight sync |
|---|---|
| main | hangs, NCCL watchdog SIGABRT after 30 min |
| this PR | completes, training proceeds |

Same topology class (tp2 x 4, tp2 x 6, tp4 x 4) deadlocked identically at 8B and 32B during the benchmark that surfaced this; tp2 x 2 was the only working configuration before this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed weight-sync timing on the critical path to vLLM; behavior change is narrow but affects all multi-rank AsyncGRPO runs and adds per-parameter stream sync overhead.
> 
> **Overview**
> Fixes **AsyncGRPO weight sync deadlocks** when the trainer uses more than two FSDP ranks. Rank 0 drives `_streaming_iter` from inside vLLM’s packed transfer path on a **side CUDA stream**, so lazy `full_tensor()` training-group collectives could queue behind transfer-group NCCL work while other ranks issued the same collectives on the **default stream**—cross-group ordering then hung until the NCCL watchdog fired.
> 
> **`_streaming_iter`** now runs each parameter’s `full_tensor()` (and device move) inside `torch.cuda.stream(default_stream)`, **`synchronize()`s** before yielding, and documents why. vLLM only sees fully gathered tensors, so training and transfer NCCL groups stay ordered. Cost is one stream sync per parameter (on the order of a few ms per sync overall).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f155e144fd2189828d1782c7aa03ab7b61a3bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->