### PR TITLE
Post the Docker image build results to the shared CI Slack channel

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: docker-image-builds
   cancel-in-progress: false
 
+env:
+  CI_SLACK_CHANNEL: ${{ secrets.CI_PUSH_MAIN_CHANNEL }}
+
 jobs:
   trl:
     name: "Build and push TRL Docker image"
@@ -56,7 +59,7 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -90,7 +93,7 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR sends the Docker image build results to the shared CI Slack channel, like every other workflow.

### Motivation

`docker-build.yml` was the only workflow pointing to its own channel, as noted in revision https://github.com/huggingface/trl/pull/6895#discussion_r3844347430. Every other workflow declares `CI_SLACK_CHANNEL` once at the workflow level and passes it at each call site, so the thirteen call sites did not all resolve the channel the same way.

Note that this changes where those notifications are delivered.

### To do on merge

- [ ] Delete the now unused `CI_DOCKER_CHANNEL` repository secret. It is no longer referenced anywhere once this PR is merged, and deleting it is a repository setting rather than something this PR can do.

### Changes

- Declare `CI_SLACK_CHANNEL` at the workflow level in `docker-build.yml`, from the same secret as the other workflows
- Use it in both `Post to Slack` steps, in place of the Docker specific channel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes which Slack channel receives CI notifications; no runtime or build logic changes.
> 
> **Overview**
> Aligns **Docker image build** Slack notifications with the rest of the repo’s CI workflows.
> 
> **`docker-build.yml`** now sets workflow-level `CI_SLACK_CHANNEL` from `CI_PUSH_MAIN_CHANNEL` (same pattern as workflows like `slow-tests.yml`). Both `Post to Slack` steps (`trl` and `trl-dev`) pass `env.CI_SLACK_CHANNEL` instead of `CI_DOCKER_CHANNEL`, so build results land in the **shared CI channel** rather than the Docker-only channel. After merge, `CI_DOCKER_CHANNEL` can be removed from repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e42c37f50aa0347a276227bd630309be5b705b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->