### PR TITLE
Add a test for the SFT trainer quantization_config argument

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2259,6 +2259,44 @@ class TestSFTTrainer(TrlTestCase):
                 raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
 
     @require_peft
+    @require_bitsandbytes
+    def test_peft_with_quantization_config_arg(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+
+        quantization_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+        training_args = SFTConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",  # identifier, so that the trainer quantizes it
+            args=training_args,
+            train_dataset=dataset,
+            quantization_config=quantization_config,
+            peft_config=LoraConfig(),
+        )
+
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
+                assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @require_peft
     def test_prompt_tuning_peft_model(self):
         """Test that SFT works with Prompt Tuning and a pre-converted PeftModel"""
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")


### PR DESCRIPTION
This PR adds a test for the `quantization_config` argument of `SFTTrainer`.

### Motivation

Seven trainers expose a `quantization_config` argument, documented as the way to do QLoRA training ("Combine with `peft_config` for QLoRA training"), and no test passes it: every existing quantization test passes the config to `from_pretrained` and hands an already quantized model to the trainer. The branch that forwards the config to the model loading, and the QLoRA specific handling that follows, are therefore never exercised through the documented entry point.

`SFTTrainer` is covered here as the most used entry point. The same argument is covered for GRPO in #6909 and #6910.

### Solution

Add a test next to `test_peft_with_quantization`, which passes the model as an identifier together with a `quantization_config` and a `peft_config`, and checks that the trainer loads the model in 4-bit and trains the adapter.

The existing `test_peft_with_quantization` is left untouched, so both entry points stay covered.

### Changes

- Add a test that passes a `quantization_config` to `SFTTrainer` together with a `peft_config`
- Check that the model is loaded in 4-bit, and that the adapter weights are trained and cast to bf16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; it only adds regression coverage for an existing trainer API.
> 
> **Overview**
> Adds **`test_peft_with_quantization_config_arg`** so the documented QLoRA setup is exercised: pass a **model id** (not a pre-quantized checkpoint), **`quantization_config`**, and **`peft_config`** into `SFTTrainer`.
> 
> The test checks that the trainer loads the base model in **4-bit**, runs training, and that **LoRA** weights **update** and sit in **bfloat16** (per QLoRA). It deliberately does **not** assert frozen base weights, because bitsandbytes can mutate 4-bit linear biases during forward.
> 
> **`test_peft_with_quantization`** (pre-quantized model handed to the trainer) is unchanged, so both entry points stay covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697d83b5e4b556a465a5022dc8505cf10f67265d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->