### PR TITLE
Hotfix CI: skip the offloading test when several accelerators are visible

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -33,7 +33,7 @@ from transformers import (
     BitsAndBytesConfig,
     TrainingArguments,
 )
-from transformers.testing_utils import backend_empty_cache, torch_device
+from transformers.testing_utils import backend_device_count, backend_empty_cache, torch_device
 from transformers.utils import is_peft_available
 
 from trl import SFTConfig, SFTTrainer
@@ -2530,6 +2530,11 @@ class TestSFTTrainerSlow(TrlTestCase):
         ],
     )
     @require_torch_accelerator
+    @pytest.mark.skipif(
+        backend_device_count(torch_device) > 1,
+        reason="segfaults in accelerate's get_max_memory when more than one accelerator is visible, taking the whole "
+        "pytest process down; cause not yet diagnosed (https://github.com/huggingface/trl/issues/6836)",
+    )
     def test_train_offloading(self, model_name, packing):
         """Test that activation offloading works with SFTTrainer."""
         training_args = SFTConfig(


### PR DESCRIPTION
This PR stops the multi-GPU slow-tests job from being killed by a segmentation fault, so it reports its results instead of dying halfway.

Related to #6836.

### Motivation

`test_train_offloading` segfaults on the multi-GPU runner, taking the whole pytest process down with exit code 139:

```
Current thread (most recent call first):
  File ".../accelerate/utils/modeling.py", line 817 in get_max_memory
  File ".../transformers/integrations/accelerate.py", line 272 in get_balanced_memory
  File ".../transformers/modeling_utils.py", line 4328 in from_pretrained
  File "trl/trainer/utils.py", line 1174 in create_model_from_path
  File "trl/trainer/sft_trainer.py", line 977 in __init__
  File "tests/test_sft_trainer.py", line 2544 in test_train_offloading
```

Because the process dies, pytest never prints `short test summary info`, the `--report-log` file is truncated, and the other failures in the run cannot be identified at all. For #6836 they had to be recovered by hand, by mapping the progress characters onto the collection order.

The crash only happens when more than one accelerator is visible; the test passes in the single-GPU job. The cause is not yet understood, and no marker can catch a segfault, so the test has to not run there.

### Changes

- Skip `TestSFTTrainerSlow::test_train_offloading` when more than one accelerator is visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip; no production or training-path changes. Coverage of activation offloading is reduced on multi-GPU CI until the underlying Accelerate crash is fixed.
> 
> **Overview**
> Skips `test_train_offloading` when more than one accelerator is visible so the multi-GPU slow-test job is not killed by a segfault in Accelerate’s `get_max_memory`.
> 
> The test still runs on single-accelerator jobs. The crash (issue #6836) takes down the whole pytest process, which truncates reports and hides other failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229eaebecb5dd52d0a8c535e1326f6d1d972a009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->