### PR TITLE
Remove the redundant VERSION env from the Docker build step

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Build and Push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
-        env:
-          VERSION: ${{ env.VERSION }}
         with:
           context: docker/trl
           push: true


### PR DESCRIPTION
This PR removes a redundant environment variable declaration from the TRL Docker image build step.

### Motivation

The build and push step declares `VERSION` in its own `env` block, but the image tags read the value from the job environment, where it was already set. The declaration has no effect.

### Changes

- Remove the redundant `VERSION` environment variable from the Docker build and push step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow cleanup only; Docker tags and version resolution are unchanged.
> 
> **Overview**
> Removes the **Build and Push** step’s `env.VERSION` block in `.github/workflows/docker-build.yml`. Image tags still use `${{ env.VERSION }}` from the earlier **Get TRL version from PyPI** step, which writes `VERSION` to `$GITHUB_ENV`.
> 
> No change to tagging or build behavior—only drops duplicate configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ee4e4801c203345604148288c191a480f2d179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->