### PR TITLE
fix(data): support content-less vLLM tool calls

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -270,6 +270,30 @@ class TestPrepareMultimodalMessages:
 
 @require_vision
 class TestPrepareMultimodalMessagesVLLM:
+    def test_tool_call_message_without_content(self):
+        messages = prepare_multimodal_messages(
+            [
+                {"role": "user", "content": "What is the weather in New York?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "type": "tool",
+                            "function": {"name": "get_current_weather", "arguments": {"location": "New York"}},
+                        }
+                    ],
+                },
+            ]
+        )
+        original = copy.deepcopy(messages)
+
+        result = prepare_multimodal_messages_vllm(messages)
+
+        assert result == original
+        assert result is not messages
+        assert result[1] is not messages[1]
+        assert messages == original
+
     def test_single_image_conversion(self):
         messages = [
             {

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -132,7 +132,8 @@ def prepare_multimodal_messages_vllm(messages: list[dict[str, Any]]) -> list[dic
 
     Args:
         messages (`list[dict[str, Any]]`):
-            Messages with `"role"` and `"content"`. Content is expected to be a list of structured blocks.
+            Messages with `"role"` and `"content"` (or `"tool_calls"`). Content is expected to be a list of structured
+            blocks when present.
 
     Returns:
         `list[dict[str, Any]]`:
@@ -149,8 +150,9 @@ def prepare_multimodal_messages_vllm(messages: list[dict[str, Any]]) -> list[dic
     """
     messages = copy.deepcopy(messages)  # avoid modifying the original messages
     for message in messages:
-        if isinstance(message["content"], list):
-            for part in message["content"]:
+        content = message.get("content")
+        if isinstance(content, list):
+            for part in content:
                 if part["type"] == "image":
                     part["type"] = "image_pil"  # vLLM expects 'image_pil' key for images
                     part["image_pil"] = part.pop("image")


### PR DESCRIPTION
# What does this PR do?

`prepare_multimodal_messages` already produces valid assistant tool-call messages without a `content` field. `prepare_multimodal_messages_vllm` then unconditionally accesses `message["content"]`, raising `KeyError` instead of preserving the tool-call message.

This patch reads `content` defensively and performs the existing image conversion only when it is a structured-content list. It adds a regression that exercises the base helper followed by the vLLM helper, verifies the content-less tool-call message is preserved, and verifies the input is not mutated.

Fixes #6928

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? The linked issue contains a reproducible failure.
- [x] Did you make sure to update the documentation with your changes? The helper docstring now documents content-less `tool_calls` messages.
- [x] Did you write any new necessary tests?

## Tests

Executed locally:

```text
uv run --no-sync python -m pytest tests/test_data_utils.py -k 'tool_call_message_without_content' -vv -ra
# 1 passed

uv run --no-sync python -m pytest tests/test_data_utils.py -k 'PrepareMultimodalMessagesVLLM' -vv -ra
# 6 passed, 588 deselected

uvx ruff check --select F,I trl/data_utils.py tests/test_data_utils.py
uvx ruff format --check trl/data_utils.py tests/test_data_utils.py
git diff --check
```

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

AI assistance was used to investigate, draft, and test this contribution. The human submitter reviewed every changed line, understands the behavior, and witnessed the tests listed above.

## Who can review?

Anyone in the community is welcome to review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in message preprocessing with a focused regression test; no auth or training-core logic touched.
> 
> **Overview**
> Fixes a **`KeyError`** when `prepare_multimodal_messages_vllm` processes assistant turns that only have **`tool_calls`** (no `content`), which `prepare_multimodal_messages` already allows.
> 
> The vLLM helper now reads **`content` via `message.get("content")`** and runs the existing image `image` → `image_pil` conversion only when that value is a structured list. The docstring notes messages with **`tool_calls`** instead of `content`.
> 
> A regression test chains **`prepare_multimodal_messages`** → **`prepare_multimodal_messages_vllm`** on a tool-call turn and checks the message is unchanged, deep-copied, and the input is not mutated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8976ecf0fee649b3fc6d8b6f6cf1e00d98007170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->