### PR TITLE
fix(async-grpo): forward generation kwargs to vLLM

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -27,6 +27,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer
 from transformers.testing_utils import torch_device
 
+import trl.experimental.async_grpo.async_grpo_trainer as trainer_module
 import trl.experimental.async_grpo.async_rollout_worker as worker
 from trl.experimental.async_grpo import AsyncGRPOConfig, AsyncGRPOTrainer
 from trl.experimental.async_grpo.async_grpo_trainer import (
@@ -139,6 +140,50 @@ class _StubWeightTransfer:
 
     def destroy(self):
         pass
+
+
+class TestAsyncGRPOTrainerConfigPlumbing(TrlTestCase):
+    def test_init_passes_generation_kwargs_to_rollout_worker(self, monkeypatch):
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
+        captured_kwargs = {}
+
+        class _CapturingRolloutWorker:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+                self.rollout_buffer = queue.Queue()
+                self.metrics_queue = queue.Queue()
+
+        original_from_pretrained = trainer_module.AutoModelForCausalLM.from_pretrained
+
+        class _EagerAutoModelForCausalLM:
+            @staticmethod
+            def from_pretrained(*args, **kwargs):
+                kwargs["attn_implementation"] = "eager"
+                return original_from_pretrained(*args, **kwargs)
+
+        monkeypatch.setattr(trainer_module, "AutoModelForCausalLM", _EagerAutoModelForCausalLM)
+        monkeypatch.setattr(trainer_module, "AsyncRolloutWorker", _CapturingRolloutWorker)
+        monkeypatch.setattr(trainer_module, "patch_chunked_lm_head", lambda *args, **kwargs: None)
+        args = AsyncGRPOConfig(
+            output_dir=self.tmp_dir,
+            generation_kwargs={"temperature": 0.2, "seed": 123},
+            use_cpu=True,
+            bf16=False,
+            gradient_checkpointing=False,
+            report_to="none",
+        )
+
+        AsyncGRPOTrainer(
+            model=model_id,
+            reward_funcs=dummy_reward_func,
+            args=args,
+            train_dataset=dataset,
+            processing_class=AutoTokenizer.from_pretrained(model_id),
+            weight_transfer=_StubWeightTransfer(),
+        )
+
+        assert captured_kwargs["generation_kwargs"] == {"temperature": 0.2, "seed": 123}
 
 
 @pytest.mark.skipif(
@@ -698,6 +743,47 @@ def _run(monkeypatch, *, prompt_ids, turns, assistants, fork_threshold=1024, max
 
 
 class TestRolloutLoop(TrlTestCase):
+    def test_generation_kwargs_override_named_sampling_parameters(self):
+        loop = object.__new__(_AsyncRolloutLoop)
+        loop.model_name = "Qwen/Qwen3-4B"
+        loop.max_tokens = 32
+        loop.temperature = 0.9
+        loop.top_p = 0.95
+        loop.top_k = 10
+        loop.min_p = None
+        loop.repetition_penalty = 1.1
+        loop.generation_kwargs = {"temperature": 0.2, "top_k": 50, "seed": 123}
+        loop.request_timeout = 17
+        captured = {}
+
+        async def fake_post(path, payload, timeout):
+            captured["path"] = path
+            captured["payload"] = payload
+            captured["timeout"] = timeout
+            return {"choices": [{"token_ids": [42], "logprobs": {"token_logprobs": [-0.5]}}]}
+
+        loop._post = fake_post
+
+        completion_ids, completion_logprobs = asyncio.run(loop._generate_one_turn([1, 2, 3]))
+
+        assert completion_ids == [42]
+        assert completion_logprobs == [-0.5]
+        assert captured["path"] == "/v1/completions"
+        assert captured["timeout"] == 17
+        assert captured["payload"] == {
+            "model": "Qwen/Qwen3-4B",
+            "prompt": [1, 2, 3],
+            "max_tokens": 32,
+            "temperature": 0.2,
+            "top_p": 0.95,
+            "top_k": 50,
+            "repetition_penalty": 1.1,
+            "n": 1,
+            "return_token_ids": True,
+            "logprobs": 0,
+            "seed": 123,
+        }
+
     def test_single_turn_no_tool_call(self, monkeypatch):
         completion, completion_ids, sequences, n_calls, n_failures, _ = _run(
             monkeypatch,

--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -67,6 +67,11 @@ class AsyncGRPOConfig(_BaseConfig):
         min_p (`float`, *optional*):
             Minimum token probability, which will be scaled by the probability of the most likely token. It must be a
             value between 0.0 and 1.0. Typical values are in the 0.01-0.2 range.
+        generation_kwargs (`dict[str, Any]`, *optional*):
+            Additional keyword arguments to pass to [`~transformers.GenerationConfig`] (if using transformers) or
+            `SamplingParams` (if using vLLM) when sampling completions. This can be used to further customize the
+            generation behavior, such as setting `suppress_tokens`, `num_beams`, etc. If it contains keys that conflict
+            with the other generation parameters (like `min_p`, `top_p`, etc.), they will override them.
         repetition_penalty (`float`, *optional*, defaults to `1.0`):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > 1.0 encourage the model to use new tokens, while values < 1.0 encourage the model to repeat
@@ -249,6 +254,15 @@ class AsyncGRPOConfig(_BaseConfig):
         metadata={
             "help": "Minimum token probability, which will be scaled by the probability of the most likely token. It "
             "must be a value between 0.0 and 1.0. Typical values are in the 0.01-0.2 range."
+        },
+    )
+    generation_kwargs: dict | None = field(
+        default=None,
+        metadata={
+            "help": "Additional keyword arguments to pass to `GenerationConfig` (if using transformers) or "
+            "`SamplingParams` (if using vLLM) when sampling completions. This can be used to further customize the "
+            "generation behavior, such as setting `suppress_tokens`, `num_beams`, etc. If it contains keys that "
+            "conflict with the other generation parameters (like `min_p`, `top_p`, etc.), they will override them."
         },
     )
     repetition_penalty: float = field(

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -970,6 +970,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
                     top_k=self.args.top_k,
                     min_p=self.args.min_p,
                     repetition_penalty=self.args.repetition_penalty,
+                    generation_kwargs=self.args.generation_kwargs,
                     request_timeout=self.args.request_timeout,
                     chat_template_kwargs=self.args.chat_template_kwargs,
                     max_tool_calling_iterations=self.args.max_tool_calling_iterations,

--- a/trl/experimental/async_grpo/async_rollout_worker.py
+++ b/trl/experimental/async_grpo/async_rollout_worker.py
@@ -319,6 +319,7 @@ class _AsyncRolloutLoop:
         top_k: int = 0,
         min_p: float | None = None,
         repetition_penalty: float = 1.0,
+        generation_kwargs: dict[str, Any] | None = None,
         request_timeout: int = 120,
         chat_template_kwargs: dict[str, Any] | None = None,
         max_tool_calling_iterations: int | None = None,
@@ -367,6 +368,7 @@ class _AsyncRolloutLoop:
         self.top_k = top_k
         self.min_p = min_p
         self.repetition_penalty = repetition_penalty
+        self.generation_kwargs = generation_kwargs or {}
         self.request_timeout = request_timeout
         self.chat_template_kwargs = chat_template_kwargs or {}
         self.max_tool_calling_iterations = max_tool_calling_iterations
@@ -957,6 +959,7 @@ class _AsyncRolloutLoop:
         }
         if self.min_p is not None:
             payload["min_p"] = self.min_p
+        payload.update(self.generation_kwargs)
         output = await self._retry(
             lambda: self._post("/v1/completions", payload, self.request_timeout),
             max_attempts=30,


### PR DESCRIPTION
# What does this PR do?

This is a follow-up to #5418. In the [closing review](https://github.com/huggingface/trl/pull/5418#pullrequestreview-4856664035), @albertvillanova  noted that #6608 had already superseded the named sampling-parameter changes, but that the missing `generation_kwargs` passthrough with override-on-conflict remained a bug against `GRPOTrainer`. This PR fixes that remaining bug.

It:

- adds `generation_kwargs` to `AsyncGRPOConfig`, matching the existing `GRPOConfig` field and documentation;
- forwards it through `AsyncGRPOTrainer` to the async rollout worker;
- applies it to the vLLM request after the named sampling parameters, so conflicting keys override them as documented; and
- adds regression tests for trainer-to-worker forwarding and final payload precedence.

## Testing

- `uv run pytest -q tests/experimental/test_async_grpo_trainer.py` (37 passed, 6 skipped)
- Ruff check and format on all four changed files
- `doc-builder style trl tests docs/source --max_len 119`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? The focused follow-up was identified in the [closing review of #5418](https://github.com/huggingface/trl/pull/5418#pullrequestreview-4856664035).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow config plumbing and vLLM request assembly change with tests; no auth, data, or training-loss logic touched.
> 
> **Overview**
> **Async GRPO** now supports the same optional `generation_kwargs` as `GRPOConfig`, so extra sampling options (e.g. `seed`) reach the vLLM `/v1/completions` payload instead of being ignored.
> 
> The field is added on `AsyncGRPOConfig`, passed from `AsyncGRPOTrainer` into `AsyncRolloutWorker`, and merged into the request **after** the named sampling fields (`temperature`, `top_p`, etc.), so conflicting keys in `generation_kwargs` win as documented.
> 
> Regression tests cover trainer→worker forwarding and the final payload precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f1895ab9eaf5566f7baadaa749f4a7d8829a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->