### PR TITLE
Fix equals syntax for accelerate config

### DIFF
--- a/tests/test_accelerate_config.py
+++ b/tests/test_accelerate_config.py
@@ -1,0 +1,36 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from trl.cli.accelerate_config import resolve_accelerate_config_argument
+
+
+@pytest.mark.parametrize(
+    "config_argument", [["--accelerate_config", "single_gpu"], ["--accelerate_config=single_gpu"]]
+)
+def test_resolve_packaged_accelerate_config(config_argument):
+    launch_args = resolve_accelerate_config_argument([*config_argument, "--num_processes", "2"])
+
+    assert launch_args[0] == "--config_file"
+    assert Path(launch_args[1]).name == "single_gpu.yaml"
+    assert launch_args[2:] == ["--num_processes", "2"]
+
+
+@pytest.mark.parametrize("config_argument", ["--accelerate_config", "--accelerate_config="])
+def test_resolve_accelerate_config_requires_value(config_argument):
+    with pytest.raises(ValueError, match="Expected a value"):
+        resolve_accelerate_config_argument([config_argument])

--- a/trl/cli/accelerate_config.py
+++ b/trl/cli/accelerate_config.py
@@ -23,14 +23,22 @@ def resolve_accelerate_config_argument(launch_args: list[str]) -> list[str]:
     The function supports either a filesystem path or a predefined config name shipped in `trl/accelerate_configs`
     (without the `.yaml` suffix).
     """
-    if "--accelerate_config" not in launch_args:
+    for config_index, argument in enumerate(launch_args):
+        if argument == "--accelerate_config":
+            if config_index + 1 >= len(launch_args):
+                raise ValueError("Expected a value after `--accelerate_config`.")
+            config_name = launch_args[config_index + 1]
+            argument_count = 2
+            break
+        if argument.startswith("--accelerate_config="):
+            config_name = argument.split("=", 1)[1]
+            if not config_name:
+                raise ValueError("Expected a value after `--accelerate_config`.")
+            argument_count = 1
+            break
+    else:
         return launch_args
 
-    config_index = launch_args.index("--accelerate_config")
-    if config_index + 1 >= len(launch_args):
-        raise ValueError("Expected a value after `--accelerate_config`.")
-
-    config_name = launch_args[config_index + 1]
     if Path(config_name).is_file():
         accelerate_config_path = config_name
     else:
@@ -42,6 +50,6 @@ def resolve_accelerate_config_argument(launch_args: list[str]) -> list[str]:
             )
         accelerate_config_path = candidate
 
-    # Remove '--accelerate_config <value>'.
-    launch_args = launch_args[:config_index] + launch_args[config_index + 2 :]
+    # Remove '--accelerate_config <value>' or '--accelerate_config=<value>'.
+    launch_args = launch_args[:config_index] + launch_args[config_index + argument_count :]
     return ["--config_file", str(accelerate_config_path)] + launch_args


### PR DESCRIPTION
# What does this PR do?

Normalize the standard `--accelerate_config=<name>` spelling before forwarding launch arguments to Accelerate. Both the equals form and the existing two-token form now resolve packaged configurations while preserving the remaining launch arguments.

Fixes #6874

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only argument parsing change with new unit tests; no auth, data, or training logic touched.
> 
> **Overview**
> **`resolve_accelerate_config_argument`** now accepts **`--accelerate_config=<name>`** in addition to the two-token **`--accelerate_config <name>`** form, strips the correct number of argv tokens for each spelling, and raises **`ValueError`** when the equals form has no value (e.g. **`--accelerate_config=`**).
> 
> Behavior is unchanged otherwise: packaged names still map to **`trl/accelerate_configs`**, paths still work, and the flag is still rewritten to **`--config_file`** with trailing launch args preserved.
> 
> Adds **`tests/test_accelerate_config.py`** with parametrized coverage for both spellings and missing-value cases. Fixes #6874.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382ccac910cf30ae66023984435673e3ff4f314c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->