### PR TITLE
Fix SDPO PEFT EMA initialization under ZeRO-3

### DIFF
--- a/tests/experimental/test_sdpo_teacher_sync.py
+++ b/tests/experimental/test_sdpo_teacher_sync.py
@@ -77,3 +77,47 @@ def test_peft_ema_student_state_is_gathered_and_cloned_under_zero3():
     assert events == ["enter", "exit"]
     assert torch.equal(state_dict["adapter.weight"], source)
     assert state_dict["adapter.weight"].data_ptr() != source.data_ptr()
+
+
+def test_peft_ema_teacher_state_is_gathered_when_written_under_zero3():
+    parameter = MagicMock()
+    parameter.numel.return_value = 0
+    model = MagicMock()
+    model.active_adapter = "default"
+    model.named_parameters.return_value = [("base_model.layer.lora_A.teacher.weight", parameter)]
+    accelerator = MagicMock()
+    accelerator.unwrap_model.return_value = model
+    accelerator.state.deepspeed_plugin.zero_stage = 3
+    callback = PEFTAdapterEMACallback(model=model, update_rate=0.5, accelerator=accelerator)
+    callback._initialized = True
+    callback.shadow_weights = {"adapter.weight": torch.tensor([0.0])}
+    callback._get_student_state_dict = lambda: {"adapter.weight": torch.tensor([2.0])}
+    events = []
+
+    class GatheredParameters:
+        def __init__(self, parameters, modifier_rank):
+            assert parameters == [parameter]
+            assert modifier_rank == 0
+
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            events.append("exit")
+
+    def set_teacher_state_dict(target_model, state_dict, adapter_name):
+        assert target_model is model
+        assert adapter_name == "teacher"
+        assert events == ["enter"]
+        torch.testing.assert_close(state_dict["adapter.weight"], torch.tensor([1.0]))
+        events.append("write")
+
+    deepspeed = types.SimpleNamespace(zero=types.SimpleNamespace(GatheredParameters=GatheredParameters))
+    with (
+        patch.dict(sys.modules, {"deepspeed": deepspeed}),
+        patch("peft.set_peft_model_state_dict", side_effect=set_teacher_state_dict),
+    ):
+        callback.on_step_end(None, types.SimpleNamespace(global_step=1), None)
+
+    assert events == ["enter", "write", "exit"]
+    assert model.set_adapter.call_args_list == [(("teacher",),), (("default",),)]

--- a/tests/experimental/test_sdpo_teacher_sync.py
+++ b/tests/experimental/test_sdpo_teacher_sync.py
@@ -1,0 +1,79 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from trl.experimental.sdpo.sdpo_trainer import SDPOTrainer
+from trl.experimental.sdpo.teacher_sync import PEFTAdapterEMACallback
+
+
+def test_peft_ema_teacher_is_initialized_before_callback_registration():
+    trainer = object.__new__(SDPOTrainer)
+    trainer.args = types.SimpleNamespace(
+        teacher_model_kind="ema",
+        teacher_update_rate=0.05,
+        teacher_sync_steps=1,
+    )
+    trainer.model = MagicMock()
+    trainer.accelerator = MagicMock()
+    trainer._use_peft_ema_teacher_adapter = lambda: True
+    events = []
+    trainer.add_callback = lambda callback: events.append(("register", callback))
+
+    callback = MagicMock()
+    callback._initialize_teacher_adapter.side_effect = lambda: events.append(("initialize", callback))
+    with patch("trl.experimental.sdpo.sdpo_trainer.PEFTAdapterEMACallback", return_value=callback):
+        trainer._setup_teacher_model()
+
+    assert events == [("initialize", callback), ("register", callback)]
+    assert trainer.teacher_model is trainer.model
+
+
+def test_peft_ema_student_state_is_gathered_and_cloned_under_zero3():
+    parameter = MagicMock(requires_grad=True)
+    parameter.numel.return_value = 0
+    model = MagicMock()
+    model.parameters.return_value = [parameter]
+    accelerator = MagicMock()
+    accelerator.unwrap_model.return_value = model
+    accelerator.state.deepspeed_plugin.zero_stage = 3
+    callback = PEFTAdapterEMACallback(model=model, accelerator=accelerator)
+    source = torch.tensor([1.0])
+    events = []
+
+    class GatheredParameters:
+        def __init__(self, parameters, modifier_rank):
+            assert parameters == [parameter]
+            assert modifier_rank is None
+
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            events.append("exit")
+
+    deepspeed = types.SimpleNamespace(zero=types.SimpleNamespace(GatheredParameters=GatheredParameters))
+    with (
+        patch.dict(sys.modules, {"deepspeed": deepspeed}),
+        patch("peft.get_peft_model_state_dict", return_value={"adapter.weight": source}),
+    ):
+        state_dict = callback._get_student_state_dict()
+
+    assert events == ["enter", "exit"]
+    assert torch.equal(state_dict["adapter.weight"], source)
+    assert state_dict["adapter.weight"].data_ptr() != source.data_ptr()

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -727,15 +727,15 @@ class SDPOTrainer(_BaseTrainer):
 
         if self._use_peft_ema_teacher_adapter():
             # Must run after super().__init__ so self.callback_handler exists.
-            self.add_callback(
-                PEFTAdapterEMACallback(
-                    model=self.model,
-                    teacher_adapter_name="teacher",
-                    update_rate=self.args.teacher_update_rate,
-                    sync_steps=self.args.teacher_sync_steps,
-                    accelerator=self.accelerator,
-                )
+            ema_callback = PEFTAdapterEMACallback(
+                model=self.model,
+                teacher_adapter_name="teacher",
+                update_rate=self.args.teacher_update_rate,
+                sync_steps=self.args.teacher_sync_steps,
+                accelerator=self.accelerator,
             )
+            ema_callback._initialize_teacher_adapter()
+            self.add_callback(ema_callback)
             self.teacher_model = self.model
             return
 

--- a/trl/experimental/sdpo/teacher_sync.py
+++ b/trl/experimental/sdpo/teacher_sync.py
@@ -187,10 +187,31 @@ class PEFTAdapterEMACallback(TrainerCallback):
         else:
             unwrapped_model = self.model
 
+        deepspeed_plugin = self.accelerator.state.deepspeed_plugin if self.accelerator is not None else None
+        teacher_parameters = [
+            parameter
+            for name, parameter in unwrapped_model.named_parameters()
+            if f".{self.teacher_adapter_name}." in name
+        ]
+        should_gather = (
+            deepspeed_plugin is not None
+            and deepspeed_plugin.zero_stage == 3
+            and any(parameter.numel() == 0 for parameter in teacher_parameters)
+        )
         original_adapter = unwrapped_model.active_adapter
-        unwrapped_model.set_adapter(self.teacher_adapter_name)
-        set_peft_model_state_dict(unwrapped_model, self.shadow_weights, adapter_name=self.teacher_adapter_name)
-        unwrapped_model.set_adapter(original_adapter)
+        try:
+            unwrapped_model.set_adapter(self.teacher_adapter_name)
+            if should_gather:
+                from deepspeed import zero
+
+                with zero.GatheredParameters(teacher_parameters, modifier_rank=0):
+                    set_peft_model_state_dict(
+                        unwrapped_model, self.shadow_weights, adapter_name=self.teacher_adapter_name
+                    )
+            else:
+                set_peft_model_state_dict(unwrapped_model, self.shadow_weights, adapter_name=self.teacher_adapter_name)
+        finally:
+            unwrapped_model.set_adapter(original_adapter)
 
     def on_train_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         if self.accelerator is None and "accelerator" in kwargs:

--- a/trl/experimental/sdpo/teacher_sync.py
+++ b/trl/experimental/sdpo/teacher_sync.py
@@ -109,11 +109,25 @@ class PEFTAdapterEMACallback(TrainerCallback):
             model = self.accelerator.unwrap_model(self.model)
         else:
             model = self.model
+        deepspeed_plugin = self.accelerator.state.deepspeed_plugin if self.accelerator is not None else None
+        trainable_parameters = [parameter for parameter in model.parameters() if parameter.requires_grad]
+        should_gather = (
+            deepspeed_plugin is not None
+            and deepspeed_plugin.zero_stage == 3
+            and any(parameter.numel() == 0 for parameter in trainable_parameters)
+        )
+        if should_gather:
+            from deepspeed import zero
+
+            with zero.GatheredParameters(trainable_parameters, modifier_rank=None):
+                state_dict = get_peft_model_state_dict(model)
+                return {key: value.detach().clone() for key, value in state_dict.items()}
+
         return get_peft_model_state_dict(model)
 
     def _initialize_teacher_adapter(self):
         """Create teacher adapter with zero weights initialized from student adapter."""
-        from peft import get_peft_model_state_dict, set_peft_model_state_dict
+        from peft import set_peft_model_state_dict
 
         if self._initialized:
             return
@@ -129,7 +143,7 @@ class PEFTAdapterEMACallback(TrainerCallback):
 
         self.teacher_adapter_config = model.peft_config.get(adapter_name)
 
-        student_state = get_peft_model_state_dict(model)
+        student_state = self._get_student_state_dict()
 
         teacher_state = {k: torch.zeros_like(v) for k, v in student_state.items()}
 


### PR DESCRIPTION
# What does this PR do?

SDPO's PEFT EMA teacher adapter was initialized lazily from `on_train_begin()`. Under DeepSpeed ZeRO-3, that happens after the student model has been prepared and partitioned.

This caused two related failures:

- `get_peft_model_state_dict()` could read zero-sized LoRA shards when initializing or updating EMA state;
- adding the teacher adapter after DeepSpeed preparation left the new parameters outside the original ZeRO instrumentation and could fail during forward with `AttributeError: 'dict' object has no attribute '_in_forward'`.

This change:

- creates the teacher adapter during SDPO trainer setup, before callback registration and before the training model is wrapped;
- gathers only trainable adapter parameters when ZeRO-3 shards are present;
- clones gathered PEFT state before leaving the gather context;
- keeps callback initialization idempotent and preserves the existing active-adapter restoration behavior;
- adds focused tests for initialization ordering and gathered cloned state.

SDPO VLM support, vLLM weight mapping, reward behavior, and non-PEFT teacher paths are intentionally outside this PR.

Fixes #6828

## Verification

- Two-rank DeepSpeed ZeRO-3 before the fix:
  - 28 zero-sized student adapter tensors observed
  - late adapter insertion failed during forward
- Same two-rank setup after the fix:
  - 28 student adapter tensors, zero zero-sized tensors on both ranks
  - one optimizer step completed
- `pytest -q tests/experimental/test_sdpo_teacher_sync.py`: 2 passed
- Ruff check: passed
- Ruff format check: passed
- `compileall`: passed
- `git diff --check`: passed

## Before submitting

- [x] Did you read the contributor guidelines?
- [x] Was this discussed via a GitHub issue? #6828
- [x] Did you make sure to update the documentation? No user-facing documentation change is required.
- [x] Did you write the necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed SDPO teacher sync and PEFT adapter lifecycle; incorrect gather/write ordering could corrupt LoRA weights under ZeRO-3, but scope is limited to the PEFT EMA path with new regression tests.
> 
> **Overview**
> Fixes SDPO pure-LoRA **EMA teacher** setup when training with **DeepSpeed ZeRO-3**, where lazy adapter creation after model preparation led to empty LoRA shards and broken DeepSpeed instrumentation.
> 
> **`SDPOTrainer._setup_teacher_model`** now calls **`PEFTAdapterEMACallback._initialize_teacher_adapter()`** immediately after constructing the callback and **before** registering it, so the `"teacher"` adapter exists during trainer setup rather than only in **`on_train_begin`**.
> 
> **`PEFTAdapterEMACallback`** gathers ZeRO-3 shards when reading student PEFT state (**`GatheredParameters`**, **`modifier_rank=None`**) and clones tensors before leaving the gather context; teacher EMA writes use a gather on teacher adapter parameters (**`modifier_rank=0`**) with **`try`/`finally`** to restore the active adapter. Initialization reuses **`_get_student_state_dict()`** instead of calling **`get_peft_model_state_dict`** directly.
> 
> Adds **`tests/experimental/test_sdpo_teacher_sync.py`** for init ordering and ZeRO-3 gather/clone behavior (mocked DeepSpeed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6f0337001c044fd4d2ffc0fedae2dee953d439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->