### PR TITLE
Notify Slack when the tests of the latest release fail

### DIFF
--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -62,6 +62,7 @@ jobs:
           make test
 
       - name: Post to Slack
+        if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@50acccfe9afb8927b9b74ed7e750f2b0d3991b62  # main
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}


### PR DESCRIPTION
This PR makes the `Tests latest TRL release with dev dependencies` workflow notify Slack when it fails.

**Alternative to #6899, which removes the workflow instead. The two are mutually exclusive, pick one.**

### Motivation

The `Post to Slack` step of that workflow has no `if:`, so it inherits the default `if: success()` and only runs when every preceding step succeeded. It can only ever post `🟢 Tests are passing!`, and `status: ${{ job.status }}` is always `success` when it is evaluated.

The consequence is that the workflow has never reported a failure. 29 of its last 100 runs failed, including six consecutive days from 2026-07-23 to 2026-07-28, without a single notification. It is the only call site missing the condition: `slow-tests.yml`, `tests_python_versions.yml`, `tests.yml`, `tests_transformers_branch.yml` and `docker-build.yml` all gate their Slack step on `always()` or on an explicit condition including it.

### Which one to pick

The case for removing it (#6899) is that it spends a GPU runner nightly on a signal nobody reads, and that the failures it does produce are not the ones it exists to catch. The 2026-07-24 one is representative:

```
FAILED tests/test_sft_trainer.py::TestSFTTrainer::test_train_with_liger
  RuntimeError: gemm input type at::BFloat16 and output type float is only
  supported for CUDA devices with compute capability 8.0 or higher
```

That is the T4 of `aws-g4dn-2xlarge`, compute capability 7.5. The workflow is on that runner group rather than the L40S used elsewhere because it checks out an old release branch, so its results diverge from the rest of our CI.

The case for keeping it is that nothing else covers what it covers:

- `tests.yml` runs the same three dependencies from git in its `Tests with dev dependencies` job, but it has no `schedule`: it only runs on pushes. Breakages coming from upstream are driven by the calendar, not by our pushes.
- `tests_python_versions.yml` does run daily, but installs `".[dev]"` only, so it gives no signal on development versions.

So this is currently the only daily signal against the development versions of `accelerate`, `datasets` and `transformers`, and it also covers the released branch rather than `main`, which matters because we ship patch releases.

There is evidence of what it catches, which @qgallouedec documented in https://github.com/huggingface/trl/pull/6899#issuecomment-5397139568 and which is worth recording here, since #6899 will be closed and this is the PR that stays in the history of the file:

- The workflow was created in reaction to a real incident. huggingface/transformers#34507 added a `start_time` argument to `Trainer.log()`, merged 2024-11-19, and broke the released TRL when it shipped in transformers 4.47.0 on 2024-12-05. A user reported it in #2445 before we noticed, an emergency pin went out the same day as #2447, released as v0.12.2, and the workflow was added four days later in #2457 so that users are not our canary. It could have been caught 18 days earlier.
- huggingface/transformers#43972 (`mm_token_type_ids`, merged 2026-02-24) broke us again. `main` was fixed two days later in #5178, so the dev-dependencies job on `main` went back to green, while users on v0.29.0 hit the `IndexError` for real once transformers 5.3.0 shipped on 2026-03-04. For the 16 days until v0.29.1 delivered the fix on 2026-03-20, this nightly was the only CI reporting the breakage.

That second incident is the point the analysis above misses: the dev-dependencies job on `main` cannot catch this class of breakage by design, because `main` gets fixed within days and its CI returns to green while the released version stays broken. This workflow reports what users **will** hit when the next upstream release ships, which is also what tells us what the next patch release needs.

### Changes

- Add `if: always()` to the `Post to Slack` step of `tests_latest.yml`, so failures are reported like in every other workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line CI condition change; no application, auth, or data-handling code is modified. Only Slack notification behavior on job failure changes.
> 
> **Overview**
> Makes the daily `tests_latest.yml` Slack step run even when tests fail by adding `if: always()`.
> 
> Previously the step inherited GitHub’s default `if: success()`, so it never posted failures. This matches how other CI workflows already gate Slack notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2f6561b8dfca62b55af65df697af139a2c85f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
