### PR TITLE
Pin Python version in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Debug - Show version.txt content
         run: echo "Version is ${{ steps.get_version.outputs.version }}"
 
-      - name: Set up Python
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: "3.x"
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR pins the Python version used to build and publish the package, instead of tracking whatever the runner image provides.

Follow-up to #6881 and #6882.

### Motivation

The publish workflow requested `3.x`, which resolves to the newest Python available on the GitHub runner image. That version changes without any action on our side, so a runner image update can silently change the interpreter that builds a release, along with the `pip`, `build` and `setuptools` versions that come with it. A release build is the last place where we want an environment we did not choose.

Pinning to 3.12 also makes the workflow consistent with the rest of CI, where 3.12 is the single version used since #6763.

TRL is a pure Python package built with setuptools, so the resulting wheel is `py3-none-any` and is not affected by the interpreter used to build it. This change only makes the build environment predictable.

### Changes

- Pin the Python version to 3.12 in the publish workflow
- Name the setup step after the version it installs, consistent with the other workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pin of the Python version used to build a pure-Python wheel; no application, auth, or package-content changes.
> 
> **Overview**
> Pins the PyPI publish workflow to **Python 3.12** instead of `3.x`, so the interpreter used to build and upload packages no longer tracks whatever the runner image currently ships.
> 
> The setup step is renamed to `Set up Python 3.12` to match other CI workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6271af74426eed4b71258c2e83c1bd34cf46f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->