### PR TITLE
Remove the unused TRL dev Docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,37 +63,3 @@ jobs:
           title: 🤗 Results of the TRL Dev Docker Image build
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
-
-  trl-dev:
-    name: "Build and push TRL Dev Docker image"
-    runs-on:
-      group: aws-general-8-plus
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
-        with:
-          context: docker/trl-dev
-          push: true
-          tags: |
-            huggingface/trl:dev
-
-      - name: Post to Slack
-        if: always()
-        uses: ./.github/actions/post-slack
-        with:
-          slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: 🤗 Results of the TRL Dev Docker Image build
-          status: ${{ job.status }}
-          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/docker/trl-dev/Dockerfile
+++ b/docker/trl-dev/Dockerfile
@@ -1,5 +1,0 @@
-FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-RUN pip install --upgrade pip uv
-RUN uv pip install --system --no-cache "git+https://github.com/huggingface/trl.git#egg=trl[liger,peft,vlm]"
-RUN uv pip install --system kernels liger_kernel peft trackio


### PR DESCRIPTION
This PR removes the TRL dev Docker image, which has had no consumer for almost a year.

### Motivation

The Docker images were introduced in #1215 as pre-baked GPU environments for the slow tests workflow, which was created one day later in #1223 and consumed them as a `container:` matrix. The dev image is the descendant of `huggingface/trl-source-gpu`, named "Latest TRL + HF ecosystem from source", whose only purpose was to give the slow tests an environment built from the main branch.

#3931 replaced the two old images with `huggingface/trl` and `huggingface/trl:dev`. Three days later, #4085 switched the slow tests to `pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel` with `uv pip install ".[dev]"`, dropping both images.

Since then, `huggingface/trl:dev` has had no consumer:

- No workflow references it.
- It is not mentioned anywhere in the documentation, unlike `huggingface/trl`, which the Jobs guide documents as `--image huggingface/trl`.

It is still rebuilt and pushed on every single push to main, which is about 150 builds per month of a 9.6 GB image that nothing pulls.

Removing it is also a prerequisite for building the released image on release rather than on every push to main: the dev image tracks the main branch, so it is the only reason the workflow needs to run per commit.

### Changes

- Remove the dev image Dockerfile
- Remove the dev image build job from the Docker build workflow

### Before merging

Does anyone rely on `huggingface/trl:dev`? It has never been documented, so I assume not, but I would rather confirm than break an undocumented workflow. Keeping this as a draft until then.

CC: @huggingface/trl 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only cleanup with no application or runtime code changes; only removes an undocumented image that nothing in the repo references.
> 
> **Overview**
> Stops building and publishing **`huggingface/trl:dev`** by deleting the **`trl-dev`** workflow job and removing **`docker/trl-dev/Dockerfile`**.
> 
> The main **`docker-build`** workflow now only builds the release **`huggingface/trl`** image (version-tagged from PyPI plus **`latest`**), with Slack notification unchanged for that job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b5a8935fda2cdf0d43b0bffb85a0a61366328d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->