### PR TITLE
Stop excluding the trufflehog lob detector

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -31,7 +31,5 @@ jobs:
         # pins only the wrapper. pin the image by digest too, and bump it together with the action SHA.
         version: 3.97.0@sha256:ff4c95e9df7d645daf2140e3ca1039031c63106268d5fbb25feb43ceca1bcc33
         # exclude buggy detectors that cause false positives and are not relevant to our codebase.
-        # lob matches `(live|test)_[a-zA-Z0-9_]{35}`, which any pytest name of exactly 35 characters after
-        # `test_` satisfies (e.g. `test_reward_func_wrong_number_of_rewards`).
         # without --fail-on-scan-errors, a scan that errors out and covers nothing passes as a scan that found nothing.
-        extra_args: --results=verified,unknown --exclude-detectors=postgres,lob --fail-on-scan-errors
+        extra_args: --results=verified,unknown --exclude-detectors=postgres --fail-on-scan-errors


### PR DESCRIPTION
This PR re-enables the `lob` detector in the secret scanning workflow, now that the false positive it was excluded for has been fixed upstream.

Reverts the exclusion added in #6674.

Follow-up to the trufflesecurity/trufflehog v3.97.0 release and pin by:
- #6902

### Motivation

#6674 disabled the detector because eight ordinary pytest names on `main` were reported as verified secrets. Two upstream bugs combined to cause it, and trufflesecurity/trufflehog#5188, released in v3.97.0 and pulled in by #6902, fixes both.

The pattern no longer matches identifiers:

```diff
-keyPat = regexp.MustCompile(`\b((live|test)_[a-zA-Z0-9_]{35})\b`)
+keyPat = regexp.MustCompile(`\b((live|test)_[a-f0-9]{35})\b`)
```

Requiring 35 lowercase hex characters rules out every name of the form `test_<words>`, since those contain letters outside `[a-f]` and underscores. Checking the two patterns against the eight names listed in #6674 confirms it: all eight match the old one, none match the new one.

The `403` handling no longer treats a Cloudflare block as proof of a live key either. It now decodes the response body and only reports a key as verified for the `billing_address_required` and `feature_limit_reached` error codes, so the HTML `403` that Cloudflare returns to TruffleHog's hardcoded user agent, which was what made these findings verified, now fails to decode and is not a verification.

### Solution

Scanning the full history of `main` with the currently pinned scanner and no exclusions at all reports nothing:

```
docker run --rm -v .:/repo ghcr.io/trufflesecurity/trufflehog:3.97.0@sha256:ff4c95e9... \
  git file:///repo --results=verified,unknown --fail-on-scan-errors

chunks: 34856, bytes: 23333266, verified_secrets: 0, unverified_secrets: 0  -> exit 0
```

That is 3426 commits, the same scope as our weekly full-history sweep. The harness was sanity-checked against a synthetic key of the shape the new pattern accepts, which the detector does report, so the clean result reflects the detector running and finding nothing rather than the detector being inactive.

### Changes

- Remove `lob` from `--exclude-detectors`
- Remove the comment describing the false positive, which no longer applies

### Note

#6921 removes `postgres` from the same list. The two touch the same line, so whichever merges second needs a rebase, and at that point `--exclude-detectors` becomes empty and should be dropped along with the comment introducing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that widens secret scanning with an upstream fix validated on full repo history; no application or auth logic is touched.
> 
> **Overview**
> **Re-enables TruffleHog’s `lob` detector** in the secret-leaks workflow by dropping it from `--exclude-detectors`, so scans again cover Lob API keys alongside the existing `postgres` exclusion.
> 
> The workflow comment that explained excluding `lob` because pytest names looked like keys is removed, since upstream TruffleHog v3.97.0 (already pinned in this file) tightened the key pattern and fixed verification behavior that caused those false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a278820549b6901fa2661a7e4161da792ef2ca8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
