### PR TITLE
Read the Slack channel from the environment in the local Slack action

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -4,29 +4,42 @@ description: 'Send results to slack'
 author: 'Hugging Face'
 inputs:
   slack_channel:
-    description: 'Slack channel id, channel name, or user id to post the message to'
     required: true
+    type: string
   title:
-    description: 'Title of the message'
     required: true
+    type: string
   status:
-    description: 'Status of the job, as reported by `job.status`'
     required: true
+    type: string
   slack_token:
-    description: 'Slack bot token'
     required: true
+    type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Post results to Slack
+    - name: Create content to post
+      id: create-message
+      run: |
+        if [ "${{ inputs.status }}" == "success" ]; then
+          echo STATUS_MESSAGE='🟢 Tests are passing!' >> $GITHUB_ENV
+        else
+          echo STATUS_MESSAGE='🔴 Tests failed! Please check the GitHub action link below' >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Post Canceled results Slack channel
+      id: post-slack
       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
         # Fail the step when the Slack API call fails, as v1 did by default
         errors: true
-        # For posting a rich message using Block Kit
+        # For posting a rich message using Block Kit. The channel is a Slack
+        # channel id, channel name, or user id to post message to.
+        # See also: https://api.slack.com/methods/chat.postMessage#channels
         payload: |
           {
             "channel": "${{ inputs.slack_channel }}",
@@ -43,7 +56,7 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "${{ inputs.status == 'success' && '🟢 Tests are passing!' || '🔴 Tests failed! Please check the GitHub action link below' }}"
+                  "text": "${{ env.STATUS_MESSAGE }}"
                 }
               },
               {

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -4,42 +4,29 @@ description: 'Send results to slack'
 author: 'Hugging Face'
 inputs:
   slack_channel:
+    description: 'Slack channel id, channel name, or user id to post the message to'
     required: true
-    type: string
   title:
+    description: 'Title of the message'
     required: true
-    type: string
   status:
+    description: 'Status of the job, as reported by `job.status`'
     required: true
-    type: string
   slack_token:
+    description: 'Slack bot token'
     required: true
-    type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Create content to post
-      id: create-message
-      run: |
-        if [ "${{ inputs.status }}" == "success" ]; then
-          echo STATUS_MESSAGE='🟢 Tests are passing!' >> $GITHUB_ENV
-        else
-          echo STATUS_MESSAGE='🔴 Tests failed! Please check the GitHub action link below' >> $GITHUB_ENV
-        fi
-      shell: bash
-
-    - name: Post Canceled results Slack channel
-      id: post-slack
+    - name: Post results to Slack
       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
         # Fail the step when the Slack API call fails, as v1 did by default
         errors: true
-        # For posting a rich message using Block Kit. The channel is a Slack
-        # channel id, channel name, or user id to post message to.
-        # See also: https://api.slack.com/methods/chat.postMessage#channels
+        # For posting a rich message using Block Kit
         payload: |
           {
             "channel": "${{ inputs.slack_channel }}",
@@ -56,7 +43,7 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "${{ env.STATUS_MESSAGE }}"
+                  "text": "${{ inputs.status == 'success' && '🟢 Tests are passing!' || '🔴 Tests failed! Please check the GitHub action link below' }}"
                 }
               },
               {

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -3,9 +3,6 @@ name: Send message to slack
 description: 'Send results to slack'
 author: 'Hugging Face'
 inputs:
-  slack_channel:
-    required: true
-    type: string
   title:
     required: true
     type: string
@@ -37,12 +34,13 @@ runs:
         token: ${{ inputs.slack_token }}
         # Fail the step when the Slack API call fails, as v1 did by default
         errors: true
-        # For posting a rich message using Block Kit. The channel is a Slack
-        # channel id, channel name, or user id to post message to.
+        # For posting a rich message using Block Kit. The channel is read from the
+        # CI_SLACK_CHANNEL environment variable, which every workflow using this action
+        # declares. It is a Slack channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
         payload: |
           {
-            "channel": "${{ inputs.slack_channel }}",
+            "channel": "${{ env.CI_SLACK_CHANNEL }}",
             "text": "${{ inputs.title }}",
             "blocks": [
               {

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,7 +59,6 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -93,7 +92,6 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -66,7 +66,6 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -124,7 +123,6 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -150,7 +149,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -201,7 +199,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -256,7 +253,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -309,7 +305,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -75,7 +75,6 @@ jobs:
         if: always()
         uses: ./slack-action/.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -63,7 +63,6 @@ jobs:
         if: always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -65,7 +65,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -121,7 +120,6 @@ jobs:
         if: github.ref == 'refs/heads/main' && always()
         uses: ./.github/actions/post-slack
         with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR moves the Slack channel from the call sites into the local Slack action.

Stacked on top of #6903. Please review and merge that one first: this PR targets its branch and the base will switch to `main` once it lands.

### Motivation

Once #6903 lands, all thirteen call sites pass the very same `slack_channel: ${{ env.CI_SLACK_CHANNEL }}`. Repeating an identical value thirteen times is what the action exists to avoid, as suggested while reviewing #6895.

### Solution

Drop the `slack_channel` input and read `CI_SLACK_CHANNEL` from the environment inside the action, which every workflow using it already declares at the workflow level. A comment in the action records that expectation.

The action already read a job scoped environment variable this way, for the message built by its first step, so the channel resolves through the same mechanism.

Only the channel is moved. The rest of the action is left exactly as it was copied from the shared one in #6895.

### Changes

- Drop the `slack_channel` input from the action and read the channel from `CI_SLACK_CHANNEL`
- Remove the input from the thirteen call sites in `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml` and `tests_transformers_branch.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification wiring only; behavior is unchanged as long as workflows keep declaring `CI_SLACK_CHANNEL`, with slightly weaker explicit coupling at call sites.
> 
> **Overview**
> Centralizes Slack destination configuration in the composite **`post-slack`** action instead of repeating it at every workflow step.
> 
> The action **drops** the `slack_channel` input and sets the Block Kit payload’s `channel` from **`${{ env.CI_SLACK_CHANNEL }}`**, with comments noting that callers must define that workflow-level env (already mapped from `secrets.CI_PUSH_MAIN_CHANNEL`). **Thirteen** `Post to Slack` steps across `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml`, and `tests_transformers_branch.yml` no longer pass `slack_channel`; they still pass `title`, `status`, and `slack_token` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6f85107933944d38ac419edc3ed6f32ed64ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->