### PR TITLE
Pin the mutable post-slack action reference to a commit SHA

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
@@ -140,7 +140,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
@@ -191,7 +191,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
@@ -246,7 +246,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
@@ -299,7 +299,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
@@ -140,7 +140,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
@@ -191,7 +191,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
@@ -246,7 +246,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
@@ -299,7 +299,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -62,7 +62,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -62,7 +62,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}


### PR DESCRIPTION
This PR replaces the mutable `@main` reference to the `huggingface/hf-workflows/.github/actions/post-slack` action with a commit SHA, so that all thirteen call sites are pinned to the same SHA already used by the existing pinned ones.

Related to #6890, which it does not resolve: this change is behavior neutral, so the `Node.js 20 is deprecated` annotation still appears.

### Motivation

`post-slack` was the only action in our CI still referenced by a mutable ref. Eleven of the thirteen call sites used `@main`, which is resolved at run time, while every other action in our workflows (`actions/checkout`, `actions/setup-python`, `astral-sh/setup-uv`, `docker/*`, `trufflesecurity/trufflehog`, `github/codeql-action`, `huggingface/doc-builder`) is pinned to a SHA. Since these steps receive `secrets.SLACK_CIFEEDBACK_BOT_TOKEN`, any push to the `hf-workflows` default branch takes effect immediately in our jobs.

### Solution

Pin the eleven `@main` references to `a88e7fa2eaee28de5a4d6142381b1fb792349b67`, the SHA the two other call sites already use, following the `# main` comment convention also used for `huggingface/doc-builder`.

Keeping the same SHA as the existing pinned references makes this PR purely about removing the mutable ref, with no change to the action code being run. Bumping that SHA is left out on purpose, so that the two concerns can be reviewed separately.

Note that pinning is not a guarantee that the reference stays frozen: Dependabot does bump SHA references that track a branch, including in repositories without matching tags. It has been doing so for our `huggingface/doc-builder` references, most recently in #6727. It has never bumped `post-slack`, most likely because Dependabot does not track composite actions living in a repository subdirectory, but that is an implementation detail rather than something to rely on.

### Changes

- Pin the eleven `post-slack@main` references in `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml` and `tests_transformers_branch.yml` to `a88e7fa2eaee28de5a4d6142381b1fb792349b67`
