### PR TITLE
Convert the QLoRA tests to the quantization_config trainer argument

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1410,26 +1410,26 @@ class TestDPOTrainer(TrlTestCase):
 
     @require_peft
     @require_bitsandbytes
-    def test_peft_with_quantization(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    def test_train_peft_and_quantization(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
 
+        training_args = DPOConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
         quantization_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=True,
             bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.float16,
+            bnb_4bit_compute_dtype=torch.bfloat16,
         )
-        model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            dtype="float32",
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",  # identifier, so that the trainer quantizes it
+            args=training_args,
+            train_dataset=dataset,
             quantization_config=quantization_config,
+            peft_config=LoraConfig(),
         )
 
-        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
-
-        # Initialize the trainer with the already configured PeftModel
-        training_args = DPOConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
-        trainer = DPOTrainer(model=model, args=training_args, train_dataset=dataset, peft_config=LoraConfig())
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
@@ -1438,38 +1438,14 @@ class TestDPOTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
         assert trainer.state.log_history[-1]["mean_token_accuracy"] is not None
 
-        # In bitsandbytes, a Linear4bit's bias is cast in-place to the input dtype during the forward pass if its
-        # dtype doesn't match, which changes these specific bias parameters unexpectedly during the first forward
-        # pass of training. Before bitsandbytes 0.50.0, this only affected the biases below; from 0.50.0 on
-        # (https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1904), the cast happens after the input is
-        # cast to the compute dtype, so it now affects every layer's biases instead of only some.
-        import bitsandbytes as bnb
-
-        bnb_bias_params_that_change = [
-            "base_model.model.model.layers.1.self_attn.k_proj.bias",
-            "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-            "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-        ]
-        if Version(bnb.__version__) >= Version("0.50.0"):
-            bnb_bias_params_that_change += [
-                "base_model.model.model.layers.0.self_attn.k_proj.bias",
-                "base_model.model.model.layers.0.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.0.self_attn.v_proj.base_layer.bias",
-            ]
-
-        # Check that the peft params have changed and the base model params have not changed
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            if n in bnb_bias_params_that_change:
-                param = param.float()
-                new_param = new_param.float()
-
-            if "lora" not in n:  # We expect the base model params to be the same (up to the bnb bias dtype cast above)
-                torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
-            elif "lora" in n:  # We expect the peft params to be different
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
-            else:
-                raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
 
 
 @require_vision

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -1334,26 +1334,26 @@ class TestKTOTrainer(TrlTestCase):
 
     @require_peft
     @require_bitsandbytes
-    def test_peft_with_quantization(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    def test_train_peft_and_quantization(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
 
+        training_args = KTOConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
         quantization_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=True,
             bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.float16,
+            bnb_4bit_compute_dtype=torch.bfloat16,
         )
-        model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            dtype="float32",
+        trainer = KTOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",  # identifier, so that the trainer quantizes it
+            args=training_args,
+            train_dataset=dataset,
             quantization_config=quantization_config,
+            peft_config=LoraConfig(),
         )
 
-        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
-
-        # Initialize the trainer with the already configured PeftModel
-        training_args = KTOConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
-        trainer = KTOTrainer(model=model, args=training_args, train_dataset=dataset, peft_config=LoraConfig())
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
@@ -1361,38 +1361,14 @@ class TestKTOTrainer(TrlTestCase):
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
 
-        # In bitsandbytes, a Linear4bit's bias is cast in-place to the input dtype during the forward pass if its
-        # dtype doesn't match, which changes these specific bias parameters unexpectedly during the first forward
-        # pass of training. Before bitsandbytes 0.50.0, this only affected the biases below; from 0.50.0 on
-        # (https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1904), the cast happens after the input is
-        # cast to the compute dtype, so it now affects every layer's biases instead of only some.
-        import bitsandbytes as bnb
-
-        bnb_bias_params_that_change = [
-            "base_model.model.model.layers.1.self_attn.k_proj.bias",
-            "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-            "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-        ]
-        if Version(bnb.__version__) >= Version("0.50.0"):
-            bnb_bias_params_that_change += [
-                "base_model.model.model.layers.0.self_attn.k_proj.bias",
-                "base_model.model.model.layers.0.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.0.self_attn.v_proj.base_layer.bias",
-            ]
-
-        # Check that the peft params have changed and the base model params have not changed
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            if n in bnb_bias_params_that_change:
-                param = param.float()
-                new_param = new_param.float()
-
-            if "lora" not in n:  # We expect the base model params to be the same (up to the bnb bias dtype cast above)
-                torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
-            elif "lora" in n:  # We expect the peft params to be different
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
-            else:
-                raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
 
 
 @require_vision

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2197,26 +2197,26 @@ class TestSFTTrainer(TrlTestCase):
 
     @require_peft
     @require_bitsandbytes
-    def test_peft_with_quantization(self):
-        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    def test_train_peft_and_quantization(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
 
+        training_args = SFTConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
         quantization_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=True,
             bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.float16,
+            bnb_4bit_compute_dtype=torch.bfloat16,
         )
-        model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            dtype="float32",
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",  # identifier, so that the trainer quantizes it
+            args=training_args,
+            train_dataset=dataset,
             quantization_config=quantization_config,
+            peft_config=LoraConfig(),
         )
 
-        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
-
-        # Initialize the trainer with the already configured PeftModel
-        training_args = SFTConfig(output_dir=self.tmp_dir, learning_rate=0.1, report_to="none")
-        trainer = SFTTrainer(model=model, args=training_args, train_dataset=dataset, peft_config=LoraConfig())
+        # Check that the trainer applied the quantization config when loading the model
+        assert trainer.model.base_model.model.is_loaded_in_4bit
 
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
 
@@ -2225,38 +2225,14 @@ class TestSFTTrainer(TrlTestCase):
         assert trainer.state.log_history[-1]["train_loss"] is not None
         assert trainer.state.log_history[-1]["mean_token_accuracy"] is not None
 
-        # In bitsandbytes, a Linear4bit's bias is cast in-place to the input dtype during the forward pass if its
-        # dtype doesn't match, which changes these specific bias parameters unexpectedly during the first forward
-        # pass of training. Before bitsandbytes 0.50.0, this only affected the biases below; from 0.50.0 on
-        # (https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1904), the cast happens after the input is
-        # cast to the compute dtype, so it now affects every layer's biases instead of only some.
-        import bitsandbytes as bnb
-
-        bnb_bias_params_that_change = [
-            "base_model.model.model.layers.1.self_attn.k_proj.bias",
-            "base_model.model.model.layers.1.self_attn.q_proj.base_layer.bias",
-            "base_model.model.model.layers.1.self_attn.v_proj.base_layer.bias",
-        ]
-        if Version(bnb.__version__) >= Version("0.50.0"):
-            bnb_bias_params_that_change += [
-                "base_model.model.model.layers.0.self_attn.k_proj.bias",
-                "base_model.model.model.layers.0.self_attn.q_proj.base_layer.bias",
-                "base_model.model.model.layers.0.self_attn.v_proj.base_layer.bias",
-            ]
-
-        # Check that the peft params have changed and the base model params have not changed
+        # Check that the peft params have changed, and that they are cast to bfloat16, as recommended by the QLoRA
+        # paper. The base model params are not checked: bitsandbytes casts the biases of a Linear4bit in-place during
+        # the forward pass, so some of them change in a way that is unrelated to training.
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
-            if n in bnb_bias_params_that_change:
-                param = param.float()
-                new_param = new_param.float()
-
-            if "lora" not in n:  # We expect the base model params to be the same (up to the bnb bias dtype cast above)
-                torch.testing.assert_close(param, new_param, msg=f"Parameter {n} has changed.")
-            elif "lora" in n:  # We expect the peft params to be different
+            if "lora" in n:  # We expect the peft params to be different
+                assert param.dtype == torch.bfloat16, f"Parameter {n} is not in bfloat16."
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
-            else:
-                raise ValueError(f"Unexpected parameter {n} in model: {trainer.model}")
 
     @require_peft
     def test_prompt_tuning_peft_model(self):


### PR DESCRIPTION
This PR converts the QLoRA tests of SFT, DPO and KTO to the `quantization_config` trainer argument, so that all the trainers that support it are tested the same way.

Companion of #6909 and #6910, which add the same test to the trainers that had none.

### Motivation

`test_peft_with_quantization` quantizes the model with `from_pretrained` and hands the instantiated model to the trainer. This leaves the `quantization_config` trainer argument untested, although it is the documented way to do QLoRA training ("Combine with `peft_config` for QLoRA training"), and it is the only shape that the new tests of #6909 and #6910 could not reuse:

- the branch that forwards the config to the model loading is never exercised
- the assertion that the base model params are unchanged relies on a hardcoded list of the biases that bitsandbytes casts in-place during the forward pass, gated on bitsandbytes 0.50.0. That list depends on which layers ran a forward pass, so it cannot be reused in GRPO and RLOO, where generation runs before training. It also has to be revisited whenever bitsandbytes changes that behavior, as in #6546.

### Solution

Rewrite the three tests onto the shape used by #6909 and #6910: the model is passed as an identifier together with a `quantization_config`, and the test checks that the trainer loaded it in 4-bit and that the adapter weights are trained and cast to bf16. The seven trainers that expose `quantization_config` then share the same test, the trainer call, its config and the dataset aside.

Two things are dropped on purpose:

- the coverage of an already quantized model passed to the trainer. That branch logs two warnings and contains no quantization logic: the detection of a quantized model, the QLoRA bf16 cast and the PEFT wrapping all happen after it, and are reached the same way through the trainer argument.
- the assertion that the base model params are unchanged, with the bitsandbytes bias list it needs. Each of the three test files already asserts it in its non-quantized PEFT tests.

### Changes

- Pass the model as an identifier together with a `quantization_config` in the SFT, DPO and KTO QLoRA tests
- Check that the model is loaded in 4-bit, and that the adapter weights are trained and cast to bf16
- Remove the hardcoded bitsandbytes bias list and its version gate
- Rename the tests to `test_train_peft_and_quantization`, matching the tests added in #6909 and #6910

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no trainer or library behavior changes; slightly narrower assertions on quantized base weights by design.
> 
> **Overview**
> **Aligns SFT, DPO, and KTO QLoRA integration tests** with the documented path: model hub id plus `quantization_config` and `peft_config` on the trainer, instead of handing in a pre-quantized `from_pretrained` model.
> 
> Each renamed `test_train_peft_and_quantization` now asserts **4-bit load** (`is_loaded_in_4bit`), runs a short train step, and checks that **LoRA weights update and stay in bfloat16** (compute dtype switched from fp16 to bf16). The old **bitsandbytes bias allowlist** and **frozen base-weight** checks are removed because in-place bias casts make those assertions brittle; non-quantized PEFT tests still cover frozen bases elsewhere.
> 
> This matches the shared QLoRA test shape used for other trainers in related PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b058f9484dd297ff35b4e72dd58588579cf54f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->