### PR TITLE
Fix epoch indexing for experimental schedules

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -15,7 +15,13 @@
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, GenerationConfig
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    GenerationConfig,
+    TrainerState,
+)
 from transformers.utils import is_peft_available
 
 from trl.experimental.nash_md import NashMDConfig, NashMDTrainer
@@ -27,6 +33,15 @@ from ..testing_utils import TrlTestCase, require_peft
 
 if is_peft_available():
     from peft import LoraConfig, get_peft_model
+
+
+@pytest.mark.parametrize("epoch, expected_coef", [(None, 0.1), (0.25, 0.1), (1.0, 0.2), (2.0, 0.2)])
+def test_mixture_coef_schedule(epoch, expected_coef):
+    trainer = object.__new__(NashMDTrainer)
+    trainer._mixture_coef = [0.1, 0.2]
+    trainer.state = TrainerState(epoch=epoch)
+
+    assert trainer.mixture_coef == expected_coef
 
 
 class TestGeometricMixtureWrapper(TrlTestCase):

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 from datasets import Dataset, DatasetDict, features, load_dataset
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, TrainerState
 from transformers.utils import is_peft_available, is_vision_available
 
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
@@ -30,6 +30,15 @@ if is_vision_available():
     import numpy as np
     from PIL import Image
     from transformers import AutoModelForImageTextToText, AutoProcessor
+
+
+@pytest.mark.parametrize("epoch, expected_beta", [(None, 0.1), (0.25, 0.1), (1.0, 0.2), (2.0, 0.2)])
+def test_beta_schedule(epoch, expected_beta):
+    trainer = object.__new__(OnlineDPOTrainer)
+    trainer._beta = [0.1, 0.2]
+    trainer.state = TrainerState(epoch=epoch)
+
+    assert trainer.beta == expected_beta
 
 
 class TestOnlineDPOTrainer(TrlTestCase):

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -14,7 +14,7 @@
 
 import pytest
 from datasets import DatasetDict, load_dataset
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, TrainerState
 from transformers.utils import is_peft_available
 
 from trl.experimental.xpo import XPOConfig, XPOTrainer
@@ -24,6 +24,15 @@ from ..testing_utils import TrlTestCase, require_peft
 
 if is_peft_available():
     from peft import LoraConfig, get_peft_model
+
+
+@pytest.mark.parametrize("epoch, expected_alpha", [(None, 0.1), (0.25, 0.1), (1.0, 0.2), (2.0, 0.2)])
+def test_alpha_schedule(epoch, expected_alpha):
+    trainer = object.__new__(XPOTrainer)
+    trainer._alpha = [0.1, 0.2]
+    trainer.state = TrainerState(epoch=epoch)
+
+    assert trainer.alpha == expected_alpha
 
 
 @pytest.mark.low_priority

--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -234,7 +234,7 @@ class NashMDTrainer(OnlineDPOTrainer):
     @property
     def mixture_coef(self):
         if isinstance(self._mixture_coef, list):
-            epoch = self.state.epoch
+            epoch = int(self.state.epoch or 0)
             return self._mixture_coef[epoch] if epoch < len(self._mixture_coef) else self._mixture_coef[-1]
         else:
             return self._mixture_coef

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -562,7 +562,7 @@ class OnlineDPOTrainer(_BaseTrainer):
     @property
     def beta(self):
         if isinstance(self._beta, list):
-            epoch = self.state.epoch
+            epoch = int(self.state.epoch or 0)
             return self._beta[epoch] if epoch < len(self._beta) else self._beta[-1]
         else:
             return self._beta

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -180,7 +180,7 @@ class XPOTrainer(OnlineDPOTrainer):
     @property
     def alpha(self):
         if isinstance(self._alpha, list):
-            epoch = self.state.epoch
+            epoch = int(self.state.epoch or 0)
             return self._alpha[epoch] if epoch < len(self._alpha) else self._alpha[-1]
         else:
             return self._alpha


### PR DESCRIPTION
Fixes #6806

The schedule properties indexed Python lists with `TrainerState.epoch`, which is `None` before training and a float during training. Convert it to an integer epoch, defaulting to epoch zero, in OnlineDPO, XPO, and Nash-MD.

Regression tests cover pre-training access, fractional epochs, epoch boundaries, and schedules shorter than the training run. The three affected test modules passed on a Linux node with NVIDIA A40 GPUs using CPU execution, with 41 passed and 13 skipped. Ruff lint and format checks passed.

GPU execution was not verified because the installed PyTorch CUDA runtime required a newer driver. The combined pre-commit entry point could not run because the node's Git lacks `git ls-files --deduplicate`; its configured Ruff checks passed when run directly.

Thanks to @mmjerge for reporting the issue and identifying the affected trainers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to hyperparameter schedule lookup in experimental trainers, with direct regression tests and no API changes.
> 
> **Overview**
> Fixes incorrect indexing when **beta**, **alpha**, or **mixture_coef** are configured as per-epoch lists in `OnlineDPOTrainer`, `XPOTrainer`, and `NashMDTrainer`.
> 
> Those properties used `self.state.epoch` directly as a list index, but `TrainerState.epoch` is `None` before training and a **float** while training, which can raise errors or pick the wrong schedule step. Each property now uses `int(self.state.epoch or 0)` so pre-training reads epoch 0, fractional epochs map to the current integer epoch, and out-of-range epochs still fall back to the last list entry.
> 
> Parametrized tests were added for all three trainers covering `None`, fractional, boundary, and overrun epochs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cb3ac746222ff06a7a351c1e522cb753db8b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->