### PR TITLE
Quote python-version value in the tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: 3.12
+          python-version: '3.12'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files


### PR DESCRIPTION
This PR quotes the `python-version` value in the tests workflow, making it consistent with every other `setup-python` usage in the repository.

Follow-up to #6881.

### Motivation

In YAML, an unquoted `3.12` is parsed as a float rather than a string. It happens to work here, but it is the classic pitfall behind versions such as `3.10` silently becoming `3.1`. Every other `setup-python` usage in the repository already quotes the value.

### Changes

- Quote the `python-version` value in the code quality job of the tests workflow, the only remaining unquoted occurrence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line CI YAML quoting change with no runtime or security impact.
> 
> **Overview**
> Quotes `python-version` as `'3.12'` in the `check_code_quality` job of `tests.yml`.
> 
> This matches other `setup-python` usages and avoids YAML parsing the version as a float.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fec6cab1112ff2011a618ef6ef45798f9e5d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->