### PR TITLE
Add a QLoRA test to the GRPO and RLOO VLM test suites

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4098,6 +4098,60 @@ class TestGRPOTrainerVLM(TrlTestCase):
             "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
         ],
     )
+    @require_peft
+    @require_bitsandbytes
+    def test_train_vlm_peft_and_quantization(self, model_id):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        quantization_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+        trainer = GRPOTrainer(
+            model=model_id,  # pass the model as an identifier, so that the trainer applies the quantization config
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            quantization_config=quantization_config,
+            peft_config=LoraConfig(target_modules=["q_proj", "v_proj"]),
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+        ],
+    )
     def test_train_vlm_and_importance_sampling(self, model_id):
         dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
 

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -4131,6 +4131,9 @@ class TestGRPOTrainerVLM(TrlTestCase):
             peft_config=LoraConfig(target_modules=["q_proj", "v_proj"]),
         )
 
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
+
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
         trainer.train()

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -24,12 +24,13 @@ from transformers import (
     AutoModelForImageTextToText,
     AutoModelForSequenceClassification,
     AutoTokenizer,
+    BitsAndBytesConfig,
 )
 from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
 
-from .testing_utils import TrlTestCase, require_peft, require_vision, require_vllm
+from .testing_utils import TrlTestCase, require_bitsandbytes, require_peft, require_vision, require_vllm
 
 
 if is_peft_available():
@@ -2000,6 +2001,63 @@ class TestRLOOTrainerVLM(TrlTestCase):
             if n in base_param_names:  # We expect the base model params to be the same
                 torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
             elif "base_layer" not in n:  # We expect the peft params to be different (except for the base layer)
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+        ],
+    )
+    @require_peft
+    @require_bitsandbytes
+    def test_train_vlm_peft_and_quantization(self, model_id):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+
+        def reward_func(completions, **kwargs):
+            """Reward function that rewards longer completions."""
+            return [float(len(completion[0]["content"])) for completion in completions]
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=2,  # VLM training is memory intensive, reduce batch size to avoid OOM
+            num_generations=2,  # VLM training is memory intensive, reduce num_generations to avoid OOM
+            # note: num_generations=2 is only suitable for CI testing; production training should use more generations
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            report_to="none",
+        )
+        quantization_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+        trainer = RLOOTrainer(
+            model=model_id,  # pass the model as an identifier, so that the trainer applies the quantization config
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+            quantization_config=quantization_config,
+            peft_config=LoraConfig(target_modules=["q_proj", "v_proj"]),
+        )
+
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds a QLoRA test to the GRPO and RLOO VLM test suites.

Follow-up of the review comment in #6889.

### Motivation

QLoRA training is currently only covered by the slow `test_vlm_training`, which is `xfail` because of the Flash Attention 2 kernel issues, and which tests quantization, kernels, bf16 and LoRA all at once. Removing it (#6912) needs a focused replacement first.

Two code paths are involved, and are not covered by any other test:

- the detection of a quantized model, which decides whether `autocast_adapter_dtype=False` is passed to `get_peft_model`
- the cast of the adapter weights to bf16 for quantized models, following the QLoRA paper recommendation

Both are duplicated identically in GRPO and RLOO, so the test is added to both.

The `quantization_config` trainer argument is also untested, in every trainer that exposes it: all existing quantization tests pass the config to `from_pretrained` instead. Since it is the documented way to do QLoRA training ("Combine with `peft_config` for QLoRA training"), the new test uses it.

### Solution

Add a small QLoRA test next to `test_train_vlm_peft` in each trainer, with the same tiny model, dataset and training config, so that quantization is the only difference between the two. The GRPO and RLOO copies are identical modulo the trainer name.

The test does not check that the base model params are unchanged, unlike the equivalent tests in SFT, DPO and KTO: bitsandbytes casts the biases of a `Linear4bit` in-place during the forward pass, and those tests keep a hardcoded list of the affected biases to work around it. That list depends on which layers ran a forward pass, which is not predictable in GRPO and RLOO, since generation runs before training.

### Changes

- Add a QLoRA test to the GRPO VLM test suite, using the `quantization_config` trainer argument together with `peft_config`
- Add the same test to the RLOO VLM test suite
- Check that the model is loaded in 4-bit, and that the adapter weights are trained and cast to bf16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production trainer or runtime logic modified.
> 
> **Overview**
> Adds focused **QLoRA** integration tests for vision-language training on **GRPO** and **RLOO**, mirroring the existing `test_train_vlm_peft` setup but loading the model with **`quantization_config`** (4-bit BitsAndBytes) plus **`peft_config`** (LoRA on `q_proj` / `v_proj`).
> 
> Each new test runs a short train step on the tiny Qwen2.5-VL fixture, asserts the model is loaded in 4-bit, checks that **`train_loss`** is logged, and verifies **LoRA weights update** and stay in **bfloat16** as expected for QLoRA. Base quantized weights are intentionally not compared to pre-training snapshots because bitsandbytes can mutate some biases during forward passes.
> 
> **RLOO** test file also wires in `BitsAndBytesConfig` and the `@require_bitsandbytes` marker for the new case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55d9e369b48aca918e646079dfae14849e2fc21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->