### PR TITLE
Fix missing GMPO loss terms

### DIFF
--- a/tests/experimental/test_gmpo_trainer.py
+++ b/tests/experimental/test_gmpo_trainer.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
+from transformers import PretrainedConfig
 
 from trl.experimental.gmpo import GMPOConfig, GMPOTrainer
 
@@ -31,6 +34,87 @@ class TestGMPOConfig:
 
 
 class TestGMPOTrainer(TrlTestCase):
+    def test_rejects_liger_kernel(self, monkeypatch):
+        monkeypatch.setattr("trl.experimental.gmpo.gmpo_trainer.GRPOTrainer.__init__", lambda *args, **kwargs: None)
+        args = GMPOConfig(output_dir=self.tmp_dir, use_liger_kernel=True)
+
+        with pytest.raises(NotImplementedError, match="Liger kernel is not supported by GMPOTrainer"):
+            GMPOTrainer(PretrainedConfig(), reward_funcs=None, args=args)
+
+    @pytest.mark.parametrize("use_adaptive_entropy", [False, True])
+    def test_aux_loss_and_entropy_bonus(self, use_adaptive_entropy):
+        trainer = GMPOTrainer.__new__(GMPOTrainer)
+        trainer.model = torch.nn.Linear(1, 1)
+        trainer.beta = 0.0
+        trainer.top_entropy_quantile = 1.0
+        trainer.epsilon_low = 0.4
+        trainer.epsilon_high = 0.4
+        trainer.current_gradient_accumulation_steps = 1
+        trainer.aux_loss_enabled = True
+        trainer.router_aux_loss_coef = 0.1
+        trainer._entropy_bonus_enabled = True
+        trainer.use_adaptive_entropy = use_adaptive_entropy
+        trainer.entropy_coef = 0.25
+        trainer._last_world_entropy = 1.0
+        trainer._entropy_window_stats = None
+        trainer.args = SimpleNamespace(
+            entropy_target=2.0, entropy_coef_delta=0.01, entropy_coef_max=1.0, entropy_coef_min=0.0
+        )
+        trainer._metrics = {
+            "train": {
+                "policy_loss": [],
+                "aux_loss": [],
+                "entropy_coef": [],
+                "entropy": [],
+                "clip_ratio/low_mean": [],
+                "clip_ratio/high_mean": [],
+                "clip_ratio/region_mean": [],
+                "clip_ratio/low_min": [],
+                "clip_ratio/high_max": [],
+            }
+        }
+
+        class Accelerator:
+            sync_gradients = True
+
+            @staticmethod
+            def gather(value):
+                return value.reshape(1)
+
+            @staticmethod
+            def gather_for_metrics(value):
+                return value.reshape(1)
+
+            @staticmethod
+            def reduce(value, reduction):
+                return value
+
+        trainer.accelerator = Accelerator()
+        per_token_logps = torch.zeros((1, 2), requires_grad=True)
+        entropies = torch.full((1, 2), 2.0, requires_grad=True)
+        aux_loss = torch.tensor(3.0, requires_grad=True)
+
+        def get_per_token_logps_and_entropies(*args, **kwargs):
+            assert kwargs["compute_aux_loss"] is True
+            assert "spatial_shapes" in kwargs
+            assert "num_tiles" in kwargs
+            return per_token_logps, entropies, aux_loss
+
+        trainer._get_per_token_logps_and_entropies = get_per_token_logps_and_entropies
+        inputs = {
+            "prompt_ids": torch.tensor([[1]]),
+            "prompt_mask": torch.ones((1, 1)),
+            "completion_ids": torch.tensor([[2, 3]]),
+            "completion_mask": torch.ones((1, 2)),
+            "advantages": torch.tensor([1.0]),
+        }
+
+        loss = trainer._compute_loss(trainer.model, inputs)
+
+        torch.testing.assert_close(loss, torch.tensor(-1.2))
+        assert trainer._metrics["train"]["policy_loss"] == [-1.0]
+        assert trainer._metrics["train"]["aux_loss"] == [3.0]
+
     def test_train(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
 

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -37,6 +37,8 @@ class GMPOTrainer(GRPOTrainer):
         if args is None:
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             args = GMPOConfig(f"{model_name.split('/')[-1]}-GMPO")
+        if args.use_liger_kernel:
+            raise NotImplementedError("Liger kernel is not supported by GMPOTrainer.")
 
         super().__init__(model, reward_funcs, args=args, **kwargs)
 
@@ -50,16 +52,19 @@ class GMPOTrainer(GRPOTrainer):
         mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]
 
         # Compute the per_token_logps and the entropy at each position in the completion
-        per_token_logps, entropies, _ = self._get_per_token_logps_and_entropies(
+        per_token_logps, entropies, aux_loss = self._get_per_token_logps_and_entropies(
             model,
             input_ids,
             attention_mask,
             logits_to_keep,
             compute_entropy=True,
+            compute_aux_loss=self.aux_loss_enabled,
             pixel_values=inputs.get("pixel_values"),
             image_grid_thw=inputs.get("image_grid_thw"),
             num_images=inputs.get("num_images"),
             pixel_attention_mask=inputs.get("pixel_attention_mask"),
+            spatial_shapes=inputs.get("spatial_shapes"),
+            num_tiles=inputs.get("num_tiles"),
             image_sizes=inputs.get("image_sizes"),
             token_type_ids=inputs.get("token_type_ids"),
             mm_token_type_ids=inputs.get("mm_token_type_ids"),
@@ -118,8 +123,75 @@ class GMPOTrainer(GRPOTrainer):
         # already lives inside the geometric mean.
         mode = "train" if self.model.training else "eval"
         loss = per_sequence_loss.mean()
+        policy_loss = loss.detach()
         normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0  # no accum in eval
         loss = loss / normalizer
+
+        # Entropy bonus: add entropy regularization to encourage exploration. _entropy_bonus_enabled is set
+        # whenever a non-zero static coef is set OR adaptive mode is enabled (adaptive stays enabled even when
+        # entropy_coef has been decremented to entropy_coef_min so it can recover once entropy drops again).
+        if self._entropy_bonus_enabled:
+            # When top_entropy_quantile < 1.0, entropy_mask restricts policy gradients to high-entropy
+            # tokens. Use the same effective mask for the entropy bonus so it acts on the same tokens.
+            effective_mask = mask if entropy_mask is None else mask * entropy_mask
+            # Entropy bonus = mean per-token entropy H (the documented objective L = L_policy - coef * H), so
+            # H does not depend on how each loss type normalizes its policy term. The bonus is a mean over the
+            # tokens it acts on (effective_mask), scaled only for gradient accumulation, never by a loss-type-
+            # specific policy normalizer. (The adaptive controller below tracks a window-global token-weighted mean,
+            # which can differ from this per-micro-batch mean when token counts vary across micro-batches.)
+            accumulation_factor = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            entropy_loss = (
+                (entropies * effective_mask).sum() / effective_mask.sum().clamp(min=1.0) / accumulation_factor
+            )
+
+            # Apply the coefficient and gating from the end of the previous optimizer step, so that every
+            # micro-batch in the current accumulation window applies the same entropy bonus. The adaptive
+            # update below only takes effect on the next step.
+            if self.use_adaptive_entropy:
+                apply_coef = self.entropy_coef if self._last_world_entropy <= self.args.entropy_target else 0.0
+            else:
+                apply_coef = self.entropy_coef
+
+            loss = loss - apply_coef * entropy_loss
+            self._metrics[mode]["policy_loss"].append(self.accelerator.gather(policy_loss).nanmean().item())
+
+            # Adaptive update. Gated on train mode so evaluation cannot mutate the entropy controller state.
+            if self.use_adaptive_entropy and mode == "train":
+                # Accumulate the entropy sum and active-token count of every micro-batch into a running window
+                # buffer, so the controller measures the exact window-global entropy rather than just the last
+                # micro-batch (which would be a 1 / gradient_accumulation_steps subsample).
+                stats = torch.stack([(entropies * effective_mask).sum(), effective_mask.sum()]).detach()
+                if self._entropy_window_stats is None:
+                    self._entropy_window_stats = stats
+                else:
+                    self._entropy_window_stats = self._entropy_window_stats + stats
+                # At the optimizer-step boundary, reduce the window totals across ranks (sum and token count
+                # jointly, for a true global mean unbiased when ranks have different completion lengths),
+                # update the coefficient for the next step, then reset the window buffer.
+                if self.accelerator.sync_gradients:
+                    window_stats = self.accelerator.reduce(self._entropy_window_stats, reduction="sum")
+                    world_entropy = (window_stats[0] / window_stats[1].clamp(min=1.0)).item()
+                    if world_entropy <= self.args.entropy_target:
+                        self.entropy_coef = min(
+                            self.entropy_coef + self.args.entropy_coef_delta, self.args.entropy_coef_max
+                        )
+                    else:
+                        self.entropy_coef = max(
+                            self.entropy_coef - self.args.entropy_coef_delta, self.args.entropy_coef_min
+                        )
+                    self._last_world_entropy = world_entropy
+                    self._entropy_window_stats = None
+
+            # Log entropy_coef on train optimizer-step boundaries (constant for static control; updated just
+            # above for adaptive control). sync_gradients is always True in eval (no accumulation context).
+            if mode == "train" and self.accelerator.sync_gradients:
+                self._metrics[mode]["entropy_coef"].append(self.entropy_coef)
+
+        # The policy loss above is scaled for gradient accumulation (HF auto-scaling is off here), so scale aux too
+        if self.aux_loss_enabled:
+            normalizer = self.current_gradient_accumulation_steps if mode == "train" else 1.0
+            loss = loss + self.router_aux_loss_coef * aux_loss / normalizer
+            self._metrics[mode]["aux_loss"].append(self.accelerator.gather_for_metrics(aux_loss).mean().item())
 
         # Log the metrics
         def masked_seq_mean(x):


### PR DESCRIPTION
# What does this PR do?

Fixes #6808

`GMPOTrainer` inherited the Liger dispatch to the fused GRPO objective, bypassing GMPO's geometric-mean loss. This change rejects the unsupported combination and restores the MoE auxiliary loss, entropy bonus, and missing multimodal forward arguments in GMPO's duplicated loss code.

The focused regression test failed before the fix and passes after it. All 12 GMPO tests and the configured pre-commit checks pass on Linux using CPU execution. GPU execution and a real MoE training run were not verified because the resolved PyTorch CUDA build requires a newer driver than the node provides.

Thanks to @mmjerge for reporting the issue and identifying the affected paths.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

No documentation update is needed for this bug fix.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RL training loss composition for GMPO (entropy controller state, aux loss scaling); behavior should match GRPO but affects MoE/multimodal GMPO runs.
> 
> **Overview**
> **`GMPOTrainer`** overrides **`_compute_loss`** for the geometric-mean objective, but that path was missing pieces that **`GRPOTrainer`** already applies: MoE router auxiliary loss, entropy regularization (static and adaptive), and multimodal forward kwargs **`spatial_shapes`** / **`num_tiles`**.
> 
> This PR wires those terms back into GMPO’s loss (including gradient-accumulation scaling and metrics for **`policy_loss`**, **`aux_loss`**, and **`entropy_coef`**), and **raises `NotImplementedError`** when **`use_liger_kernel=True`** so training cannot silently use the fused GRPO path instead of GMPO’s loss.
> 
> Regression coverage adds a unit test for the combined aux + entropy loss math and an init test for the Liger rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7bec1f739d187803fcd07107c58a4fc1128a072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->