### PR TITLE
Fix missing EOS penalties for XPO and Nash-MD

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -85,6 +88,23 @@ class TestNashMDTrainer(TrlTestCase):
         self.reward_model = AutoModelForSequenceClassification.from_pretrained(self.model_id, num_labels=1)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    def test_missing_eos_penalty_ignores_prompt(self):
+        trainer = SimpleNamespace(
+            args=SimpleNamespace(missing_eos_penalty=1.0),
+            processing_class=SimpleNamespace(eos_token_id=2, pad_token_id=0),
+            reward_funcs=None,
+        )
+        data = {"input_ids": torch.tensor([[2, 3], [2, 2]])}
+
+        with patch(
+            "trl.experimental.nash_md.nash_md_trainer.get_reward",
+            side_effect=lambda *args: (None, torch.zeros(2), None),
+        ):
+            model_scores, mixture_scores = NashMDTrainer._compute_rewards(trainer, data, data, context_length=1)
+
+        torch.testing.assert_close(model_scores, torch.tensor([-1.0, 0.0]))
+        torch.testing.assert_close(mixture_scores, torch.tensor([-1.0, 0.0]))
 
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_nash_md_trainer_training(self, config_name):

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
+import torch
 from datasets import DatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available
@@ -35,6 +39,22 @@ class TestXPOTrainer(TrlTestCase):
         self.reward_model = AutoModelForSequenceClassification.from_pretrained(self.model_id, num_labels=1)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    def test_missing_eos_penalty_ignores_prompt(self):
+        trainer = SimpleNamespace(
+            args=SimpleNamespace(missing_eos_penalty=1.0),
+            processing_class=SimpleNamespace(eos_token_id=2, pad_token_id=0),
+            reward_funcs=None,
+        )
+        data = {"input_ids": torch.tensor([[2, 3], [2, 2]])}
+
+        with patch(
+            "trl.experimental.xpo.xpo_trainer.get_reward", side_effect=lambda *args: (None, torch.zeros(2), None)
+        ):
+            model_scores, ref_scores = XPOTrainer._compute_rewards(trainer, data, data, context_length=1)
+
+        torch.testing.assert_close(model_scores, torch.tensor([-1.0, 0.0]))
+        torch.testing.assert_close(ref_scores, torch.tensor([-1.0, 0.0]))
 
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_xpo_trainer_training(self, config_name):

--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -332,8 +332,12 @@ class NashMDTrainer(OnlineDPOTrainer):
 
         # Apply EOS penalty if needed
         if self.args.missing_eos_penalty is not None:
-            model_contain_eos = torch.any(model_data["input_ids"] == self.processing_class.eos_token_id, dim=-1)
-            mixture_contain_eos = torch.any(mixture_data["input_ids"] == self.processing_class.eos_token_id, dim=-1)
+            model_contain_eos = torch.any(
+                model_data["input_ids"][:, context_length:] == self.processing_class.eos_token_id, dim=-1
+            )
+            mixture_contain_eos = torch.any(
+                mixture_data["input_ids"][:, context_length:] == self.processing_class.eos_token_id, dim=-1
+            )
             model_scores[~model_contain_eos] -= self.args.missing_eos_penalty
             mixture_scores[~mixture_contain_eos] -= self.args.missing_eos_penalty
 

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -263,8 +263,12 @@ class XPOTrainer(OnlineDPOTrainer):
 
         # Apply EOS penalty if needed
         if self.args.missing_eos_penalty is not None:
-            model_contain_eos = torch.any(model_data["input_ids"] == self.processing_class.eos_token_id, dim=-1)
-            ref_contain_eos = torch.any(ref_data["input_ids"] == self.processing_class.eos_token_id, dim=-1)
+            model_contain_eos = torch.any(
+                model_data["input_ids"][:, context_length:] == self.processing_class.eos_token_id, dim=-1
+            )
+            ref_contain_eos = torch.any(
+                ref_data["input_ids"][:, context_length:] == self.processing_class.eos_token_id, dim=-1
+            )
             model_scores[~model_contain_eos] -= self.args.missing_eos_penalty
             ref_scores[~ref_contain_eos] -= self.args.missing_eos_penalty
 


### PR DESCRIPTION
# What does this PR do?

Fixes #6805

XPO and Nash-MD checked the full prompt plus completion for EOS before applying `missing_eos_penalty`. This change limits the check to completion tokens, so an EOS token in a chat-formatted prompt cannot hide a missing completion EOS.

Regression tests cover both trainers with EOS in the prompt and completions with and without EOS. Both experimental trainer test files passed on Linux using CPU execution, with 17 tests passed and 6 skipped. Ruff, formatting, and doc-builder style checks passed.

GPU execution and full-size Qwen training were not verified because the installed PyTorch build required a newer CUDA driver than the available driver. The full repository test suite was not run.

Thanks to @mmjerge for reporting the issue and identifying the affected trainers.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward shaping in experimental RLHF trainers when missing_eos_penalty is enabled; behavior shifts for chat-formatted prompts but matches intended semantics and is covered by new unit tests.
> 
> **Overview**
> Fixes **missing EOS penalty** behavior in **XPO** and **Nash-MD** when `missing_eos_penalty` is set. `_compute_rewards` used to treat an EOS anywhere in `input_ids` (prompt + completion) as satisfying the check, so chat-style prompts that already contain EOS could skip the penalty even when the generated completion had no EOS.
> 
> The EOS check is now limited to **completion tokens** via `input_ids[:, context_length:]`, aligned with how `_log_statistics` already measures EOS. Regression tests call `_compute_rewards` with mocked rewards and assert the penalty applies when only the prompt has EOS but the completion does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4fb60bb088f691788f5c0e6102c5f9b28398e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->