### PR TITLE
Fix AsyncGRPOTrainer crashing on environment-owned datasets

### DIFF
--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -851,13 +851,13 @@ class AsyncGRPOTrainer(_BaseTrainer):
                     "`environment` column to route each example to its environment. Provide a dataset, or pass a "
                     "single environment factory."
                 )
-            if self.args.max_steps <= 0:
+            if args.max_steps <= 0:
                 raise ValueError(
                     "When training without a `train_dataset` (the environment owns the data and returns the prompt "
                     "from `reset()`), `max_steps` must be set to a positive value to define the training length. Set "
                     "it via `AsyncGRPOConfig(max_steps=...)`."
                 )
-            num_placeholder_rows = self.args.per_device_train_batch_size * self.args.gradient_accumulation_steps
+            num_placeholder_rows = args.per_device_train_batch_size * args.gradient_accumulation_steps
             train_dataset = Dataset.from_dict({"prompt": [[{"role": "user", "content": ""}]] * num_placeholder_rows})
 
         # Initialize the Trainer


### PR DESCRIPTION
This PR fixes `AsyncGRPOTrainer` raising `AttributeError: 'AsyncGRPOTrainer' object has no attribute 'args'` when it is built without a `train_dataset`.

> FAILED tests/experimental/test_async_grpo_trainer.py::TestAsyncGRPOTrainer::test_environment_owned_data_requires_max_steps - AttributeError: 'AsyncGRPOTrainer' object has no attribute 'args'

Bug introduced by PR:
- #6349

The feature #6349 added has never worked.

### Motivation

`AsyncGRPOTrainer.__init__` reads `self.args` while building the placeholder dataset, but `self.args` is only set by `Trainer.__init__`, which runs a few lines later. Every environment-owned run, meaning `train_dataset=None` together with an `environment_factory`, fails there before it can reach either the intended `max_steps` `ValueError` or the placeholder dataset construction.

The existing regression test, `TestAsyncGRPOTrainer::test_environment_owned_data_requires_max_steps`, does cover this, but it never ran: `tests/experimental` is excluded from the regular suite through `norecursedirs`, and in `tests-experimental.yml` the whole class is gated behind `is_ampere_or_newer()`, which was false on the T4 runner. Moving that job to an L40S in #6741 makes the test execute for the first time and surfaces the failure.

### Solution

Use the local `args` instead of `self.args` in the pre-`super().__init__()` region, consistent with every other config read in that block. `AsyncDistillationTrainer` is unaffected: it assigns `self.args = args` before its own `super().__init__()`.

### Changes

- Read `max_steps`, `per_device_train_batch_size` and `gradient_accumulation_steps` from the local `args` when building the placeholder dataset in `AsyncGRPOTrainer.__init__`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cfa49135af1b2c4e1376f7a2b934269b216c15f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->