### PR TITLE
Document how to change the training objective by subclassing a trainer

### DIFF
--- a/docs/source/customization.md
+++ b/docs/source/customization.md
@@ -111,3 +111,55 @@ training_args = DPOConfig(
     gradient_accumulation_steps=8,
 )
 ```
+
+## Change the training objective
+
+The loss of a trainer is defined in its `compute_loss` method. To train with a different objective, subclass the trainer and override it. Data preparation, generation, logging, and checkpointing are inherited, so the subclass holds only what actually changes.
+
+```python
+from trl import DPOTrainer
+
+
+class MyDPOTrainer(DPOTrainer):
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        ...
+```
+
+TRL relies on this pattern internally. [`experimental.gkd.GKDTrainer`] subclasses [`SFTTrainer`] and overrides `compute_loss` to replace the cross-entropy with a generalized Jensen-Shannon divergence against a teacher model. [`experimental.gold.GOLDTrainer`] extends [`SFTTrainer`] and [`experimental.gmpo.GMPOTrainer`] extends [`GRPOTrainer`] the same way.
+
+### Add parameters to the config
+
+Subclass the config to declare the parameters your loss needs:
+
+```python
+from dataclasses import dataclass, field
+
+from trl import DPOConfig
+
+
+@dataclass
+class MyDPOConfig(DPOConfig):
+    my_coef: float = field(default=0.1, metadata={"help": "Coefficient of the custom term."})
+```
+
+[`experimental.gkd.GKDConfig`] extends [`SFTConfig`] and [`experimental.gmpo.GMPOConfig`] extends [`GRPOConfig`] in the same way.
+
+### Change the batch format
+
+When the loss needs inputs that the default collator doesn't produce, replace the collator as well, and override `_prepare_dataset` to pass the dataset through when it is already in the expected format:
+
+```python
+class MyDPOTrainer(DPOTrainer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data_collator = my_collator
+
+    def _prepare_dataset(self, dataset, *args, **kwargs):
+        return dataset
+```
+
+### Complete example
+
+The block-diffusion SFT example [`examples/sft_diffusion_gemma/sft_diffusion_gemma.py`](https://github.com/huggingface/trl/blob/main/examples/sft_diffusion_gemma/sft_diffusion_gemma.py) combines the three: `DiffusionGemmaSFTConfig` extends [`SFTConfig`] with the canvas and corruption parameters, and `DiffusionGemmaSFTTrainer` extends [`SFTTrainer`] and replaces the autoregressive cross-entropy with a block-diffusion denoising objective. Neither requires a change to the library.
+
+[Antidoom](https://github.com/Liquid4All/antidoom), an open-source tool from [Liquid AI](https://huggingface.co/LiquidAI), extends [`DPOTrainer`] with Final Token Preference Optimization ([Antislop](https://huggingface.co/papers/2510.15061)), a preference loss over a single token position that reduces repetition loops in reasoning models.

--- a/docs/source/customization.md
+++ b/docs/source/customization.md
@@ -114,7 +114,7 @@ training_args = DPOConfig(
 
 ## Change the training objective
 
-The loss of a trainer is defined in its `compute_loss` method. To train with a different objective, subclass the trainer and override it. Data preparation, generation, logging, and checkpointing are inherited, so the subclass holds only what actually changes.
+Subclassing a trainer is the simplest way to customize training. The loss is defined in the `compute_loss` method, so to train with a different objective, subclass the trainer and override it. Data preparation, generation, logging, and checkpointing are inherited, so the subclass holds only what actually changes.
 
 ```python
 import torch
@@ -142,8 +142,6 @@ class MyDPOTrainer(DPOTrainer):
         return torch.relu(1 - self.beta * delta).mean()
 ```
 
-TRL relies on this pattern internally. [`experimental.gkd.GKDTrainer`] subclasses [`SFTTrainer`] and overrides `compute_loss` to replace the cross-entropy with a generalized Jensen-Shannon divergence against a teacher model. [`experimental.gold.GOLDTrainer`] extends [`SFTTrainer`] and [`experimental.gmpo.GMPOTrainer`] extends [`GRPOTrainer`] the same way.
-
 ### Add parameters to the config
 
 Subclass the config to declare the parameters your loss needs:
@@ -159,20 +157,17 @@ class MyDPOConfig(DPOConfig):
     my_coef: float = field(default=0.1, metadata={"help": "Coefficient of the custom term."})
 ```
 
-[`experimental.gkd.GKDConfig`] extends [`SFTConfig`] and [`experimental.gmpo.GMPOConfig`] extends [`GRPOConfig`] in the same way.
-
 ### Change the batch format
 
-When the loss needs inputs that the default collator doesn't produce, replace the collator as well, and override `_prepare_dataset` to pass the dataset through when it is already in the expected format:
+When the loss needs inputs that the default collator doesn't produce, pass your own collator, and override `_prepare_dataset` to leave the dataset untouched when it is already in the expected format:
 
 ```python
 class MyDPOTrainer(DPOTrainer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.data_collator = my_collator
-
     def _prepare_dataset(self, dataset, *args, **kwargs):
         return dataset
+
+
+trainer = MyDPOTrainer(..., data_collator=my_collator)
 ```
 
 ### Complete example

--- a/docs/source/customization.md
+++ b/docs/source/customization.md
@@ -117,12 +117,29 @@ training_args = DPOConfig(
 The loss of a trainer is defined in its `compute_loss` method. To train with a different objective, subclass the trainer and override it. Data preparation, generation, logging, and checkpointing are inherited, so the subclass holds only what actually changes.
 
 ```python
+import torch
+
 from trl import DPOTrainer
+from trl.trainer.utils import selective_log_softmax
 
 
 class MyDPOTrainer(DPOTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        ...
+        # In this example: the hinge loss from https://huggingface.co/papers/2309.06657
+        input_ids, attention_mask = inputs["input_ids"], inputs["attention_mask"]
+        shift_labels, shift_completion_mask = input_ids[:, 1:], inputs["completion_mask"][:, 1:]
+        logits = model(input_ids=input_ids, attention_mask=attention_mask).logits
+        with torch.no_grad():
+            ref_logits = self.ref_model(input_ids=input_ids, attention_mask=attention_mask).logits
+
+        # Sum the log-probs over the completion tokens, for the policy and for the reference model
+        logps = (selective_log_softmax(logits[:, :-1], shift_labels) * shift_completion_mask).sum(dim=1)
+        ref_logps = (selective_log_softmax(ref_logits[:, :-1], shift_labels) * shift_completion_mask).sum(dim=1)
+
+        chosen_logps, rejected_logps = logps.chunk(2, dim=0)  # batch is [chosen, rejected]
+        ref_chosen_logps, ref_rejected_logps = ref_logps.chunk(2, dim=0)
+        delta = (chosen_logps - ref_chosen_logps) - (rejected_logps - ref_rejected_logps)
+        return torch.relu(1 - self.beta * delta).mean()
 ```
 
 TRL relies on this pattern internally. [`experimental.gkd.GKDTrainer`] subclasses [`SFTTrainer`] and overrides `compute_loss` to replace the cross-entropy with a generalized Jensen-Shannon divergence against a teacher model. [`experimental.gold.GOLDTrainer`] extends [`SFTTrainer`] and [`experimental.gmpo.GMPOTrainer`] extends [`GRPOTrainer`] the same way.


### PR DESCRIPTION
# What does this PR do?

Adds a `Change the training objective` section to the training customization guide.

Every section in `customization.md` today customizes training by passing an argument: optimizers and schedulers, an 8-bit reference model, callbacks, evaluation metrics, mixed precision, gradient accumulation. The guide says nothing about the case where the objective itself differs, even though subclassing a trainer and overriding `compute_loss` is a pattern the library relies on throughout:

- `GKDTrainer` and `GOLDTrainer` extend `SFTTrainer`
- `GMPOTrainer`, `MiniLLMTrainer` and `GRPOWithReplayBufferTrainer` extend `GRPOTrainer`
- `XPOTrainer` and `NashMDTrainer` extend `OnlineDPOTrainer`
- `examples/sft_diffusion_gemma/sft_diffusion_gemma.py` extends `SFTTrainer` with a block-diffusion objective, entirely from an example script

Today the only traces of this in the docs are a one-line pointer in `sft_trainer.md` and a row in `example_overview.md`.

The new section documents the three override points (`compute_loss`, the config, the collator plus `_prepare_dataset`), then links to the block-diffusion example as a complete in-repo case and to one external project using the same pattern.

Note on scope: this documents subclassing a *public* trainer for a small, local delta, which is what GMPO, GKD, GOLD, XPO and NashMD do. It does not touch the self-contained trainer route on `_BaseTrainer` described in `AGENTS.md`, which remains the way to add a full new method.

Docs only, no code changes.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Change the training objective** section to the training customization guide (`customization.md`), filling a gap where other sections only cover config/callback-style tweaks.
> 
> The new content explains subclassing a trainer (e.g. `DPOTrainer`) and overriding `compute_loss`, with a concrete hinge-loss DPO example using `selective_log_softmax`. It also covers extending `DPOConfig` for custom hyperparameters, supplying a custom collator and skipping default dataset prep via `_prepare_dataset`, and points readers to the in-repo block-diffusion SFT example and the external Antidoom/Antislop `DPOTrainer` extension as end-to-end references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8710f4acf2b772a1c8ac7b8f2353b16694a874a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->