### PR TITLE
Read the job status from the job context in the local Slack action

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -9,9 +9,6 @@ inputs:
   title:
     required: true
     type: string
-  status:
-    required: true
-    type: string
   slack_token:
     required: true
     type: string
@@ -22,7 +19,7 @@ runs:
     - name: Create content to post
       id: create-message
       run: |
-        if [ "${{ inputs.status }}" == "success" ]; then
+        if [ "${{ job.status }}" == "success" ]; then
           echo STATUS_MESSAGE='🟢 Tests are passing!' >> $GITHUB_ENV
         else
           echo STATUS_MESSAGE='🔴 Tests failed! Please check the GitHub action link below' >> $GITHUB_ENV

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Docker Image build
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   trl-dev:
@@ -93,5 +92,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: 🤗 Results of the TRL Dev Docker Image build
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on a single GPU
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   run_all_tests_multi_gpu:
@@ -126,5 +125,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of the slow tests on multiple GPUs
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with latest dependencies
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_dev:
@@ -152,7 +151,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with dev dependencies
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_wo_optional_deps:
@@ -203,7 +201,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results without optional dependencies
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_min_versions:
@@ -258,7 +255,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with minimum versions
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   distributed_smoke:
@@ -311,5 +307,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -77,5 +77,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of latest TRL with Python 3.12 and dev dependencies
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -65,5 +65,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Python ${{ matrix.python-version }}
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results with Transformers ${{ inputs.transformers_ref }}
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   distributed_smoke:
@@ -123,5 +122,4 @@ jobs:
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}
-          status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR moves the job status from the call sites into the local Slack action.

### Motivation

All thirteen call sites pass the very same `status: ${{ job.status }}`, which is the only value the action needs that is a property of where it runs rather than something to configure. It can be read inside the action instead of being handed in thirteen times.

The other inputs stay at the call site: `title` differs every time, `slack_channel` is configuration, and `slack_token` is a credential that is better kept in the inputs of a single step than in the environment of every step of every job.

### Solution

Drop the `status` input and read `job.status` in the action.

A composite action runs inline in the job that calls it, so the job context it sees is the caller's, evaluated when the step runs. That is exactly what the call sites were passing, so the message is unchanged.

Note that this also drops the ability for a call site to report something other than its own job status. Nothing does that today, and the input can come back if we ever need to notify on a combination of jobs.

### Changes

- Drop the `status` input from the action and read `job.status` instead
- Remove the input from the thirteen call sites in `docker-build.yml`, `slow-tests.yml`, `tests.yml`, `tests_latest.yml`, `tests_python_versions.yml` and `tests_transformers_branch.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Slack notification wiring with equivalent behavior; no application or security logic changes.
> 
> **Overview**
> The **`post-slack`** composite action no longer takes a **`status`** input. It reads **`job.status`** in the “Create content to post” step when choosing the green vs red Slack message, instead of relying on callers to pass the same value every time.
> 
> All **13** “Post to Slack” steps across **`docker-build.yml`**, **`slow-tests.yml`**, **`tests.yml`**, **`tests_latest.yml`**, **`tests_python_versions.yml`**, and **`tests_transformers_branch.yml`** drop **`status: ${{ job.status }}`**. **`title`**, **`slack_channel`**, and **`slack_token`** are unchanged at the call sites.
> 
> Because composite steps run in the calling job’s context, notifications should match what they did before; callers can no longer override status with a different value (nothing did that today).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37939c2aa27473d8adcdf14ee4157703a981ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->