### PR TITLE
pin fastapi>=0.133 in vllm extra to match vllm requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
 ]
 vllm = [
     "vllm>=0.18.0,<=0.27.1",
-    "fastapi",
+    "fastapi>=0.133",  # match vllm>=0.26 requirement; unconstrained fastapi breaks vllm-serve with starlette 1.x
     "pydantic",
     "aiohttp>=3.13.3",
     "requests",


### PR DESCRIPTION
## Problem

`trl[vllm]` declares an unconstrained `fastapi` in its vllm extra.  vllm's own metadata requires `fastapi>=0.133,<0.137` (and `starlette>=1.0.1`).  In an environment where an older fastapi is already installed (e.g. fastapi 0.110.x, which pins `starlette<0.38`), resolving/installing vllm in the same venv can silently leave a broken combination:

- fastapi 0.110.3 + starlette 1.6.0 → `trl vllm-serve` crashes at startup with
  `TypeError: Router.__init__() got an unexpected keyword argument 'on_startup'` (starlette 1.x removed that kwarg; old fastapi still passes it internally).

We hit exactly this on a shared 2xRTX6000D box (trl 1.10.0 + vllm 0.26.0) and the failure is confusing because nothing in the traceback mentions trl or the version conflict.

## Fix

Pin `fastapi>=0.133` in the vllm extra, matching vllm's own floor (vllm>=0.18...0.27.1 all require >=0.133).  The upper bound is left to vllm's constraint (`<0.137`), so this is purely a floor alignment.  With the constraint in place, a resolver in a dirty venv upgrades fastapi instead of leaving a broken pair.

Minimal repro (observed on autodl2):

```
pip install fastapi==0.110.3 trl[vllm] vllm==0.26.0   # or any order that keeps fastapi at 0.110
trl vllm-serve --model <any>                          # TypeError at FastAPI() construction
```

With the pin, the resolver upgrades fastapi to >=0.133 and `trl vllm-serve` starts normally.

Note: I filed no separate issue since this is a one-line dependency alignment; happy to open one if maintainers prefer a discussion first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line optional-dependency floor; no runtime or security logic changes.
> 
> **Overview**
> Aligns the `vllm` extra so `fastapi` is at least `0.133`, matching vLLM’s own floor.
> 
> This stops pip from leaving an old FastAPI (e.g. 0.110) next to Starlette 1.x, which made `trl vllm-serve` crash with `Router.__init__() got an unexpected keyword argument 'on_startup'`. The upper bound stays with vLLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf132fbe277a752fb264071af6f784ffb00553e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->