### PR TITLE
Run the training invariant tests in CI

### DIFF
--- a/.github/workflows/tests_invariant.yml
+++ b/.github/workflows/tests_invariant.yml
@@ -1,0 +1,65 @@
+name: Training invariant tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Runs daily at 2am UTC
+
+  workflow_dispatch:
+
+env:
+  TQDM_DISABLE: 1
+  CI_SLACK_CHANNEL: ${{ secrets.CI_PUSH_MAIN_CHANNEL }}
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  PYTORCH_ALLOC_CONF: "expandable_segments:True"
+
+jobs:
+  tests:
+    name: Training invariant tests
+    runs-on:
+      group: aws-g5-12xlarge-cache  # the ddp2 configs need 2 GPUs
+    container:
+      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
+      options: --gpus all --shm-size "16gb"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Make and Git
+        run: |
+          apt-get update && apt-get install -y make git curl
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+
+      - name: Create Python virtual environment
+        run: |
+          uv venv
+          uv pip install --upgrade setuptools wheel
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install ".[dev]"
+
+      - name: Test with pytest
+        run: |
+          source .venv/bin/activate
+          make invariant_tests
+
+      - name: Post to Slack
+        if: always()
+        uses: ./.github/actions/post-slack
+        with:
+          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
+          title: Results of the training invariant tests
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_invariant.yml
+++ b/.github/workflows/tests_invariant.yml
@@ -1,6 +1,9 @@
 name: Training invariant tests
 
 on:
+  push:
+    branches: [invariant-ci]  # TEMPORARY: drop before merging
+
   schedule:
     - cron: '0 2 * * *'  # Runs daily at 2am UTC
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test precommit common_tests slow_tests tests_gpu test_experimental codex claude clean-ai
+.PHONY: test precommit common_tests slow_tests tests_gpu test_experimental invariant_tests codex claude clean-ai
 
 check_dirs := examples tests trl
 
@@ -16,6 +16,9 @@ slow_tests:
 
 test_experimental:
 	pytest -n auto -s -v tests/experimental
+
+invariant_tests:
+	pytest -m "invariant" -v --tb=short tests/invariant $(PYTEST_ARGS)
 
 codex:
 	mkdir -p .agents


### PR DESCRIPTION
Moves the daily invariant run off my local SLURM cron into GitHub Actions, same shape as the other scheduled test workflows. Daily at 2am UTC (midnight and 1am are taken by tests_latest and tests_python_versions), plus workflow_dispatch. Also adds a `make invariant_tests` target so the workflow looks like its siblings.

Runner is aws-g5-12xlarge-cache, not g6e-4xlarge, because sft_ddp2 and dpo_ddp2 need 2 GPUs.

Caveat: the references in tests/invariant/references/ are recorded on H100 80GB and there is no H100 runner group, so this runs on A10G. If the tolerances don't hold, we re-record on the CI GPU and lose the H100 pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Makefile wiring only; no application or training code changes, though GPU mismatch vs reference snapshots could cause initial CI failures.
> 
> **Overview**
> Adds a **scheduled GitHub Actions workflow** that runs the training invariant test suite daily at 2am UTC (with `workflow_dispatch`), replacing a local SLURM cron setup.
> 
> The job uses the **2-GPU** `aws-g5-12xlarge-cache` runner and the same PyTorch CUDA container / `uv` install pattern as sibling workflows, then runs **`make invariant_tests`**. Results are posted to Slack on every run.
> 
> The **Makefile** gains an `invariant_tests` target that runs `pytest -m "invariant"` against `tests/invariant`.
> 
> Note: push is temporarily limited to `invariant-ci` until merge; references were recorded on H100 while CI uses A10G, so tolerances may need re-recording if the job flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74af71748f6b73b67b10a240fc6eb4f3170e7e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->