### PR TITLE
Ignore benign torch inductor TF32 advisory warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,4 +242,13 @@ filterwarnings = [
     # Upstream issue: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/2027
     # Remove once: no supported bitsandbytes version emits it
     "ignore:inner dimension \\(\\d+\\) is not aligned for fast kernel:UserWarning",
+
+    # torch inductor advises enabling TF32 on every compile when the float32 matmul precision is left at its default
+    # (upstream, not actionable in TRL: the precision is a process-wide numerics setting only the user should change)
+    # Triggered by the DPO and KTO Liger tests, the only ones that compile, since the GPU CI moved from T4 to L40S:
+    # the advisory is guarded on compute capability >= (8, 0), unreachable on T4
+    # Tracking issue: https://github.com/huggingface/trl/issues/6849
+    # Upstream issue: https://github.com/pytorch/pytorch/issues/175484
+    # Remove once: no supported torch version emits it
+    "ignore:TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled:UserWarning",
 ]


### PR DESCRIPTION
This PR silences the benign `torch._inductor` TF32 advisory `UserWarning` emitted by the Liger tests in CI.

Fix #6849.

### Motivation

Since #6741 moved the GPU CI from T4 to L40S, the DPO and KTO Liger tests emit:

```
tests/test_dpo_trainer.py::TestDPOTrainerVLM::test_train_vlm_liger
tests/test_kto_trainer.py::TestKTOTrainer::test_train_with_liger
tests/test_dpo_trainer.py::TestDPOTrainer::test_train_with_liger
tests/test_kto_trainer.py::TestKTOTrainerVLM::test_train_vlm_liger
  /__w/trl/trl/.venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py:321: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
    warnings.warn(
```

Inductor emits this advisory on every compile when TF32 tensor cores exist and the float32 matmul precision is left at its default. It is guarded on compute capability `>= (8, 0)`, so it was unreachable on T4 (sm75) and now fires on L40S (sm89). The four Liger tests are the only ones that reach an inductor compile, through the `torch.compile` in Liger's chunked-loss base classes.

Nothing is actionable on the TRL side: what the advisory asks for, `torch.set_float32_matmul_precision('high')`, is a process-wide numerics setting that a library must not change for its users, and setting it in the test session would alter the numerics of every float32 matmul under our tolerance-based training tests. The message is informational only, compilation and execution succeed either way, and torch offers no way to opt out, since it cannot distinguish the default precision from a user-set one.

Already reported upstream by others, neither fixed: https://github.com/pytorch/pytorch/issues/175484 asks for a way to opt out, and https://github.com/pytorch/pytorch/pull/185541 proposed demoting the advisory to `log.info()`.

### Solution

Suppress the warning through `filterwarnings` in `pyproject.toml`, documented like the other upstream warning filters and linked to the tracking and upstream issues, so the entry can be removed once no supported `torch` version emits it.

### Changes

- Add a `filterwarnings` entry for the inductor TF32 advisory `UserWarning`, with a comment explaining the cause, what triggers it, and links to the tracking and upstream issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pytest warning filter; no runtime, training, or security behavior changes.
> 
> **Overview**
> Suppresses a benign torch inductor `UserWarning` about TF32 tensor cores not being enabled, which started firing in GPU CI after the T4 → L40S move.
> 
> Adds a documented `filterwarnings` entry in `pyproject.toml` so DPO/KTO Liger tests (the only ones that `torch.compile`) stay clean without changing process-wide matmul precision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80bee61499aa918e87ea81b0fe33ef2bc56d75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->