### PR TITLE
Bump the pinned post-slack action SHA to the current main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
@@ -140,7 +140,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
@@ -191,7 +191,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
@@ -246,7 +246,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
@@ -299,7 +299,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -62,7 +62,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}


### PR DESCRIPTION
This PR bumps the pinned SHA of the `huggingface/hf-workflows/.github/actions/post-slack` action to the current `hf-workflows` default branch head.

Stacked on top of #6891, which pins the mutable `@main` references without changing the SHA. Please review and merge that one first: this PR targets its branch and the base will switch to `main` once it lands.

Related to #6890, which it does not resolve: the annotation still appears, since the action content is unchanged at the new SHA.

### Motivation

The SHA the call sites are pinned to, `a88e7fa2`, is eight commits behind the `hf-workflows` default branch head. Dependabot has never bumped this reference, most likely because it does not track composite actions living in a repository subdirectory, so it has to be updated manually today.

### Solution

Bump all thirteen references to `50acccfe9afb8927b9b74ed7e750f2b0d3991b62`.

None of the eight commits in that range touches `.github/actions/post-slack/`, so the action being run is byte identical and this change is behavior neutral.

### Changes

- Bump the thirteen `post-slack` references in `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml` and `tests_transformers_branch.yml` from `a88e7fa2eaee28de5a4d6142381b1fb792349b67` to `50acccfe9afb8927b9b74ed7e750f2b0d3991b62`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only SHA pin bump for Slack notifications; no application or security logic changes, and the action content is reported as unchanged.
> 
> **Overview**
> Updates all thirteen `huggingface/hf-workflows/.github/actions/post-slack` pins from `a88e7fa2…` to `50acccfe…` (current `main`) in Docker, test, and slow-test workflows.
> 
> The pin was several commits behind and is not Dependabot-tracked. The action directory itself is unchanged in that range, so Slack posting behavior should be identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432584353b06790e9d6a7682821fc158c1c07bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->