### PR TITLE
Retry tests failing on cuBLAS allocation errors the rerun filter missed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ check_dirs := examples tests trl
 
 ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
 
+# Transient infrastructure errors that are worth retrying, matched against "<ExceptionType>: <message>":
+#  - OSError, Timeout, HTTPError 502/504: Hub flakiness
+#  - OutOfMemoryError, STATUS_ALLOC_FAILED: GPU memory pressure from the parallel workers
+rerun_errors := (OSError|Timeout|HTTPError.*502|HTTPError.*504|OutOfMemoryError|STATUS_ALLOC_FAILED)
+
 test:
-	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '(OSError|Timeout|HTTPError.*502|HTTPError.*504|OutOfMemoryError)' tests
+	pytest -n auto -m "not slow and not low_priority" -s -v --reruns 5 --reruns-delay 1 --only-rerun '$(rerun_errors)' tests
 
 precommit:
 	python scripts/add_copyrights.py


### PR DESCRIPTION
This PR makes the CI rerun filter retry cuBLAS allocation failures, which it was silently letting through even though they are pure GPU memory pressure on the shared runner.

Partially addresses #6917.

### Motivation

`pytest-rerunfailures` matches `--only-rerun` against the outermost exception only, building the string it tests as `f"{excinfo.type.__name__}: {excinfo.value}"`. The chained `__cause__` is never consulted.

A cuBLAS handle failing to allocate under memory pressure therefore escaped the filter, since it arrives as a plain `RuntimeError` that no pattern matched:

> RuntimeError: CUDA error: CUBLAS_STATUS_ALLOC_FAILED when calling `cublasCreate(handle)`

This hit the dev-dependencies job in https://github.com/huggingface/trl/actions/runs/32855030464/job/97824800816, on a GPU with 16 MiB free across roughly 33 concurrent workers. The affected test passed in the three sibling jobs of that run and again on a re-run, so nothing was broken, the retry that exists for exactly this case just did not fire.

### Solution

Add `STATUS_ALLOC_FAILED` to the pattern list, matched rather than the cuBLAS-specific spelling so cuSOLVER and cuSPARSE allocation failures are covered too, and lift the list into a `rerun_errors` variable so each entry can carry a comment explaining what it is for.

Verified against synthetic failures reproducing each shape: a direct OOM and a cuBLAS allocation error are retried, while a plain failing assertion, an `assert_close` value mismatch, and a genuine `TypeError` raised inside a comparison are all still failed immediately.

### Not addressed here

The second half of #6917 is left open on purpose. When an OOM is raised inside `torch.testing.assert_close`, `torch.testing` wraps it in `RuntimeError("Comparing\n\n{pair}\n\nresulted in the unexpected exception above. ...")`, and that message drops the original error text, so the failure surfaces as `RuntimeError: Comparing` with `OutOfMemoryError` demoted to a chained cause. Nothing in the outer message indicates memory pressure, so no regex can distinguish it from a real defect surfacing inside a comparison. Matching the wrapper text would retry genuine bugs, including nondeterministic ones that the narrow filter exists to avoid masking. The proper fix is for `pytest-rerunfailures` to match against the exception chain.

### Changes

- Add `STATUS_ALLOC_FAILED` to the `--only-rerun` pattern list
- Move the pattern list into a documented `rerun_errors` Makefile variable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes pytest retry rules in the Makefile; no library or runtime behavior is affected.
> 
> **Overview**
> CI’s default `make test` retry list is refactored into a documented **`rerun_errors`** Makefile variable and wired into **`--only-rerun`**, so the pattern is easier to maintain and comment.
> 
> The regex now also matches **`STATUS_ALLOC_FAILED`**, covering transient cuBLAS/cuSOLVER/cuSPARSE handle allocation failures under parallel GPU load that previously surfaced as unmatched `RuntimeError` messages and were not retried (unlike direct **`OutOfMemoryError`** cases that were already in the list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce6daed060d033706cca05930d3a77fbcc97add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->