### PR TITLE
Align Python version in the experimental tests workflow

### DIFF
--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -21,10 +21,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Set up Python 3.13
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: 3.13
+          python-version: '3.12'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files
@@ -43,10 +43,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: 3.13
+          python-version: '3.12'
 
       - name: Install Make and Git
         run: |


### PR DESCRIPTION
This PR aligns the Python version used by the experimental tests workflow with the one used by all other test workflows.

Follow-up to #6763.

### Motivation

#6763 established a single Python version for PR CI: PRs test 3.12 only, and the other supported versions (3.10, 3.11, 3.13, 3.14) moved to the nightly `tests_python_versions.yml` matrix on `main`.

The experimental tests workflow was not updated to follow that policy and still runs on Python 3.13, making it the only PR workflow that does not use 3.12. It has been on 3.13 since it was introduced in #4330, without a stated reason.

No coverage is lost: Python 3.13 remains covered by the nightly matrix.

### Changes

- Set the Python version to 3.12 in the code quality and tests jobs of the experimental tests workflow
- Quote the version value, consistent with the other workflows and avoiding the YAML float pitfall

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Python version pin with no application, security, or data-handling changes.
> 
> **Overview**
> Switches `tests-experimental.yml` code quality and test jobs from Python **3.13** to **3.12**, matching other PR CI workflows.
> 
> The version is quoted as `'3.12'` to avoid YAML treating it as a float. Python 3.13 coverage stays on the nightly matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874d0b8703df44c3e7ce927028ec162041f982b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->