### PR TITLE
Remove the slow GRPO VLM training test

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -19,12 +19,11 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 import torch
 import transformers
 from accelerate.utils.memory import release_memory
-from datasets import Dataset, DatasetDict, Image, IterableDatasetDict, load_dataset
+from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import (
     AutoModelForCausalLM,
@@ -44,7 +43,6 @@ from .testing_utils import (
     TrlTestCase,
     is_ampere_or_newer,
     require_bitsandbytes,
-    require_kernels,
     require_liger_kernel,
     require_peft,
     require_response_parsing,
@@ -57,7 +55,7 @@ from .testing_utils import (
 
 if is_peft_available():
     import peft
-    from peft import LoraConfig, PeftModel, PromptTuningConfig, get_peft_model
+    from peft import LoraConfig, PromptTuningConfig, get_peft_model
     from peft.utils import TaskType
 
 
@@ -4696,142 +4694,6 @@ class TestGRPOTrainerSlow(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
-
-        release_memory(model, trainer)
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "HuggingFaceTB/SmolVLM-Instruct",  # Only test the smaller model to avoid OOM
-        ],
-    )
-    @pytest.mark.skipif(
-        not is_ampere_or_newer() and torch_device != "xpu",
-        reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
-    )
-    @pytest.mark.xfail(
-        reason="kernels-community/flash-attn2 is currently unusable for training: no build variant for torch 2.13 "
-        "(https://github.com/huggingface/kernels-community/issues/1082), and the v3 stable-ABI build raises in the "
-        "backward pass for GQA models (https://github.com/huggingface/kernels-community/issues/1085)",
-    )
-    @require_kernels
-    @require_bitsandbytes
-    @require_peft
-    def test_vlm_training(self, model_name):
-        """
-        Test VLM training with aggressive memory optimization.
-
-        This test uses multiple memory reduction techniques:
-        - 4-bit quantization with double quantization
-        - LoRA with very low rank (r=4)
-        - Minimal batch size (1) with gradient accumulation
-        - Small images (64x64 instead of 224x224)
-        - Short sequences (max_completion_length=8)
-        - Only 4 training samples
-        - Only 1 training step
-        - Gradient checkpointing and bfloat16
-        """
-
-        from PIL import Image as PILImage
-
-        # Create processor once outside the data generator
-        processor = AutoProcessor.from_pretrained(model_name, use_fast=True, padding_side="left")
-        prompt = [{"role": "user", "content": "What is in the image?"}]
-
-        # Build the images as PIL images: an array column is stored as nested lists, and casting it to Image reads it
-        # back as int64, which makes datasets warn about downcasting to uint8
-        dataset = Dataset.from_list(
-            [
-                {
-                    "prompt": prompt,
-                    "image": PILImage.fromarray(
-                        np.random.uniform(low=0.0, high=255.0, size=(64, 64, 3)).astype(np.uint8)
-                    ),
-                }
-                for _ in range(4)
-            ],
-        ).cast_column("image", Image())
-        # reduce memory requirements as much as possible
-        quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_compute_dtype="bfloat16",
-            bnb_4bit_quant_type="nf4",
-            bnb_4bit_use_double_quant=True,
-            bnb_4bit_quant_storage="bfloat16",
-        )
-        model = AutoModelForImageTextToText.from_pretrained(
-            model_name,
-            attn_implementation="kernels-community/flash-attn2",
-            dtype="bfloat16",
-            quantization_config=quantization_config,
-        )
-
-        def reward_func(prompts, completions, **kwargs):
-            # Use hash-based reward to ensure different completions get different rewards,
-            # avoiding zero-std advantages which would result in zero loss and no parameter updates.
-            return [float(hash(c[0]["content"]) % 100) for c in completions]
-
-        training_args = GRPOConfig(
-            output_dir=self.tmp_dir,
-            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
-            per_device_train_batch_size=1,  # Minimal batch size
-            gradient_accumulation_steps=2,  # Maintain effective batch size
-            num_generations=2,
-            max_completion_length=8,  # Much shorter completions
-            bf16=True,  # Use bfloat16 precision
-            max_steps=1,  # Only do 1 training step to save time and memory
-            report_to="none",
-            logging_strategy="no",
-        )
-        lora_config = LoraConfig(
-            task_type="CAUSAL_LM",
-            r=4,  # Much lower rank for minimal memory
-            lora_alpha=8,  # Reduced alpha proportionally
-            lora_dropout=0.1,
-            target_modules=["q_proj", "v_proj"],  # Minimal target modules
-            # For VLM models, we typically want to freeze the vision encoder
-            # and only adapt the language model parameters
-            modules_to_save=None,
-        )
-
-        try:
-            trainer = GRPOTrainer(
-                model=model,
-                processing_class=processor,
-                reward_funcs=[reward_func],
-                args=training_args,
-                train_dataset=dataset,
-                peft_config=lora_config,
-            )
-
-            assert isinstance(trainer.model, PeftModel)
-
-            previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
-
-            trainer.train()
-
-            assert trainer.state.log_history[-1]["train_loss"] is not None
-
-            # Check that LoRA parameters have changed
-            # For VLM models, we're more permissive about which parameters can change
-            lora_params_changed = False
-            for n, param in previous_trainable_params.items():
-                new_param = trainer.model.get_parameter(n)
-                if "lora" in n.lower():  # LoRA parameters should change
-                    if not torch.equal(param, new_param):
-                        lora_params_changed = True
-
-            # At least some LoRA parameters should have changed during training
-            assert lora_params_changed, "No LoRA parameters were updated during training."
-
-        except torch.OutOfMemoryError as e:
-            pytest.skip(f"Skipping VLM training test due to insufficient GPU memory: {e}")
-        except Exception as e:
-            # Check for other memory-related errors
-            if any(keyword in str(e).lower() for keyword in ["memory", "cuda", "out of memory", "insufficient"]):
-                pytest.skip(f"Skipping VLM training test due to hardware constraints: {e}")
-            else:
-                raise
 
         release_memory(model, trainer)
 


### PR DESCRIPTION
This PR removes the slow GRPO VLM training test.

Follow-up of the review comment in https://github.com/huggingface/trl/pull/6889#pullrequestreview-5008783233.

### Motivation

`test_vlm_training` adds almost no value:

- It is `xfail`, since `kernels-community/flash-attn2` is currently unusable for training (https://github.com/huggingface/kernels-community/issues/1082 and https://github.com/huggingface/kernels-community/issues/1085), so it never reports a real result.
- On top of that, it wraps its whole body in a `try/except` that turns any exception whose message mentions memory or cuda into a skip, so even without the `xfail` it can pass without testing anything.
- It tests many things at once: 4-bit bitsandbytes quantization, Flash Attention 2 kernels, bf16, LoRA, and a full VLM checkpoint. When it fails, it is impossible to tell which piece broke.
- Its docstring is partly wrong: it claims to use gradient checkpointing, which the training config never enables, and it sets `bf16=True`, which is already the `GRPOConfig` default.

The only thing it covers that the fast suite does not is quantization, which is now covered by the QLoRA tests added on tiny models, in the fast suite, in:
- #6909
- #6910

The Flash Attention 2 kernels path is not covered by a GRPO test anymore, and this is intentional. `GRPOTrainer` has no kernel specific code, unlike `SFTTrainer` and `DPOTrainer` which handle `FLASH_ATTENTION_VARIANTS` for padding-free training. A GRPO kernels test would exercise transformers plumbing only, and would be born `xfail` alongside the SFT and DPO ones.

A real VLM checkpoint is still loaded in the slow suite by `test_vlm_processor_vllm_colocate_mode`.

### Changes

- Remove the slow GRPO VLM training test
- Remove the imports that it was the only user of


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion with no production code changes; slightly reduces GRPO VLM + flash-attn kernel coverage but intentionally, with overlapping tests elsewhere.
> 
> **Overview**
> Removes **`test_vlm_training`** from `tests/test_grpo_trainer.py`, a slow GRPO vision-language training integration test (SmolVLM, 4-bit QLoRA, flash-attn2 kernels) that was marked **xfail** and could also **skip** on memory-related errors, so it rarely asserted real training behavior.
> 
> Cleans up imports that were only used by that test: **`numpy`**, **`Image`** from `datasets`, **`require_kernels`**, and top-level **`PeftModel`**. VLM coverage in this file remains via **`test_vlm_processor_vllm_colocate_mode`** and other tests; quantization/QLoRA is covered elsewhere in the fast suite per the PR rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d6cf87b1d92efebd34f132abb8820141d61cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->