### PR TITLE
Remove the stale detector exclusion comment

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -30,6 +30,5 @@ jobs:
         # the action runs the scanner as a container and defaults to the mutable `:latest` tag, so the SHA above
         # pins only the wrapper. pin the image by digest too, and bump it together with the action SHA.
         version: 3.97.0@sha256:ff4c95e9df7d645daf2140e3ca1039031c63106268d5fbb25feb43ceca1bcc33
-        # exclude buggy detectors that cause false positives and are not relevant to our codebase.
         # without --fail-on-scan-errors, a scan that errors out and covers nothing passes as a scan that found nothing.
         extra_args: --results=verified,unknown --fail-on-scan-errors


### PR DESCRIPTION
This PR removes a comment left behind by #6920 and #6921, which describes a flag that no longer exists.

### Motivation

#6920 and #6921 re-enabled the `lob` and `postgres` detectors, and the second of the two dropped `--exclude-detectors` entirely, since the list had become empty. The comment introducing it was not removed with it:

```yaml
        # exclude buggy detectors that cause false positives and are not relevant to our codebase.
        # without --fail-on-scan-errors, a scan that errors out and covers nothing passes as a scan that found nothing.
        extra_args: --results=verified,unknown --fail-on-scan-errors
```

We no longer exclude any detector, so the first line documents nothing.

### Changes

- Remove the comment describing the detector exclusions

### Note

No behaviour change: the file is only stripped of one comment line, and `grep` confirms nothing under `.github/` still refers to `--exclude-detectors`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in CI workflow; no scanner flags or runtime behavior modified.
> 
> **Overview**
> Removes an obsolete comment in `.github/workflows/trufflehog.yml` that still claimed the secret scan **excludes buggy detectors** via flags that were already dropped in earlier PRs.
> 
> **TruffleHog** `extra_args` (`--results=verified,unknown --fail-on-scan-errors`) and the remaining inline comment about `--fail-on-scan-errors` are unchanged—this is comment-only cleanup so the workflow docs match current behavior (no detector exclusions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4240c53d79fd76bd314938dbbf645007e13297a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->