### PR TITLE
Fix unpairing IterableDatasetDict preference datasets

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -18,7 +18,7 @@ from time import strftime
 
 import pytest
 import transformers
-from datasets import Dataset, DatasetDict
+from datasets import Dataset, DatasetDict, IterableDatasetDict
 from packaging.version import Version
 from transformers import AutoProcessor, AutoTokenizer, is_vision_available
 
@@ -1089,6 +1089,15 @@ class TestUnpairPreferenceDataset(TrlTestCase):
         assert unpaired_dataset_dict["abc"].to_dict() == self.unpaired_dataset.to_dict(), (
             "The paired dataset should be converted to unpaired."
         )
+
+    def test_unpair_preference_iterable_dataset_dict(self):
+        # Test that a paired iterable dataset dict is correctly converted to unpaired
+        paired_dataset_dict = IterableDatasetDict({"abc": self.paired_dataset.to_iterable_dataset()})
+        unpaired_dataset_dict = unpair_preference_dataset(paired_dataset_dict)
+        assert list(unpaired_dataset_dict["abc"]) == [
+            dict(zip(self.unpaired_dataset.column_names, vals, strict=False))
+            for vals in zip(*self.unpaired_dataset.to_dict().values(), strict=False)
+        ]
 
     def test_maybe_unpair_preference_dataset(self):
         # Test that a paired dataset is correctly converted to unpaired with maybe_unpair_preference_dataset

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -494,7 +494,7 @@ def unpair_preference_dataset(
     {'prompt': 'The sky is', 'completion': ' blue.', 'label': True}
     ```
     """
-    if isinstance(dataset, DatasetDict):
+    if isinstance(dataset, (DatasetDict, IterableDatasetDict)):
         column_names = next(iter(dataset.values())).column_names
     elif isinstance(dataset, Dataset):
         column_names = dataset.column_names


### PR DESCRIPTION
# What does this PR do?

Fixes #6877.

`unpair_preference_dataset` handled `DatasetDict` separately but sent `IterableDatasetDict.column_names`, a split-to-columns mapping, directly to `remove_columns`. The iterable map therefore retained `chosen` and `rejected`, whose original batch length conflicts with the doubled unpaired output.

This change reads the column names from the first split for both dataset-dictionary types and adds regression coverage that materializes the unpaired iterable split.

Validation:

- `10 passed` for `TestUnpairPreferenceDataset`
- focused Ruff check and format check
- `git diff --check`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in preference dataset preprocessing with regression tests; no auth or security impact.
> 
> **Overview**
> Fixes **#6877** by correcting how `unpair_preference_dataset` resolves columns for **`IterableDatasetDict`**.
> 
> Previously only **`DatasetDict`** took column names from the first split; **`IterableDatasetDict`** fell through to the iterable path and passed **`column_names`** (a per-split dict) into **`remove_columns`**, so **`chosen`** / **`rejected`** were not dropped and batched unpairing could misalign lengths. The function now treats **`DatasetDict`** and **`IterableDatasetDict`** the same: **`column_names`** comes from **`next(iter(dataset.values())).column_names`**.
> 
> Adds **`test_unpair_preference_iterable_dataset_dict`** to assert an iterable split unpairs to the expected rows when materialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c8397e29ced72d6b209617c26995de6453b7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->