### PR TITLE
pin fastapi>=0.133 in vllm extra to match vllm requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
 ]
 vllm = [
     "vllm>=0.18.0,<=0.27.1",
-    "fastapi",
+    "fastapi>=0.133",  # match vllm>=0.26 requirement; unconstrained fastapi breaks vllm-serve with starlette 1.x
     "pydantic",
     "aiohttp>=3.13.3",
     "requests",


### PR DESCRIPTION
## What does this PR do?

Pins `fastapi>=0.133` in the `[vllm]` extra.  vllm's own metadata already requires `fastapi>=0.133,<0.137` (and `starlette>=1.0.1`); leaving trl's fastapi unconstrained lets a resolver in a dirty venv keep an old fastapi (e.g. 0.110.3, which pins `starlette<0.38`) next to a re-resolved vllm, producing a broken pair where `trl vllm-serve` crashes at startup:

```
TypeError: Router.__init__() got an unexpected keyword argument 'on_startup'
```

(starlette 1.x removed that kwarg; old fastapi still passes it internally.)  Observed on a shared 2xRTX6000D box with trl 1.10.0 + vllm 0.26.0.  The pin is a floor alignment only — the upper bound stays with vllm's own constraint, and a resolver in a dirty venv now upgrades fastapi instead of leaving the broken pair.

Fixes: (no issue filed; one-line dependency alignment)

## Before submitting

- [x] This PR fixes a typo or improves docs (you can dismiss the other checks if that's the case)
- [x] I have read the contribution guidelines: https://huggingface.co/docs/trl/contributing
- [x] This change was discussed in an issue (link): no — one-line dependency floor alignment matching vllm's own declared requirement
- [x] Documentation was updated, if needed: no docs change needed (dependency metadata only)
- [x] Any new necessary tests were written: dependency metadata change; CI (install + tests) validates it

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line optional-dependency floor with no runtime or security logic changes.
> 
> **Overview**
> Pins `fastapi>=0.133` in the `[vllm]` extra so it matches vLLM’s own requirement.
> 
> Without a floor, a dirty env can keep an old FastAPI next to a newer vLLM/Starlette 1.x pair, which breaks `trl vllm-serve` at startup (`Router.__init__` / `on_startup`). The upper bound remains vLLM’s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf132fbe277a752fb264071af6f784ffb00553e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->