### PR TITLE
Ignore benign NumPy `__array_wrap__` deprecation warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,4 +242,13 @@ filterwarnings = [
     # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
     # Remove once: no supported bitsandbytes version emits it
     "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
+
+    # transformers passes the `num_patches` torch tensor to np.cumsum in the InternVL processor, so numpy falls back to
+    # the legacy Tensor.__array_wrap__ path, whose signature predates NumPy 2.0 (upstream, not actionable in TRL)
+    # Triggered by the InternVL cases of the GRPO, RLOO and Distillation VLM tests
+    # Tracking issue: https://github.com/huggingface/trl/issues/6848
+    # Upstream issue: https://github.com/huggingface/transformers/issues/48177
+    # Upstream issue (torch, for the outdated signature): https://github.com/pytorch/pytorch/issues/180657
+    # Remove once: no supported transformers version passes a tensor to np.cumsum there
+    "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
 ]


### PR DESCRIPTION
This PR silences the benign NumPy `__array_wrap__` `DeprecationWarning` emitted by the InternVL VLM tests in CI.

Fix #6848.

### Motivation

Since #6619 added `trl-internal-testing/tiny-InternVLForConditionalGeneration` to the VLM parametrizations, the GRPO, RLOO and Distillation tests emit 126 warnings per run:

```
tests/test_distillation_trainer.py: 24 warnings
tests/test_grpo_trainer.py: 51 warnings
tests/test_rloo_trainer.py: 51 warnings
  /__w/trl/trl/.venv/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:45: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
    return conv.wrap(result, to_scalar=False)
```

`InternVLProcessor.__call__` passes the `num_patches` torch tensor to `np.cumsum`. NumPy tries `Tensor.cumsum(axis=…, dtype=…, out=…)`, which raises `TypeError`, so it falls back to its legacy path and wraps the result through `Tensor.__array_wrap__`, whose signature still predates NumPy 2.0. The tests pass; there is nothing actionable on the TRL side, and we never pass a tensor to NumPy in these code paths.

Reported upstream: https://github.com/huggingface/transformers/issues/48177 (still present in 5.15.1 and on `main`). The torch side of the chain is https://github.com/pytorch/pytorch/issues/180657, open since April with several unmerged attempts, so the transformers fix is the realistic one.

### Solution

Suppress the warning through `filterwarnings` in `pyproject.toml`, documented like the other upstream warning filters and linked to the tracking and upstream issues, so the entry can be removed once a fixed `transformers` release is available in CI.

### Changes

- Add a `filterwarnings` entry for the NumPy `__array_wrap__` `DeprecationWarning`, with a comment explaining the cause, what triggers it, and links to the tracking and upstream issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-config only: adds a pytest warning filter with no runtime, security, or training-path changes.
> 
> **Overview**
> Silences a benign NumPy 2.0 `DeprecationWarning` (`__array_wrap__` signature) in pytest so InternVL VLM runs of GRPO, RLOO, and Distillation tests no longer flood CI.
> 
> The warning comes from transformers passing a torch tensor to `np.cumsum` in the InternVL processor (upstream, not actionable in TRL). The new `filterwarnings` entry in `pyproject.toml` is documented with tracking and upstream issue links so it can be dropped once a fixed transformers release is in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526ad84e816e216d3133a580d83819c19527c500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->