### PR TITLE
Add `loss_type="cce"`, a fused linear cross-entropy loaded from the Hub

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1245,6 +1245,31 @@ trainer = SFTTrainer(
 )
 ```
 
+### Cut Your Losses in Large-Vocabulary Language Models
+
+**📜 Paper**: https://huggingface.co/papers/2411.09009
+
+Cut Cross-Entropy (CCE) computes the next-token cross-entropy without ever materializing the logits. A standard loss
+builds a `[num_tokens, vocab_size]` tensor, which for a large vocabulary dominates the memory of a training step. CCE
+instead fuses the `lm_head` projection into the loss, computing each logit tile in on-chip memory and keeping only the
+running log-sum-exp, so peak memory no longer scales with `vocab_size`.
+
+$$
+\mathcal{L}(\theta) = - \sum_t \left[ \textcolor{red}{x_t^\top W_{y_t}} - \log \sum_{v} \exp\left(\textcolor{red}{x_t^\top W_v}\right) \right]
+$$
+
+where the terms in red are recomputed tile by tile rather than stored. To use CCE with SFT, use the `loss_type="cce"`
+argument:
+
+```python
+from trl import SFTConfig
+
+training_args = SFTConfig(
+    loss_type="cce",
+    ...
+)
+```
+
 ### On the Generalization of SFT: A Reinforcement Learning Perspective with Reward Rectification
 
 **📜 Paper**: https://huggingface.co/papers/2508.05629

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ deepspeed = [
 kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
+    "kernels>=0.14.0",  # `get_kernel(trust_remote_code=...)`, needed by loss_type="cce"
 ]
 liger = [
     "liger-kernel>=0.8.2"
@@ -109,6 +110,7 @@ dev = [
     # kernels: transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
+    "kernels>=0.14.0",  # `get_kernel(trust_remote_code=...)`, needed by loss_type="cce"
     # liger
     "liger-kernel>=0.8.2",
     # openreward (requires Python 3.11+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ deepspeed = [
 kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
-    "kernels>=0.14.0",  # `get_kernel(trust_remote_code=...)`, needed by loss_type="cce"
+    # `get_kernel(trust_remote_code=...)`, needed by loss_type="cce". Not in `dev`: the minimum-versions
+    # CI job pins an old transformers, whose `hub-kernels` extra caps `kernels` well below this.
+    "kernels>=0.14.0",
 ]
 liger = [
     "liger-kernel>=0.8.2"
@@ -110,7 +112,6 @@ dev = [
     # kernels: transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
-    "kernels>=0.14.0",  # `get_kernel(trust_remote_code=...)`, needed by loss_type="cce"
     # liger
     "liger-kernel>=0.8.2",
     # openreward (requires Python 3.11+)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -49,6 +49,7 @@ from .testing_utils import (
     ignore_warnings,
     is_ampere_or_newer,
     require_bitsandbytes,
+    require_cut_cross_entropy,
     require_kernels,
     require_liger_kernel,
     require_peft,
@@ -433,6 +434,40 @@ class TestSFTTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the params have changed
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @require_torch_accelerator
+    @require_cut_cross_entropy
+    def test_train_cce_loss(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
+
+        # CCE's backward kernel is half-precision only, so the model has to be loaded in bf16 -- `bf16=True`
+        # alone would not do it, since under autocast the norm feeding the `lm_head` still emits fp32.
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            loss_type="cce",
+            model_init_kwargs={"dtype": "bfloat16"},
+            learning_rate=0.1,  # use higher lr because bf16 updates at the default lr round to zero
+            report_to="none",
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset["train"],
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        # `cce` fuses the projection into the CE kernel, so there are no logits to read these off.
+        assert "mean_token_accuracy" not in trainer.state.log_history[-1]
+        assert "entropy" not in trainer.state.log_history[-1]
 
         # Check that the params have changed
         for n, param in previous_trainable_params.items():

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -49,7 +49,6 @@ from .testing_utils import (
     ignore_warnings,
     is_ampere_or_newer,
     require_bitsandbytes,
-    require_cut_cross_entropy,
     require_kernels,
     require_liger_kernel,
     require_peft,
@@ -441,19 +440,11 @@ class TestSFTTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_torch_accelerator
-    @require_cut_cross_entropy
+    @require_kernels
     def test_train_cce_loss(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
 
-        # CCE's backward kernel is half-precision only, so the model has to be loaded in bf16 -- `bf16=True`
-        # alone would not do it, since under autocast the norm feeding the `lm_head` still emits fp32.
-        training_args = SFTConfig(
-            output_dir=self.tmp_dir,
-            loss_type="cce",
-            model_init_kwargs={"dtype": "bfloat16"},
-            learning_rate=0.1,  # use higher lr because bf16 updates at the default lr round to zero
-            report_to="none",
-        )
+        training_args = SFTConfig(output_dir=self.tmp_dir, loss_type="cce", report_to="none")
         trainer = SFTTrainer(
             model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
             args=training_args,
@@ -465,9 +456,9 @@ class TestSFTTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
-        # `cce` fuses the projection into the CE kernel, so there are no logits to read these off.
-        assert "mean_token_accuracy" not in trainer.state.log_history[-1]
-        assert "entropy" not in trainer.state.log_history[-1]
+        # Both come out of the same fused pass, so they are logged exactly as on the chunked path.
+        assert trainer.state.log_history[-1]["mean_token_accuracy"] is not None
+        assert trainer.state.log_history[-1]["entropy"] is not None
 
         # Check that the params have changed
         for n, param in previous_trainable_params.items():

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2823,6 +2823,7 @@ class TestChunkedCrossEntropyLoss:
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
 
     @require_torch_accelerator
+    @require_kernels
     def test_cce_all_ignored_returns_zero(self):
         """Same contract as the chunked path when every label is ignored, for the fused CCE path.
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2822,6 +2822,32 @@ class TestChunkedCrossEntropyLoss:
         assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
 
+    @require_torch_accelerator
+    def test_cce_all_ignored_returns_zero(self):
+        """Same contract as the chunked path when every label is ignored, for the fused CCE path.
+
+        Every trainable parameter must still receive a gradient — otherwise DDP / FSDP synchronization hangs or
+        errors at the all-reduce step.
+        """
+        from trl.trainer.sft_trainer import _cut_cross_entropy_loss
+
+        hidden, weight, labels = self._inputs(requires_grad=True)
+        hidden = hidden.to(torch_device).to(torch.bfloat16).detach().requires_grad_(True)
+        weight = weight.to(torch_device).to(torch.bfloat16).detach().requires_grad_(True)
+        bias = torch.zeros(self.V, dtype=torch.bfloat16, device=torch_device, requires_grad=True)
+        labels = labels.to(torch_device)
+        labels[:] = -100
+        loss, correct, ent_sum, n_valid = _cut_cross_entropy_loss(hidden, weight, labels, lm_head_bias=bias)
+        assert loss.item() == 0.0
+        assert correct.item() == 0.0
+        assert ent_sum.item() == 0.0
+        assert n_valid.item() == 0
+        assert not torch.isnan(loss)
+        loss.backward()
+        assert hidden.grad is not None and hidden.grad.abs().sum().item() == 0.0
+        assert weight.grad is not None and weight.grad.abs().sum().item() == 0.0
+        assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
+
     def test_shift_labels_matches_labels(self):
         """`shift_labels` path (CP/SP) must match the default `labels` path after external shifting."""
         hidden, weight, labels = self._inputs(ignore_positions=slice(0, 3))

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -50,13 +50,13 @@ from .testing_utils import (
     is_ampere_or_newer,
     require_bitsandbytes,
     require_kernels,
-    require_kernels_trust_remote_code,
     require_liger_kernel,
     require_peft,
     require_torch_accelerator,
     require_torch_multi_accelerator,
     require_vision,
     xfail_data_parallel,
+    xfail_old_kernels,
 )
 
 
@@ -441,7 +441,8 @@ class TestSFTTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_torch_accelerator
-    @require_kernels_trust_remote_code
+    @require_kernels
+    @xfail_old_kernels
     def test_train_cce_loss(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
 
@@ -2824,7 +2825,8 @@ class TestChunkedCrossEntropyLoss:
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
 
     @require_torch_accelerator
-    @require_kernels_trust_remote_code
+    @require_kernels
+    @xfail_old_kernels
     def test_cce_all_ignored_returns_zero(self):
         """Same contract as the chunked path when every label is ignored, for the fused CCE path.
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2826,8 +2826,8 @@ class TestChunkedCrossEntropyLoss:
     def test_cce_all_ignored_returns_zero(self):
         """Same contract as the chunked path when every label is ignored, for the fused CCE path.
 
-        Every trainable parameter must still receive a gradient — otherwise DDP / FSDP synchronization hangs or
-        errors at the all-reduce step.
+        Every trainable parameter must still receive a gradient — otherwise DDP / FSDP synchronization hangs or errors
+        at the all-reduce step.
         """
         from trl.trainer.sft_trainer import _cut_cross_entropy_loss
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -50,6 +50,7 @@ from .testing_utils import (
     is_ampere_or_newer,
     require_bitsandbytes,
     require_kernels,
+    require_kernels_trust_remote_code,
     require_liger_kernel,
     require_peft,
     require_torch_accelerator,
@@ -440,7 +441,7 @@ class TestSFTTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_torch_accelerator
-    @require_kernels
+    @require_kernels_trust_remote_code
     def test_train_cce_loss(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling")
 
@@ -2823,7 +2824,7 @@ class TestChunkedCrossEntropyLoss:
         assert bias.grad is not None and bias.grad.abs().sum().item() == 0.0
 
     @require_torch_accelerator
-    @require_kernels
+    @require_kernels_trust_remote_code
     def test_cce_all_ignored_returns_zero(self):
         """Same contract as the chunked path when every label is ignored, for the fused CCE path.
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import importlib.metadata
 import signal
 import warnings
 from collections.abc import Callable
@@ -20,6 +21,7 @@ from collections.abc import Callable
 import psutil
 import pytest
 import torch
+from packaging.version import Version
 from transformers import is_bitsandbytes_available, is_comet_available, is_sklearn_available, is_wandb_available
 from transformers.testing_utils import backend_device_count, torch_device
 from transformers.utils import (
@@ -49,6 +51,12 @@ require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reaso
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
 require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test requires kernels")
+# `loss_type="cce"` calls `get_kernel(trust_remote_code=...)`, which older `kernels` do not accept. The
+# minimum-versions CI job resolves to 0.9.0, so gate on the version and not just on the import.
+require_kernels_trust_remote_code = pytest.mark.skipif(
+    not is_kernels_available() or Version(importlib.metadata.version("kernels")) < Version("0.14.0"),
+    reason="test requires kernels>=0.14.0",
+)
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")
 require_math_latex = pytest.mark.skipif(not is_math_verify_available(), reason="test requires math_verify")
 require_mergekit = pytest.mark.skipif(not is_mergekit_available(), reason="test requires mergekit")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -34,7 +34,6 @@ from transformers.utils import (
 
 from trl.chat_template_utils import _SUPPORTS_RESPONSE_TEMPLATE
 from trl.import_utils import (
-    is_cut_cross_entropy_available,
     is_harbor_available,
     is_jmespath_available,
     is_joblib_available,
@@ -48,9 +47,6 @@ from trl.import_utils import (
 
 require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reason="test requires bitsandbytes")
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
-require_cut_cross_entropy = pytest.mark.skipif(
-    not is_cut_cross_entropy_available(), reason="test requires cut-cross-entropy"
-)
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
 require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test requires kernels")
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import importlib.metadata
 import signal
 import warnings
 from collections.abc import Callable
@@ -21,11 +20,12 @@ from collections.abc import Callable
 import psutil
 import pytest
 import torch
-from packaging.version import Version
 from transformers import is_bitsandbytes_available, is_comet_available, is_sklearn_available, is_wandb_available
 from transformers.testing_utils import backend_device_count, torch_device
 from transformers.utils import (
-    is_kernels_available,
+    is_kernels_available as is_kernels_installed,
+)
+from transformers.utils import (
     is_peft_available,
     is_rich_available,
     is_torch_available,
@@ -36,9 +36,11 @@ from transformers.utils import (
 
 from trl.chat_template_utils import _SUPPORTS_RESPONSE_TEMPLATE
 from trl.import_utils import (
+    KERNELS_MIN_VERSION,
     is_harbor_available,
     is_jmespath_available,
     is_joblib_available,
+    is_kernels_available,
     is_liger_kernel_available,
     is_math_verify_available,
     is_mergekit_available,
@@ -50,12 +52,14 @@ from trl.import_utils import (
 require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reason="test requires bitsandbytes")
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
-require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test requires kernels")
-# `loss_type="cce"` calls `get_kernel(trust_remote_code=...)`, which older `kernels` do not accept. The
-# minimum-versions CI job resolves to 0.9.0, so gate on the version and not just on the import.
-require_kernels_trust_remote_code = pytest.mark.skipif(
-    not is_kernels_available() or Version(importlib.metadata.version("kernels")) < Version("0.14.0"),
-    reason="test requires kernels>=0.14.0",
+require_kernels = pytest.mark.skipif(not is_kernels_installed(), reason="test requires kernels")
+# `loss_type="cce"` needs `get_kernel(trust_remote_code=...)`. Rather than skip on an older `kernels`,
+# assert that it fails, and fail loudly the day it stops failing (when the pin or the flag goes away).
+xfail_old_kernels = pytest.mark.xfail(
+    not is_kernels_available(),
+    strict=True,
+    raises=ImportError,
+    reason=f"requires kernels>={KERNELS_MIN_VERSION}",
 )
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")
 require_math_latex = pytest.mark.skipif(not is_math_verify_available(), reason="test requires math_verify")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -34,6 +34,7 @@ from transformers.utils import (
 
 from trl.chat_template_utils import _SUPPORTS_RESPONSE_TEMPLATE
 from trl.import_utils import (
+    is_cut_cross_entropy_available,
     is_harbor_available,
     is_jmespath_available,
     is_joblib_available,
@@ -47,6 +48,9 @@ from trl.import_utils import (
 
 require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reason="test requires bitsandbytes")
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
+require_cut_cross_entropy = pytest.mark.skipif(
+    not is_cut_cross_entropy_available(), reason="test requires cut-cross-entropy"
+)
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
 require_kernels = pytest.mark.skipif(not is_kernels_available(), reason="test requires kernels")
 require_liger_kernel = pytest.mark.skipif(not is_liger_kernel_available(), reason="test requires liger-kernel")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -22,9 +22,7 @@ import pytest
 import torch
 from transformers import is_bitsandbytes_available, is_comet_available, is_sklearn_available, is_wandb_available
 from transformers.testing_utils import backend_device_count, torch_device
-from transformers.utils import (
-    is_kernels_available as is_kernels_installed,
-)
+from transformers.utils import is_kernels_available as is_kernels_installed
 from transformers.utils import (
     is_peft_available,
     is_rich_available,

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -57,10 +57,6 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
         return package_exists
 
 
-def is_cut_cross_entropy_available() -> bool:
-    return _is_package_available("cut_cross_entropy")
-
-
 def is_deepspeed_available() -> bool:
     return _is_package_available("deepspeed")
 

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -57,6 +57,10 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
         return package_exists
 
 
+def is_cut_cross_entropy_available() -> bool:
+    return _is_package_available("cut_cross_entropy")
+
+
 def is_deepspeed_available() -> bool:
     return _is_package_available("deepspeed")
 

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from packaging.version import Version
 
 
+KERNELS_MIN_VERSION = "0.14.0"  # first release whose `get_kernel` accepts `trust_remote_code`
 LIGER_KERNEL_MIN_VERSION = "0.8.2"
 PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
 
@@ -71,6 +72,11 @@ def is_jmespath_available() -> bool:
 
 def is_joblib_available() -> bool:
     return _is_package_available("joblib")
+
+
+def is_kernels_available(min_version: str = KERNELS_MIN_VERSION) -> bool:
+    _kernels_available, _kernels_version = _is_package_available("kernels", return_version=True)
+    return _kernels_available and Version(_kernels_version) >= Version(min_version)
 
 
 def is_liger_kernel_available(min_version: str = LIGER_KERNEL_MIN_VERSION) -> bool:

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -108,6 +108,12 @@ class SFTConfig(_BaseConfig):
 
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
+            - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by
+              [cut-cross-entropy](https://github.com/apple/ml-cross-entropy), so peak memory does not scale with
+              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half
+              precision (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since
+              under autocast the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and
+              `entropy` are not logged, since there are no logits to compute them from.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -108,12 +108,8 @@ class SFTConfig(_BaseConfig):
 
             - `"nll"`: standard negative log-likelihood.
             - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
-            - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by
-              [cut-cross-entropy](https://github.com/apple/ml-cross-entropy), so peak memory does not scale with
-              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half precision
-              (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since under autocast
-              the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and `entropy` are not logged,
-              since there are no logits to compute them from.
+            - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by a
+              fused hub kernel, so peak memory does not scale with `vocab_size`. Requires `kernels` to be installed.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -110,10 +110,10 @@ class SFTConfig(_BaseConfig):
             - `"dft"`: Dynamic Fine-Tuning, as described in [this paper](https://huggingface.co/papers/2508.05629).
             - `"cce"`: same math as `"nll"`, but the `lm_head` projection is fused into the cross-entropy kernel by
               [cut-cross-entropy](https://github.com/apple/ml-cross-entropy), so peak memory does not scale with
-              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half
-              precision (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since
-              under autocast the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and
-              `entropy` are not logged, since there are no logits to compute them from.
+              `vocab_size`. Requires `cut_cross_entropy` to be installed, and the model to be loaded in half precision
+              (the kernel's backward is bfloat16/float16 only; `bf16=True` alone is not enough, since under autocast
+              the norm feeding the `lm_head` still emits float32). `mean_token_accuracy` and `entropy` are not logged,
+              since there are no logits to compute them from.
             - `"chunked_nll"`: same math as `"nll"`, but the `lm_head` projection is computed on non-ignored tokens
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -130,13 +130,13 @@ _FUSED_LINEAR_CE_REVISION = "00e29bdf4e142fafa8f558be414c7a9f344d61d0"  # head o
 
 @functools.lru_cache(maxsize=1)
 def _fused_linear_cross_entropy():
-    from kernels import get_kernel
-
     if not is_kernels_available():
         raise ImportError(
             f'`loss_type="cce"` requires kernels>={KERNELS_MIN_VERSION}, whose `get_kernel` accepts '
             "`trust_remote_code`. Install it with `pip install -U kernels`."
         )
+    from kernels import get_kernel
+
     # `trust_remote_code=True` is required until `trustedKernelPublisher` is enabled for `trl-lib` on
     # the Hub. Drop it once it is.
     return get_kernel(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -153,8 +153,8 @@ def _cut_cross_entropy_loss(
     at all. `return_metrics=True` also gets the accuracy and entropy out of the same fused pass: the kernel already
     holds each logit tile while accumulating the log-sum-exp, so no logits have to be materialised to compute them.
 
-    Both are sums over non-ignored positions, matching [`_chunked_cross_entropy_loss`], so the caller can gather
-    across ranks before dividing.
+    Both are sums over non-ignored positions, matching [`_chunked_cross_entropy_loss`], so the caller can gather across
+    ranks before dividing.
 
     Returns:
         `tuple` of the loss, the number of correct tokens, the entropy sum, and the number of non-ignored target

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -121,9 +121,10 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     return chunk_loss, chunk_correct, chunk_entropy
 
 
-# Pinned so a new upload cannot silently change the loss under a running job.
+# Pinned to a commit, not a version: `version=N` resolves to the `vN` *branch*, which moves on every
+# push, so it would not stop a new upload from silently changing the loss under a running job.
 _FUSED_LINEAR_CE_KERNEL = "trl-lib/fused-linear-ce"
-_FUSED_LINEAR_CE_VERSION = 1
+_FUSED_LINEAR_CE_REVISION = "00e29bdf4e142fafa8f558be414c7a9f344d61d0"  # head of the `v1` branch
 
 
 @functools.lru_cache(maxsize=1)
@@ -133,7 +134,7 @@ def _fused_linear_cross_entropy():
     # `trust_remote_code=True` is required until `trustedKernelPublisher` is enabled for `trl-lib` on
     # the Hub. Drop it once it is.
     return get_kernel(
-        _FUSED_LINEAR_CE_KERNEL, version=_FUSED_LINEAR_CE_VERSION, trust_remote_code=True
+        _FUSED_LINEAR_CE_KERNEL, revision=_FUSED_LINEAR_CE_REVISION, trust_remote_code=True
     ).fused_linear_cross_entropy
 
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -189,11 +189,14 @@ def _cut_cross_entropy_loss(
         return loss, correct, entropy_sum, n_valid
 
     with maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+        # Like the chunked projection, the weight can be an fp32 master weight while the hidden states are bf16
+        # (FSDP2 mixed precision reads the sharded weight directly, bypassing the cast its forward hooks apply),
+        # so cast it to the dtype `lm_head`'s own forward would compute in.
         loss, metrics = fused_linear_cross_entropy(
             hidden_states,
-            lm_head_weight,
+            lm_head_weight.to(hidden_states.dtype),
             targets,
-            bias=lm_head_bias,
+            bias=lm_head_bias.to(hidden_states.dtype) if lm_head_bias is not None else None,
             ignore_index=-100,
             logit_scale=logit_scale,
             softcap=final_logit_softcapping,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -122,7 +122,7 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
 
 
 # Pinned so a new upload cannot silently change the loss under a running job.
-_FUSED_LINEAR_CE_KERNEL = "qgallouedec/fused-linear-ce"  # TODO: move to `trl-lib` once the kernel is transferred
+_FUSED_LINEAR_CE_KERNEL = "trl-lib/fused-linear-ce"
 _FUSED_LINEAR_CE_VERSION = 1
 
 
@@ -130,8 +130,8 @@ _FUSED_LINEAR_CE_VERSION = 1
 def _fused_linear_cross_entropy():
     from kernels import get_kernel
 
-    # `trust_remote_code=True` is required while the kernel lives outside an organisation with
-    # `trustedKernelPublisher` enabled on the Hub. Drop it once the repository moves to one.
+    # `trust_remote_code=True` is required until `trustedKernelPublisher` is enabled for `trl-lib` on
+    # the Hub. Drop it once it is.
     return get_kernel(
         _FUSED_LINEAR_CE_KERNEL, version=_FUSED_LINEAR_CE_VERSION, trust_remote_code=True
     ).fused_linear_cross_entropy

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -67,6 +67,7 @@ from ..data_utils import (
     pack_dataset,
     prepare_multimodal_messages,
 )
+from ..import_utils import KERNELS_MIN_VERSION, is_kernels_available
 from ..models import get_act_offloading_ctx_manager
 from .base_trainer import _BaseTrainer
 from .sft_config import SFTConfig
@@ -131,6 +132,11 @@ _FUSED_LINEAR_CE_REVISION = "00e29bdf4e142fafa8f558be414c7a9f344d61d0"  # head o
 def _fused_linear_cross_entropy():
     from kernels import get_kernel
 
+    if not is_kernels_available():
+        raise ImportError(
+            f'`loss_type="cce"` requires kernels>={KERNELS_MIN_VERSION}, whose `get_kernel` accepts '
+            "`trust_remote_code`. Install it with `pip install -U kernels`."
+        )
     # `trust_remote_code=True` is required until `trustedKernelPublisher` is enabled for `trl-lib` on
     # the Hub. Drop it once it is.
     return get_kernel(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -123,10 +123,10 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
 def _cut_cross_entropy_loss(hidden, w, labels, shift_labels, num_items_in_batch, final_logit_softcapping):
     """Next-token cross-entropy that never materialises the logits, via `cut_cross_entropy`.
 
-    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory
-    does not scale with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`]
-    there are no logits to read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable —
-    the same trade `use_liger_kernel=True` already makes.
+    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory does not scale
+    with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`] there are no logits to
+    read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable — the same trade
+    `use_liger_kernel=True` already makes.
 
     Returns:
         `tuple` of the loss and the number of non-ignored target tokens.
@@ -289,9 +289,9 @@ def _patch_chunked_ce_lm_head(
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
         use_cce (`bool`):
-            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it.
-            Peak memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and
-            `entropy_sum`, which need logits and are left as `None`.
+            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it. Peak
+            memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and `entropy_sum`,
+            which need logits and are left as `None`.
         is_vlm (`bool`):
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -169,21 +169,41 @@ def _cut_cross_entropy_loss(
     hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
     targets = targets.reshape(-1)
     n_valid = (targets != -100).sum()
-    loss, metrics = fused_linear_cross_entropy(
-        hidden_states,
-        lm_head_weight,
-        targets,
-        bias=lm_head_bias,
-        ignore_index=-100,
-        logit_scale=logit_scale,
-        softcap=final_logit_softcapping,
-        reduction="sum",
-        return_metrics=True,
-    )
+
+    correct = hidden_states.new_zeros((), dtype=torch.float32)
+    entropy_sum = hidden_states.new_zeros((), dtype=torch.float32)
+    if n_valid == 0:
+        # Whole micro-batch masked (e.g. completion-only loss + truncation). Keep the loss connected
+        # to the autograd graph through every trainable parameter so `.backward()` succeeds and DDP /
+        # FSDP gradient sync doesn't hang on a missing param.
+        with maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+            loss = (hidden_states.float().sum() + lm_head_weight.float().sum()) * 0.0
+            if lm_head_bias is not None:
+                loss = loss + lm_head_bias.float().sum() * 0.0
+        return loss, correct, entropy_sum, n_valid
+
+    with maybe_gather_lm_head_ctx(lm_head_weight, lm_head_bias):
+        loss, metrics = fused_linear_cross_entropy(
+            hidden_states,
+            lm_head_weight,
+            targets,
+            bias=lm_head_bias,
+            ignore_index=-100,
+            logit_scale=logit_scale,
+            softcap=final_logit_softcapping,
+            reduction="sum",
+            return_metrics=True,
+        )
     correct = metrics["num_correct_tokens"]
     entropy_sum = metrics["entropy_sum"]
+
     # `num_items_in_batch` is the global count, matching HF's gradient-accumulation-correct reduction.
-    loss = loss / (num_items_in_batch if num_items_in_batch is not None else n_valid.clamp(min=1))
+    if num_items_in_batch is None:
+        loss = loss / n_valid
+    else:
+        if isinstance(num_items_in_batch, torch.Tensor):
+            num_items_in_batch = num_items_in_batch.to(loss.device)
+        loss = loss / num_items_in_batch
     return loss, correct, entropy_sum, n_valid
 
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -120,6 +120,37 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     return chunk_loss, chunk_correct, chunk_entropy
 
 
+def _cut_cross_entropy_loss(hidden, w, labels, shift_labels, num_items_in_batch, final_logit_softcapping):
+    """Next-token cross-entropy that never materialises the logits, via `cut_cross_entropy`.
+
+    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory
+    does not scale with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`]
+    there are no logits to read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable —
+    the same trade `use_liger_kernel=True` already makes.
+
+    Returns:
+        `tuple` of the loss and the number of non-ignored target tokens.
+    """
+    from cut_cross_entropy import linear_cross_entropy
+
+    targets = shift_labels if shift_labels is not None else torch.roll(labels, shifts=-1, dims=-1)
+    if shift_labels is None:
+        targets[..., -1] = -100
+    hidden = hidden.reshape(-1, hidden.shape[-1])
+    targets = targets.reshape(-1)
+    n_valid = (targets != -100).sum()
+    loss = linear_cross_entropy(
+        hidden,
+        w,
+        targets,
+        ignore_index=-100,
+        softcap=final_logit_softcapping,
+        reduction="sum",
+    )
+    # `num_items_in_batch` is the global count, matching HF's gradient-accumulation-correct reduction.
+    return loss / (num_items_in_batch if num_items_in_batch is not None else n_valid.clamp(min=1)), n_valid
+
+
 def _chunked_cross_entropy_loss(
     hidden_states: torch.Tensor,
     lm_head_weight: torch.Tensor,
@@ -234,7 +265,9 @@ def _chunked_cross_entropy_loss(
     return loss, correct, entropy_sum, n_valid_tensor
 
 
-def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: bool = False) -> None:
+def _patch_chunked_ce_lm_head(
+    model: torch.nn.Module, chunk_size: int, is_vlm: bool = False, use_cce: bool = False
+) -> None:
     """
     Patch `model.forward` to compute the LM loss via [`_chunked_cross_entropy_loss`].
 
@@ -255,6 +288,10 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             `PeftModel.forward` before delegating into the patched forward.
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
+        use_cce (`bool`):
+            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it.
+            Peak memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and
+            `entropy_sum`, which need logits and are left as `None`.
         is_vlm (`bool`):
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss
@@ -327,17 +364,50 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             lm_head_weight = lm_head_weight.full_tensor()
             if lm_head_bias is not None:
                 lm_head_bias = lm_head_bias.full_tensor()
-        loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
-            hidden_states,
-            lm_head_weight,
-            chunk_size,
-            labels=labels,
-            shift_labels=shift_labels,
-            num_items_in_batch=num_items_in_batch,
-            logit_scale=logit_scale,
-            final_logit_softcapping=final_logit_softcapping,
-            lm_head_bias=lm_head_bias,
-        )
+        if use_cce:
+            if logit_scale != 1.0:
+                # `linear_cross_entropy` has no equivalent of `logit_scale`, and silently dropping it would
+                # train on a different loss than the model defines.
+                raise ValueError(
+                    f"`loss_type='cce'` does not support models with a logit scale (got {logit_scale}). "
+                    "Use `loss_type='chunked_nll'` for this model."
+                )
+            if lm_head_bias is not None:
+                # Same reason: `linear_cross_entropy` fuses the projection itself and takes no bias term.
+                raise ValueError(
+                    "`loss_type='cce'` does not support models whose `lm_head` has a bias. "
+                    "Use `loss_type='chunked_nll'` for this model."
+                )
+            if hidden_states.dtype not in (torch.bfloat16, torch.float16):
+                # The CCE backward kernel is half-precision only. Note that `bf16=True` alone does not satisfy this:
+                # under autocast the norm feeding the `lm_head` still emits fp32. The model itself has to be loaded
+                # in half precision, e.g. `model_init_kwargs={"dtype": "bfloat16"}`.
+                raise ValueError(
+                    f"`loss_type='cce'` requires bfloat16 or float16 hidden states, got {hidden_states.dtype}. "
+                    "Load the model in half precision (e.g. `model_init_kwargs={'dtype': 'bfloat16'}`), or use "
+                    "`loss_type='chunked_nll'`."
+                )
+            loss, num_valid_tokens = _cut_cross_entropy_loss(
+                hidden_states,
+                lm_head_weight,
+                labels,
+                shift_labels,
+                num_items_in_batch,
+                final_logit_softcapping,
+            )
+            num_correct_tokens = entropy_sum = None
+        else:
+            loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
+                hidden_states,
+                lm_head_weight,
+                chunk_size,
+                labels=labels,
+                shift_labels=shift_labels,
+                num_items_in_batch=num_items_in_batch,
+                logit_scale=logit_scale,
+                final_logit_softcapping=final_logit_softcapping,
+                lm_head_bias=lm_head_bias,
+            )
 
         aux_loss = None
         if output_router_logits:
@@ -1321,9 +1391,10 @@ class SFTTrainer(_BaseTrainer):
                         "passing a `compute_loss_func` is not allowed."
                     )
                 compute_loss_func = dft_loss
-            elif args.loss_type == "chunked_nll":
-                # Same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the CE is computed in
-                # chunks of tokens. Implemented by patching the model's forward before `super().__init__` so accelerate
+            elif args.loss_type in ("chunked_nll", "cce"):
+                # `"chunked_nll"`: same math as `"nll"` but the `lm_head` matmul is skipped on ignored tokens and the
+                # CE is computed in chunks of tokens. `"cce"`: the projection is fused into the CE kernel instead, so
+                # the logits never exist. Implemented by patching the model's forward before `super().__init__` so accelerate
                 # wraps the patched forward.
                 # For PEFT, patch the inner causal LM rather than the `PeftModel` wrapper. LoRA / IA³ /
                 # `modules_to_save` adapters live in the module tree, so they're hit even when we bypass
@@ -1342,14 +1413,19 @@ class SFTTrainer(_BaseTrainer):
                             "`lm_head` from `target_modules`, or switch to `loss_type='nll'`. If this is a real use "
                             "case for you, please open an issue at https://github.com/huggingface/trl/issues."
                         )
-                _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
+                _patch_chunked_ce_lm_head(
+                    target,
+                    chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE,
+                    is_vlm=self._is_vlm,
+                    use_cce=args.loss_type == "cce",
+                )
             else:
                 raise ValueError(
-                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
-                    "'chunked_nll'."
+                    f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', "
+                    "'chunked_nll', and 'cce'."
                 )
-        elif args.loss_type == "chunked_nll":
-            raise ValueError("`loss_type='chunked_nll'` is not compatible with `use_liger_kernel=True`.")
+        elif args.loss_type in ("chunked_nll", "cce"):
+            raise ValueError(f"`loss_type='{args.loss_type}'` is not compatible with `use_liger_kernel=True`.")
 
         # Transformers explicitly set use_reentrant=True in the past to silence a PyTorch warning, but the default was
         # never updated once PyTorch switched to recommending use_reentrant=False. Until that change lands upstream
@@ -1815,7 +1891,7 @@ class SFTTrainer(_BaseTrainer):
             entropy_sum = self.accelerator.gather_for_metrics(outputs.entropy_sum).sum()
             entropy = (entropy_sum / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["entropy"].append(entropy)
-        elif not self.args.use_liger_kernel:  # liger doesn't return logits
+        elif not self.args.use_liger_kernel and self.args.loss_type != "cce":  # neither returns logits
             with torch.no_grad():
                 if "shift_labels" in inputs:
                     # When using CP or SP, labels are pre-shifted.
@@ -1866,6 +1942,8 @@ class SFTTrainer(_BaseTrainer):
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
         if self.args.loss_type == "chunked_nll":
+            # `"cce"` deliberately has no branch here: fusing the projection into the CE kernel means there are no
+            # logits to take an argmax over, so `mean_token_accuracy` is simply not logged.
             correct = self.accelerator.gather_for_metrics(outputs.num_correct_tokens).sum()
             accuracy = (correct / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["mean_token_accuracy"].append(accuracy)

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import functools
 import inspect
 import json
 import os
@@ -120,35 +121,69 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     return chunk_loss, chunk_correct, chunk_entropy
 
 
-def _cut_cross_entropy_loss(hidden, w, labels, shift_labels, num_items_in_batch, final_logit_softcapping):
-    """Next-token cross-entropy that never materialises the logits, via `cut_cross_entropy`.
+# Pinned so a new upload cannot silently change the loss under a running job.
+_FUSED_LINEAR_CE_KERNEL = "qgallouedec/fused-linear-ce"  # TODO: move to `trl-lib` once the kernel is transferred
+_FUSED_LINEAR_CE_VERSION = 1
 
-    `linear_cross_entropy` fuses the `lm_head` projection into the cross-entropy kernel, so peak memory does not scale
-    with `vocab_size` at all. It returns only the loss: unlike [`_chunked_cross_entropy_loss`] there are no logits to
-    read `mean_token_accuracy` or `entropy` off, so those metrics are unavailable — the same trade
-    `use_liger_kernel=True` already makes.
+
+@functools.lru_cache(maxsize=1)
+def _fused_linear_cross_entropy():
+    from kernels import get_kernel
+
+    # `trust_remote_code=True` is required while the kernel lives outside an organisation with
+    # `trustedKernelPublisher` enabled on the Hub. Drop it once the repository moves to one.
+    return get_kernel(
+        _FUSED_LINEAR_CE_KERNEL, version=_FUSED_LINEAR_CE_VERSION, trust_remote_code=True
+    ).fused_linear_cross_entropy
+
+
+def _cut_cross_entropy_loss(
+    hidden_states: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    labels: torch.Tensor | None = None,
+    shift_labels: torch.Tensor | None = None,
+    num_items_in_batch: torch.Tensor | int | None = None,
+    logit_scale: float = 1.0,
+    final_logit_softcapping: float | None = None,
+    lm_head_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Next-token cross-entropy that never materialises the logits.
+
+    The kernel fuses the `lm_head` projection into the cross-entropy, so peak memory does not scale with `vocab_size`
+    at all. `return_metrics=True` also gets the accuracy and entropy out of the same fused pass: the kernel already
+    holds each logit tile while accumulating the log-sum-exp, so no logits have to be materialised to compute them.
+
+    Both are sums over non-ignored positions, matching [`_chunked_cross_entropy_loss`], so the caller can gather
+    across ranks before dividing.
 
     Returns:
-        `tuple` of the loss and the number of non-ignored target tokens.
+        `tuple` of the loss, the number of correct tokens, the entropy sum, and the number of non-ignored target
+        tokens.
     """
-    from cut_cross_entropy import linear_cross_entropy
+    fused_linear_cross_entropy = _fused_linear_cross_entropy()
 
     targets = shift_labels if shift_labels is not None else torch.roll(labels, shifts=-1, dims=-1)
     if shift_labels is None:
         targets[..., -1] = -100
-    hidden = hidden.reshape(-1, hidden.shape[-1])
+    hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
     targets = targets.reshape(-1)
     n_valid = (targets != -100).sum()
-    loss = linear_cross_entropy(
-        hidden,
-        w,
+    loss, metrics = fused_linear_cross_entropy(
+        hidden_states,
+        lm_head_weight,
         targets,
+        bias=lm_head_bias,
         ignore_index=-100,
+        logit_scale=logit_scale,
         softcap=final_logit_softcapping,
         reduction="sum",
+        return_metrics=True,
     )
+    correct = metrics["num_correct_tokens"]
+    entropy_sum = metrics["entropy_sum"]
     # `num_items_in_batch` is the global count, matching HF's gradient-accumulation-correct reduction.
-    return loss / (num_items_in_batch if num_items_in_batch is not None else n_valid.clamp(min=1)), n_valid
+    loss = loss / (num_items_in_batch if num_items_in_batch is not None else n_valid.clamp(min=1))
+    return loss, correct, entropy_sum, n_valid
 
 
 def _chunked_cross_entropy_loss(
@@ -289,9 +324,8 @@ def _patch_chunked_ce_lm_head(
         chunk_size (`int`):
             Number of valid tokens processed per CE chunk.
         use_cce (`bool`):
-            Fuse the `lm_head` projection into the cross-entropy with `cut_cross_entropy` instead of chunking it. Peak
-            memory then no longer scales with `vocab_size`, at the cost of `num_correct_tokens` and `entropy_sum`,
-            which need logits and are left as `None`.
+            Fuse the `lm_head` projection into the cross-entropy with a hub kernel instead of chunking it. Peak memory
+            then no longer scales with `vocab_size`.
         is_vlm (`bool`):
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss
@@ -365,37 +399,16 @@ def _patch_chunked_ce_lm_head(
             if lm_head_bias is not None:
                 lm_head_bias = lm_head_bias.full_tensor()
         if use_cce:
-            if logit_scale != 1.0:
-                # `linear_cross_entropy` has no equivalent of `logit_scale`, and silently dropping it would
-                # train on a different loss than the model defines.
-                raise ValueError(
-                    f"`loss_type='cce'` does not support models with a logit scale (got {logit_scale}). "
-                    "Use `loss_type='chunked_nll'` for this model."
-                )
-            if lm_head_bias is not None:
-                # Same reason: `linear_cross_entropy` fuses the projection itself and takes no bias term.
-                raise ValueError(
-                    "`loss_type='cce'` does not support models whose `lm_head` has a bias. "
-                    "Use `loss_type='chunked_nll'` for this model."
-                )
-            if hidden_states.dtype not in (torch.bfloat16, torch.float16):
-                # The CCE backward kernel is half-precision only. Note that `bf16=True` alone does not satisfy this:
-                # under autocast the norm feeding the `lm_head` still emits fp32. The model itself has to be loaded
-                # in half precision, e.g. `model_init_kwargs={"dtype": "bfloat16"}`.
-                raise ValueError(
-                    f"`loss_type='cce'` requires bfloat16 or float16 hidden states, got {hidden_states.dtype}. "
-                    "Load the model in half precision (e.g. `model_init_kwargs={'dtype': 'bfloat16'}`), or use "
-                    "`loss_type='chunked_nll'`."
-                )
-            loss, num_valid_tokens = _cut_cross_entropy_loss(
+            loss, num_correct_tokens, entropy_sum, num_valid_tokens = _cut_cross_entropy_loss(
                 hidden_states,
                 lm_head_weight,
-                labels,
-                shift_labels,
-                num_items_in_batch,
-                final_logit_softcapping,
+                labels=labels,
+                shift_labels=shift_labels,
+                num_items_in_batch=num_items_in_batch,
+                logit_scale=logit_scale,
+                final_logit_softcapping=final_logit_softcapping,
+                lm_head_bias=lm_head_bias,
             )
-            num_correct_tokens = entropy_sum = None
         else:
             loss, num_correct_tokens, entropy_sum, num_valid_tokens = _chunked_cross_entropy_loss(
                 hidden_states,
@@ -1882,7 +1895,7 @@ class SFTTrainer(_BaseTrainer):
             raise
 
         # Compute entropy
-        if self.args.loss_type == "chunked_nll":
+        if self.args.loss_type in ("chunked_nll", "cce"):
             # Use `num_valid_tokens` from the patched forward rather than recomputing from `labels`. Prompt-learning
             # PEFT (PromptTuning, P-Tuning) prepends `-100`-padded virtual tokens before delegating into the patched
             # forward, so the valid-token count over the padded labels can differ from the un-padded `labels[..., 1:]`
@@ -1891,7 +1904,7 @@ class SFTTrainer(_BaseTrainer):
             entropy_sum = self.accelerator.gather_for_metrics(outputs.entropy_sum).sum()
             entropy = (entropy_sum / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["entropy"].append(entropy)
-        elif not self.args.use_liger_kernel and self.args.loss_type != "cce":  # neither returns logits
+        elif not self.args.use_liger_kernel:  # liger doesn't return logits
             with torch.no_grad():
                 if "shift_labels" in inputs:
                     # When using CP or SP, labels are pre-shifted.
@@ -1941,9 +1954,7 @@ class SFTTrainer(_BaseTrainer):
             self._total_train_tokens += num_tokens_in_batch
         self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
 
-        if self.args.loss_type == "chunked_nll":
-            # `"cce"` deliberately has no branch here: fusing the projection into the CE kernel means there are no
-            # logits to take an argmax over, so `mean_token_accuracy` is simply not logged.
+        if self.args.loss_type in ("chunked_nll", "cce"):
             correct = self.accelerator.gather_for_metrics(outputs.num_correct_tokens).sum()
             accuracy = (correct / num_valid).item() if num_valid > 0 else 0.0
             self._metrics[mode]["mean_token_accuracy"].append(accuracy)


### PR DESCRIPTION
Adds `SFTConfig(loss_type="cce")`: a fused linear cross-entropy that computes the loss of `hidden @ lm_head.T` without ever materialising the `(tokens, vocab)` logit matrix. The kernel is fetched through [`kernels`](https://github.com/huggingface/kernels), so this adds no pip dependency.

```python
SFTConfig(loss_type="cce")
```

## Benchmark

<!-- figure -->

Stacked on #6863, so the baseline is `chunked_nll` **with the projection fix** (against today's `chunked_nll`, most of the apparent gain would really be the fp32-projection bug #6863 fixes). Same GPU and config per row, 1×H100 unless noted, seq 2048:

| model | mode | vs `chunked_nll` + #6863 | peak VRAM |
|---|---|---|---|
| gemma-3-270m (vocab 262k) | full FT | **1.65x** | 3.1 → 2.6 GB |
| Llama-3.2-1B (vocab 128k) | full FT | 1.33x | 10.3 → 10.3 GB |
| Qwen3-0.6B (vocab 152k) | full FT | 1.32x | 5.2 → 5.2 GB |
| Qwen3-8B | full FT | 1.07x | 61.1 → 61.1 GB |
| Qwen3-8B | LoRA r16, 8k tok/step | 1.06x | 19.7 → 19.7 GB |
| Qwen3-8B | LoRA r16, 2k tok/step | 1.02x | 16.7 → 16.6 GB |
| Qwen3-30B-A3B (MoE) | LoRA r16, FSDP2×EP, 4×H100 | 1.02x | 19.1 → 19.1 GB |

**This is a throughput change, not a memory one**: chunking already bounds the loss memory, and the peak is unchanged at every size measured (on gemma-3-270m at 64k and 128k tokens per step the two are identical to the decimal, while cce is 1.61x faster).

## When it is worth turning on

The gain is the share of the step spent in the `lm_head` projection + cross-entropy, which tracks vocabulary size relative to the rest of the model. Measured against the fixed baseline at 16k tokens per step:

| model | vocab / (layers × hidden) | speedup |
|---|---|---|
| Qwen3-8B | 1.03 | 1.06x |
| Qwen3-0.6B | 5.30 | 1.29x |
| gemma-3-1b | 8.75 | 1.39x |
| gemma-3-270m | 22.76 | **1.76x** |

<!-- figure: ratio -->

Rule of thumb: worth it above a ratio of roughly 5, marginal near 1.

## What it supports

Everything `chunked_nll` does: an `lm_head` bias, a non-unit `logit_scale` (Cohere / Command-R), float32 hidden states, and `final_logit_softcapping`. `mean_token_accuracy` and `entropy` come out of the same fused pass and are logged as usual — unlike `use_liger_kernel=True`, which drops them. `_cut_cross_entropy_loss` takes the same arguments and returns the same 4-tuple as `_chunked_cross_entropy_loss`.

## Correctness

Against `chunked_nll` on `Qwen3-0.6B`, one step at `learning_rate=0.0`:

| | `chunked_nll` | `cce` | rel diff |
|---|---|---|---|
| loss | 6.008524 | 6.006553 | 3.3e-04 |
| entropy | 4.381336 | 4.385639 | 9.8e-04 |

`mean_token_accuracy` differed by one position on that run (a bf16 near-tie argmax flip); with targets set to the true fp32 argmax the kernel reports exact accuracy at `V` = 200000, 32000 and 150000.

## Before merging

- The kernel is at `qgallouedec/fused-linear-ce` and should move to `trl-lib` first — a TRL default should not point at a personal namespace.
- `trust_remote_code=True` is needed until it lives under an organisation with `trustedKernelPublisher` enabled on the Hub.

Both are marked `TODO` in the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in change to the core SFT loss path that loads and executes a pinned remote Hub kernel with trust_remote_code; distributed-training edge cases are explicitly handled and covered by new tests.
> 
> **Overview**
> Adds **`SFTConfig(loss_type="cce")`** for Cut Cross-Entropy SFT: next-token loss is computed with the **`lm_head` fused into a Hub-loaded kernel** (`trl-lib/fused-linear-ce`, pinned revision) so the full **`[tokens × vocab]` logits tensor is never materialized**, targeting better throughput on large-vocabulary models while matching the **`chunked_nll` training path** (forward patch, MoE aux loss, **`mean_token_accuracy`** / **`entropy`** from the same fused pass).
> 
> **`cce`** reuses the existing chunked-CE forward patch via **`use_cce`** on **`_patch_chunked_ce_lm_head`**, with a new **`_cut_cross_entropy_loss`** helper (including an all-**`-100`** labels branch so **DDP/FSDP backward still touches every parameter**). **`kernels>=0.14.0`** is added to the **`kernels`** optional extra; version gating and **`xfail_old_kernels`** tests enforce **`get_kernel(..., trust_remote_code=True)`**. Docs add the CCE paper entry in **`paper_index.md`**. **`cce`** remains incompatible with **`use_liger_kernel=True`** (same as **`chunked_nll`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3bc8f3683293971009dc1794bb2bfb855762e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


