### PR TITLE
Support the --accelerate_config=<name> equals-sign CLI syntax

### DIFF
--- a/tests/test_cli_accelerate_config.py
+++ b/tests/test_cli_accelerate_config.py
@@ -1,0 +1,56 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from trl.cli.accelerate_config import resolve_accelerate_config_argument
+
+
+class TestResolveAccelerateConfigArgument:
+    def test_two_token_form(self):
+        """`--accelerate_config <name>` is resolved into `--config_file <path>`."""
+        result = resolve_accelerate_config_argument(["--accelerate_config", "single_gpu", "--num_processes", "1"])
+        assert result[0] == "--config_file"
+        assert result[1].endswith("single_gpu.yaml")
+        assert result[2:] == ["--num_processes", "1"]
+
+    def test_equals_form(self):
+        """`--accelerate_config=<name>` (equals-sign form) is resolved the same way as the two-token form."""
+        result = resolve_accelerate_config_argument(["--accelerate_config=single_gpu", "--num_processes", "1"])
+        assert result[0] == "--config_file"
+        assert result[1].endswith("single_gpu.yaml")
+        assert result[2:] == ["--num_processes", "1"]
+
+    def test_equals_form_matches_two_token_form(self):
+        """Both syntaxes should resolve to the exact same launch arguments."""
+        equals_form = resolve_accelerate_config_argument(["--accelerate_config=single_gpu", "--foo", "bar"])
+        two_token_form = resolve_accelerate_config_argument(["--accelerate_config", "single_gpu", "--foo", "bar"])
+        assert equals_form == two_token_form
+
+    def test_no_accelerate_config_argument(self):
+        """When `--accelerate_config` isn't present, the arguments are returned unchanged."""
+        args = ["--foo", "bar"]
+        assert resolve_accelerate_config_argument(args) == args
+
+    def test_missing_value_raises(self):
+        """`--accelerate_config` with no value after it raises a clear error."""
+        with pytest.raises(ValueError, match="Expected a value after `--accelerate_config`"):
+            resolve_accelerate_config_argument(["--accelerate_config"])
+
+    def test_invalid_config_name_raises(self):
+        """An unknown config name (and not a file) raises a clear error, for both syntaxes."""
+        with pytest.raises(ValueError, match="is neither a file nor a valid config"):
+            resolve_accelerate_config_argument(["--accelerate_config", "does_not_exist"])
+        with pytest.raises(ValueError, match="is neither a file nor a valid config"):
+            resolve_accelerate_config_argument(["--accelerate_config=does_not_exist"])

--- a/trl/cli/accelerate_config.py
+++ b/trl/cli/accelerate_config.py
@@ -21,8 +21,17 @@ def resolve_accelerate_config_argument(launch_args: list[str]) -> list[str]:
     Resolve `--accelerate_config` from CLI arguments into `accelerate --config_file`.
 
     The function supports either a filesystem path or a predefined config name shipped in `trl/accelerate_configs`
-    (without the `.yaml` suffix).
+    (without the `.yaml` suffix). Both the two-token form (`--accelerate_config single_gpu`) and the `=`-joined form
+    (`--accelerate_config=single_gpu`) are supported.
     """
+    # Normalize the `--accelerate_config=<value>` form into the two-token `--accelerate_config <value>` form so the
+    # rest of the function only has to handle a single case.
+    for index, arg in enumerate(launch_args):
+        if arg.startswith("--accelerate_config="):
+            config_name = arg.split("=", 1)[1]
+            launch_args = launch_args[:index] + ["--accelerate_config", config_name] + launch_args[index + 1 :]
+            break
+
     if "--accelerate_config" not in launch_args:
         return launch_args
 


### PR DESCRIPTION
# What does this PR do?

`trl.cli.accelerate_config.resolve_accelerate_config_argument()` is responsible for turning
`--accelerate_config <name_or_path>` on the `trl <command>` CLI into the `--config_file <path>` argument that gets
forwarded to `accelerate launch`. It only recognized the two-token form
(`--accelerate_config single_gpu`): it looks up `"--accelerate_config"` as a standalone element of `launch_args`
with `launch_args.index("--accelerate_config")` and reads the following element as the value.

The equals-sign form that argparse-style CLIs commonly support, `--accelerate_config=single_gpu`, doesn't match
that lookup at all. Because `"--accelerate_config" not in launch_args` is true in that case, the function returns
`launch_args` unchanged, `--accelerate_config=single_gpu` gets passed straight through to `accelerate launch`
(which has no idea what to do with it) instead of being resolved to `--config_file .../single_gpu.yaml`, and the
requested config is silently ignored.

## Root cause

`resolve_accelerate_config_argument()` assumed `--accelerate_config` and its value are always two separate argv
elements, with no handling for the `--flag=value` form.

## Fix

Before doing the existing lookup, scan `launch_args` for an element starting with `"--accelerate_config="`, and if
found, split it into the two-token form (`["--accelerate_config", "<value>"]`) and rebuild `launch_args` with that
substitution. The rest of the function is untouched and now only ever has to deal with the two-token form, so both
syntaxes resolve identically (same `--config_file <path>` output and remaining args preserved).

## Tests

Added `tests/test_cli_accelerate_config.py` with regression tests for:
- the two-token form still works,
- the new `--accelerate_config=<name>` form resolves correctly,
- both forms produce the exact same output for the same input,
- `--accelerate_config` absent from args is a no-op,
- missing value after `--accelerate_config` still raises `ValueError`,
- an invalid config name still raises `ValueError`, for both syntaxes.

I confirmed these tests fail on `main` (3 of the 6 fail: the equals-form test, the equivalence test, and the
invalid-name-for-equals-form test) and pass after the fix.

### Test output (after fix)

```
$ python -m pytest tests/test_cli_accelerate_config.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
collected 6 items

tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_two_token_form PASSED [ 16%]
tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_equals_form PASSED [ 33%]
tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_equals_form_matches_two_token_form PASSED [ 50%]
tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_no_accelerate_config_argument PASSED [ 66%]
tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_missing_value_raises PASSED [ 83%]
tests/test_cli_accelerate_config.py::TestResolveAccelerateConfigArgument::test_invalid_config_name_raises PASSED [100%]

============================== 6 passed in 7.95s ===============================
```

Also ran the full existing CLI test suite to check for regressions:

```
$ python -m pytest tests/test_cli_utils.py tests/test_cli_accelerate_config.py -q
.........................................                                [100%]
41 passed in 41.92s
```

`pre-commit run --files trl/cli/accelerate_config.py tests/test_cli_accelerate_config.py` passes (ruff check, ruff
format, doc-builder style check all green).

Fixes #6874

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI argument parsing change with dedicated tests; no auth, data, or training logic touched.
> 
> **Overview**
> Fixes a bug where **`--accelerate_config=single_gpu`** was passed through to `accelerate launch` unchanged instead of being rewritten to **`--config_file`** with the bundled YAML path.
> 
> `resolve_accelerate_config_argument` now **normalizes** any `--accelerate_config=<value>` argv token into the existing two-token form before lookup, so both CLI styles behave the same and the rest of the resolver is unchanged.
> 
> Adds **`tests/test_cli_accelerate_config.py`** with regression coverage for both forms, equivalence, no-op when the flag is absent, missing values, and invalid config names (including equals form).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb6ae0394997cd745c0f4cda275078770462713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->