### PR TITLE
Emit position_ids from the SFT collator when sequence parallelism is enabled

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -135,6 +135,30 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
         torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
         torch.testing.assert_close(result["labels"], torch.tensor([[1, 2, 3], [4, 5, -100]]))
 
+    def test_return_position_ids(self):
+        """Padded mode with return_position_ids: position IDs are returned alongside the attention mask."""
+        collator = DataCollatorForLanguageModeling(pad_token_id=0, return_position_ids=True)
+        examples = [{"input_ids": [1, 2, 3], "labels": [1, 2, 3]}, {"input_ids": [4, 5], "labels": [4, 5]}]
+
+        result = collator(examples)
+
+        assert set(result.keys()) == {"input_ids", "attention_mask", "position_ids", "labels"}
+        torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
+        torch.testing.assert_close(result["attention_mask"], torch.tensor([[1, 1, 1], [1, 1, 0]]))
+        torch.testing.assert_close(result["position_ids"], torch.tensor([[0, 1, 2], [0, 1, 0]]))
+        torch.testing.assert_close(result["labels"], torch.tensor([[1, 2, 3], [4, 5, -100]]))
+
+    def test_return_position_ids_packed(self):
+        """Padded mode with return_position_ids on packed examples: position IDs reset at document boundaries."""
+        collator = DataCollatorForLanguageModeling(pad_token_id=0, return_position_ids=True)
+        examples = [{"input_ids": [1, 2, 3, 4, 5], "seq_lengths": [3, 2]}, {"input_ids": [6, 7], "seq_lengths": [2]}]
+
+        result = collator(examples)
+
+        assert set(result.keys()) == {"input_ids", "attention_mask", "position_ids", "labels"}
+        torch.testing.assert_close(result["input_ids"], torch.tensor([[1, 2, 3, 4, 5], [6, 7, 0, 0, 0]]))
+        torch.testing.assert_close(result["position_ids"], torch.tensor([[0, 1, 2, 0, 1], [0, 1, 0, 0, 0]]))
+
     def test_padding_free_mode(self):
         """Test padding-free mode where sequences are concatenated."""
         collator = DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -421,6 +421,10 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
         padding_free (`bool`, *optional*, defaults to `False`):
             If set to `True`, the sequences will be flattened into a single sequence, and the position IDs will be
             generated accordingly and returned instead of the attention mask.
+        return_position_ids (`bool`, *optional*, defaults to `False`):
+            If set to `True`, position IDs are returned alongside the attention mask in the padded (non-padding-free)
+            mode. Required by sequence parallelism (Ulysses/ALST), which shards batches along the sequence dimension
+            and needs each token's global position.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
         return_tensors (`str`, *optional*, defaults to `"pt"`):
@@ -464,6 +468,7 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
 
     pad_token_id: int
     padding_free: bool = False
+    return_position_ids: bool = False
     pad_to_multiple_of: int | None = None
     return_tensors: str = "pt"
 
@@ -478,12 +483,12 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
 
         # For padding-free, we should NOT create attention_mask as it causes FlashAttention to ignore position_ids and
         # compute wrong cu_seq_lens from the all-1s mask
-        if self.padding_free:
+        if self.padding_free or self.return_position_ids:
             if batch_seq_lengths is not None:
                 position_ids = self.get_position_ids_from_packed_seq_lengths(batch_seq_lengths)
             else:
                 position_ids = [torch.arange(len(ids)) for ids in input_ids]
-        else:
+        if not self.padding_free:
             attention_mask = [torch.ones_like(ids) for ids in input_ids]
 
         # If padding_free, flatten everything into a single sequence
@@ -509,6 +514,10 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
             )
             output["labels"][output["position_ids"] == 0] = -100
         else:
+            if self.return_position_ids:
+                output["position_ids"] = pad(
+                    position_ids, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
+                )
             output["attention_mask"] = pad(
                 attention_mask, padding_value=0, padding_side="right", pad_to_multiple_of=self.pad_to_multiple_of
             )
@@ -1359,6 +1368,16 @@ class SFTTrainer(_BaseTrainer):
             optimizer_cls_and_kwargs=optimizer_cls_and_kwargs,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
+
+        # Sequence parallelism (Ulysses/ALST) shards batches along the sequence dimension and requires
+        # `position_ids` in every batch to preserve each token's global position.
+        parallelism_config = self.accelerator.parallelism_config
+        if (
+            parallelism_config is not None
+            and parallelism_config.sp_enabled
+            and isinstance(self.data_collator, DataCollatorForLanguageModeling)
+        ):
+            self.data_collator.return_position_ids = True
 
         # Initialize activation offloading context
         if self.args.activation_offloading:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import accelerate
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -1372,11 +1373,12 @@ class SFTTrainer(_BaseTrainer):
         )
 
         # Sequence parallelism (Ulysses/ALST) shards batches along the sequence dimension and requires
-        # `position_ids` in every batch to preserve each token's global position.
-        parallelism_config = self.accelerator.parallelism_config
+        # `position_ids` in every batch to preserve each token's global position. Sequence parallelism was added in
+        # accelerate 1.12.0.
         if (
-            parallelism_config is not None
-            and parallelism_config.sp_enabled
+            Version(accelerate.__version__) >= Version("1.12.0")
+            and self.accelerator.parallelism_config is not None
+            and self.accelerator.parallelism_config.sp_enabled
             and isinstance(self.data_collator, DataCollatorForLanguageModeling)
         ):
             self.data_collator.return_position_ids = True


### PR DESCRIPTION
Running SFT with the documented ALST/Ulysses setup (`distributed_type: DEEPSPEED` + `parallelism_config_sp_backend: deepspeed`, e.g. `examples/accelerate_configs/alst_ulysses_4gpu.yaml`) fails on the first batch:

```
ValueError: Ulysses SP requires `position_ids` in every dataloader batch so that each token
retains its correct global position after sequence sharding. ...
```

`DataCollatorForLanguageModeling` only emits `position_ids` in padding-free mode; the standard padded path never includes them, so the documented Ulysses configuration doesn't work out of
the box.

### Fix

- `DataCollatorForLanguageModeling` gains `return_position_ids` (default `False`): in padded mode it then returns `position_ids` alongside `attention_mask`; per-sample `arange`, or boundary-resetting ids for packed examples (reusing the existing `get_position_ids_from_packed_seq_lengths`).
- `SFTTrainer` flips it on automatically when `accelerator.parallelism_config.sp_enabled`.

No behavior change for any existing configuration (flag defaults off; SP configs previously crashed).



### Repro

`ulysses2.yaml` (2 GPUs):

```yaml
compute_environment: LOCAL_MACHINE
deepspeed_config:
  zero_stage: 3
  seq_parallel_communication_data_type: bf16
  zero3_init_flag: true
distributed_type: DEEPSPEED
mixed_precision: bf16
num_machines: 1
num_processes: 2
parallelism_config:
  parallelism_config_dp_replicate_size: 1
  parallelism_config_dp_shard_size: 1
  parallelism_config_tp_size: 1
  parallelism_config_sp_size: 2
  parallelism_config_sp_backend: deepspeed
  parallelism_config_sp_seq_length_is_variable: true
  parallelism_config_sp_attn_implementation: sdpa
```

`repro.py`:

```python
from datasets import Dataset
from trl import SFTConfig, SFTTrainer

dataset = Dataset.from_dict({"text": ["The quick brown fox jumps over the lazy dog. " * 20] * 16})
trainer = SFTTrainer(
    model="trl-internal-testing/tiny-Qwen3ForCausalLM",
    args=SFTConfig(max_steps=2, per_device_train_batch_size=1, pad_to_multiple_of=2, report_to=[]),
    train_dataset=dataset,
)
trainer.train()
print("training OK")
```

```bash
accelerate launch --config_file ulysses2.yaml repro.py
```

Before (main): the `ValueError` above at the first batch. After (this branch): `training OK`.


### Tested

End-to-end on 8×H100 (`sp_size=8`, ZeRO-3, Qwen3-0.6B, 1,048,576-token sequences): before → the `ValueError` above; after → trains at 234 s/step, 24.3 GB/GPU (loss/metrics consistent with the ring-attention CP run of the same setup).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SFT batch collation used in training, but the new path is opt-in (default off) and only auto-enabled under sequence parallelism.
> 
> **Overview**
> Fixes SFT with Ulysses/ALST sequence parallelism, which previously crashed because padded batches lacked `position_ids`.
> 
> `DataCollatorForLanguageModeling` adds `return_position_ids` so padded batches include `position_ids` next to the attention mask (resetting at packed document boundaries). `SFTTrainer` turns this on automatically when Accelerate sequence parallelism is enabled (accelerate ≥ 1.12). Default behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc238caedcd3b7020860e3fc35c4355f8caefb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->