### PR TITLE
Pass position IDs when scoring online preference data

### DIFF
--- a/tests/experimental/test_nash_md_trainer.py
+++ b/tests/experimental/test_nash_md_trainer.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 import torch
 from datasets import DatasetDict, load_dataset
@@ -85,6 +88,21 @@ class TestNashMDTrainer(TrlTestCase):
         self.reward_model = AutoModelForSequenceClassification.from_pretrained(self.model_id, num_labels=1)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    def test_compute_logprobs_passes_position_ids(self):
+        trainer = NashMDTrainer.__new__(NashMDTrainer)
+        trainer.ref_model = Mock(return_value=SimpleNamespace(logits=torch.zeros(2, 5, 8)))
+        model = Mock(return_value=SimpleNamespace(logits=torch.zeros(2, 5, 8)))
+        data = {
+            "input_ids": torch.tensor([[0, 0, 1, 5, 6], [2, 3, 4, 5, 6]]),
+            "attention_mask": torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]]),
+        }
+
+        trainer._compute_logprobs(model, data, context_length=3)
+
+        expected = data["attention_mask"].cumsum(1) - data["attention_mask"].long()
+        for call in model.call_args_list + trainer.ref_model.call_args_list:
+            torch.testing.assert_close(call.kwargs["position_ids"], expected)
 
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_nash_md_trainer_training(self, config_name):

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
+import torch
 from datasets import Dataset, DatasetDict, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
@@ -44,6 +48,22 @@ class TestOnlineDPOTrainer(TrlTestCase):
         self.reward_model = AutoModelForSequenceClassification.from_pretrained(self.reward_model_id, num_labels=1)
         self.reward_tokenizer = AutoTokenizer.from_pretrained(self.reward_model_id)
         self.reward_tokenizer.pad_token = self.reward_tokenizer.eos_token
+
+    def test_forward_passes_position_ids(self):
+        trainer = OnlineDPOTrainer.__new__(OnlineDPOTrainer)
+        trainer.max_length = 8
+        model = Mock(return_value=SimpleNamespace(logits=torch.zeros(2, 5, 8)))
+        prompt_ids = torch.tensor([[0, 0, 1], [2, 3, 4]])
+        prompt_mask = torch.tensor([[0, 0, 1], [1, 1, 1]])
+        completion_ids = torch.tensor([[5, 6], [5, 6]])
+        completion_mask = torch.ones_like(completion_ids)
+
+        trainer._forward(model, prompt_ids, prompt_mask, completion_ids, completion_mask)
+
+        attention_mask = torch.cat((prompt_mask, completion_mask), dim=1)
+        torch.testing.assert_close(
+            model.call_args.kwargs["position_ids"], attention_mask.cumsum(1) - attention_mask.long()
+        )
 
     def test_trust_remote_code(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/experimental/test_xpo_trainer.py
+++ b/tests/experimental/test_xpo_trainer.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
+import torch
 from datasets import DatasetDict, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available
@@ -35,6 +39,21 @@ class TestXPOTrainer(TrlTestCase):
         self.reward_model = AutoModelForSequenceClassification.from_pretrained(self.model_id, num_labels=1)
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    def test_compute_logprobs_passes_position_ids(self):
+        trainer = XPOTrainer.__new__(XPOTrainer)
+        trainer.ref_model = Mock(return_value=SimpleNamespace(logits=torch.zeros(2, 5, 8)))
+        model = Mock(return_value=SimpleNamespace(logits=torch.zeros(2, 5, 8)))
+        data = {
+            "input_ids": torch.tensor([[0, 0, 1, 5, 6], [2, 3, 4, 5, 6]]),
+            "attention_mask": torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]]),
+        }
+
+        trainer._compute_logprobs(model, data, data, context_length=3)
+
+        expected = data["attention_mask"].cumsum(1) - data["attention_mask"].long()
+        for call in model.call_args_list + trainer.ref_model.call_args_list:
+            torch.testing.assert_close(call.kwargs["position_ids"], expected)
 
     @pytest.mark.parametrize("config_name", ["standard_prompt_only", "conversational_prompt_only"])
     def test_xpo_trainer_training(self, config_name):

--- a/trl/experimental/nash_md/nash_md_trainer.py
+++ b/trl/experimental/nash_md/nash_md_trainer.py
@@ -341,7 +341,8 @@ class NashMDTrainer(OnlineDPOTrainer):
 
     def _compute_logprobs(self, model, model_data, context_length):
         def compute_logprobs_for_data(m, data):
-            output = m(data["input_ids"], attention_mask=data["attention_mask"])
+            position_ids = data["attention_mask"].cumsum(1) - data["attention_mask"].long()
+            output = m(data["input_ids"], attention_mask=data["attention_mask"], position_ids=position_ids)
             logits = output.logits[:, context_length - 1 : -1]
             token_logprobs = selective_log_softmax(logits, data["input_ids"][:, context_length:])
             return token_logprobs

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -1069,7 +1069,10 @@ class OnlineDPOTrainer(_BaseTrainer):
         prompt_completion_mask = torch.cat((prompt_mask, completion_mask), dim=1)
 
         # Prepare model kwargs with vision inputs if available
-        model_kwargs = {"attention_mask": prompt_completion_mask}
+        model_kwargs = {
+            "attention_mask": prompt_completion_mask,
+            "position_ids": prompt_completion_mask.cumsum(1) - prompt_completion_mask.long(),
+        }
         if vision_inputs is not None:
             if "pixel_values" in vision_inputs:
                 model_kwargs["pixel_values"] = vision_inputs["pixel_values"]

--- a/trl/experimental/xpo/xpo_trainer.py
+++ b/trl/experimental/xpo/xpo_trainer.py
@@ -272,7 +272,8 @@ class XPOTrainer(OnlineDPOTrainer):
 
     def _compute_logprobs(self, model, model_data, ref_data, context_length):
         def compute_logprobs_for_data(m, data):
-            output = m(data["input_ids"], attention_mask=data["attention_mask"])
+            position_ids = data["attention_mask"].cumsum(1) - data["attention_mask"].long()
+            output = m(data["input_ids"], attention_mask=data["attention_mask"], position_ids=position_ids)
             logits = output.logits[:, context_length - 1 : -1]
             token_logprobs = selective_log_softmax(logits, data["input_ids"][:, context_length:])
             return token_logprobs


### PR DESCRIPTION
# What does this PR do?

Fixes #6800

Online DPO, XPO, and Nash-MD scored left-padded sequences without passing mask-relative `position_ids`. This made scoring positions disagree with generation positions for models such as GPT-2.

The affected forwards now derive `position_ids` from the attention mask. Regression tests cover all three trainers. Thanks to @mmjerge for reporting the issue and providing the GPT-2 repro.

Verified on Linux and CPU with an A40 host. The GPT-2 repro showed a 34.005 sequence log-prob difference before the fix. All 32 tests in the three trainer modules passed, with 13 existing skips, and all pre-commit hooks passed. GPU execution and the full repository suite were not run.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how preference losses compute log-probs for padded sequences, which directly affects training gradients; scope is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes incorrect log-probability scoring for **left-padded** batches in Online DPO, XPO, and Nash-MD (issue #6800). Scoring forwards previously omitted `position_ids`, so token positions could disagree with generation—especially on models like GPT-2.
> 
> **Online DPO** `_forward` now includes `position_ids` derived from the prompt+completion attention mask (`cumsum(mask) - mask`). **XPO** and **Nash-MD** apply the same rule in `_compute_logprobs` for policy and reference calls.
> 
> Regression tests assert mocked model forwards receive the expected `position_ids` for padded sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845b712319085740183989ce822e5c7eb89d66ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->