### PR TITLE
Support tool-returned images across VLM architectures

### DIFF
--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1284,10 +1284,11 @@ class TestDistillationTrainer(TrlTestCase):
 @require_vision
 class TestDistillationTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
-        "model_id",
+        "model_id,image_token",
         [
             pytest.param(
                 "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+                "<image_soft_token>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("4.57.0"),
                     reason="transformers<4.57 Gemma3 image processor can't batch variable-size images",
@@ -1295,17 +1296,19 @@ class TestDistillationTrainerVLM(TrlTestCase):
             ),
             pytest.param(
                 "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                "<|image|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.5.0"),
                     reason="Gemma4 models were introduced in transformers-5.5.0",
                 ),
             ),
-            "trl-internal-testing/tiny-InternVLForConditionalGeneration",
-            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            ("trl-internal-testing/tiny-InternVLForConditionalGeneration", "<IMG_CONTEXT>"),
+            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "<image>"),
+            ("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", "<|image_pad|>"),
+            ("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", "<|image_pad|>"),
             pytest.param(
                 "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                "<|image_pad|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -1313,6 +1316,7 @@ class TestDistillationTrainerVLM(TrlTestCase):
             ),
             pytest.param(
                 "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+                "<|image_pad|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -1321,7 +1325,7 @@ class TestDistillationTrainerVLM(TrlTestCase):
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
         ],
     )
-    def test_train_vlm(self, model_id):
+    def test_train_vlm(self, model_id, image_token):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         training_args = DistillationConfig(
@@ -1336,6 +1340,7 @@ class TestDistillationTrainerVLM(TrlTestCase):
             args=training_args,
             train_dataset=dataset,
         )
+        assert trainer._image_token_id == trainer._tokenizer.convert_tokens_to_ids(image_token)
 
         trainer.train()
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -3893,22 +3893,24 @@ class TestGRPOTrainer(TrlTestCase):
 @require_vision
 class TestGRPOTrainerVLM(TrlTestCase):
     @pytest.mark.parametrize(
-        "model_id",
+        "model_id,image_token",
         [
-            "trl-internal-testing/tiny-Gemma3ForConditionalGeneration",
+            ("trl-internal-testing/tiny-Gemma3ForConditionalGeneration", "<image_soft_token>"),
             pytest.param(
                 "trl-internal-testing/tiny-Gemma4ForConditionalGeneration",
+                "<|image|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.5.0"),
                     reason="Gemma4 models were introduced in transformers-5.5.0",
                 ),
             ),
-            "trl-internal-testing/tiny-InternVLForConditionalGeneration",
-            "trl-internal-testing/tiny-LlavaNextForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
-            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            ("trl-internal-testing/tiny-InternVLForConditionalGeneration", "<IMG_CONTEXT>"),
+            ("trl-internal-testing/tiny-LlavaNextForConditionalGeneration", "<image>"),
+            ("trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration", "<|image_pad|>"),
+            ("trl-internal-testing/tiny-Qwen2VLForConditionalGeneration", "<|image_pad|>"),
             pytest.param(
                 "trl-internal-testing/tiny-Qwen3_5ForConditionalGeneration-NoThink",
+                "<|image_pad|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -3916,6 +3918,7 @@ class TestGRPOTrainerVLM(TrlTestCase):
             ),
             pytest.param(
                 "trl-internal-testing/tiny-Qwen3_5MoeForConditionalGeneration-3.6",
+                "<|image_pad|>",
                 marks=pytest.mark.skipif(
                     Version(transformers.__version__) < Version("5.2.0"),
                     reason="Qwen3.5 models were introduced in transformers-5.2.0",
@@ -3924,7 +3927,7 @@ class TestGRPOTrainerVLM(TrlTestCase):
             # "trl-internal-testing/tiny-SmolVLMForConditionalGeneration", seems not to support bf16 properly
         ],
     )
-    def test_train_vlm(self, model_id):
+    def test_train_vlm(self, model_id, image_token):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 
         def reward_func(completions, **kwargs):
@@ -3946,6 +3949,7 @@ class TestGRPOTrainerVLM(TrlTestCase):
             args=training_args,
             train_dataset=dataset,
         )
+        assert trainer._image_token_id == trainer._tokenizer.convert_tokens_to_ids(image_token)
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -484,13 +484,13 @@ class DistillationTrainer(_BaseTrainer):
 
         # Resolve vision placeholder token IDs once. Used by the forward pass to rebuild mm_token_type_ids
         # when tool responses inject images into the completion (see _generate forward_kwargs block).
-        self._image_pad_token_id = None
+        self._image_token_id = None
         self._video_pad_token_id = None
         if self._is_vlm:
-            for candidate in ("<|image_pad|>", "<|image|>"):
+            for candidate in ("<IMG_CONTEXT>", "<image_soft_token>", "<image>", "<|image|>", "<|image_pad|>"):
                 tid = self._tokenizer.convert_tokens_to_ids(candidate)
                 if tid != self._tokenizer.unk_token_id:
-                    self._image_pad_token_id = tid
+                    self._image_token_id = tid
                     break
             tid = self._tokenizer.convert_tokens_to_ids("<|video_pad|>")
             if tid != self._tokenizer.unk_token_id:
@@ -1111,8 +1111,8 @@ class DistillationTrainer(_BaseTrainer):
             # For VLM tool images: build token type IDs from the padded input IDs.
             if self._is_vlm and self.tools and has_tool_images:
                 mm_ids = torch.zeros_like(padded_ids)
-                if self._image_pad_token_id is not None:
-                    mm_ids[padded_ids == self._image_pad_token_id] = 1
+                if self._image_token_id is not None:
+                    mm_ids[padded_ids == self._image_token_id] = 1
                 if self._video_pad_token_id is not None:
                     mm_ids[padded_ids == self._video_pad_token_id] = 2
 
@@ -1730,8 +1730,8 @@ class DistillationTrainer(_BaseTrainer):
         if self.tools and any(imgs for imgs in tool_images) and self._is_vlm:
             prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)  # (B, P+C)
             mm_ids = torch.zeros_like(prompt_completion_ids)
-            if self._image_pad_token_id is not None:
-                mm_ids[prompt_completion_ids == self._image_pad_token_id] = 1
+            if self._image_token_id is not None:
+                mm_ids[prompt_completion_ids == self._image_token_id] = 1
             if self._video_pad_token_id is not None:
                 mm_ids[prompt_completion_ids == self._video_pad_token_id] = 2
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -394,13 +394,13 @@ class GRPOTrainer(_BaseTrainer):
 
         # Resolve vision placeholder token IDs once. Used by the forward pass to rebuild mm_token_type_ids
         # when tool responses inject images into the completion (see _generate forward_kwargs block).
-        self._image_pad_token_id = None
+        self._image_token_id = None
         self._video_pad_token_id = None
         if self._is_vlm:
-            for candidate in ("<|image_pad|>", "<|image|>"):
+            for candidate in ("<IMG_CONTEXT>", "<image_soft_token>", "<image>", "<|image|>", "<|image_pad|>"):
                 tid = self._tokenizer.convert_tokens_to_ids(candidate)
                 if tid != self._tokenizer.unk_token_id:
-                    self._image_pad_token_id = tid
+                    self._image_token_id = tid
                     break
             tid = self._tokenizer.convert_tokens_to_ids("<|video_pad|>")
             if tid != self._tokenizer.unk_token_id:
@@ -1881,8 +1881,8 @@ class GRPOTrainer(_BaseTrainer):
             # For VLM tool images: build token type IDs from the padded input IDs.
             if self._is_vlm and self.tools and has_tool_images:
                 mm_ids = torch.zeros_like(padded_ids)
-                if self._image_pad_token_id is not None:
-                    mm_ids[padded_ids == self._image_pad_token_id] = 1
+                if self._image_token_id is not None:
+                    mm_ids[padded_ids == self._image_token_id] = 1
                 if self._video_pad_token_id is not None:
                     mm_ids[padded_ids == self._video_pad_token_id] = 2
 
@@ -2605,8 +2605,8 @@ class GRPOTrainer(_BaseTrainer):
         # not just the prompt).
         if self.tools and any(imgs for imgs in tool_images) and self._is_vlm:
             mm_ids = torch.zeros_like(prompt_completion_ids)
-            if self._image_pad_token_id is not None:
-                mm_ids[prompt_completion_ids == self._image_pad_token_id] = 1
+            if self._image_token_id is not None:
+                mm_ids[prompt_completion_ids == self._image_token_id] = 1
             if self._video_pad_token_id is not None:
                 mm_ids[prompt_completion_ids == self._video_pad_token_id] = 2
 


### PR DESCRIPTION
# What does this PR do?

Follow up on the multimodal tool-response path added in #6723 by resolving the image placeholder used by each supported VLM family.

The current code recognizes only `<|image_pad|>` and `<|image|>`. Gemma 3, InternVL, and LLaVA use `<image_soft_token>`, `<IMG_CONTEXT>`, and `<image>` respectively, so their rebuilt `mm_token_type_ids` contain no image positions after a tool returns an image. This change keeps the trainer-local logic aligned in GRPO and Distillation and extends the existing VLM matrices to pin the expected placeholder for every covered architecture.

Validation:

- `4 passed, 12 deselected` for Gemma 3/Gemma 4 GRPO and Distillation VLM training
- `2 passed` for the GRPO and Distillation multimodal tool-response tests
- focused Ruff check and format check
- `git diff --check`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multimodal forward/generate wiring for tool images across several VLM families; wrong token resolution could silently mis-tag image tokens, but scope is limited to the new candidate list and existing tool-image paths.
> 
> **Overview**
> Extends **GRPO** and **Distillation** VLM handling so tool-returned images mark the correct positions in rebuilt `mm_token_type_ids` / `token_type_ids`, not only Qwen/Gemma-style `<|image_pad|>` / `<|image|>`.
> 
> Trainers now probe a fixed candidate list (`<IMG_CONTEXT>`, `<image_soft_token>`, `<image>`, `<|image|>`, `<|image_pad|>`) and store the first valid ID in `_image_token_id` (renamed from `_image_pad_token_id`). That ID is used everywhere image positions are flagged during generation and forward when tools inject images into completions.
> 
> VLM matrix tests in `test_grpo_trainer.py` and `test_distillation_trainer.py` parametrize the expected placeholder per architecture and assert it matches `trainer._image_token_id` after init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbff6bda634257ebd4850a03fc473229c6fc8e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->