### PR TITLE
Use Flash Attention compatible models in the continuous batching test

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4646,22 +4646,21 @@ class TestGRPOTrainerSlow(TrlTestCase):
 
         release_memory(model, trainer)
 
+    # Flash Attention requires a `head_size` multiple of 8, hence the `small-*` models (`head_size` 32 and 128)
+    # rather than the `tiny-*` ones (`head_size=2`) used before. This drops the coverage of
+    # `trl-internal-testing/tiny-LlamaForCausalLM-3.2` and `trl-internal-testing/tiny-MistralForCausalLM-0.2`;
+    # restoring it needs `small-LlamaForCausalLM-3.2` and `small-MistralForCausalLM-0.2`, which don't exist yet.
     @pytest.mark.parametrize(
         "model_name",
         [
-            "trl-internal-testing/tiny-LlamaForCausalLM-3.2",
-            "trl-internal-testing/tiny-MistralForCausalLM-0.2",
+            "trl-internal-testing/small-Qwen2ForCausalLM-2.5",
+            "trl-internal-testing/small-Qwen3ForCausalLM",
         ],
     )
     @pytest.mark.skipif(
         not is_ampere_or_newer() and torch_device != "xpu",
         reason="transformers continuous batching switches attention to Flash Attention, which requires an Ampere or "
         "newer GPU, or XPU (see https://github.com/huggingface/transformers/issues/47926)",
-    )
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so continuous-batching generation returns no "
-        "completions (https://github.com/huggingface/trl/issues/6834)",
     )
     def test_train_with_transformers_continuous_batching(self, model_name):
         """Test that training works with transformers continuous batching (requires GPU)."""


### PR DESCRIPTION
This PR runs the transformers continuous batching test on models whose `head_size` is a multiple of 8, so it passes instead of being expected to fail.

Fix #6834.

### Motivation

Continuous-batching generation loads the model with Flash Attention, whose kernels reject a `head_size` that is not a multiple of 8. The `tiny-*` models are `hidden_size=8` over 4 attention heads, so `head_size=2`, the generation thread dies during warm-up and the trainer raises because no completions came back. The test was marked `xfail` in #6835 to unbreak CI.

### Solution

Parametrize over `small-Qwen2ForCausalLM-2.5` and `small-Qwen3ForCausalLM`, which are `hidden_size=128` with `head_size` 32 and 128, and drop the `xfail` marker. The pre-Ampere `skipif` stays: it covers hardware that cannot run Flash Attention at all.

Verified green on the L40S single-GPU slow job: https://github.com/huggingface/trl/actions/runs/32467963441

This drops the coverage of `trl-internal-testing/tiny-LlamaForCausalLM-3.2` and `trl-internal-testing/tiny-MistralForCausalLM-0.2`, as noted in a comment on the test. Restoring those two architectures would need `small-*` variants of them, which don't exist yet.

### Changes

- Parametrize `test_train_with_transformers_continuous_batching` over the two `small-*` models
- Remove its `xfail` marker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only parametrization change; no production or training-path code is modified.
> 
> **Overview**
> Makes `test_train_with_transformers_continuous_batching` actually pass by switching from `tiny-*` Llama/Mistral models (`head_size=2`) to `small-Qwen2` and `small-Qwen3` (`head_size` 32 and 128), which Flash Attention accepts.
> 
> Removes the `xfail` that was covering empty completions from FA kernel rejection. Llama/Mistral architectures are no longer covered until `small-*` variants exist. Hardware `skipif` for pre-Ampere GPUs is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecc372e68ba9a2030da7b7598f7d281ac4fa449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->