### PR TITLE
Make the Slack CI report readable at a glance

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -19,14 +19,21 @@ runs:
     - name: Create content to post
       id: create-message
       run: |
-        if [ "${{ job.status }}" == "success" ]; then
-          echo STATUS_MESSAGE='🟢 Tests are passing!' >> $GITHUB_ENV
-        else
-          echo STATUS_MESSAGE='🔴 Tests failed! Please check the GitHub action link below' >> $GITHUB_ENV
-        fi
+        case "${{ job.status }}" in
+          success)   echo "STATUS_EMOJI=🟢" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#2eb886" >> $GITHUB_ENV
+                     echo "STATUS_TEXT=passing" >> $GITHUB_ENV ;;
+          cancelled) echo "STATUS_EMOJI=⚪" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#8d8d8d" >> $GITHUB_ENV
+                     echo "STATUS_TEXT=cancelled" >> $GITHUB_ENV ;;
+          *)         echo "STATUS_EMOJI=🔴" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
+                     echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
+        esac
+        echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       shell: bash
 
-    - name: Post Canceled results Slack channel
+    - name: Post results to Slack channel
       id: post-slack
       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
       with:
@@ -37,33 +44,44 @@ runs:
         # For posting a rich message using Block Kit. The channel is a Slack
         # channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
+        # The blocks live inside an attachment so the message gets a coloured
+        # bar matching the job status. Slack has no Block Kit equivalent for it.
         payload: |
           {
             "channel": "${{ inputs.slack_channel }}",
-            "text": "${{ inputs.title }}",
-            "blocks": [
+            "text": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}: ${{ env.STATUS_TEXT }}",
+            "attachments": [
               {
-                "type": "header",
-                "text": {
-                    "type": "plain_text",
-                    "text": "${{ inputs.title }}"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "${{ env.STATUS_MESSAGE }}"
-                }
-              },
-              {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "*Click here for more details about the action ran*"},
-                "accessory": {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "Check Action results"},
-                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                }
+                "color": "${{ env.STATUS_COLOR }}",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {"type": "mrkdwn", "text": "*Workflow*\n${{ github.workflow }}"},
+                      {"type": "mrkdwn", "text": "*Branch*\n`${{ github.ref_name }}`"},
+                      {"type": "mrkdwn", "text": "*Commit*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ env.SHORT_SHA }}`>"},
+                      {"type": "mrkdwn", "text": "*Triggered by*\n${{ github.actor }}"}
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View run", "emoji": true},
+                        "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -30,11 +30,6 @@ runs:
                      echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
                      echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
         esac
-        # Read the SHA from the checkout, not from the event: workflows that test another
-        # ref (tests_latest checks out the release branch) would otherwise link a main commit.
-        SHA=$(git rev-parse HEAD)
-        echo "SHA=$SHA" >> $GITHUB_ENV
-        echo "SHORT_SHA=${SHA:0:7}" >> $GITHUB_ENV
       shell: bash
 
     - name: Post results to Slack channel
@@ -62,7 +57,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}* · <${{ github.server_url }}/${{ github.repository }}/commit/${{ env.SHA }}|`${{ env.SHORT_SHA }}`>"
+                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}*"
                     },
                     "accessory": {
                       "type": "button",

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -30,7 +30,11 @@ runs:
                      echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
                      echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
         esac
-        echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+        # Read the SHA from the checkout, not from the event: workflows that test another
+        # ref (tests_latest checks out the release branch) would otherwise link a main commit.
+        SHA=$(git rev-parse HEAD)
+        echo "SHA=$SHA" >> $GITHUB_ENV
+        echo "SHORT_SHA=${SHA:0:7}" >> $GITHUB_ENV
       shell: bash
 
     - name: Post results to Slack channel
@@ -58,7 +62,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}* · <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ env.SHORT_SHA }}`>"
+                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}* · <${{ github.server_url }}/${{ github.repository }}/commit/${{ env.SHA }}|`${{ env.SHORT_SHA }}`>"
                     },
                     "accessory": {
                       "type": "button",

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -20,13 +20,13 @@ runs:
       id: create-message
       run: |
         case "${{ job.status }}" in
-          success)   echo "STATUS_EMOJI=🟢" >> $GITHUB_ENV
+          success)   echo "STATUS_EMOJI=✅" >> $GITHUB_ENV
                      echo "STATUS_COLOR=#2eb886" >> $GITHUB_ENV
                      echo "STATUS_TEXT=passing" >> $GITHUB_ENV ;;
           cancelled) echo "STATUS_EMOJI=⚪" >> $GITHUB_ENV
                      echo "STATUS_COLOR=#8d8d8d" >> $GITHUB_ENV
                      echo "STATUS_TEXT=cancelled" >> $GITHUB_ENV ;;
-          *)         echo "STATUS_EMOJI=🔴" >> $GITHUB_ENV
+          *)         echo "STATUS_EMOJI=❌" >> $GITHUB_ENV
                      echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
                      echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
         esac
@@ -44,7 +44,7 @@ runs:
         # For posting a rich message using Block Kit. The channel is a Slack
         # channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
-        # The blocks live inside an attachment so the message gets a coloured
+        # The block lives inside an attachment so the message gets a coloured
         # bar matching the job status. Slack has no Block Kit equivalent for it.
         payload: |
           {
@@ -55,31 +55,16 @@ runs:
                 "color": "${{ env.STATUS_COLOR }}",
                 "blocks": [
                   {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}",
-                      "emoji": true
-                    }
-                  },
-                  {
                     "type": "section",
-                    "fields": [
-                      {"type": "mrkdwn", "text": "*Workflow*\n${{ github.workflow }}"},
-                      {"type": "mrkdwn", "text": "*Branch*\n`${{ github.ref_name }}`"},
-                      {"type": "mrkdwn", "text": "*Commit*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ env.SHORT_SHA }}`>"},
-                      {"type": "mrkdwn", "text": "*Triggered by*\n${{ github.actor }}"}
-                    ]
-                  },
-                  {
-                    "type": "actions",
-                    "elements": [
-                      {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": "View run", "emoji": true},
-                        "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                      }
-                    ]
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}* · <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ env.SHORT_SHA }}`>"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {"type": "plain_text", "text": "View run", "emoji": true},
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
                   }
                 ]
               }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: 🤗 Results of the TRL Docker Image build
+          title: Build and push TRL Docker image
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   trl-dev:
@@ -91,5 +91,5 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: 🤗 Results of the TRL Dev Docker Image build
+          title: Build and push TRL Dev Docker image
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results of the slow tests on a single GPU
+          title: Slow tests on a single GPU
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   run_all_tests_multi_gpu:
@@ -124,5 +124,5 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results of the slow tests on multiple GPUs
+          title: Slow tests on multiple GPUs
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results with latest dependencies
+          title: Tests with latest dependencies
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_dev:
@@ -150,7 +150,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results with dev dependencies
+          title: Tests with dev dependencies
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_wo_optional_deps:
@@ -200,7 +200,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results without optional dependencies
+          title: Tests without optional dependencies
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   tests_min_versions:
@@ -254,7 +254,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results with minimum versions
+          title: Tests with minimum versions
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   distributed_smoke:
@@ -306,5 +306,5 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results of distributed smoke tests
+          title: Distributed smoke tests
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -76,5 +76,5 @@ jobs:
         uses: ./slack-action/.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results of latest TRL with Python 3.12 and dev dependencies
+          title: Tests latest TRL release with dev dependencies
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_python_versions.yml
+++ b/.github/workflows/tests_python_versions.yml
@@ -64,5 +64,5 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results with Python ${{ matrix.python-version }}
+          title: Tests with Python ${{ matrix.python-version }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/tests_transformers_branch.yml
+++ b/.github/workflows/tests_transformers_branch.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results with Transformers ${{ inputs.transformers_ref }}
+          title: Tests with Transformers ${{ inputs.transformers_ref }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   distributed_smoke:
@@ -121,5 +121,5 @@ jobs:
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Results of distributed smoke tests with Transformers ${{ inputs.transformers_ref }}
+          title: Distributed smoke tests with Transformers ${{ inputs.transformers_ref }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
Follow-up to #6908. The Slack report is now a single line, `✅ *<job name>*` with a "View run" button, in a status-coloured attachment. The status word moved into the top-level `text`, which is what mobile notifications use, so pass and fail no longer look identical there. Cancelled is no longer reported as a failure.

Also aligned the 13 `title:` values on one rule: the Slack title is the job's `name:`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification formatting and copy only; no application runtime or security-sensitive logic changes.
> 
> **Overview**
> **Slack CI notifications** are redesigned so status is obvious at a glance and on mobile push text.
> 
> The composite `post-slack` action now maps `job.status` to **success / cancelled / failure** with distinct emoji, attachment color, and a short status word (`passing`, `cancelled`, `failed`) instead of treating everything non-success as failure. Messages use a **colored attachment** with a compact line (`emoji` + bold title) and a **View run** button; the fallback `text` field includes the status word so notifications no longer look the same for pass vs fail.
> 
> Across **13 workflow call sites**, `title` strings were normalized to match each job’s `name:` (e.g. “Tests with …”, “Build and push …”) rather than “Results of …”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89c9c5b89e091b37d9a71607d5ccc0a1ad9a6af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->