### PR TITLE
Hotfix CI: Xfail MoE LoRA tests against a broken peft dev build

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -733,6 +733,14 @@ class TestDPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
@@ -801,6 +809,14 @@ class TestDPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -736,7 +736,7 @@ class TestDPOTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,
@@ -812,7 +812,7 @@ class TestDPOTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -930,6 +930,14 @@ class TestGRPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -933,7 +933,7 @@ class TestGRPOTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -813,6 +813,14 @@ class TestKTOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -816,7 +816,7 @@ class TestKTOTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -347,7 +347,7 @@ class TestRewardTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -18,6 +18,7 @@ import pathlib
 import pytest
 import torch
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
+from packaging.version import Version
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available
 
@@ -28,6 +29,7 @@ from .testing_utils import TrlTestCase, require_peft
 
 
 if is_peft_available():
+    import peft
     from peft import LoraConfig, get_peft_model
 
 
@@ -342,6 +344,14 @@ class TestRewardTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         model = AutoModelForSequenceClassification.from_pretrained(model_id, dtype="float32")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -562,7 +562,7 @@ class TestRLOOTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -559,6 +559,14 @@ class TestRLOOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -756,7 +756,7 @@ class TestSFTTrainer(TrlTestCase):
     @pytest.mark.xfail(
         is_peft_available() and Version(peft.__version__).is_devrelease,
         reason=(
-            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
             "`register_parametrization` rejects (see #6914)."
         ),
         strict=True,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -753,6 +753,14 @@ class TestSFTTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
+    @pytest.mark.xfail(
+        is_peft_available() and Version(peft.__version__).is_devrelease,
+        reason=(
+            "peft's LoRA parametrization for `target_parameters` returns bf16 under autocast, which "
+            "`register_parametrization` rejects (see #6914)."
+        ),
+        strict=True,
+    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")


### PR DESCRIPTION
This PR marks the seven MoE LoRA `target_parameters` training tests as expected failures (xfail, `strict=True`) when running against a `peft` dev build.

Hotfix:
- #6914

### Motivation

The CI job that installs dev dependencies started failing every test that trains a MoE model with a `LoraConfig` using `target_parameters`:

> ValueError: Registering a parametrization may not change the dtype of the tensor, unless `unsafe` flag is enabled.
> unparametrized dtype: torch.float32
> parametrized dtype: torch.bfloat16

### Solution

This is a short-term, TRL-side workaround to keep CI green while the fix lands upstream in `peft`, no TRL library code is changed here.

### Changes

- Add a conditional xfail mark to the seven affected tests in `test_dpo_trainer.py`, `test_grpo_trainer.py`, `test_kto_trainer.py`, `test_reward_trainer.py`, `test_rloo_trainer.py` and `test_sft_trainer.py`, alongside the existing `require_peft` mark
- Condition the xfail on `Version(peft.__version__).is_devrelease`, so it only applies where the bug actually reproduces, the released `peft` is unaffected
- Use `strict=True` so that once `peft` ships the real fix, the tests flip to an unexpected pass and fail CI loudly, forcing removal of the marker instead of letting it go stale
- Add the `Version` and `peft` imports needed for the mark in `test_reward_trainer.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI workaround with a narrow peft dev-release gate; production behavior and released peft versions are unchanged.
> 
> **Overview**
> **CI hotfix (#6914):** MoE + LoRA tests that use `target_parameters` are marked **expected failures** only when `peft` is a dev release, so CI stays green while upstream fixes a dtype bug in LoRA parametrization for MoE experts (bf16 under autocast vs float32 `register_parametrization`).
> 
> The same conditional `@pytest.mark.xfail(..., strict=True)` is added on **seven** tests across DPO, GRPO, KTO, RLOO, SFT, and Reward trainer suites (`test_train_moe_with_peft_config` / `test_train_moe_peft_model` as applicable). **`strict=True`** forces removal of the marker once dev `peft` passes again. **`test_reward_trainer.py`** also gains `Version` and `peft` imports for the condition. No TRL library code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ae775fc930d0fbcd8594719c295f0fffb4a8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->