### PR TITLE
Fix the Slack title of the TRL Docker image build job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: 🤗 Results of the TRL Dev Docker Image build
+          title: 🤗 Results of the TRL Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 


### PR DESCRIPTION
This PR fixes the Slack notification title of the TRL Docker image build job, which announced itself as the dev image build.

### Motivation

Both jobs in `docker-build.yml` post the same title, so the two notifications in the CI channel cannot be told apart.

Before #3931, the two titles were distinct: `🤗 Results of the trl-latest-gpu Docker Image build` and `🤗 Results of the trl-source-gpu Docker Image build`. That PR renamed the images and replaced both titles with the dev one, so the job building `huggingface/trl` has been mislabeled since then.

### Changes

- Drop "Dev" from the Slack title of the TRL Docker image build job
