### PR TITLE
Set up Python explicitly in the slow tests workflow

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y make git curl
@@ -81,6 +86,11 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
This PR makes the slow tests workflow set up Python explicitly, like every other test workflow, instead of relying on the interpreter that happens to ship in the Docker image.

Follow-up to #6881, #6882 and #6883.

### Motivation

The slow tests workflow was the only test workflow without a `Set up Python` step. Its jobs went straight from checkout to `uv venv`, so the virtual environment was built on the container interpreter rather than on a version we choose.

The effect is visible in the run logs. In the slow tests:

```
Using CPython 3.11.13 interpreter at: /opt/conda/bin/python3
platform linux -- Python 3.11.13, pytest-9.1.1
```

while every job of the tests workflow runs:

```
Using CPython 3.12.14 interpreter at: /__w/_tool/Python/3.12.14/x64/bin/python3
platform linux -- Python 3.12.14, pytest-9.1.1
```

So the slow tests, which are the ones exercising the heaviest and least frequently run code paths, were the only ones running on a version that is not the version the project targets on pull requests since #6763. Worse, that version was implicit: bumping the Docker image would silently change the interpreter used by the slow tests.

The virtual environment is isolated and resolves its own dependencies from PyPI, `torch` included, so the image only provides the CUDA system libraries and the Python version is decided solely by the presence of this step.

### Solution

Add the same `Set up Python 3.12` step used by the other workflows to both slow tests jobs, placed after checkout so that `uv venv` picks it up. Both jobs now follow the exact same step sequence as the tests workflow.

### Changes

- Set up Python 3.12 explicitly in the single GPU and multi GPU slow tests jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application, auth, or data-handling code is modified.
> 
> **Overview**
> Adds an explicit `Set up Python 3.12` step to both single-GPU and multi-GPU jobs in `slow-tests.yml`, matching the other test workflows.
> 
> `uv venv` now uses the chosen 3.12 interpreter instead of the container’s implicit 3.11, so slow tests run on the same Python version as PR tests and no longer change silently when the Docker image is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c4542daf98c823c0032ca0dcad108bb1299e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->