### PR TITLE
Let Dependabot update actions pinned in local composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+
+  # Actions pinned inside our local composite actions. The "/" directory above
+  # does not cover them: it only scans .github/workflows and the root action.yml.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      local-actions:
+        patterns: ["*"]


### PR DESCRIPTION
This PR lets Dependabot update the actions pinned inside our local composite actions.

Stacked on top of #6896. Please review and merge that one first: this PR targets its branch and the base will switch to `main` once it lands.

### Motivation

Now that we own the Slack action locally, we also own the `slackapi/slack-github-action` reference pinned inside it, and Dependabot does not see it.

The [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) is explicit about what our current entry covers:

> For GitHub Actions, use the value `/`. Dependabot will search the `/.github/workflows` directory, as well as the `action.yml/action.yaml` file from the root directory.

`.github/actions/post-slack/action.yml` is neither, so the pin it contains would silently go stale. That is exactly how the shared action ended up on a January 2024 release and caused #6890, and this reference is used on a step that receives our Slack bot token, so it should keep receiving updates.

The thirteen `uses: ./.github/actions/post-slack` references need nothing: a local action carries no version.

### Solution

Add a second `github-actions` entry targeting `/.github/actions/*`.

`directories` is used rather than `directory` because only the former supports globs, which keeps any local action we add later covered without touching the configuration again.

It is a separate entry rather than an extra value on the existing one, so that the entry currently doing the work is left untouched: a malformed `dependabot.yml` stops all updates for the repository without reporting anything, and a silent failure is the one worth designing against here.

The two entries do not overlap, as required when several blocks target the same ecosystem: the first resolves to `.github/workflows` plus the root `action.yml`, the second to `.github/actions/*/action.yml`.

Schedule, cooldown and grouping match the existing entry.

### Changes

- Add a `github-actions` update entry for `/.github/actions/*`, grouped as `local-actions`, weekly with the same 7 day cooldown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependabot YAML only; no application or CI logic changes beyond broader action update coverage.
> 
> **Overview**
> Adds a **second** `github-actions` Dependabot block so pins inside **local composite actions** (e.g. `slackapi/slack-github-action` in `post-slack`) get weekly update PRs, not only workflow files and root `action.yml`.
> 
> The new entry uses `directories: ["/.github/actions/*"]` with the same weekly schedule, 7-day cooldown, and grouped updates (`local-actions`), kept separate from the existing `/` entry to avoid breaking the working config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11a0028fadb87e7506c3805d77b37da0b86a148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->