### PR TITLE
Update slack-github-action from v1 to v4 in the local Slack action

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -31,14 +31,18 @@ runs:
 
     - name: Post Canceled results Slack channel
       id: post-slack
-      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001  # v1.25.0
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
       with:
-        # Slack channel id, channel name, or user id to post message.
+        method: chat.postMessage
+        token: ${{ inputs.slack_token }}
+        # Fail the step when the Slack API call fails, as v1 did by default
+        errors: true
+        # For posting a rich message using Block Kit. The channel is a Slack
+        # channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
-        channel-id: ${{ inputs.slack_channel }}
-        # For posting a rich message using Block Kit
         payload: |
           {
+            "channel": "${{ inputs.slack_channel }}",
             "text": "${{ inputs.title }}",
             "blocks": [
               {
@@ -66,5 +70,3 @@ runs:
               }
             ]
           }
-      env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}


### PR DESCRIPTION
This PR updates `slackapi/slack-github-action` from v1.25.0 to v4.0.0 in our local Slack action.

Fix #6890.

Stacked on top of #6895, which adds the local action. Please review and merge that one first: this PR targets its branch and the base will switch to `main` once it lands.

### Motivation

v1.25.0 declares the Node 20 runtime, which is what makes CI emit the deprecation annotation. Node 20 reached end of life in April 2026, runners have been forcing these actions onto Node 24 since 2026-06-16, and GitHub plans to remove Node 20 from the runner image in the fall of 2026.

The runtime is only updated in v3.0.0, so neither the rest of the v1 series nor v2 fixes the annotation:

| version | runtime |
| --- | --- |
| v1.25.0 to v1.27.1 | `node20` |
| v2.0.0 to v2.1.1 | `node20` |
| v3.0.0 to v3.0.5 | `node24` |
| v4.0.0 | `node24` |

Going through v2 first would not help either: the inputs and outputs of v2.1.1, v3.0.5 and v4.0.0 are identical, so all the migration work is at the v1 to v2 boundary and stepping through the intermediate majors would mean the same rewrite for a version that still warns.

### Solution

Move to v4.0.0 directly. Four of the breaking changes between v1.25.0 and v4.0.0 affect the way we call the action:

- The Slack API method must now be specified, since v1 called `chat.postMessage` implicitly
- The token must be passed as a step input, since the `SLACK_BOT_TOKEN` environment variable no longer authenticates
- `channel-id` was removed, and the arguments of the Slack API method now go inside the payload
- The runtime is `node24`, which is the change that fixes the annotation

The remaining breaking changes do not apply: we pass a single payload and a single channel, we do not use `payload-file-path` or its templating options, and our action declares no outputs, so the change of the `time` output is not observable. The stricter multiline YAML parsing introduced in v4.0.0 does not apply either, since every value of our payload is on a single line.

`errors` is set explicitly to `true`. It defaults to `false` in v2 and later, meaning a failed Slack call would be logged while the step still passes. Combined with the `if: always()` on our steps, a broken payload would show up as notifications silently disappearing. v1.25.0 calls `core.setFailed` when the API call fails, so this keeps the current behavior.

The message payload itself, the four inputs of the action and the thirteen call sites are unchanged.

### Changes

- Update the pinned `slackapi/slack-github-action` reference from v1.25.0 to v4.0.0
- Add `method: chat.postMessage`
- Pass the token with the `token` input and drop the `SLACK_BOT_TOKEN` environment variable
- Move the channel from the `channel-id` input into the payload
- Set `errors: true` to keep failing the step when the Slack call fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only notification wiring with explicit parity for failure behavior; no app runtime or security-sensitive logic changes.
> 
> **Overview**
> Upgrades the composite **post-slack** action to `slackapi/slack-github-action` **v4.0.0** (Node 24) so CI stops hitting Node 20 deprecation warnings on Slack notification steps.
> 
> The Slack step is migrated to the v4 API: **`method: chat.postMessage`**, **`token`** input instead of `SLACK_BOT_TOKEN`, **`channel`** inside the JSON payload instead of `channel-id`, and **`errors: true`** so failed Slack API calls still fail the step like v1. Block Kit message content and the action’s four inputs are unchanged; workflows that call `./.github/actions/post-slack` need no updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa360ce673f80ffc6e3fc6e0af1e74130e2b22a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->