### PR TITLE
Stop excluding the trufflehog postgres detector

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -34,4 +34,4 @@ jobs:
         # lob matches `(live|test)_[a-zA-Z0-9_]{35}`, which any pytest name of exactly 35 characters after
         # `test_` satisfies (e.g. `test_reward_func_wrong_number_of_rewards`).
         # without --fail-on-scan-errors, a scan that errors out and covers nothing passes as a scan that found nothing.
-        extra_args: --results=verified,unknown --exclude-detectors=postgres,lob --fail-on-scan-errors
+        extra_args: --results=verified,unknown --exclude-detectors=lob --fail-on-scan-errors


### PR DESCRIPTION
This PR re-enables the `postgres` detector in the secret scanning workflow.

Reverts the exclusion added in #3192.

### Motivation

The exclusion is the oldest thing in this workflow, added in March 2025 with the comment "exclude buggy postgres detector that is causing false positives and not relevant to our codebase". It was adapted from the `text-generation-inference` workflow rather than diagnosed here, so unlike the `lob` exclusion there is no record of a specific false positive that it was suppressing in this repository, and no way to check whether the upstream bug that motivated it still exists.

Since then the scanner has moved from an unpinned `main` to v3.97.0. Rather than keep carrying an exclusion whose justification cannot be reconstructed, this checks whether it is still needed.

### Solution

Scanning the full history of `main` with the currently pinned scanner and no exclusions at all reports nothing:

```
docker run --rm -v .:/repo ghcr.io/trufflesecurity/trufflehog:3.97.0@sha256:ff4c95e9... \
  git file:///repo --results=verified,unknown --fail-on-scan-errors

chunks: 34856, bytes: 23333266, verified_secrets: 0, unverified_secrets: 0  -> exit 0
```

That is 3426 commits, the same scope as our weekly full-history sweep, so the detector finds nothing to report anywhere in the repository, not just in the current tree. The harness was sanity-checked against a synthetic secret that the scanner does report, so the clean result reflects detectors running and finding nothing rather than a scan that covered nothing.

This is weaker evidence than for `lob`, where the upstream fix can be pointed at directly. Here the argument is only that the detector is currently silent across the whole history. If it turns out to produce false positives on some future commit, the exclusion can be restored with an actual example attached, which is a better state than an exclusion nobody can justify.

### Changes

- Remove `postgres` from `--exclude-detectors`

### Note

#6920 removes `lob` from the same list. The two touch the same line, so whichever merges second needs a rebase, and at that point `--exclude-detectors` becomes empty and should be dropped along with the comment introducing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only TruffleHog flag change with no app or auth impact; main risk is future postgres-detector false positives failing the workflow.
> 
> **Overview**
> **Re-enables the TruffleHog `postgres` secret detector** in the GitHub Actions secret-leaks workflow by dropping `--exclude-detectors=postgres` from `extra_args`. Scanning still uses `--results=verified,unknown` and `--fail-on-scan-errors` on the pinned v3.97.0 image.
> 
> This reverses a long-standing exclusion that was copied from another project without a documented false positive in this repo. Full-history validation with the current pin reportedly finds no postgres hits, so the workflow now runs that detector again; if noise shows up later, the exclusion can be restored with a concrete example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949a4d209e5037c749a23e2bfdca66ebfe15c174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->