### PR TITLE
Derive head_dim when the model config does not declare it

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1562,6 +1562,14 @@ class TestComputeFlopsPerToken(TrlTestCase):
         expected_delta = 3 * moe_layers * (2 - 1) * per_expert_per_layer
         assert f_hi - f_lo == expected_delta
 
+    def test_config_without_head_dim(self):
+        # `head_dim` is optional on configs: Qwen2 doesn't declare it. Falling back to `hidden_size //
+        # num_attention_heads` must give the same result as setting it explicitly.
+        cfg = AutoConfig.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        derived = compute_flops_per_token(cfg, 16384)
+        cfg.head_dim = cfg.hidden_size // cfg.num_attention_heads
+        assert compute_flops_per_token(cfg, 16384) == derived
+
 
 class TestComputeMfu(TrlTestCase):
     def test_perfect_utilization(self):
@@ -1603,3 +1611,11 @@ class TestAdjustedMfu(TrlTestCase):
         f_med = adjusted_mfu(100.0, cfg, 16384)
         f_long = adjusted_mfu(100.0, cfg, 65536)
         assert f_short > f_med > f_long
+
+    def test_config_without_head_dim(self):
+        # `head_dim` is optional on configs: Qwen2 doesn't declare it. Falling back to `hidden_size //
+        # num_attention_heads` must give the same result as setting it explicitly.
+        cfg = AutoConfig.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        derived = adjusted_mfu(100.0, cfg, 16384)
+        cfg.head_dim = cfg.hidden_size // cfg.num_attention_heads
+        assert adjusted_mfu(100.0, cfg, 16384) == pytest.approx(derived)

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1565,7 +1565,9 @@ def compute_flops_per_token(config: PretrainedConfig, seq_len: int) -> int:
     V = config.vocab_size
     n_heads = config.num_attention_heads
     n_kv_heads = config.num_key_value_heads
-    head_dim = config.head_dim
+    # `head_dim` is optional on configs: Llama and Mistral declare it, Qwen2 doesn't. Derive it when missing, like
+    # transformers' own modeling code does.
+    head_dim = getattr(config, "head_dim", None) or h // n_heads
 
     # Attention: Q/K/V/O projections + attention score (Q·Kᵀ and attn·V).
     qkv_flops = 2 * h * (n_heads * head_dim + 2 * n_kv_heads * head_dim)
@@ -1651,5 +1653,6 @@ def adjusted_mfu(mfu: float, config: PretrainedConfig, seq_len: int) -> float:
     """
     flops_full = compute_flops_per_token(config, seq_len)
     # Half of the attention-score FLOPs (Q·Kᵀ and attn·V), per layer, ×3 for fwd+bwd.
-    half_attn_score = config.num_hidden_layers * 3 * 2 * config.num_attention_heads * config.head_dim * seq_len
+    head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+    half_attn_score = config.num_hidden_layers * 3 * 2 * config.num_attention_heads * head_dim * seq_len
     return mfu * (flops_full - half_attn_score) / flops_full


### PR DESCRIPTION
This PR fixes `compute_flops_per_token` and `adjusted_mfu` raising `AttributeError: 'Qwen2Config' object has no attribute 'head_dim'`.

Fix #6852.

### Motivation

Both functions read `config.head_dim` unconditionally, but `head_dim` is an optional config attribute: `LlamaConfig` and `MistralConfig` declare it, `Qwen2Config` does not. transformers never promises it exists and derives it when missing in its own modeling code.

Surveying every `configuration_*.py` in transformers that has `num_attention_heads`:
- 103 declare `head_dim`,
- 308 don't. 

Omitting it is the majority, not an anomaly. Among decoder LMs alone, Qwen2, Qwen2-MoE, Qwen3-MoE, OLMo/OLMo2/OLMo3, StarCoder2, GPT-NeoX, Falcon, Phi-3, StableLM, Granite and SmolLM3 all omit it; Qwen3 is one of the minority that declares it.

`AsyncGRPOTrainer` and `AsyncDistillationTrainer` call `compute_flops_per_token` from `_log_step_metrics`, so they fail on the first logged step for any Qwen2-family model.

### Solution

Fall back to `hidden_size // num_attention_heads`, matching `modeling_qwen2`. `getattr` is used here because the attribute is genuinely optional upstream, consistent with the `num_experts_per_tok` lookup a few lines below.

### Changes

- Derive `head_dim` when absent, in `compute_flops_per_token` and `adjusted_mfu`
- Add a test to each of `TestComputeFlopsPerToken` and `TestAdjustedMfu` checking the derived value matches an explicitly set one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fallback in FLOPs/MFU math used for logging, not training. Behavior is unchanged when `head_dim` is already present.
> 
> **Overview**
> Stops FLOPs/MFU helpers from crashing on configs that omit `head_dim` (e.g. Qwen2). `compute_flops_per_token` and `adjusted_mfu` now fall back to `hidden_size // num_attention_heads`, matching transformers modeling code.
> 
> That unblocks step-metric logging in `AsyncGRPOTrainer` and `AsyncDistillationTrainer` for Qwen2-family models. Tests check that the derived value matches an explicitly set `head_dim`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b036cc3969c3458df01fadf379cd5fd3350f5322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->