### PR TITLE
Mask Online DPO objective metrics at padding

### DIFF
--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import torch
 from datasets import Dataset, DatasetDict, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
@@ -169,6 +170,44 @@ class TestOnlineDPOTrainer(TrlTestCase):
         trainer.train()
 
         assert "train_loss" in trainer.state.log_history[-1]
+
+    def test_objective_metrics_ignore_padding(self, monkeypatch):
+        training_args = OnlineDPOConfig(output_dir=self.tmp_dir, beta=1.0, report_to="none")
+        dataset = Dataset.from_dict({"prompt": ["What is 2 + 2?"]})
+
+        trainer = OnlineDPOTrainer(
+            model=self.model,
+            ref_model=self.ref_model,
+            reward_funcs=lambda prompts, **kwargs: [0.5] * len(prompts),
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=self.tokenizer,
+        )
+        completion_mask = torch.tensor([[1, 0], [1, 1]])
+        monkeypatch.setattr(
+            trainer,
+            "_generate",
+            lambda model, prompts, images: (
+                torch.tensor([[1]]),
+                torch.tensor([[1]]),
+                torch.tensor([[2, 0], [3, 4]]),
+                completion_mask,
+            ),
+        )
+        logprobs = iter(
+            [
+                torch.tensor([[-1.0, -10.0], [-2.0, -3.0]], requires_grad=True),
+                torch.tensor([[-0.5, -4.0], [-1.0, -1.0]]),
+            ]
+        )
+        monkeypatch.setattr(trainer, "_forward", lambda *args, **kwargs: next(logprobs))
+
+        trainer.training_step(trainer.model, {"prompt": ["What is 2 + 2?"]})
+
+        assert trainer.stats["objective/kl"] == pytest.approx([-1.75])
+        assert trainer.stats["objective/non_score_reward"] == pytest.approx([1.75])
+        assert trainer.stats["objective/rlhf_reward"] == pytest.approx([2.25])
+        assert trainer.stats["objective/entropy"] == pytest.approx([3.0])
 
     def test_ref_model_is_model(self):
         training_args = OnlineDPOConfig(

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -1249,7 +1249,7 @@ class OnlineDPOTrainer(_BaseTrainer):
         self.stats["logps/chosen"].append(self.accelerator.gather_for_metrics(chosen_logprobs_sum).mean().item())
         self.stats["logps/rejected"].append(self.accelerator.gather_for_metrics(rejected_logprobs_sum).mean().item())
 
-        kl = logprobs - ref_logprobs
+        kl = (logprobs - ref_logprobs) * completion_mask
         mean_kl = kl.sum(1).mean()
         self.stats["objective/kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
         non_score_reward = (-self.beta * kl).sum(1)
@@ -1262,7 +1262,7 @@ class OnlineDPOTrainer(_BaseTrainer):
             rlhf_reward = rewards + non_score_reward
             self.stats["objective/rlhf_reward"].append(self.accelerator.gather_for_metrics(rlhf_reward).mean().item())
 
-        mean_entropy = -logprobs.sum(1).mean()
+        mean_entropy = -(logprobs * completion_mask).sum(1).mean()
         self.stats["objective/entropy"].append(self.accelerator.gather_for_metrics(mean_entropy).mean().item())
         chosen_rewards = self.beta * (chosen_logprobs_sum - chosen_ref_logprobs_sum)
         gathered_chosen_rewards = self.accelerator.gather_for_metrics(chosen_rewards)


### PR DESCRIPTION
# What does this PR do?

Fixes #6803

Online DPO summed finite log probabilities from padded completion positions when calculating objective statistics. This applies `completion_mask` to KL and entropy inputs, which also corrects the derived non-score and RLHF rewards.

The regression test failed before the fix and passed after it. The full Online DPO test module passed on Linux with an NVIDIA A40, using CPU execution because the installed PyTorch CUDA build requires a newer driver. The PEFT, vLLM, and vision tests were skipped because their optional dependencies were not installed, and distributed training was not tested.

Thanks to @mmjerge for reporting the issue and identifying the affected metrics.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

No documentation update is needed for this logging fix.

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to training-step metric aggregation only; no change to the DPO loss computation path.
> 
> **Overview**
> Fixes incorrect **logged** objective statistics in `OnlineDPOTrainer` when completions are padded to a fixed length.
> 
> **KL** and **entropy** (and metrics derived from them—**non_score_reward**, **objective/rlhf_reward**) now multiply per-token log-probability terms by `completion_mask` before summing, matching how chosen/rejected log-prob sums already ignore padding. Training loss behavior is unchanged; this is a metrics/logging fix.
> 
> Adds `test_objective_metrics_ignore_padding`, which monkeypatches generation and forward passes with a known mask and asserts the expected stat values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e797c2c36375382d576994abd0a0ccacc8248765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->