### PR TITLE
Fix Nemotron 3 SFT example: correct LoRA target modules for hybrid Mamba architecture

### DIFF
--- a/examples/scripts/sft_nemotron_3.py
+++ b/examples/scripts/sft_nemotron_3.py
@@ -25,6 +25,20 @@
 """
 Fine-tune NVIDIA Nemotron 3 models with SFT.
 
+Nemotron 3 uses a hybrid Mamba-Attention architecture. The majority of layers
+are Mamba SSM blocks (with `in_proj`/`out_proj`), not attention blocks. The
+LoRA target modules below cover both the attention projections
+(`q_proj`/`k_proj`/`v_proj`/`o_proj`), the Mamba input projection (`in_proj`),
+and the MLP projections (`up_proj`/`down_proj`).
+
+`gate_proj` is intentionally excluded: NemotronH uses a non-gated MLP
+(`up_proj`/`down_proj` only), so `gate_proj` does not exist in the model.
+`out_proj` is intentionally excluded: PEFT raises `ValueError` when `out_proj`
+is targeted on `nemotron_h` (and other Mamba-based model types) because the
+fused SSM kernel consumes `out_proj.weight` as a raw tensor, bypassing the
+LoRA-wrapped module's forward pass. See
+https://github.com/huggingface/peft/issues/3554 for details.
+
 Prerequisites:
 
     pip install "transformers>=5.7.0"
@@ -52,7 +66,7 @@ accelerate launch \
     --use_peft \
     --lora_r 8 \
     --lora_alpha 16 \
-    --lora_target_modules q_proj k_proj v_proj o_proj gate_proj up_proj down_proj
+    --lora_target_modules q_proj k_proj v_proj o_proj in_proj up_proj down_proj
 """
 
 from datasets import load_dataset


### PR DESCRIPTION
## What does this PR do?

Fixes the LoRA `--lora_target_modules` in the Nemotron 3 SFT example (`examples/scripts/sft_nemotron_3.py`), which had two problems for the hybrid Mamba-Attention architecture:

1. **`gate_proj` does not exist in NemotronH.** The MLP layers use a non-gated `up_proj`/`down_proj` architecture (verified in `transformers/models/nemotron_h/modeling_nemotron_h.py` — `NemotronHMLP` has only `up_proj`/`down_proj`, and `NemotronHExperts` explicitly comments "No gating mechanism unlike Mixtral"). PEFT silently skips target module names that do not match any module in the model, so `gate_proj` was a no-op.

2. **Mamba layers were missing from the target list.** NemotronH is a hybrid Mamba-Attention architecture where the majority of layers are Mamba SSM blocks with `in_proj`/`out_proj` projections. The previous target list only covered attention and MLP layers, leaving the Mamba layers frozen during fine-tuning. This PR adds `in_proj`, the Mamba input projection, which is a standard `nn.Linear` called as a module in the forward pass and is not blocked by PEFT's Mamba compatibility check.

`out_proj` is intentionally **not** added. PEFT raises `ValueError` when `out_proj` is targeted on `nemotron_h` (and other Mamba-based model types) because the fused SSM kernel (`mamba_split_conv1d_scan_combined`) consumes `out_proj.weight` as a raw tensor argument, bypassing the LoRA-wrapped module's `forward()` method. This means LoRA on `out_proj` would be a silent no-op during training and a shape mismatch crash at `merge_and_unload()`. The ban is enforced in `peft/tuners/tuners_utils.py` (`_check_lora_target_modules_mamba`, `incompatible_modules = {"out_proj", "conv1d"}`).

Fixes #6773

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. — #6773
- [x] Did you make sure to update the documentation with your changes? — Added explanatory comment in the docstring describing which modules are targeted and why `gate_proj`/`out_proj` are excluded.
- [x] Did you write any new necessary tests? — N/A, this is a one-line fix to an example script docstring. No testable code path changed.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human. The technical analysis (verifying module names against `modeling_nemotron_h.py`, checking PEFT's `_check_lora_target_modules_mamba` ban list, confirming `in_proj` is called as a module vs `out_proj` passed as a raw tensor) was performed by reviewing the source code directly.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR. @qgallouedec — this supersedes the closed #6777. That PR added `out_proj` to the target list, which PEFT rejects with `ValueError` for `nemotron_h`. This PR adds only `in_proj` (not banned, called as a module) and removes `gate_proj` (does not exist).
