### PR TITLE
Hotfix CI: xfail the transformers continuous batching test

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4641,6 +4641,11 @@ class TestGRPOTrainerSlow(TrlTestCase):
         reason="transformers continuous batching switches attention to Flash Attention, which requires an Ampere or "
         "newer GPU, or XPU (see https://github.com/huggingface/transformers/issues/47926)",
     )
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so continuous-batching generation returns no "
+        "completions (https://github.com/huggingface/trl/issues/6834)",
+    )
     def test_train_with_transformers_continuous_batching(self, model_name):
         """Test that training works with transformers continuous batching (requires GPU)."""
         if not Version(transformers.__version__) >= Version("5.8.0"):


### PR DESCRIPTION
This PR restores a green slow-tests CI by marking `test_train_with_transformers_continuous_batching` as `xfail`.

Hotfix for:
- #6834

### Motivation

The slow-tests job has been red on `main` since #6741 moved the single-GPU runner from a T4 to an L40S: https://github.com/huggingface/trl/actions/runs/32366421358/job/96416805348

The test was previously skipped by the `is_ampere_or_newer` guard added in #6712, so it runs for the first time on Ampere or newer hardware. Continuous-batching generation loads the model with Flash Attention, whose kernel rejects a `head_size` that is not a multiple of 8. The tiny models used here are `hidden_size=8` over 4 attention heads, so `head_size=2`, the generation thread dies during warm-up, and the trainer raises because no completions came back.

### Solution

Mark the test non-strict `xfail` while #6834 is addressed, so it reports `XPASS` once the tests run on a model with a supported `head_size`. The existing pre-Ampere `skipif` is kept, since that condition is unrelated and still applies.

### Changes

- Add an `xfail` marker to `TestGRPOTrainerSlow::test_train_with_transformers_continuous_batching`, pointing at #6834

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9cc8c9a6f5b277d3ce18a7cdb42fdd09c7972b03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->