### PR TITLE
Hotfix CI: xfail the tests that DataParallel breaks on multiple GPUs

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -51,6 +51,7 @@ from .testing_utils import (
     require_torch_accelerator,
     require_vision,
     require_vllm,
+    xfail_data_parallel,
 )
 
 
@@ -4482,6 +4483,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
         ],
     )
     @require_liger_kernel
+    @xfail_data_parallel
     def test_train_with_liger_grpo_kernel(self, model_name):
         training_args = GRPOConfig(
             output_dir=self.tmp_dir,
@@ -4528,6 +4530,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
     )
     @require_liger_kernel
     @require_peft
+    @xfail_data_parallel
     def test_train_with_liger_grpo_kernel_and_peft(self, model_name):
         from peft import LoraConfig, TaskType
 
@@ -4589,6 +4592,7 @@ class TestGRPOTrainerSlow(TrlTestCase):
         release_memory(model, trainer)
 
     @require_liger_kernel
+    @xfail_data_parallel
     def test_liger_grpo_kernel_importance_sampling(self):
         model_name = "trl-internal-testing/tiny-LlamaForCausalLM-3.2"
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -55,6 +55,7 @@ from .testing_utils import (
     require_torch_accelerator,
     require_torch_multi_accelerator,
     require_vision,
+    xfail_data_parallel,
 )
 
 
@@ -2283,7 +2284,7 @@ class TestSFTTrainerSlow(TrlTestCase):
         backend_empty_cache(torch_device)
         gc.collect()
 
-    @pytest.mark.parametrize("packing", [True, False])
+    @pytest.mark.parametrize("packing", [True, pytest.param(False, marks=xfail_data_parallel)])
     @pytest.mark.parametrize(
         "model_name",
         [
@@ -2326,7 +2327,7 @@ class TestSFTTrainerSlow(TrlTestCase):
     @pytest.mark.parametrize(
         "gradient_checkpointing_kwargs", [None, {"use_reentrant": False}, {"use_reentrant": True}]
     )
-    @pytest.mark.parametrize("packing", [True, False])
+    @pytest.mark.parametrize("packing", [True, pytest.param(False, marks=xfail_data_parallel)])
     @pytest.mark.parametrize(
         "model_name",
         [
@@ -2470,7 +2471,7 @@ class TestSFTTrainerSlow(TrlTestCase):
 
         release_memory(model, trainer)
 
-    @pytest.mark.parametrize("packing", [True, False])
+    @pytest.mark.parametrize("packing", [True, pytest.param(False, marks=xfail_data_parallel)])
     @pytest.mark.parametrize(
         "model_name",
         [

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -78,6 +78,13 @@ require_3_accelerators = pytest.mark.skipif(
     not (getattr(torch, torch_device, torch.cuda).device_count() >= 3),
     reason=f"test requires at least 3 {torch_device}s",
 )
+# `Trainer` wraps the model in `nn.DataParallel` whenever more than one accelerator is visible and no distributed
+# launcher is used. TRL trainers don't support it: they rewire `forward` on a single module instance, which
+# `DataParallel` breaks by replicating the module and scattering the inputs across devices.
+xfail_data_parallel = pytest.mark.xfail(
+    is_torch_available() and backend_device_count(torch_device) > 1,
+    reason="TRL trainers do not support nn.DataParallel (https://github.com/huggingface/trl/issues/6836)",
+)
 
 
 def is_bitsandbytes_multi_backend_available() -> bool:


### PR DESCRIPTION
This PR marks as `xfail` the 21 slow tests that fail on the multi-GPU runner because `Trainer` wraps the model in `nn.DataParallel`.

Related to #6836. Stacked on top of #6840, without which the job never reaches these results.

### Motivation

With two accelerators visible and no distributed launcher, `TrainingArguments.n_gpu` is 2, so `Trainer` uses `nn.DataParallel`. TRL trainers do not support it: they rewire `forward` on a single module instance, which `DataParallel` breaks by replicating the module and scattering the inputs across devices. This surfaces in two ways:

- `model.forward = types.MethodType(_chunked_ce_forward, model)` is copied verbatim into every replica, so replica 1 still reads device-0 weights:
  > RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:1, different from other tensors on cuda:0
- `_ForwardRedirection` calls the wrapper module with `(unwrapped_model, inputs)`, so `DataParallel` tries to scatter an `nn.Module`:
  > RuntimeError: chunk expects at least a 1-dimensional tensor

Multi-GPU training in TRL goes through Accelerate, one process per GPU, as documented in `distributing_training.md`; `nn.DataParallel` is not a supported mode. This job is the first to actually run on two GPUs, since it was pinned to the single-GPU runner group while setting `CUDA_VISIBLE_DEVICES: "0,1"` until #6741.

### Solution

Add a shared `xfail_data_parallel` marker, conditional on more than one accelerator being visible, so these tests are only expected to fail under `DataParallel` and keep reporting normally in the single-GPU job.

For the SFT tests the marker goes on the `packing=False` parameter only: packing implies padding-free, which flattens the microbatch into a single row, and `DataParallel` then takes its single-chunk shortcut and never replicates, so the `packing=True` variants genuinely pass.

### Changes

- Add an `xfail_data_parallel` marker to `tests/testing_utils.py`
- Apply it to `test_train_with_liger_grpo_kernel`, `test_train_with_liger_grpo_kernel_and_peft` and `test_liger_grpo_kernel_importance_sampling`
- Apply it to the `packing=False` parameter of `test_sft_trainer_transformers_mp`, `test_sft_trainer_transformers_mp_gc_device_map` and `test_sft_trainer_with_liger`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI hotfix; no production or trainer logic changes. Risk is limited to masking real failures if DataParallel support is added later without updating the marker.
> 
> **Overview**
> Marks GRPO and SFT tests that fail under `nn.DataParallel` as expected failures when more than one accelerator is visible, so the multi-GPU CI job stays green without changing trainer behavior.
> 
> Adds a shared `xfail_data_parallel` marker. It is applied to three Liger GRPO tests, and only to the `packing=False` variants of three SFT tests (packing already avoids DataParallel replication).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3494d3a6ae235f1871267dd99c769fadc7148f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->