### PR TITLE
Stub the weight transfer in the AsyncGRPO epoch-stop test

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -1053,7 +1053,12 @@ class TestEpochStop(TrlTestCase):
         )
         worker = _StubRolloutWorker(AutoTokenizer.from_pretrained(model_id), dataset, num_generations=3, fork_k=fork_k)
         trainer = AsyncGRPOTrainer(
-            model=model_id, reward_funcs=dummy_reward_func, args=args, train_dataset=dataset, rollout_worker=worker
+            model=model_id,
+            reward_funcs=dummy_reward_func,
+            args=args,
+            train_dataset=dataset,
+            rollout_worker=worker,
+            weight_transfer=_StubWeightTransfer(),
         )
         trainer.train()
         return trainer, len(dataset)


### PR DESCRIPTION
This PR fixes `TestEpochStop::test_epoch_stop_is_fork_independent` failing with `ImportError: vLLM >= 0.22.0 is required to use WeightTransferClient`.

> FAILED tests/experimental/test_async_grpo_trainer.py::TestEpochStop::test_epoch_stop_is_fork_independent - ImportError: vLLM >= 0.22.0 is required to use WeightTransferClient. Install it with: pip install 'vllm>=0.22.0'

### Motivation

The test builds a real `AsyncGRPOTrainer` but only passes `rollout_worker`, leaving `weight_transfer` unset. The trainer then constructs a real `WeightTransferClient`, which requires vLLM >= 0.22.0 and so cannot work in a test that has no vLLM server to talk to. Every other trainer-building test in the file already passes `_StubWeightTransfer()`; this one was missed.

The failure is not visible today because the class is gated behind `is_ampere_or_newer()` and the experimental CI runner is a T4, so the test is skipped. Moving that job to an L40S in #6741 makes it run for the first time.

### Changes

- Pass `weight_transfer=_StubWeightTransfer()` when building the trainer in `TestEpochStop._train`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only wiring change; no production or security impact.
> 
> **Overview**
> Passes `_StubWeightTransfer()` into `AsyncGRPOTrainer` in `TestEpochStop._train`, matching the other trainer tests in the file.
> 
> Without it the trainer builds a real `WeightTransferClient` and fails with an ImportError unless vLLM >= 0.22.0 is installed. That would surface once the experimental GPU job moves off T4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65322bfc6f3189a1541bcbdc9b7f3ca6509c6599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->