### PR TITLE
Do the chunked-CE `lm_head` projection on tensor cores instead of in fp32

### DIFF
--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -135,6 +135,16 @@ class TestChunkedDivergenceLoss(TrlTestCase):
         torch.testing.assert_close(loss, expected)
         assert n_valid.item() == int(mask.sum().item())
 
+    def test_bf16_hidden_fp32_weight(self):
+        """bf16 hidden states against fp32 `lm_head` weights, as an FSDP2 master weight gathered outside the forward.
+
+        Both projections are covered: the student's and the teacher's, which the loss computes per chunk.
+        """
+        sh, th, sw, tw, mask = self._inputs()
+        loss, _, _ = _chunked_divergence_loss(sh.bfloat16(), th.bfloat16(), sw, tw, mask, beta=0.5, chunk_size=4)
+        expected = _reference_chunked_divergence(sh.bfloat16().float(), th.bfloat16().float(), sw, tw, mask, beta=0.5)
+        torch.testing.assert_close(loss, expected, atol=2e-2, rtol=2e-2)
+
     def test_different_teacher_student_hidden_sizes(self):
         # Teacher and student may have different hidden widths; only the vocabulary must match.
         g = torch.Generator().manual_seed(2)

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -136,10 +136,7 @@ class TestChunkedDivergenceLoss(TrlTestCase):
         assert n_valid.item() == int(mask.sum().item())
 
     def test_bf16_hidden_fp32_weight(self):
-        """bf16 hidden states against fp32 `lm_head` weights, as an FSDP2 master weight gathered outside the forward.
-
-        Both projections are covered: the student's and the teacher's, which the loss computes per chunk.
-        """
+        """A bf16 hidden state against an fp32 `lm_head` weight projects without a dtype mismatch."""
         sh, th, sw, tw, mask = self._inputs()
         loss, _, _ = _chunked_divergence_loss(sh.bfloat16(), th.bfloat16(), sw, tw, mask, beta=0.5, chunk_size=4)
         expected = _reference_chunked_divergence(sh.bfloat16().float(), th.bfloat16().float(), sw, tw, mask, beta=0.5)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2740,7 +2740,7 @@ class TestChunkedCrossEntropyLoss:
         assert n_valid_c.item() == expected_n_valid.item()
 
     def test_bf16_hidden_fp32_weight(self):
-        """A bf16 `h` against an fp32 `w` projects without a dtype mismatch, whatever the caller's autocast state."""
+        """A bf16 hidden state against an fp32 `lm_head` weight projects without a dtype mismatch."""
         hidden, weight, labels = self._inputs()
         loss_c, *_ = _chunked_cross_entropy_loss(hidden.bfloat16(), weight, self.CHUNK_SIZE, labels)
         loss_r, *_ = self._reference(hidden.bfloat16().float(), weight, labels)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2739,6 +2739,13 @@ class TestChunkedCrossEntropyLoss:
         torch.testing.assert_close(ent_sum_c / n_valid_c, ent_r, atol=1e-5, rtol=1e-5)
         assert n_valid_c.item() == expected_n_valid.item()
 
+    def test_bf16_hidden_fp32_weight(self):
+        """A bf16 `h` against an fp32 `w` projects without a dtype mismatch, whatever the caller's autocast state."""
+        hidden, weight, labels = self._inputs()
+        loss_c, *_ = _chunked_cross_entropy_loss(hidden.bfloat16(), weight, self.CHUNK_SIZE, labels)
+        loss_r, *_ = self._reference(hidden.bfloat16().float(), weight, labels)
+        torch.testing.assert_close(loss_c, loss_r, atol=2e-2, rtol=2e-2)
+
     def test_num_items_in_batch_reduction(self):
         """When num_items_in_batch is provided, loss is sum / num_items_in_batch."""
         hidden, weight, labels = self._inputs(ignore_positions=slice(0, 3))

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -225,7 +225,7 @@ def _jsd_loss_chunk(
         are `torch.no_grad()` sums for this chunk only — callers accumulate them across chunks and reduce across ranks,
         exactly as the non-chunked path already did.
     """
-    # Same as the other chunked projections: project in the model dtype, upcast afterwards.
+    # Project in the model dtype and upcast only afterwards, as the other chunked projections do.
     logits = (hidden_chunk @ lm_head_weight.t()).float()
     if lm_head_bias is not None:
         logits = logits + lm_head_bias.float()

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -225,7 +225,8 @@ def _jsd_loss_chunk(
         are `torch.no_grad()` sums for this chunk only — callers accumulate them across chunks and reduce across ranks,
         exactly as the non-chunked path already did.
     """
-    logits = hidden_chunk.float() @ lm_head_weight.float().t()
+    # Same as the other chunked projections: project in the model dtype, upcast afterwards.
+    logits = (hidden_chunk @ lm_head_weight.t()).float()
     if lm_head_bias is not None:
         logits = logits + lm_head_bias.float()
     if logit_scale != 1.0:

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -225,8 +225,9 @@ def _jsd_loss_chunk(
         are `torch.no_grad()` sums for this chunk only — callers accumulate them across chunks and reduce across ranks,
         exactly as the non-chunked path already did.
     """
-    # Project in the model dtype and upcast only afterwards, as the other chunked projections do.
-    logits = (hidden_chunk @ lm_head_weight.t()).float()
+    # Project in the compute dtype and upcast only afterwards, as the other chunked projections do, casting
+    # the weight to the hidden-states dtype in case it is an fp32 master weight (FSDP2 mixed precision).
+    logits = (hidden_chunk @ lm_head_weight.to(hidden_chunk.dtype).t()).float()
     if lm_head_bias is not None:
         logits = logits + lm_head_bias.float()
     if logit_scale != 1.0:

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -225,9 +225,7 @@ def _jsd_loss_chunk(
         are `torch.no_grad()` sums for this chunk only — callers accumulate them across chunks and reduce across ranks,
         exactly as the non-chunked path already did.
     """
-    # Project in the compute dtype and upcast only afterwards, as the other chunked projections do, casting
-    # the weight to the hidden-states dtype in case it is an fp32 master weight (FSDP2 mixed precision).
-    logits = (hidden_chunk @ lm_head_weight.to(hidden_chunk.dtype).t()).float()
+    logits = hidden_chunk.float() @ lm_head_weight.float().t()
     if lm_head_bias is not None:
         logits = logits + lm_head_bias.float()
     if logit_scale != 1.0:

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -112,9 +112,11 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # the backward, never `(chunk, V)`. ZeRO-3 shards the `lm_head`, so gather it tightly around each projection.
     # `logit_scale` (Cohere) / `final_logit_softcapping` (Gemma) are applied per model to match its full forward.
     with maybe_gather_lm_head_ctx(w_s, b_s):
-        # Project in the model dtype and upcast only afterwards, as `"nll"` and `transformers`'
-        # `ForCausalLMLoss` do.
-        student_logits = (h_s @ w_s.t()).float()
+        # Project in the compute dtype and upcast only afterwards, as `"nll"` and `transformers`'
+        # `ForCausalLMLoss` do. The weight can be an fp32 master weight while the hidden states are
+        # bf16 (FSDP2 mixed precision reads the sharded weight directly, bypassing the cast its
+        # forward hooks apply), so cast it to the dtype `lm_head`'s own forward would compute in.
+        student_logits = (h_s @ w_s.to(h_s.dtype).t()).float()
         if b_s is not None:
             student_logits = student_logits + b_s.float()
     if s_scale != 1.0:
@@ -125,7 +127,7 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # and the teacher accumulates no gradients (the teacher params are not frozen by `prepare_model`). Everything
     # downstream inherits this since `teacher_logits` is already detached.
     with maybe_gather_lm_head_ctx(w_t, b_t), torch.no_grad():
-        teacher_logits = (h_t @ w_t.t()).float()
+        teacher_logits = (h_t @ w_t.to(h_t.dtype).t()).float()
         if b_t is not None:
             teacher_logits = teacher_logits + b_t.float()
     if t_scale != 1.0:

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -112,7 +112,10 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # the backward, never `(chunk, V)`. ZeRO-3 shards the `lm_head`, so gather it tightly around each projection.
     # `logit_scale` (Cohere) / `final_logit_softcapping` (Gemma) are applied per model to match its full forward.
     with maybe_gather_lm_head_ctx(w_s, b_s):
-        student_logits = h_s.float() @ w_s.float().t()
+        # Project in the model dtype and upcast only afterwards, as `"nll"` and `transformers`'
+        # `ForCausalLMLoss` do. Upcasting `h_s` and `w_s` first forces a non-tensor-core fp32 GEMM
+        # and materialises an fp32 copy of the whole `lm_head` weight, per chunk.
+        student_logits = (h_s @ w_s.t()).float()
         if b_s is not None:
             student_logits = student_logits + b_s.float()
     if s_scale != 1.0:
@@ -123,7 +126,7 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # and the teacher accumulates no gradients (the teacher params are not frozen by `prepare_model`). Everything
     # downstream inherits this since `teacher_logits` is already detached.
     with maybe_gather_lm_head_ctx(w_t, b_t), torch.no_grad():
-        teacher_logits = h_t.float() @ w_t.float().t()
+        teacher_logits = (h_t @ w_t.t()).float()
         if b_t is not None:
             teacher_logits = teacher_logits + b_t.float()
     if t_scale != 1.0:

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -113,8 +113,7 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # `logit_scale` (Cohere) / `final_logit_softcapping` (Gemma) are applied per model to match its full forward.
     with maybe_gather_lm_head_ctx(w_s, b_s):
         # Project in the model dtype and upcast only afterwards, as `"nll"` and `transformers`'
-        # `ForCausalLMLoss` do. Upcasting `h_s` and `w_s` first forces a non-tensor-core fp32 GEMM
-        # and materialises an fp32 copy of the whole `lm_head` weight, per chunk.
+        # `ForCausalLMLoss` do.
         student_logits = (h_s @ w_s.t()).float()
         if b_s is not None:
             student_logits = student_logits + b_s.float()

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -232,12 +232,14 @@ def _chunked_divergence_loss(
     # gradient-checkpointed chunk loop causes FSDP2 to re-gather it once per chunk during backward recomputation.
     # full_tensor() converts it to a plain tensor once; all chunks reference that tensor, so only one all-gather occurs
     # (in full_tensor()'s backward). Done per model since the student and teacher have their own heads.
+    # Under mixed precision the gathered weight is the fp32 master copy, so cast it to the hidden-states dtype here:
+    # the projection needs it in that dtype, and doing it once beats rebuilding a vocab-sized copy per chunk.
     if isinstance(student_lm_head_weight, torch.distributed.tensor.DTensor):
-        student_lm_head_weight = student_lm_head_weight.full_tensor()
+        student_lm_head_weight = student_lm_head_weight.full_tensor().to(student_hidden_states.dtype)
         if student_lm_head_bias is not None:
             student_lm_head_bias = student_lm_head_bias.full_tensor()
     if isinstance(teacher_lm_head_weight, torch.distributed.tensor.DTensor):
-        teacher_lm_head_weight = teacher_lm_head_weight.full_tensor()
+        teacher_lm_head_weight = teacher_lm_head_weight.full_tensor().to(teacher_hidden_states.dtype)
         if teacher_lm_head_bias is not None:
             teacher_lm_head_bias = teacher_lm_head_bias.full_tensor()
 

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -112,10 +112,9 @@ def _chunk(h_s, w_s, b_s, s_scale, s_softcap, h_t, w_t, b_t, t_scale, t_softcap,
     # the backward, never `(chunk, V)`. ZeRO-3 shards the `lm_head`, so gather it tightly around each projection.
     # `logit_scale` (Cohere) / `final_logit_softcapping` (Gemma) are applied per model to match its full forward.
     with maybe_gather_lm_head_ctx(w_s, b_s):
-        # Project in the compute dtype and upcast only afterwards, as `"nll"` and `transformers`'
-        # `ForCausalLMLoss` do. The weight can be an fp32 master weight while the hidden states are
-        # bf16 (FSDP2 mixed precision reads the sharded weight directly, bypassing the cast its
-        # forward hooks apply), so cast it to the dtype `lm_head`'s own forward would compute in.
+        # Project in the compute dtype and upcast only for the softmax, like `"nll"` and
+        # `transformers`' own `ForCausalLMLoss` do. Matching the weight to the hidden-states dtype keeps the
+        # matmul in that dtype, which is what `lm_head`'s own forward computes in.
         student_logits = (h_s @ w_s.to(h_s.dtype).t()).float()
         if b_s is not None:
             student_logits = student_logits + b_s.float()

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -232,8 +232,8 @@ def _chunked_divergence_loss(
     # gradient-checkpointed chunk loop causes FSDP2 to re-gather it once per chunk during backward recomputation.
     # full_tensor() converts it to a plain tensor once; all chunks reference that tensor, so only one all-gather occurs
     # (in full_tensor()'s backward). Done per model since the student and teacher have their own heads.
-    # Under mixed precision the gathered weight is the fp32 master copy, so cast it to the hidden-states dtype here:
-    # the projection needs it in that dtype, and doing it once beats rebuilding a vocab-sized copy per chunk.
+    # Under mixed precision the teacher's gathered weight is still the fp32 master copy, so cast to the
+    # hidden-states dtype here: once, rather than rebuilding a vocab-sized copy per chunk.
     if isinstance(student_lm_head_weight, torch.distributed.tensor.DTensor):
         student_lm_head_weight = student_lm_head_weight.full_tensor().to(student_hidden_states.dtype)
         if student_lm_head_bias is not None:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -100,9 +100,11 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
 
 def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     with maybe_gather_lm_head_ctx(w, b):
-        # Project in the model dtype and upcast only for the softmax, like `"nll"` and
-        # `transformers`' own `ForCausalLMLoss` do.
-        logits = (h @ w.t()).float()
+        # Project in the compute dtype and upcast only for the softmax, like `"nll"` and
+        # `transformers`' own `ForCausalLMLoss` do. `w` can be an fp32 master weight while `h` is
+        # bf16 (FSDP2 mixed precision reads the sharded weight directly, bypassing the cast its
+        # forward hooks apply), so cast it to the dtype `lm_head`'s own forward would compute in.
+        logits = (h @ w.to(h.dtype).t()).float()
         if b is not None:
             logits = logits + b.float()
     if logit_scale != 1.0:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -101,8 +101,7 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
 def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     with maybe_gather_lm_head_ctx(w, b):
         # Project in the model dtype and upcast only for the softmax, like `"nll"` and
-        # `transformers`' own `ForCausalLMLoss` do. Upcasting `h` and `w` first would force a
-        # non-tensor-core fp32 GEMM and materialize an fp32 copy of the whole `lm_head` weight.
+        # `transformers`' own `ForCausalLMLoss` do.
         logits = (h @ w.t()).float()
         if b is not None:
             logits = logits + b.float()

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -100,7 +100,10 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
 
 def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     with maybe_gather_lm_head_ctx(w, b):
-        logits = h.float() @ w.float().t()
+        # Project in the model dtype and upcast only for the softmax, like `"nll"` and
+        # `transformers`' own `ForCausalLMLoss` do. Upcasting `h` and `w` first would force a
+        # non-tensor-core fp32 GEMM and materialize an fp32 copy of the whole `lm_head` weight.
+        logits = (h @ w.t()).float()
         if b is not None:
             logits = logits + b.float()
     if logit_scale != 1.0:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -101,9 +101,8 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
 def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     with maybe_gather_lm_head_ctx(w, b):
         # Project in the compute dtype and upcast only for the softmax, like `"nll"` and
-        # `transformers`' own `ForCausalLMLoss` do. `w` can be an fp32 master weight while `h` is
-        # bf16 (FSDP2 mixed precision reads the sharded weight directly, bypassing the cast its
-        # forward hooks apply), so cast it to the dtype `lm_head`'s own forward would compute in.
+        # `transformers`' own `ForCausalLMLoss` do. Matching the weight to the hidden-states dtype keeps the
+        # matmul in that dtype, which is what `lm_head`'s own forward computes in.
         logits = (h @ w.to(h.dtype).t()).float()
         if b is not None:
             logits = logits + b.float()

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -322,6 +322,7 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
         # into the gradient-checkpointed chunk loop causes FSDP2 to re-gather it once per chunk
         # during backward recomputation. full_tensor() converts it to a plain tensor once; all
         # chunks reference that tensor, so only one all-gather occurs (in full_tensor()'s backward).
+        # `_chunk` casts the weight to the hidden-states dtype per chunk.
         if isinstance(lm_head_weight, torch.distributed.tensor.DTensor):
             lm_head_weight = lm_head_weight.full_tensor()
             if lm_head_bias is not None:


### PR DESCRIPTION
`_chunk` in `sft_trainer.py`, the inner loop of the **default** `loss_type="chunked_nll"` does

https://github.com/huggingface/trl/blob/6d484baed4db18c2799b9d5b32c2520cba6b4df2/trl/trainer/sft_trainer.py#L101

Both operands are already the model dtype (bf16), so upcasting them buys no information; it just moves the GEMM off the tensor cores onto the fp32 SIMT path and materialises an fp32 copy of the entire `lm_head` weight. For a 248,320-token vocabulary that copy is **2.03 GB**, rebuilt for every chunk and again on every gradient-checkpoint recompute.

```python
logits = (h @ w.t()).float()
```

is what `loss_type="nll"` already gets (the model applies `lm_head` in bf16 and `ForCausalLMLoss` upcasts afterwards), and what the docstring for `chunked_nll` already claims ("same math as `nll`").

## The same pattern is in the distillation trainers

`DistillationTrainer._chunk` pays it **twice per chunk**: once for the student and once for the teacher. Both are fixed here. The experimental async distillation trainer has a third copy, left alone: its projection runs outside `accelerator.autocast()`, so a bf16 GEMM there needs the weight cast explicitly, and that is not worth the risk in experimental code.

`trl/trainer/utils.py:1446` looks similar and is deliberately **not** touched:

```python
grad_hidden.add_(grad_logits @ w_chunk.float())
```

there `grad_logits` genuinely is fp32, so that upcast is important.

Only the SFT path is benchmarked below; the distillation change is mechanically identical and numerically free for the same reason, but I have not measured its speedup. Its test suite is green:

## Numbers

One chunk, 256 tokens × vocab 248,320 × hidden 2048, 1×H100, bf16, fwd+bwd):

| | fwd+bwd | peak mem |
|---|---|---|
| current (`h.float() @ w.float().t()`) | 23.37 ms | 5.99 GB |
| **this PR** | **3.86 ms (6.0×)** | **3.03 GB** |

In an 8×H100 profile of `trl sft` on Qwen3.6-35B-A3B (FSDP2, seq 4096, per-device batch 4, LoRA), the two fp32 SIMT GEMM kernels (`sm80_xmma_gemm_f32f32_f32f32_f32_tn_n_...ffma`, `cutlass_80_simt_sgemm_...`) account for **985 ms of a 4.57 s step (21.6% of all GPU kernel time) in 192 launches averaging 5.1 ms each.**

End to end, on four released models, 16384 tokens per step, `loss_type="chunked_nll"` throughout:

| model | mode | today | this PR | |
|---|---|---|---|---|
| gemma-3-270m (vocab 262k) | full FT, 1×H100 | 24036 | **31609** | 1.32× |
| Qwen3-0.6B (vocab 152k) | full FT, 1×H100 | 21276 | **26641** | 1.25× |
| Qwen3-8B | full FT, 2×H100 FSDP2 | 3554 | **6009** | **1.69×** |
| Qwen3-8B | LoRA r16, 2×H100 FSDP2 | 4531 | **7125** | **1.57×** |
| Qwen3-30B-A3B (MoE) | LoRA attn, 2×H100 FSDP2 | 4251 | **5101** | 1.20× |

<img width="1258" height="867" alt="fig_pr7" src="https://github.com/user-attachments/assets/0a8a79e3-6b3f-4e91-a489-9185acd6a393" />

tokens/s/GPU, at 16k tokens per step. The win grows with `hidden_size`, because that is what sets the fp32 GEMM's cost relative to the rest of the step. Which is why the
- 8B gains most and
- the MoE, whose 3B active parameters per token make the rest of the step cheap relative to its `hidden=2048` projection, gains least.

## Numerics

The projection now computes what `nll` computes, which is what the `chunked_nll` docstring already promises. Whether that shifts your loss curve depends on whether autocast covers the projection.

**Under accelerate mixed precision it does not.** `_chunk` runs inside autocast (the patch is applied before `super().__init__()`, so accelerate wraps the patched forward), and `matmul` is on autocast's lower-precision list, so autocast casts the explicitly `.float()`-ed operands straight back down to bf16. main is already on tensor cores there, and this PR only removes the wasted fp32 materialisation. One step at `learning_rate=0.0`, gradients captured before `zero_grad` and compared in fp32:

```
Qwen3-0.6B (vocab 152k)
  loss main=6.00852442  pr7=6.00852442
  params compared: 310
  global gradient relative difference: 0.00e+00
  worst per-parameter: 0.00e+00

gemma-3-270m (vocab 262k)
  loss main=5.02741528  pr7=5.02741528
  params compared: 236
  global gradient relative difference: 0.00e+00
  worst per-parameter: 0.00e+00
```

Bit-identical, so that run measures the memory saving and not the kernel change.

**Without autocast over the projection** (bf16 model, `mixed_precision` off) the GEMM does move from the fp32 SIMT path to bf16 tensor cores. That is the configuration the 21.6% profile above comes from, and there the numerics do change: logits round to bf16 before the softmax, and the backward `grad_hidden` / `grad_weight` matmuls run in bf16 rather than fp32. That is exactly what `loss_type="nll"` already does, but loss curves in that configuration will shift by bf16 rounding.

## Why this matters for the `cce` PR

#6859
When measured against this "fixed" baseline instead of today's default, `loss_type="cce"` adds only **1.06×** on Qwen3-8B (both full finetune and LoRA), against the 1.80×/1.66× it shows versus the unfixed path.
Nearly all of that apparent gain is this bug! `cce` still earns its place on models whose vocabulary is large relative to their size (1.76× on gemma-3-270m over the fixed baseline)

<img width="1258" height="744" alt="image" src="https://github.com/user-attachments/assets/6a995cd1-936a-4077-91f2-073596c09f0e" />

`AsyncDistillationTrainer` keeps the fp32 projection for now: its chunk runs outside `accelerator.autocast()`, so the dtype path there differs from these three and gets its own follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `chunked_nll` training hot path and distillation JSD projection; numerics can shift when mixed precision does not autocast the matmul, though behavior is aligned with `nll`.
> 
> **Overview**
> **Chunked cross-entropy and distillation losses** no longer upcast hidden states and `lm_head` weights to fp32 before the vocabulary GEMM. Projection is `(h @ w.to(h.dtype).t()).float()`, matching `loss_type="nll"` and Transformers’ causal LM loss: matmul runs in the hidden-state dtype (e.g. bf16 on tensor cores), then logits are fp32 only for softmax/CE.
> 
> On **FSDP2**, after `full_tensor()` on sharded `lm_head` weights, distillation now casts gathered fp32 master weights to the hidden dtype once instead of per-chunk fp32 copies.
> 
> **Tests** add `test_bf16_hidden_fp32_weight` for SFT chunked CE and distillation chunked JSD to cover bf16 activations with fp32 `lm_head` weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4eab6dd174d9cfe4c98af855a2c62bdd6e5096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

