### PR TITLE
Align AsyncDistillationTrainer with AsyncGRPOTrainer on pre-init args

### DIFF
--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -935,12 +935,11 @@ class AsyncDistillationTrainer(_BaseTrainer):
     ):
         if args is None:
             args = AsyncDistillationConfig(f"{model.split('/')[-1]}-AsyncDistillation")
-        self.args = args
 
         # Model
         model_name = model
-        model_init_kwargs = self.args.model_init_kwargs or {}
-        model_init_kwargs.setdefault("trust_remote_code", self.args.trust_remote_code)
+        model_init_kwargs = args.model_init_kwargs or {}
+        model_init_kwargs.setdefault("trust_remote_code", args.trust_remote_code)
         # FlashAttention is required: training runs in padding-free mode, where sequences are concatenated into a
         # single row and attention is derived from `position_ids` resets. SDPA/eager can't handle this. Unlike
         # AsyncGRPOTrainer, the student's own lm_head is NOT patched (via `patch_chunked_lm_head`) to a chunked
@@ -956,19 +955,19 @@ class AsyncDistillationTrainer(_BaseTrainer):
             **model_init_kwargs,
         )
 
-        if self.args.use_liger_kernel:
+        if args.use_liger_kernel:
             raise NotImplementedError("`use_liger_kernel` is not supported yet.")
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(model_name, trust_remote_code=self.args.trust_remote_code)
+            processing_class = AutoTokenizer.from_pretrained(model_name, trust_remote_code=args.trust_remote_code)
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
 
         # Initialize the Trainer
         super().__init__(
             model=model,
-            args=self.args,
+            args=args,
             train_dataset=train_dataset,
             processing_class=processing_class,
             callbacks=callbacks,


### PR DESCRIPTION
This PR makes `AsyncDistillationTrainer.__init__` read its configuration from the local `args` before `super().__init__()`, matching `AsyncGRPOTrainer`.

Follow-up to:
- #6824

### Motivation

`AsyncDistillationTrainer` assigned `self.args = args` at the top of `__init__` and then read config through `self.args` in the region that runs before `Trainer.__init__`. That works, but it diverges from `AsyncGRPOTrainer`, where the same block reads the local `args` and `self.args` only exists once the parent trainer has set it.

Since these two trainers are deliberately duplicated, the divergence is what allowed #6824's bug to go unnoticed: the same lines in `AsyncGRPOTrainer` read `self.args` before it existed, and nothing in `AsyncDistillationTrainer` looked different enough to flag it. Keeping both copies on the same convention makes the parent-owned attribute unavailable before `super().__init__()` in both trainers, so the mistake cannot be reintroduced silently.

### Solution

Drop the early `self.args = args` assignment and read `args` directly everywhere before `super().__init__()`. Behavior is unchanged: `Trainer.__init__` sets `self.args` to the same object, and all reads after that point are untouched.

### Changes

- Remove the pre-`super().__init__()` `self.args` assignment in `AsyncDistillationTrainer`
- Read `model_init_kwargs`, `trust_remote_code` and `use_liger_kernel` from the local `args`, and pass `args` to `super().__init__()`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-only refactor with no behavior change; config is still the same object after parent construction.
> 
> **Overview**
> Aligns `AsyncDistillationTrainer.__init__` with `AsyncGRPOTrainer` by dropping the early `self.args = args` assignment and reading the local `args` until `super().__init__()`.
> 
> Pre-init config (`model_init_kwargs`, `trust_remote_code`, `use_liger_kernel`) now comes from the constructor argument, and that same object is passed to the parent. Behavior is unchanged: `Trainer` still owns `self.args` after init. The point is to keep the duplicated trainers on one convention so a pre-`super()` `self.args` use cannot slip back in unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6c2758b413cf58f307f863410943b61de9fecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->