### PR TITLE
Build the GRPO VLM test images as PIL images to avoid a datasets downcast warning

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4732,15 +4732,21 @@ class TestGRPOTrainerSlow(TrlTestCase):
         - Gradient checkpointing and bfloat16
         """
 
+        from PIL import Image as PILImage
+
         # Create processor once outside the data generator
         processor = AutoProcessor.from_pretrained(model_name, use_fast=True, padding_side="left")
         prompt = [{"role": "user", "content": "What is in the image?"}]
 
+        # Build the images as PIL images: an array column is stored as nested lists, and casting it to Image reads it
+        # back as int64, which makes datasets warn about downcasting to uint8
         dataset = Dataset.from_list(
             [
                 {
                     "prompt": prompt,
-                    "image": np.random.uniform(low=0.0, high=255.0, size=(64, 64, 3)).astype(np.uint8),
+                    "image": PILImage.fromarray(
+                        np.random.uniform(low=0.0, high=255.0, size=(64, 64, 3)).astype(np.uint8)
+                    ),
                 }
                 for _ in range(4)
             ],


### PR DESCRIPTION
This PR removes the `datasets` downcast `UserWarning` emitted by the slow GRPO VLM training test.

Fix #6888.

### Motivation

Since the slow tests moved from T4 to L40S in #6741, `test_vlm_training` is no longer skipped by its Ampere-or-newer gate, and CI emits:

```
tests/test_grpo_trainer.py::TestGRPOTrainerSlow::test_vlm_training[HuggingFaceTB/SmolVLM-Instruct]
  /__w/trl/trl/.venv/lib/python3.12/site-packages/datasets/features/image.py:397: UserWarning: Downcasting array dtype int64 to uint8 to be compatible with 'Pillow'
    warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
```

The array the test builds is already `uint8`. Since #5550 the dataset is built with `Dataset.from_list` and no feature spec, so the images are stored as nested lists and `cast_column("image", Image())` reads them back as Python integers, which `numpy` turns into `int64`, prompting `datasets` to warn about a downcast the data never needed.

The misleading message is reported upstream in https://github.com/huggingface/datasets/issues/8511, but the round-trip is avoidable on our side.

### Solution

Build the test images as PIL images. `datasets` then encodes them when the dataset is created, so the cast to the `Image` feature takes the struct path and no array dtype is ever inferred. This works with every supported `datasets` version, down to the `>=4.7.0` floor, and matches the way other tests in this file build images.

### Changes

- Build the images of the GRPO VLM slow test with `PIL.Image.fromarray` instead of passing raw arrays, with a comment explaining why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change with no production, security, or training-logic impact.
> 
> **Overview**
> Stops a `datasets` downcast `UserWarning` in the slow GRPO VLM training test by wrapping synthetic images with `PIL.Image.fromarray` before `Dataset.from_list` / `cast_column("image", Image())`.
> 
> Raw uint8 arrays were stored as nested lists and read back as int64, so the Image feature warned about a downcast that was never needed. Encoding as PIL at construction time avoids that round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd790506b95d94122e8aff5c5917f4d9f60b170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->