### PR TITLE
Fix the Slack report posting twice

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -21,13 +21,10 @@ runs:
       run: |
         case "${{ job.status }}" in
           success)   echo "STATUS_EMOJI=✅" >> $GITHUB_ENV
-                     echo "STATUS_COLOR=#2eb886" >> $GITHUB_ENV
                      echo "STATUS_TEXT=passing" >> $GITHUB_ENV ;;
           cancelled) echo "STATUS_EMOJI=⚪" >> $GITHUB_ENV
-                     echo "STATUS_COLOR=#8d8d8d" >> $GITHUB_ENV
                      echo "STATUS_TEXT=cancelled" >> $GITHUB_ENV ;;
           *)         echo "STATUS_EMOJI=❌" >> $GITHUB_ENV
-                     echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
                      echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
         esac
       shell: bash
@@ -43,29 +40,24 @@ runs:
         # For posting a rich message using Block Kit. The channel is a Slack
         # channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
-        # The block lives inside an attachment so the message gets a coloured
-        # bar matching the job status. Slack has no Block Kit equivalent for it.
+        # `text` is the notification fallback: Slack hides it from the message body
+        # as long as `blocks` is set, and mobile notifications use it exclusively.
         payload: |
           {
             "channel": "${{ inputs.slack_channel }}",
             "text": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}: ${{ env.STATUS_TEXT }}",
-            "attachments": [
+            "blocks": [
               {
-                "color": "${{ env.STATUS_COLOR }}",
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}*"
-                    },
-                    "accessory": {
-                      "type": "button",
-                      "text": {"type": "plain_text", "text": "View run", "emoji": true},
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  }
-                ]
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}*"
+                },
+                "accessory": {
+                  "type": "button",
+                  "text": {"type": "plain_text", "text": "View run", "emoji": true},
+                  "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
               }
             ]
           }

--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -21,10 +21,13 @@ runs:
       run: |
         case "${{ job.status }}" in
           success)   echo "STATUS_EMOJI=✅" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#2eb886" >> $GITHUB_ENV
                      echo "STATUS_TEXT=passing" >> $GITHUB_ENV ;;
           cancelled) echo "STATUS_EMOJI=⚪" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#8d8d8d" >> $GITHUB_ENV
                      echo "STATUS_TEXT=cancelled" >> $GITHUB_ENV ;;
           *)         echo "STATUS_EMOJI=❌" >> $GITHUB_ENV
+                     echo "STATUS_COLOR=#d5382a" >> $GITHUB_ENV
                      echo "STATUS_TEXT=failed" >> $GITHUB_ENV ;;
         esac
       shell: bash
@@ -40,24 +43,30 @@ runs:
         # For posting a rich message using Block Kit. The channel is a Slack
         # channel id, channel name, or user id to post message to.
         # See also: https://api.slack.com/methods/chat.postMessage#channels
-        # `text` is the notification fallback: Slack hides it from the message body
-        # as long as `blocks` is set, and mobile notifications use it exclusively.
+        # No top-level `text`: Slack only hides it from the message body when the
+        # blocks are top-level too, and here they sit in an attachment to get the
+        # coloured bar. The attachment `fallback` carries the notification summary.
         payload: |
           {
             "channel": "${{ inputs.slack_channel }}",
-            "text": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}: ${{ env.STATUS_TEXT }}",
-            "blocks": [
+            "attachments": [
               {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}*"
-                },
-                "accessory": {
-                  "type": "button",
-                  "text": {"type": "plain_text", "text": "View run", "emoji": true},
-                  "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                }
+                "color": "${{ env.STATUS_COLOR }}",
+                "fallback": "${{ env.STATUS_EMOJI }} ${{ inputs.title }}: ${{ env.STATUS_TEXT }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "${{ env.STATUS_EMOJI }} *${{ inputs.title }}*"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {"type": "plain_text", "text": "View run", "emoji": true},
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
Follow-up to #6934, which shipped a bug: every report posts twice, once as the plain fallback line and once as the attachment.

Slack only hides the top-level `text` from the message body when the blocks are top-level too. #6934 put them in an attachment to get the status-coloured bar, so `text` rendered as normal message content. Dropping it fixes the duplication, and the attachment's own `fallback` field carries the notification summary instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification formatting only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Fixes **duplicate Slack messages** from the composite `post-slack` action introduced after #6934: reports appeared once as plain text and again as the coloured attachment.
> 
> The `chat.postMessage` payload **drops top-level `text`** because Block Kit blocks live inside an **attachment** (for the status-coloured bar), so Slack does not suppress `text` the way it does when blocks are top-level. The same summary string moves to the attachment **`fallback`** so notifications and accessibility still get the emoji, title, and status line without a second visible line in the channel.
> 
> Comments in `action.yml` document this Slack behaviour for future edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e8c6b14abf4ef129178008d5aa44ae738852a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->