### PR TITLE
Factor the Slack notification into a local composite action

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -1,0 +1,70 @@
+name: Send message to slack
+
+description: 'Send results to slack'
+author: 'Hugging Face'
+inputs:
+  slack_channel:
+    required: true
+    type: string
+  title:
+    required: true
+    type: string
+  status:
+    required: true
+    type: string
+  slack_token:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create content to post
+      id: create-message
+      run: |
+        if [ "${{ inputs.status }}" == "success" ]; then
+          echo STATUS_MESSAGE='🟢 Tests are passing!' >> $GITHUB_ENV
+        else
+          echo STATUS_MESSAGE='🔴 Tests failed! Please check the GitHub action link below' >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Post Canceled results Slack channel
+      id: post-slack
+      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001  # v1.25.0
+      with:
+        # Slack channel id, channel name, or user id to post message.
+        # See also: https://api.slack.com/methods/chat.postMessage#channels
+        channel-id: ${{ inputs.slack_channel }}
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "text": "${{ inputs.title }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "${{ inputs.title }}"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ env.STATUS_MESSAGE }}"
+                }
+              },
+              {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "*Click here for more details about the action ran*"},
+                "accessory": {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Check Action results"},
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
@@ -148,7 +148,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
@@ -199,7 +199,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
@@ -254,7 +254,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
@@ -307,7 +307,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -61,9 +61,20 @@ jobs:
           source .venv/bin/activate
           make test
 
+      # This job checks out the release branch, which predates the local Slack action, so check
+      # the action out from the branch running the workflow. Keep the condition of this step in
+      # sync with the one of the step below: if this step is skipped, the action cannot be
+      # resolved and the notification is lost, which is precisely the case it exists for.
+      - name: Check out the Slack action
+        if: always()
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          path: slack-action
+          sparse-checkout: .github/actions
+
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./slack-action/.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -62,9 +62,8 @@ jobs:
           make test
 
       # This job checks out the release branch, which predates the local Slack action, so check
-      # the action out from the branch running the workflow. Keep the condition of this step in
-      # sync with the one of the step below: if this step is skipped, the action cannot be
-      # resolved and the notification is lost, which is precisely the case it exists for.
+      # the action out from the branch running the workflow. Keep this step on `always()`: it must
+      # never be skipped while the Slack step below runs, or the action cannot be resolved.
       - name: Check out the Slack action
         if: always()
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Post to Slack
         if: always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Post to Slack
         if: github.ref == 'refs/heads/main' && always()
-        uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}


### PR DESCRIPTION
This PR replaces the `huggingface/hf-workflows/.github/actions/post-slack` action with a local composite action, kept as a faithful copy of the shared one.

Related to #6890, which it does not resolve: the copied action still calls the same `slackapi/slack-github-action` version, so the `Node.js 20 is deprecated` annotation still appears.

### Motivation

Fixing #6890 requires moving `slackapi/slack-github-action` from v1 to a version that declares the Node 24 runtime, which is a breaking change in the way the action is called. Applying that change to the shared `hf-workflows` action would affect around 135 call sites across roughly 15 repositories in the organization, and pinning does not protect them: Dependabot bumps SHA references that track a branch, as it has been doing for our `huggingface/doc-builder` references.

Owning the action locally lets us make that change for TRL alone, on our own schedule, without touching any other project.

Keeping it factored, rather than inlining the Slack call into each workflow, avoids duplicating the message payload thirteen times.

### Solution

Add `.github/actions/post-slack/action.yml` as a copy of the shared action at `50acccfe9afb8927b9b74ed7e750f2b0d3991b62`, the SHA the workflows were pinned to, and point the call sites at it with `uses: ./.github/actions/post-slack`.

The copy is byte identical to the shared action except for the `# v1.25.0` comment added to the pinned `slackapi/slack-github-action` reference, following the convention used for every other pinned action in our workflows. Inputs, message payload and dependency versions are all unchanged, so this PR is behavior neutral.

A local action is loaded from the workspace, so it requires the repository to be checked out beforehand, and the checked out tree must be the one containing the action. That holds for twelve of the thirteen call sites: each of their jobs checks out the ref the workflow runs on, before posting to Slack.

It does not hold for `tests_latest.yml`, which checks out `v1.10-release` on purpose, since it tests the latest release. That branch predates this action, and every future release branch will too, being cut before the change that adds it. So that job checks the action out from the branch running the workflow, into a separate path:

```yaml
- name: Check out the Slack action
  if: always()
  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
  with:
    path: slack-action
    sparse-checkout: .github/actions
```

The notification is CI infrastructure rather than part of the release under test, so taking it from the workflow ref is also the right thing semantically. The checkout is sparse, so it fetches `.github/actions` rather than a second full clone.

Its `if: always()` matters and is commented in the workflow: #6900 gives the Slack step of that job the same condition, and if this checkout were left on the default `if: success()` it would be skipped exactly when the tests fail, leaving the Slack step unable to resolve the action. Both merge orders are safe, since a checkout on `always()` with a Slack step on `success()` still works.

### Changes

- Add `.github/actions/post-slack/action.yml`, copied from the shared action, with the same four inputs and the same pinned `slackapi/slack-github-action` version
- Point the thirteen `Post to Slack` steps in `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml` and `tests_transformers_branch.yml` at the local action
- Check the action out from the workflow ref in `tests_latest.yml`, whose job checks out the release branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor with behavior-neutral Slack messaging; the tests_latest checkout ordering is the main operational edge case and is explicitly guarded with `if: always()`.
> 
> **Overview**
> Replaces the org-wide `huggingface/hf-workflows` **post-slack** action with a **local composite action** at `.github/actions/post-slack`, copied from the previously pinned shared SHA so Slack payloads and inputs stay the same.
> 
> **Thirteen** “Post to Slack” steps across `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml`, and `tests_transformers_branch.yml` now use `uses: ./.github/actions/post-slack` instead of the external action—keeping notifications centralized without inlining Block Kit in every workflow.
> 
> `tests_latest.yml` is special: the job checks out a **release branch** that won’t contain the new action, so it adds an **`always()`** sparse checkout of `.github/actions` from the workflow ref into `slack-action/` and calls `./slack-action/.github/actions/post-slack`, so failure notifications still resolve the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c117ca0a6fc4161d037727f711ef72d3e724045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->