### PR TITLE
Add `loss_type="cce"`, backed by cut-cross-entropy

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -49,6 +49,7 @@ from .testing_utils import (
     ignore_warnings,
     is_ampere_or_newer,
     require_bitsandbytes,
+    require_cut_cross_entropy,
     require_kernels,
     require_liger_kernel,
     require_peft,
@@ -409,6 +410,40 @@ class TestSFTTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @require_torch_accelerator
+    @require_cut_cross_entropy
+    def test_train_cce_loss(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
+
+        # CCE's backward kernel is half-precision only, so the model has to be loaded in bf16 -- `bf16=True`
+        # alone would not do it, since under autocast the norm feeding the `lm_head` still emits fp32.
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="cce",
+            model_init_kwargs={"dtype": "bfloat16"},
+            learning_rate=0.1,  # use higher lr because bf16 updates at the default lr round to zero
+            report_to="none",
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        # `cce` fuses the projection into the CE kernel, so there are no logits to read these off.
+        assert "mean_token_accuracy" not in trainer.state.log_history[-1]
+        assert "entropy" not in trainer.state.log_history[-1]
 
         # Check that the params have changed
         for n, param in previous_trainable_params.items():

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -34,6 +34,7 @@ from transformers.utils import (
 
 from trl.chat_template_utils import _SUPPORTS_RESPONSE_TEMPLATE
 from trl.import_utils import (
+    is_cut_cross_entropy_available,
     is_harbor_available,
     is_jmespath_available,
     is_joblib_available,
@@ -47,6 +48,9 @@ from trl.import_utils import (
 
 require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reason="test requires bitsandbytes")
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
+require_cut_cross_entropy = pytest.mark.skipif(
+    not is_cut_cross_entropy_available(), reason="test requires cut-cross-entropy"
+)
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
 require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test requires kernels")
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -57,6 +57,10 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
         return package_exists
 
 
+def is_cut_cross_entropy_available() -> bool:
+    return _is_package_available("cut_cross_entropy")
+
+
 def is_deepspeed_available() -> bool:
     return _is_package_available("deepspeed")
 

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -108,6 +108,12 @@ class SFTConfig(_BaseConfig):
 
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
+            - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by
+              [cut-cross-entropy](https://github.com/apple/ml-cross-entropy), so peak memory does not scale with
+              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half
+              precision (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since
+              under autocast the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and
+              `entropy` are not logged, since there are no logits to compute them from.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -110,10 +110,10 @@ class SFTConfig(_BaseConfig):
             - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
             - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by
               [cut-cross-entropy](https://github.com/apple/ml-cross-entropy), so peak memory does not scale with
-              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half
-              precision (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since
-              under autocast the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and
-              `entropy` are not logged, since there are no logits to compute them from.
+              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half precision
+              (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since under autocast
+              the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and `entropy` are not logged,
+              since there are no logits to compute them from.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -117,10 +117,10 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
 def _cut_cross_entropy_loss(hidden, w, labels, shift_labels, num_items_in_batch, final_logit_softcapping):
     """Next-token cross-entropy that never materialises the logits, via `cut_cross_entropy`.
 
-    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory
-    does not scale with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`]
-    there are no logits to read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable —
-    the same trade `use_liger_kernel=True` already makes.
+    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory does not scale
+    with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`] there are no logits to
+    read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable — the same trade
+    `use_liger_kernel=True` already makes.
 
     Returns:
         `tuple` of the loss and the number of non-ignored target tokens.
@@ -289,9 +289,9 @@ def _patch_chunked_ce_lm_head(
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
         use_cce (`bool`):
-            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it.
-            Peak memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and
-            `entropy_sum`, which need logits and are left as `None`.
+            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it. Peak
+            memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and `entropy_sum`,
+            which need logits and are left as `None`.
         is_vlm (`bool`):
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -114,6 +114,37 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     return chunk_loss, chunk_correct, chunk_entropy
 
 
+def _cut_cross_entropy_loss(hidden, w, labels, shift_labels, num_items_in_batch, final_logit_softcapping):
+    """Next-token cross-entropy that never materialises the logits, via `cut_cross_entropy`.
+
+    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory
+    does not scale with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`]
+    there are no logits to read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable —
+    the same trade `use_liger_kernel=True` already makes.
+
+    Returns:
+        `tuple` of the loss and the number of non-ignored target tokens.
+    """
+    from cut_cross_entropy import linear_cross_entropy
+
+    targets = shift_labels if shift_labels is not None else torch.roll(labels, shifts=-1, dims=-1)
+    if shift_labels is None:
+        targets[..., -1] = -100
+    hidden = hidden.reshape(-1, hidden.shape[-1])
+    targets = targets.reshape(-1)
+    n_valid = (targets != -100).sum()
+    loss = linear_cross_entropy(
+        hidden,
+        w,
+        targets,
+        ignore_index=-100,
+        softcap=final_logit_softcapping,
+        reduction="sum",
+    )
+    # `num_items_in_batch` is the global count, matching HF's gradient-accumulation-correct reduction.
+    return loss / (num_items_in_batch if num_items_in_batch is not None else n_valid.clamp(min=1)), n_valid
+
+
 def _chunked_cross_entropy_loss(
     hidden_states: torch.Tensor,
     lm_head_weight: torch.Tensor,
@@ -234,7 +265,9 @@ def _chunked_cross_entropy_loss(
     return loss, correct, entropy_sum, n_valid_tensor
 
 
-def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: bool = False) -> None:
+def _patch_chunked_ce_lm_head(
+    model: torch.nn.Module, chunk_size: int, is_vlm: bool = False, use_cce: bool = False
+) -> None:
     """
     Patch `model.forward` to compute the LM loss via [`_chunked_cross_entropy_loss`].
 
@@ -255,6 +288,10 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             `PeftModel.forward` before delegating into the patched forward.
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
+        use_cce (`bool`):
+            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it.
+            Peak memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and
+            `entropy_sum`, which need logits and are left as `None`.
         is_vlm (`bool`):
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss
@@ -327,17 +364,50 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             lm_head_weight = lm_head_weight.full_tensor()
             if lm_head_bias is not None:
                 lm_head_bias = lm_head_bias.full_tensor()
-        loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
-            hidden_states,
-            lm_head_weight,
-            chunk_size,
-            labels=labels,
-            shift_labels=shift_labels,
-            num_items_in_batch=num_items_in_batch,
-            logit_scale=logit_scale,
-            final_logit_softcapping=final_logit_softcapping,
-            lm_head_bias=lm_head_bias,
-        )
+        if use_cce:
+            if logit_scale != 1.0:
+                # `linear_cross_entropy` has no equivalent of `logit_scale`, and silently dropping it would
+                # train on a different loss than the model defines.
+                raise ValueError(
+                    f"`loss_type='cce'` does not support models with a logit scale (got {logit_scale}). "
+                    "Use `loss_type='chunked_nll'` for this model."
+                )
+            if lm_head_bias is not None:
+                # Same reason: `linear_cross_entropy` fuses the projection itself and takes no bias term.
+                raise ValueError(
+                    "`loss_type='cce'` does not support models whose `lm_head` has a bias. "
+                    "Use `loss_type='chunked_nll'` for this model."
+                )
+            if hidden_states.dtype not in (torch.bfloat16, torch.float16):
+                # The CCE backward kernel is half-precision only. Note that `bf16=True` alone does not satisfy this:
+                # under autocast the norm feeding the `lm_head` still emits fp32. The model itself has to be loaded
+                # in half precision, e.g. `model_init_kwargs={"dtype": "bfloat16"}`.
+                raise ValueError(
+                    f"`loss_type='cce'` requires bfloat16 or float16 hidden states, got {hidden_states.dtype}. "
+                    "Load the model in half precision (e.g. `model_init_kwargs={'dtype': 'bfloat16'}`), or use "
+                    "`loss_type='chunked_nll'`."
+                )
+            loss, num_valid_tokens = _cut_cross_entropy_loss(
+                hidden_states,
+                lm_head_weight,
+                labels,
+                shift_labels,
+                num_items_in_batch,
+                final_logit_softcapping,
+            )
+            num_correct_tokens = entropy_sum = None
+        else:
+            loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
+                hidden_states,
+                lm_head_weight,
+                chunk_size,
+                labels=labels,
+                shift_labels=shift_labels,
+                num_items_in_batch=num_items_in_batch,
+                logit_scale=logit_scale,
+                final_logit_softcapping=final_logit_softcapping,
+                lm_head_bias=lm_head_bias,
+            )
 
         aux_loss = None
         if output_router_logits:
@@ -1309,9 +1379,10 @@ class SFTTrainer(_BaseTrainer):
                         "passing a `compute_loss_func` is not allowed."
                     )
                 compute_loss_func = dft_loss
-            elif args.loss_type == "chunked_nll":
-                # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
-                # chunks of tokens. Implemented by patching the model's forward before `super().__init__` so accelerate
+            elif args.loss_type in ("chunked_nll", "cce"):
+                # `"chunked_nll"`: same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the
+                # CE is computed in chunks of tokens. `"cce"`: the projection is fused into the CE kernel instead, so
+                # the logits never exist. Implemented by patching the model's forward before `super().__init__` so accelerate
                 # wraps the patched forward.
                 # For PEFT, patch the inner causal LM rather than the `PeftModel` wrapper. LoRA / IA³ /
                 # `modules_to_save` adapters live in the module tree, so they're hit even when we bypass
@@ -1330,14 +1401,19 @@ class SFTTrainer(_BaseTrainer):
                             "`lm_head` from `target_modules`, or switch to `loss_type='nll'`. If this is a real use "
                             "case for you, please open an issue at https://github.com/huggingface/trl/issues."
                         )
-                _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
+                _patch_chunked_ce_lm_head(
+                    target,
+                    chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE,
+                    is_vlm=self._is_vlm,
+                    use_cce=args.loss_type == "cce",
+                )
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
-                    "'chunked_nll'."
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', "
+                    "'chunked_nll', and 'cce'."
                 )
-        elif args.loss_type == "chunked_nll":
-            raise ValueError("`loss_type='chunked_nll'` is not compatible with `use_liger_kernel=True`.")
+        elif args.loss_type in ("chunked_nll", "cce"):
+            raise ValueError(f"`loss_type='{args.loss_type}'` is not compatible with `use_liger_kernel=True`.")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream
@@ -1773,7 +1849,7 @@ class SFTTrainer(_BaseTrainer):
             entropy_sum = self.accelerator.gather_for_metrics(outputs.entropy_sum).sum()
             entropy = (entropy_sum / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["entropy"].append(entropy)
-        elif not self.args.use_liger_kernel:  # liger doesn't return logits
+        elif not self.args.use_liger_kernel and self.args.loss_type != "cce":  # neither returns logits
             with torch.no_grad():
                 if "shift_labels" in inputs:
                     # When using CP or SP, labels are pre-shifted.
@@ -1824,6 +1900,8 @@ class SFTTrainer(_BaseTrainer):
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
         if self.args.loss_type == "chunked_nll":
+            # `"cce"` deliberately has no branch here: fusing the projection into the CE kernel means there are no
+            # logits to take an argmax over, so `mean_token_accuracy` is simply not logged.
             correct = self.accelerator.gather_for_metrics(outputs.num_correct_tokens).sum()
             accuracy = (correct / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["mean_token_accuracy"].append(accuracy)


### PR DESCRIPTION
`chunked_nll` (TRL's default) keeps the `lm_head` projection and the softmax as separate steps, so peak memory scales with `chunk_size * vocab_size` and the logits are written to HBM and read back. [cut-cross-entropy](https://github.com/apple/ml-cross-entropy) fuses the projection into the cross-entropy kernel, so the logits never exist. This adds it as a `loss_type`, next to `nll`, `dft` and `chunked_nll`.

Modern vocabularies make this matter a lot: Qwen3.5/3.6 is 248,320 tokens against a 2048 hidden size, so the `lm_head` alone is 508M parameters and the logits for one 16k-token micro-batch are 16 GB in bf16.

## Numbers

`bench/loss_bench.py`, 16384 tokens x 248320 vocab x 2048 hidden, 1xH100, bf16, fwd+bwd:

<img width="1564" height="748" alt="fig_loss" src="https://github.com/user-attachments/assets/c1e2d5d2-d33c-4c77-8357-d4e926ed37eb" />

| | time | peak memory | loss vs reference |
|---|---|---|---|
| `chunked_nll` (TRL default today) | **OOM** | — | — |
| `use_liger_kernel=True` | 321.16 ms | 6.05 GB | rel 0 |
| `chunked_nll` + PR 7 | 224.39 ms | 19.67 GB | rel 2.3e-07 |
| one big bf16 GEMM (reference) | 137.00 ms | 47.55 GB | rel 0 |
| **`loss_type="cce"`** | **92.55 ms** | **3.09 GB** | rel 3.8e-07 |

At 4096 tokens, where the current default does fit: **318.95 ms / 38.02 GB → 23.18 ms / 2.95 GB**, i.e. **13.8x faster and 12.9x lighter**.

End to end, 3.86B MoE (248k vocab, 64 experts), seq 4096, per-device batch 2, 1xH100: **9857 → 18402 tokens/s/GPU (1.87x)**.

Reproduce:

```bash
pip install cut-cross-entropy
python bench/loss_bench.py --tokens 4096 16384
```

<details>
<summary>End-to-end check that the two losses agree, on a released model</summary>

`learning_rate=0.0` matters here: with a live LR, four steps on random labels at a 248k vocabulary diverge chaotically between any two numerically-different implementations, so a multi-step comparison says nothing.

```python
import torch, numpy as np
from datasets import Dataset
from trl import SFTConfig, SFTTrainer

ds = Dataset.from_dict({"input_ids": np.random.default_rng(0).integers(0, 200000, size=(24, 512)).tolist()})
for loss_type in ("chunked_nll", "cce"):
    cfg = SFTConfig(
        output_dir="/tmp/cce", per_device_train_batch_size=2, max_steps=1, learning_rate=0.0,
        save_strategy="no", report_to=[], bf16=True, max_length=512, loss_type=loss_type, seed=0,
        dataset_kwargs={"skip_prepare_dataset": True}, remove_unused_columns=False,
        model_init_kwargs=dict(dtype=torch.bfloat16, attn_implementation="sdpa"),
    )
    trainer = SFTTrainer(model="Qwen/Qwen3.5-2B-Base", args=cfg, train_dataset=ds)
    print(loss_type, trainer.train().training_loss)
```

```
chunked_nll 14.087625
cce         14.087476        # rel 1.1e-05
```



And the two loss functions called directly on the same tensors, with and without `num_items_in_batch` (2x512 tokens, 248320 vocab, a masked prompt prefix):

```
num_items_in_batch=None: chunked 12.444077  cce 12.444086  rel 7.7e-07  n_valid 1014 vs 1014
num_items_in_batch=1012: chunked 12.468671  cce 12.468681  rel 8.4e-07  n_valid 1014 vs 1014
```
</details>

<details>
<summary>Gradient accuracy, and why <code>filter_eps</code> is left at its default</summary>

CCE's `filter_eps` drops negligible terms from the backward. Against an fp32-softmax reference
(4096 tokens, 248320 vocab), it makes no measurable difference and turning it off costs 3.2x:

```
filter_eps=high   d_hidden rel 1.032e-02   d_lm_head rel 4.695e-03    23.19 ms
filter_eps=None   d_hidden rel 1.003e-02   d_lm_head rel 4.695e-03    74.66 ms
```

Both sit at the bf16 floor, so the patch keeps the default.
</details>

Under **real FSDP2 on 2xH100** (same model, seq 4096, per-device batch 2), so the option is not just a single-GPU effect:

<img width="1564" height="669" alt="fig_options_fsdp2" src="https://github.com/user-attachments/assets/bf5f0ae0-a4c2-4d38-abf5-66f1edc640a0" />

| config | throughput | peak memory |
|---|---|---|
| TRL defaults | 6413 tokens/s/GPU | 32.3 GB |
| `compile_layers=True` | 7396 (1.15x) | 31.3 GB |
| `loss_type="cce"` | 15453 (2.41x) | 32.3 GB |
| both | **22939 (3.58x)** | **31.3 GB** |

## The trade

CCE returns the loss and nothing else, there are no logits to take an `argmax` or a softmax over, so `mean_token_accuracy` and `entropy` are not logged under `loss_type="cce"`. That is the same trade `use_liger_kernel=True` already makes in TRL, and the metric branches are guarded the same way.

`softcap` and `shift` map onto CCE's own arguments, so `final_logit_softcapping` and pre-shifted `shift_labels` (CP/SP) keep working. `logit_scale` does **not** have a CCE equivalent, so the patch raises rather than silently training on a different loss than the model defines:

```
ValueError: `loss_type='cce'` does not support models with a logit scale (got 0.0625).
Use `loss_type='chunked_nll'` for this model.
```

## Relationship to the chunked-CE projection fix

A companion PR fixes the *default* path (`chunked_nll` currently runs its `lm_head` GEMM in fp32 on bf16 operands) and is worth 1.31–1.54x on its own. Link coming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the SFT loss/forward path (including FSDP2 weight gathering and metric logging) but is opt-in, gated on an extra package, and fails closed on unsupported models.
> 
> **Overview**
> Adds `loss_type="cce"` to `SFTTrainer`: NLL with the `lm_head` fused into Apple’s `cut_cross_entropy` kernel so logits are never materialized and peak memory no longer scales with `vocab_size`.
> 
> It reuses the existing chunked-CE forward patch (`_patch_chunked_ce_lm_head(..., use_cce=True)`). Softcap and pre-shifted `shift_labels` still work; models with `logit_scale` or an `lm_head` bias, Liger, and fp32 hidden states are rejected. Because there are no logits, `mean_token_accuracy` and `entropy` are not logged (same trade as Liger). The model must be loaded in fp16/bf16 — `bf16=True` autocast is not enough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b48570574d741b7d1533b6f0e6f664d67765fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->