### PR TITLE
Hotfix CI: xfail the experimental async trainer training tests

### DIFF
--- a/tests/experimental/test_async_distillation_trainer.py
+++ b/tests/experimental/test_async_distillation_trainer.py
@@ -710,6 +710,11 @@ class TestAsyncDistillationTrainer(TrlTestCase):
             weight_transfer=_StubWeightTransfer(),
         )
 
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
+        "(https://github.com/huggingface/trl/issues/6837)",
+    )
     def test_train(self):
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
@@ -744,6 +749,11 @@ class TestAsyncDistillationTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @pytest.mark.parametrize("beta", [0.25, 0.5, 0.75, 1.0])
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
+        "(https://github.com/huggingface/trl/issues/6837)",
+    )
     def test_train_with_nonzero_beta(self, beta):
         # Adapted from ServerDistillationTrainer's own `test_reverse_kl_finite_grad_with_ragged_batch`: a real
         # training run through the narrow top-1 + actual-token support path (including the beta==1.0 special case),

--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -163,6 +163,11 @@ class TestAsyncGRPOTrainer(TrlTestCase):
             weight_transfer=_StubWeightTransfer(),
         )
 
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
+        "(https://github.com/huggingface/trl/issues/6837)",
+    )
     def test_train(self):
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
@@ -197,6 +202,11 @@ class TestAsyncGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
+        "(https://github.com/huggingface/trl/issues/6837)",
+    )
     def test_resume_from_checkpoint(self):
         # Checks that ignore_data_skip is True and that resume doesn't crash. The stub worker is not an
         # AsyncRolloutWorker, so the checkpoint-write and resume-read paths stay inert here — those are
@@ -1058,6 +1068,11 @@ class TestEpochStop(TrlTestCase):
         trainer.train()
         return trainer, len(dataset)
 
+    @pytest.mark.xfail(
+        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
+        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
+        "(https://github.com/huggingface/trl/issues/6837)",
+    )
     def test_epoch_stop_is_fork_independent(self):
         no_fork, num_prompts = self._train(fork_k=1)
         forked, _ = self._train(fork_k=3)


### PR DESCRIPTION
This PR restores a green experimental-tests CI by marking the `AsyncGRPOTrainer` and `AsyncDistillationTrainer` tests that run a forward pass as `xfail`.

Follow-up to:
- #6835 

Hotfix for:
- #6837

### Motivation

The experimental-tests job has been red since #6741 moved the runner from a T4 to an L40S: https://github.com/huggingface/trl/actions/runs/32373702417/job/96439922522

Both trainers load the model with `attn_implementation="kernels-community/flash-attn3"`, because they train in padding-free mode. The kernel rejects a `head_size` that is not a multiple of 8, and `tiny-Qwen2ForCausalLM-2.5` is `hidden_size=8` over 4 attention heads, so `head_size=2`:

> RuntimeError: mha_fwd, /build/source/flash-attn/flash_api_stable.cpp:906, head_size should be a multiple of 8

These tests were previously skipped by the `is_ampere_or_newer` guard on their classes, so they run for the first time on Ampere or newer hardware. Same root cause as #6834, in a different job and through flash-attn3 rather than the continuous-batching path.

### Solution

Mark non-strict `xfail` only the tests that reach a forward pass, so they report `XPASS` once they run on a model with a supported `head_size`. Tests that merely build a trainer, such as `test_init_minimal` and the argument-validation guards, are untouched and keep passing.

`TestEpochStop::test_epoch_stop_is_fork_independent` currently fails earlier, with `ImportError: vLLM >= 0.22.0 is required to use WeightTransferClient`, which #6826 fixes; the `xfail` covers it either way, since past that import it hits the same `head_size` error.

### Changes

- Add an `xfail` marker to `TestAsyncGRPOTrainer::test_train`, `TestAsyncGRPOTrainer::test_resume_from_checkpoint` and `TestEpochStop::test_epoch_stop_is_fork_independent`
- Add an `xfail` marker to `TestAsyncDistillationTrainer::test_train` and `TestAsyncDistillationTrainer::test_train_with_nonzero_beta`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest markers; no production or training-path code changes.
> 
> **Overview**
> Marks the experimental `AsyncGRPOTrainer` and `AsyncDistillationTrainer` tests that actually run a forward pass as non-strict `xfail`, so CI stays green until tiny models have a Flash Attention–compatible `head_size`.
> 
> The trainers load with `attn_implementation="kernels-community/flash-attn3"`. On Ampere+ runners, `tiny-Qwen2ForCausalLM-2.5` (`head_size=2`) fails because the kernel requires a multiple of 8. Init-only and validation tests are left passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b952c6a6755e59d550ae81e14041efb7e8c1d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->