### PR TITLE
TRL: document 1M-token training and add a context-parallelism example

### DIFF
--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -225,7 +225,7 @@ With the setup above plus a few levers, SFT scales to million-token sequences on
 | Qwen3-0.6B | 4M | 8 | 2135 s | 73.7 GB |
 | Qwen3-8B | 1M | 8 | 364 s | 56.2 GB |
 | Qwen3-30B-A3B (MoE) | 1M | 8 | 483 s | 46.0 GB |
-| Qwen3-32B | 1M | 8 | 1402 s | 66.5 GB |
+| Qwen3-32B | 1M | 8 | 1295 s | 60.8 GB |
 
 Context length scales with the number of nodes: sequence length and GPU count can be doubled together at
 roughly 2x step time, because each GPU keeps the same shard of the sequence.
@@ -262,7 +262,15 @@ The levers, roughly in the order you will need them as model size or sequence le
 
    Both are speed-neutral and save several GB (grad-norm deviation < 0.5%).
 5. **For ≥ 30B models, add parameter/optimizer CPU offload** (`fsdp_offload_params: true`). Model states (~12 bytes/param sharded) move to host; at 1M-token step times the gather traffic is negligible.
-6. **Context extension needs RoPE scaling.** A base model evaluated at positions far beyond its trained range starts at a high loss (10.6 vs 4.4 for Qwen3-8B at 1M with YaRN ×32). Configure it at load time, and note that in transformers v5 `rope_theta` lives inside `rope_parameters`, so the override must carry it:
+6. **For the largest dense models, tile the MLP over the sequence.** Inside a checkpointed layer, the `[seq/cp, intermediate]` gate/up projections are the last large transient, and activation offload cannot reach them — they are created and consumed within a single recompute. Splitting the MLP forward into sequence tiles caps them at `[tile, intermediate]`; the backward recomputes the same tiled code, so the bound holds there too. This is what makes Qwen3-32B fit at 1M:
+
+   ```python
+   from transformers.models.qwen3.modeling_qwen3 import Qwen3MLP
+
+   forward, tile = Qwen3MLP.forward, 16384
+   Qwen3MLP.forward = lambda self, x: torch.cat([forward(self, c) for c in x.split(tile, dim=1)], dim=1)
+   ```
+7. **Context extension needs RoPE scaling.** A base model evaluated at positions far beyond its trained range starts at a high loss (10.6 vs 4.4 for Qwen3-8B at 1M with YaRN ×32). Configure it at load time, and note that in transformers v5 `rope_theta` lives inside `rope_parameters`, so the override must carry it:
 
    ```python
    model_init_kwargs={

--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -218,19 +218,28 @@ accelerate launch --config_file context_parallel_2gpu.yaml train.py
 
 With the setup above plus a few levers, SFT scales to million-token sequences on a single 8×H100 node. Verified configurations (bf16, `per_device_train_batch_size=1`, `loss_type="chunked_nll"` — the default):
 
-| Model | Sequence length | Step time | Peak GPU memory |
+| Model | Sequence length | GPUs | Step time | Peak GPU memory |
+|---|---|---|---|---|
+| Qwen3-0.6B | 1M | 8 | 137 s | 27.9 GB |
+| Qwen3-0.6B | 2M | 8 | 538 s | 42.2 GB |
+| Qwen3-0.6B | 4M | 8 | 2135 s | 73.7 GB |
+| Qwen3-8B | 1M | 8 | 364 s | 56.2 GB |
+| Qwen3-30B-A3B (MoE) | 1M | 8 | 483 s | 46.0 GB |
+| Qwen3-32B | 1M | 8 | 1402 s | 66.5 GB |
+
+Context length scales with the number of nodes: sequence length and GPU count can be doubled together at
+roughly 2x step time, because each GPU keeps the same shard of the sequence.
+
+| Model | Sequence length | GPUs (`cp_size`) | Step time |
 |---|---|---|---|
-| Qwen3-0.6B | 1M | 137 s | 27.9 GB |
-| Qwen3-0.6B | 2M | 538 s | 42.2 GB |
-| Qwen3-0.6B | 4M | 2135 s | 73.7 GB |
-| Qwen3-8B | 1M | 386 s | 67.4 GB |
-| Qwen3-30B-A3B (MoE) | 1M | ~490 s | 48.4 GB |
-| Qwen3-32B | 1M | 1402 s | 66.5 GB |
+| Qwen3-8B | 1M | 8 (1 node) | 364 s |
+| Qwen3-8B | 2M | 16 (2 nodes) | 696 s |
+| Qwen3-8B | 4M | 32 (4 nodes) | 1346 s |
 
 The levers, roughly in the order you will need them as model size or sequence length grows:
 
 1. **Keep the default `loss_type="chunked_nll"`.** At 1M tokens, materializing `[seq, vocab]` logits costs tens of GB per GPU; the chunked loss never does.
-2. **Force the cuDNN SDPA backend** — torch ≥ 2.13's ring attention supports it, and it is ~1.7× faster than the default backend on H100. The context manager must cover forward *and* backward (checkpoint recompute must select the same backend):
+2. **Use the cuDNN SDPA backend** — it is ~1.7× faster than SDPA's default (FlashAttention) on H100, at identical accuracy. Recent Transformers prefers it automatically on Hopper and newer; on older versions, select it explicitly. The context manager must cover forward *and* backward, since activation-checkpoint recompute has to select the same backend:
 
    ```python
    from torch.nn.attention import SDPBackend, sdpa_kernel

--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -270,6 +270,14 @@ The levers, roughly in the order you will need them as model size or sequence le
    }
    ```
 
+Context parallelism can only express full causal attention, which constrains what it can train:
+
+- **Full-attention models only.** Models with sliding-window or chunked attention layers (Gemma 2/3, Mistral,
+  Qwen3 with `use_sliding_window`) cannot be used: their per-layer mask has to be dropped, which would silently
+  turn those layers into full causal attention. Accelerate rejects such models.
+- **No packing**, for the same reason (see above), and **no left padding** — right padding is fine, since causal
+  attention already ignores trailing pad positions.
+
 Attention is quadratic, so step time grows ~4× for every 2× in sequence length (137 s → 538 s → 2135 s for 0.6B at 1M/2M/4M), while memory — with the levers above — grows roughly linearly.
 
 #### Benchmarking Ring Attention

--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -239,7 +239,7 @@ roughly 2x step time, because each GPU keeps the same shard of the sequence.
 The levers, roughly in the order you will need them as model size or sequence length grows:
 
 1. **Keep the default `loss_type="chunked_nll"`.** At 1M tokens, materializing `[seq, vocab]` logits costs tens of GB per GPU; the chunked loss never does.
-2. **Use the cuDNN SDPA backend** — it is ~1.7× faster than SDPA's default (FlashAttention) on H100, at identical accuracy. Recent Transformers prefers it automatically on Hopper and newer; on older versions, select it explicitly. The context manager must cover forward *and* backward, since activation-checkpoint recompute has to select the same backend:
+2. **Use the cuDNN SDPA backend** — it is ~1.7× faster than SDPA's default (FlashAttention) on H100, at identical accuracy. Recent Transformers prefers it automatically on Hopper; elsewhere, select it explicitly. The context manager must cover forward *and* backward, since activation-checkpoint recompute has to select the same backend:
 
    ```python
    from torch.nn.attention import SDPBackend, sdpa_kernel
@@ -280,11 +280,12 @@ The levers, roughly in the order you will need them as model size or sequence le
 
 Context parallelism can only express full causal attention, which constrains what it can train:
 
-- **Full-attention models only.** Models with sliding-window or chunked attention layers (Gemma 2/3, Mistral,
-  Qwen3 with `use_sliding_window`) cannot be used: their per-layer mask has to be dropped, which would silently
-  turn those layers into full causal attention. Accelerate rejects such models.
-- **No packing**, for the same reason (see above), and **no left padding** — right padding is fine, since causal
-  attention already ignores trailing pad positions.
+- **Full-attention models only.** Models with sliding-window or chunked attention layers cannot be used: their
+  per-layer mask has to be dropped, which would silently turn those layers into full causal attention.
+  Accelerate rejects such models. This rules out much of the current crop — gpt-oss (every other layer),
+  Gemma 3 and Gemma 4 (five of every six), Muse-Glimmer (39 of 52), Mistral and Ministral (every layer).
+- **No packing**, for the same reason: packed documents are kept apart by a block-diagonal mask, which is
+  dropped too. TRL raises for this combination.
 
 Attention is quadratic, so step time grows ~4× for every 2× in sequence length (137 s → 538 s → 2135 s for 0.6B at 1M/2M/4M), while memory — with the levers above — grows roughly linearly.
 

--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -214,6 +214,55 @@ accelerate launch --config_file context_parallel_2gpu.yaml train.py
 
 5. **Monitor memory usage** across all GPUs to ensure balanced workload
 
+#### Training at 1M tokens and beyond
+
+With the setup above plus a few levers, SFT scales to million-token sequences on a single 8×H100 node. Verified configurations (bf16, `per_device_train_batch_size=1`, `loss_type="chunked_nll"` — the default):
+
+| Model | Sequence length | Step time | Peak GPU memory |
+|---|---|---|---|
+| Qwen3-0.6B | 1M | 137 s | 27.9 GB |
+| Qwen3-0.6B | 2M | 538 s | 42.2 GB |
+| Qwen3-0.6B | 4M | 2135 s | 73.7 GB |
+| Qwen3-8B | 1M | 386 s | 67.4 GB |
+| Qwen3-30B-A3B (MoE) | 1M | ~490 s | 48.4 GB |
+| Qwen3-32B | 1M | 1402 s | 66.5 GB |
+
+The levers, roughly in the order you will need them as model size or sequence length grows:
+
+1. **Keep the default `loss_type="chunked_nll"`.** At 1M tokens, materializing `[seq, vocab]` logits costs tens of GB per GPU; the chunked loss never does.
+2. **Force the cuDNN SDPA backend** — torch ≥ 2.13's ring attention supports it, and it is ~1.7× faster than the default backend on H100. The context manager must cover forward *and* backward (checkpoint recompute must select the same backend):
+
+   ```python
+   from torch.nn.attention import SDPBackend, sdpa_kernel
+
+   class FastSFTTrainer(SFTTrainer):
+       def training_step(self, *args, **kwargs):
+           with sdpa_kernel([SDPBackend.CUDNN_ATTENTION]):
+               return super().training_step(*args, **kwargs)
+   ```
+3. **Offload checkpointed activations to host memory** (≥ ~1.5M tokens, or ≥ ~8B parameters): set `fsdp_activation_checkpointing_offload: true` in the accelerate FSDP config. Each checkpointed layer's input — the dominant surviving activation, `layers × seq/cp × hidden` bytes — moves to pinned host memory during the forward and returns on demand during the backward.
+4. **At the memory edge, switch the ring rotation to alltoall and merge attention outputs in bf16**:
+
+   ```python
+   from torch.distributed.tensor.experimental._context_parallel import _attention
+   from torch.distributed.tensor.experimental._context_parallel._attention import set_rotate_method
+
+   set_rotate_method("alltoall")            # ring buffers instead of full-sequence KV gather
+   _attention._cp_options.convert_to_f32 = False  # bf16 output merging
+   ```
+
+   Both are speed-neutral and save several GB (grad-norm deviation < 0.5%).
+5. **For ≥ 30B models, add parameter/optimizer CPU offload** (`fsdp_offload_params: true`). Model states (~12 bytes/param sharded) move to host; at 1M-token step times the gather traffic is negligible.
+6. **Context extension needs RoPE scaling.** A base model evaluated at positions far beyond its trained range starts at a high loss (10.6 vs 4.4 for Qwen3-8B at 1M with YaRN ×32). Configure it at load time, and note that in transformers v5 `rope_theta` lives inside `rope_parameters`, so the override must carry it:
+
+   ```python
+   model_init_kwargs={
+       "rope_parameters": {"rope_type": "yarn", "rope_theta": 1000000, "factor": 32, "original_max_position_embeddings": 32768},
+   }
+   ```
+
+Attention is quadratic, so step time grows ~4× for every 2× in sequence length (137 s → 538 s → 2135 s for 0.6B at 1M/2M/4M), while memory — with the levers above — grows roughly linearly.
+
 #### Benchmarking Ring Attention
 
 We benchmarked Ring Attention to highlight its potential improvements in training efficiency.  


### PR DESCRIPTION
Two things, both about training on sequences far longer than the usual few thousand tokens:

- a "Training at 1M tokens and beyond" section in `docs/source/distributing_training.md`, with the configurations I verified and the levers in the order you hit them;
- `examples/sft_long_context/`, a runnable example that trains a book-length sequence per step on one 8xH100 node, plus `examples/accelerate_configs/context_parallel_8gpu.yaml`.

### Measured

One 8xH100 node, bf16, `per_device_train_batch_size=1`, `loss_type="chunked_nll"` (the default):

| Model | Sequence length | Step time | Peak GPU memory |
|---|---|---|---|
| Qwen3-0.6B | 1M | 137 s | 27.9 GB |
| Qwen3-8B | 1M | 364 s | 56.2 GB |
| Qwen3-30B-A3B (MoE) | 1M | 483 s | 46.0 GB |
| Qwen3-32B | 1M | 1295 s | 60.8 GB |
| Qwen3-0.6B | 4M | 2135 s | 73.7 GB |

Context length scales with node count (Qwen3-8B: 1M on 1 node at 364 s, 2M on 2 nodes at 696 s, 4M on
4 nodes at 1346 s), because each GPU keeps the same shard of the sequence.

It is real training, not just "it fits": Qwen3-30B-A3B with YaRN x32 on PG-19 books at 1M context goes
from loss 4.88 to 2.37 in six steps.

### Assumptions

Everything here is written as if the rest of the series has landed. Each of these is a separate PR, and the text or the example changes if one of them does not merge:

| assumption | where it shows up | if it does not land |
|---|---|---|
| huggingface/accelerate#4175 — FSDP2 `activation_checkpointing_offload` | `context_parallel_8gpu.yaml` sets `fsdp_activation_checkpointing_offload: true`; the guide lists it as lever 3 | drop the line from the YAML; models at or above 8B no longer fit at 1M |
| huggingface/transformers#48163 — cuDNN SDPA preference on Hopper | the guide says Transformers selects it automatically; the example does not select a backend | the example needs an `SFTTrainer` subclass wrapping `training_step` in `sdpa_kernel([SDPBackend.CUDNN_ATTENTION])`, and every step time above is ~1.7x larger |
| huggingface/accelerate#4177 — refuse sliding-window models under CP | the constraints section says accelerate rejects them | they are silently trained with full causal attention instead, and the section has to say so |
| huggingface/trl#6843 — refuse packing under CP | the constraints section says TRL raises | the "Do not use packing" bullet becomes advice rather than a guarantee |
| transformers `cp-eval-loss-scaling` — apply CP to the evaluation path | not mentioned, but any user who evaluates during a long-context run gets `eval_loss` multiplied by `cp_size` | worth a warning in the guide |

Two more that are *not* assumptions, just constraints of what exists today, both stated in the example:

- MLP sequence tiling (lever 6) is a user-side monkeypatch, not a feature. It is what makes Qwen3-32B fit.
- Context parallelism expresses only full causal attention, so gpt-oss, Gemma 3/4, Mistral and Qwen3.5
  and later cannot be used. Qwen3.5+ is the interesting one: three quarters of its layers are linear
  attention, which is a different problem from the sliding-window case and is not covered by #4177's
  fix, only by its refusal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime, training, or security code is modified.
> 
> **Overview**
> Adds a **Training at 1M tokens and beyond** section to the Ring Attention docs, with verified step times and peak memory for Qwen3 models from 0.6B to 32B (and a 30B MoE) on 8×H100, plus multi-node scaling for Qwen3-8B at 1M/2M/4M.
> 
> Documents the memory/speed levers in the order they become necessary: chunked NLL, cuDNN SDPA, FSDP activation offload, alltoall ring rotation + bf16 merge, param CPU offload, MLP sequence tiling, and YaRN RoPE scaling. Also states CP constraints: full causal attention only (no sliding-window models) and no packing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851fd9a0a6e0beb6a642755442e3a6bac7f587f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->