### PR TITLE
Use a Flash Attention compatible model in the async trainer tests

### DIFF
--- a/tests/experimental/test_async_distillation_trainer.py
+++ b/tests/experimental/test_async_distillation_trainer.py
@@ -52,6 +52,9 @@ from ..testing_utils import TrlTestCase, is_ampere_or_newer
 
 TEACHER_TOP_K = 4
 
+# The trainer loads the model with Flash Attention, which requires a `head_size` multiple of 8. Hence the `small-*`
+# model (`head_size=32`) below, rather than the usual `tiny-*` one (`head_size=2`).
+
 
 def _make_teacher_topk(
     vocab_size: int, actual_token_ids: list[int], top_k: int, seed: int
@@ -408,7 +411,7 @@ class TestMultiTeacherRouting:
 
     def _run(self, teacher_server_urls, *teacher_ids):
         """Score one row per `teacher_ids` entry (`None` = no `teacher_id` column) and return the requests sent."""
-        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/small-Qwen2ForCausalLM-2.5")
         loop = _bare_loop(tokenizer, teacher_server_urls)
         requests = []
 
@@ -700,7 +703,7 @@ class TestSparseGeneralizedJSDMatchesFullVocabReference:
 )
 class TestAsyncDistillationTrainer(TrlTestCase):
     def test_init_minimal(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         AsyncDistillationTrainer(
@@ -710,13 +713,8 @@ class TestAsyncDistillationTrainer(TrlTestCase):
             weight_transfer=_StubWeightTransfer(),
         )
 
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
-        "(https://github.com/huggingface/trl/issues/6837)",
-    )
     def test_train(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
@@ -749,16 +747,11 @@ class TestAsyncDistillationTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @pytest.mark.parametrize("beta", [0.25, 0.5, 0.75, 1.0])
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
-        "(https://github.com/huggingface/trl/issues/6837)",
-    )
     def test_train_with_nonzero_beta(self, beta):
         # Adapted from ServerDistillationTrainer's own `test_reverse_kl_finite_grad_with_ragged_batch`: a real
         # training run through the narrow top-1 + actual-token support path (including the beta==1.0 special case),
         # checking grad_norm/loss stay finite throughout, not just that training completes.
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 

--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -57,6 +57,10 @@ from trl.trainer.base_trainer import _BaseTrainer
 from ..testing_utils import TrlTestCase, is_ampere_or_newer
 
 
+# The trainer loads the model with Flash Attention, which requires a `head_size` multiple of 8. Hence the `small-*`
+# model (`head_size=32`) below, rather than the usual `tiny-*` one (`head_size=2`).
+
+
 def dummy_reward_func(completions, **kwargs):
     return [float(hash(c[0]["content"]) % 100) / 100.0 for c in completions]
 
@@ -153,7 +157,7 @@ class _StubWeightTransfer:
 class TestAsyncGRPOTrainer(TrlTestCase):
     def test_init_minimal(self):
         # Test that AsyncGRPOTrainer can be instantiated with only model, reward_model and train_dataset
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         AsyncGRPOTrainer(
             model=model_id,
@@ -163,13 +167,8 @@ class TestAsyncGRPOTrainer(TrlTestCase):
             weight_transfer=_StubWeightTransfer(),
         )
 
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
-        "(https://github.com/huggingface/trl/issues/6837)",
-    )
     def test_train(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
 
         training_args = AsyncGRPOConfig(
@@ -202,16 +201,11 @@ class TestAsyncGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
-        "(https://github.com/huggingface/trl/issues/6837)",
-    )
     def test_resume_from_checkpoint(self):
         # Checks that ignore_data_skip is True and that resume doesn't crash. The stub worker is not an
         # AsyncRolloutWorker, so the checkpoint-write and resume-read paths stay inert here — those are
         # covered by TestRolloutStateCheckpoint.
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
@@ -270,7 +264,7 @@ class TestAsyncGRPOTrainer(TrlTestCase):
         training_args = AsyncGRPOConfig(output_dir=self.tmp_dir, max_steps=5, report_to="none")
         with pytest.raises(ValueError, match="`train_dataset` is required"):
             AsyncGRPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                model="trl-internal-testing/small-Qwen2ForCausalLM-2.5",
                 reward_funcs=dummy_reward_func,
                 args=training_args,
             )
@@ -285,7 +279,7 @@ class TestAsyncGRPOTrainer(TrlTestCase):
         args = AsyncGRPOConfig(output_dir=self.tmp_dir, report_to="none")  # max_steps unset
         with pytest.raises(ValueError, match="max_steps"):
             AsyncGRPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                model="trl-internal-testing/small-Qwen2ForCausalLM-2.5",
                 reward_funcs=dummy_reward_func,
                 args=args,
                 environment_factory=DummyEnvironment,
@@ -303,7 +297,7 @@ class TestAsyncGRPOTrainer(TrlTestCase):
         args = AsyncGRPOConfig(output_dir=self.tmp_dir, max_steps=1, report_to="none")
         with pytest.raises(ValueError, match="requires a `train_dataset`"):
             AsyncGRPOTrainer(
-                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                model="trl-internal-testing/small-Qwen2ForCausalLM-2.5",
                 reward_funcs=dummy_reward_func,
                 args=args,
                 environment_factory={"a": EnvA, "b": EnvB},
@@ -1049,7 +1043,7 @@ class TestEpochStop(TrlTestCase):
     """
 
     def _train(self, fork_k, num_train_epochs=2):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model_id = "trl-internal-testing/small-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
         args = AsyncGRPOConfig(
             output_dir=self.tmp_dir,
@@ -1068,11 +1062,6 @@ class TestEpochStop(TrlTestCase):
         trainer.train()
         return trainer, len(dataset)
 
-    @pytest.mark.xfail(
-        reason="Flash Attention rejects a head_size that is not a multiple of 8, and the tiny models are "
-        "hidden_size=8 over 4 attention heads (head_size=2), so the forward pass raises "
-        "(https://github.com/huggingface/trl/issues/6837)",
-    )
     def test_epoch_stop_is_fork_independent(self):
         no_fork, num_prompts = self._train(fork_k=1)
         forked, _ = self._train(fork_k=3)


### PR DESCRIPTION
This PR runs the async trainer tests on a model whose `head_size` is a multiple of 8, so they pass instead of being expected to fail.

Fix #6837.

### Motivation

`AsyncGRPOTrainer` and `AsyncDistillationTrainer` load the model with `kernels-community/flash-attn3`, because they train in padding-free mode. The kernel rejects a `head_size` that is not a multiple of 8, and `tiny-Qwen2ForCausalLM-2.5` is `hidden_size=8` over 4 attention heads, so `head_size=2`. The affected tests were marked `xfail` in #6838 to unbreak CI.

### Solution

Use `small-Qwen2ForCausalLM-2.5` (`hidden_size=128`, `head_size=32`, same Qwen2.5 tokenizer and vocabulary) throughout both test files, and drop the `xfail` markers. Swapping the whole file rather than only the training tests keeps the constraint from being reintroduced by a copy-pasted model id.

A CI run confirms flash-attn3 handles this model's forward and backward: the training tests now get past the optimizer step. https://github.com/huggingface/trl/actions/runs/32467963562

### Merge order

The tests do not go green on this PR alone. They now reach `_log_step_metrics` and fail there on #6852, which must be merged first. `TestEpochStop::test_epoch_stop_is_fork_independent` additionally needs #6826.

### Changes

- Use `small-Qwen2ForCausalLM-2.5` in `test_async_grpo_trainer.py` and `test_async_distillation_trainer.py`
- Remove the `xfail` markers from the five affected tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture swap and xfail cleanup; no production code or training logic changes.
> 
> **Overview**
> Switches async GRPO and distillation trainer tests from `tiny-Qwen2ForCausalLM-2.5` (`head_size=2`) to `small-Qwen2ForCausalLM-2.5` (`head_size=32`) so Flash Attention can run a real forward/backward instead of rejecting the model.
> 
> Removes the five `xfail` markers that papered over that kernel constraint, so `test_train`, nonzero-`beta` distillation, checkpoint resume, and epoch-stop tests are expected to pass (subject to related PRs landing first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220fd39e73873e904f37050a33fa12e687366cd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->