### PR TITLE
Inline the pre-commit action in the code quality jobs

### DIFF
--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -31,10 +31,11 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
       - name: Run pre-commit
-        run: |
-          python -m pip install pre-commit
-          pre-commit run --all-files --show-diff-on-failure --color=always
+        run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   tests:
     name: Tests (experimental)

--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -25,9 +25,16 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: 3.13
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          extra_args: --all-files
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure --color=always
 
   tests:
     name: Tests (experimental)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,10 +42,11 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
       - name: Run pre-commit
-        run: |
-          python -m pip install pre-commit
-          pre-commit run --all-files --show-diff-on-failure --color=always
+        run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   tests:
     name: Tests with latest dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,16 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: 3.12
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          extra_args: --all-files
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure --color=always
 
   tests:
     name: Tests with latest dependencies


### PR DESCRIPTION
This PR replaces the third party `pre-commit/action` with the four steps it is made of, so that the code quality jobs stop emitting a Node.js deprecation warning and no longer depend on an action that is no longer developed.

### Motivation

Every run of the code quality job produces this warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

It is the only annotation on the job. The cause is not one of our pins: `pre-commit/action` internally uses `actions/cache@v4`, which declares `using: 'node20'`, while `actions/cache` v6 declares `using: 'node24'`.

That reference is out of our reach. It lives inside the third party action, so Dependabot cannot bump it, and pinning `pre-commit/action` to a newer SHA would not help either, because upstream has not updated it. Upstream is explicit that it will not:

> this action is in maintenance-only mode and will not be accepting new features

So as long as we consume the action, the warning stays, and the runners are being forced onto Node.js 24 anyway. The only way to control that reference is to stop going through the action.

There is little to lose by doing so, because the action is a thin wrapper. This is its entire definition:

```yaml
runs:
  using: composite
  steps:
  - run: python -m pip install pre-commit
    shell: bash
  - run: python -m pip freeze --local
    shell: bash
  - uses: actions/cache@v4
    with:
      path: ~/.cache/pre-commit
      key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
  - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
    shell: bash
```

Four steps, one of which is a `pip freeze` debug call. Inlining it removes a dependency rather than adding one, and it lets us pin `actions/cache` by SHA like every other action in the repository. As a nested reference, `actions/cache@v4` was in fact the only mutable action ref we were still resolving in these jobs.

### Solution

Inline the steps that matter, cache, install and run, and drop the `pip freeze` debug step, keeping the same one step per action granularity as the rest of our workflows. Behaviour is otherwise unchanged: same `pre-commit run --all-files --show-diff-on-failure --color=always` invocation, and the cache key is kept identical so existing cache entries stay valid.

### Changes

- Replace `pre-commit/action` with a cache step, an install step and a run step in the code quality job of the tests and experimental tests workflows
- Pin `actions/cache` to v6.1.0, which targets Node.js 24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with equivalent pre-commit behavior; no application or security logic is affected.
> 
> **Overview**
> Replaces the unmaintained `pre-commit/action` in the code quality jobs of `tests.yml` and `tests-experimental.yml` with explicit cache, install, and run steps.
> 
> Pins `actions/cache` to v6.1.0 (Node 24) so the jobs no longer inherit the action’s nested `actions/cache@v4` Node 20 deprecation. Pre-commit invocation and cache key stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83566d1601ce9347a4075f28437afc148610e803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->