### PR TITLE
Revert xfail for MoE LoRA tests now that peft#3602 fixed the autocast dtype bug

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -733,14 +733,6 @@ class TestDPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
@@ -809,14 +801,6 @@ class TestDPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -930,14 +930,6 @@ class TestGRPOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -813,14 +813,6 @@ class TestKTOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -18,7 +18,6 @@ import pathlib
 import pytest
 import torch
 from datasets import DatasetDict, IterableDatasetDict, load_dataset
-from packaging.version import Version
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available
 
@@ -29,7 +28,6 @@ from .testing_utils import TrlTestCase, require_peft
 
 
 if is_peft_available():
-    import peft
     from peft import LoraConfig, get_peft_model
 
 
@@ -344,14 +342,6 @@ class TestRewardTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         model = AutoModelForSequenceClassification.from_pretrained(model_id, dtype="float32")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -559,14 +559,6 @@ class TestRLOOTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -753,14 +753,6 @@ class TestSFTTrainer(TrlTestCase):
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_peft
-    @pytest.mark.xfail(
-        is_peft_available() and Version(peft.__version__).is_devrelease,
-        reason=(
-            "peft's LoRA parametrization for MoE expert parameters returns bf16 under autocast, which "
-            "`register_parametrization` rejects (see #6914)."
-        ),
-        strict=True,
-    )
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")


### PR DESCRIPTION
This PR reverts the temporary xfail markers added for the MoE LoRA tests, now that the underlying bug has been fixed upstream:
- huggingface/peft#3602

Fix #6914.

### Motivation

`peft`'s LoRA parametrization for MoE expert parameters returned bf16 under autocast, which `register_parametrization` rejects, so the MoE LoRA tests were marked xfail as a temporary hotfix (#6915) to keep CI green. The bug has since been fixed upstream in peft#3602.

### Solution

Revert the hotfix commit that added the xfail markers, restoring the tests to their normal (non-xfail) state.

### Changes

- Remove the xfail markers from the MoE LoRA tests in `test_dpo_trainer.py`, `test_grpo_trainer.py`, `test_kto_trainer.py`, `test_reward_trainer.py`, `test_rloo_trainer.py` and `test_sft_trainer.py`
- Remove the now-unused `Version` and `peft` imports from `test_reward_trainer.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths; CI may fail if the environment still uses a peft version without the upstream fix.
> 
> **Overview**
> Reverts the temporary **xfail** markers on MoE + PEFT/LoRA training tests now that **peft#3602** fixes the autocast dtype issue that broke `register_parametrization` (closes **#6914**).
> 
> Affected suites: **DPO**, **GRPO**, **KTO**, **Reward**, **RLOO**, and **SFT** (`test_train_moe_with_peft_config` / `test_train_moe_peft_model` where applicable). Those tests run as normal failures/pass again instead of expected failures on peft dev releases.
> 
> In `test_reward_trainer.py`, drops unused **`packaging.version.Version`** and top-level **`peft`** imports that only served the xfail condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec5654ee55d3d24095a14666f9a5fece859768e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->