### PR TITLE
enable compiled Liger JSD losses

### DIFF
--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -1228,7 +1228,6 @@ class TestDistillationTrainer(TrlTestCase):
                 beta=trainer.beta,
                 ignore_index=-100,
                 temperature=trainer.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/experimental/gkd/gkd_trainer.py
+++ b/trl/experimental/gkd/gkd_trainer.py
@@ -153,7 +153,6 @@ class GKDTrainer(SFTTrainer):
             self.liger_loss = LigerFusedLinearJSDLoss(
                 beta=args.beta,
                 ignore_index=-100,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/experimental/gold/gold_trainer.py
+++ b/trl/experimental/gold/gold_trainer.py
@@ -927,7 +927,6 @@ class GOLDTrainer(SFTTrainer):
                 beta=args.beta,
                 ignore_index=-100,
                 temperature=args.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -493,7 +493,6 @@ class IWOPDTrainer(_BaseTrainer):
                 beta=args.beta,
                 ignore_index=-100,
                 temperature=args.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -397,7 +397,6 @@ class SDFTTrainer(_BaseTrainer):
                 beta=args.distillation_alpha,
                 ignore_index=-100,
                 temperature=args.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -536,7 +536,6 @@ class SDPOTrainer(_BaseTrainer):
                 beta=args.distillation_alpha,
                 ignore_index=-100,
                 temperature=args.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -652,7 +652,6 @@ class DistillationTrainer(_BaseTrainer):
                 beta=args.beta,
                 ignore_index=-100,
                 temperature=args.temperature,
-                compiled=False,
                 weight_hard_loss=0.0,
                 weight_soft_loss=1.0,
             )


### PR DESCRIPTION
# What does this PR do?

This PR enables `torch.compile` for `LigerFusedLinearJSDLoss` by removing TRL's explicit `compiled=False` override.

It updates all six trainers using Liger JSD:
- `DistillationTrainer`
- `GKDTrainer`
- `GOLDTrainer`
- `IWOPDTrainer`
- `SDFTTrainer`
- `SDPOTrainer`

The corresponding DistillationTrainer parity test now also exercises Liger's compiled default.

## Motivation

`LigerFusedLinearJSDLoss` defaults to `compiled=True`, and Liger's correctness tests exercise that default. Other Liger chunked losses used by TRL, including DPO and KTO, already use compilation.

TRL has explicitly disabled compilation for JSD since its initial integration in #3946. I found no documented correctness or compatibility reason for this override in the original PR or subsequent JSD fixes and refactors, including #5731 and #6537.

## Benchmark

The benchmark used the same single H100 environment for all configurations:
- Llama 3.2 1B student and teacher
- bfloat16
- sequence length 1024
- batch size 32
- 1,000 optimizer steps
- fused AdamW
- no gradient checkpointing
- no evaluation or checkpoint saving

Elapsed time was measured from the start of training through completion, so the initial compilation cost is included.

| Chunk size | Uncompiled | Compiled | Runtime reduction | Throughput gain |
|---:|---:|---:|---:|---:|
| 512 | 1.224 s/step, 26.8k tok/s | 0.874 s/step, 37.5k tok/s | 28.6% | 40.1% |
| 1024 | 1.202 s/step, 27.3k tok/s | 0.832 s/step, 39.4k tok/s | 30.8% | 44.6% |
| 2048 | 1.165 s/step, 28.1k tok/s | 0.829 s/step, 39.5k tok/s | 28.8% | 40.5% |
| 4096 | 1.157 s/step, 28.3k tok/s | 0.811 s/step, 40.4k tok/s | 29.9% | 42.7% |

Across the four tested chunk sizes, compilation reduced elapsed training time by approximately 29.5% and increased throughput by approximately 42%.

## Tests

The affected Liger tests were run with TRL's CI configuration:
- PyTorch 2.8.0+cu128
- Liger Kernel 0.8.2
- fresh TorchInductor cache

Result:
```text
14 passed, 1 skipped, 257 deselected
```

The suite covers the compiled JSD paths in Distillation, GKD, GOLD, IW-OPD, SDFT, and SDPO, including loss-parity and end-to-end training tests.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Training loss now goes through `torch.compile` on the fused JSD path, which can affect numerics, warmup/compile behavior, and PyTorch/Liger version compatibility despite existing parity tests.
> 
> **Overview**
> Stops forcing `compiled=False` on `LigerFusedLinearJSDLoss` so TRL’s distillation trainers use Liger’s default **torch.compile** path for fused JSD.
> 
> The change is applied everywhere TRL wires up that loss: **`DistillationTrainer`**, **`GKDTrainer`**, **`GOLDTrainer`**, **`IWOPDTrainer`**, **`SDFTTrainer`**, and **`SDPOTrainer`**. **`test_liger_loss_agrees_with_chunked`** in `test_distillation_trainer.py` is updated the same way, so parity checks run against the compiled kernel instead of an explicitly uncompiled instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 720bc4634f8ebd3f13bee691e45af359312fbeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->