### PR TITLE
Fix unpair_preference_dataset for IterableDatasetDict inputs

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -18,7 +18,7 @@ from time import strftime
 
 import pytest
 import transformers
-from datasets import Dataset, DatasetDict
+from datasets import Dataset, DatasetDict, IterableDatasetDict
 from packaging.version import Version
 from transformers import AutoProcessor, AutoTokenizer, is_vision_available
 
@@ -1089,6 +1089,17 @@ class TestUnpairPreferenceDataset(TrlTestCase):
         assert unpaired_dataset_dict["abc"].to_dict() == self.unpaired_dataset.to_dict(), (
             "The paired dataset should be converted to unpaired."
         )
+
+    def test_unpair_preference_dataset_iterable_dict(self):
+        # Test that a paired IterableDatasetDict is correctly converted to unpaired (regression test for #6877:
+        # IterableDatasetDict.column_names returns a dict mapping split -> columns, which must be flattened before
+        # being passed to `remove_columns` in the underlying `map` call).
+        paired_dataset_dict = IterableDatasetDict({"abc": self.paired_dataset.to_iterable_dataset()})
+        unpaired_dataset_dict = unpair_preference_dataset(paired_dataset_dict)
+        assert list(unpaired_dataset_dict["abc"]) == [
+            dict(zip(self.unpaired_dataset.column_names, vals, strict=False))
+            for vals in zip(*self.unpaired_dataset.to_dict().values(), strict=False)
+        ]
 
     def test_maybe_unpair_preference_dataset(self):
         # Test that a paired dataset is correctly converted to unpaired with maybe_unpair_preference_dataset

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -494,12 +494,14 @@ def unpair_preference_dataset(
     {'prompt': 'The sky is', 'completion': ' blue.', 'label': True}
     ```
     """
-    if isinstance(dataset, DatasetDict):
-        column_names = next(iter(dataset.values())).column_names
-    elif isinstance(dataset, Dataset):
-        column_names = dataset.column_names
+    if isinstance(dataset, (DatasetDict, IterableDatasetDict)):
+        dataset_or_split = next(iter(dataset.values()))
+    else:  # Dataset or IterableDataset
+        dataset_or_split = dataset
+    if isinstance(dataset_or_split, Dataset):
+        column_names = dataset_or_split.column_names
     else:  # IterableDataset
-        column_names = dataset.column_names or list(next(iter(dataset)).keys())
+        column_names = dataset_or_split.column_names or list(next(iter(dataset_or_split)).keys())
     return dataset.map(_unpair_row, batched=True, remove_columns=column_names, **map_kwargs)
 
 


### PR DESCRIPTION
# What does this PR do?

`unpair_preference_dataset()` (in `trl/data_utils.py`) unpairs a preference dataset (with `"chosen"`/`"rejected"`
columns) into an unpaired one (with a single `"completion"` column). To do this it first has to figure out the
input dataset's column names so it can pass them as `remove_columns` to `dataset.map(...)`, since `_unpair_row`
returns a different, non-overlapping set of columns (`"completion"`, `"label"`, ...).

The column-name lookup branches on the input type:

```python
if isinstance(dataset, DatasetDict):
    column_names = next(iter(dataset.values())).column_names
elif isinstance(dataset, Dataset):
    column_names = dataset.column_names
else:  # IterableDataset
    column_names = dataset.column_names or list(next(iter(dataset)).keys())
```

`IterableDatasetDict` doesn't match any of these three branches (it's not a `DatasetDict` or `Dataset`), so it falls
into the `else` (`IterableDataset`) branch. There, `dataset.column_names` is evaluated on the `IterableDatasetDict`
itself, not a split — and `IterableDatasetDict.column_names` returns a `dict` mapping each split name to its column
list (e.g. `{"train": ["prompt", "chosen", "rejected"]}`), not a flat list of column names. Since that dict is
truthy, it's used as-is for `remove_columns`, which silently does the wrong thing (drops nothing useful): `chosen`
and `rejected` are never removed from the dataset, so after `_unpair_row` doubles the row count, `dataset.map` sees
the original 2 rows worth of `chosen`/`rejected` next to 4 rows of `completion`, and raises:

```
ValueError: Column lengths mismatch: columns ['chosen', 'rejected'] have length [2, 2] while completion has length 4.
```

## Root cause

The column-name lookup only special-cases `DatasetDict` explicitly; `IterableDatasetDict` isn't a subclass of
`DatasetDict` (nor of `Dataset`), so it falls through to code that assumes a single (non-dict) dataset and ends up
using the whole `IterableDatasetDict.column_names` dict (split -> columns) instead of the flat per-split column
list.

## Fix

Handle `DatasetDict` and `IterableDatasetDict` the same way (grab the first split, exactly as before for
`DatasetDict`), then handle `Dataset` and `IterableDataset` the same way (read `.column_names`, falling back to
peeking at the first row for `IterableDataset`, whose `.column_names` can be `None`). This reuses the existing
per-type logic uniformly instead of adding a fourth special case:

```python
if isinstance(dataset, (DatasetDict, IterableDatasetDict)):
    dataset_or_split = next(iter(dataset.values()))
else:  # Dataset or IterableDataset
    dataset_or_split = dataset
if isinstance(dataset_or_split, Dataset):
    column_names = dataset_or_split.column_names
else:  # IterableDataset
    column_names = dataset_or_split.column_names or list(next(iter(dataset_or_split)).keys())
```

## Tests

Added `test_unpair_preference_dataset_iterable_dict` to `tests/test_data_utils.py::TestUnpairPreferenceDataset`,
mirroring the existing `test_unpair_preference_dataset_dict` test but for an `IterableDatasetDict`. I confirmed it
fails on `main` with the exact `Column lengths mismatch` error from the issue, and passes with the fix.

### Test output (after fix)

```
$ python -m pytest tests/test_data_utils.py::TestUnpairPreferenceDataset -v
============================= test session starts ==============================
collected 10 items

tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset_extra_columns PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset_iterable PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset_iterable_extra_columns PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset_dict PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_unpair_preference_dataset_iterable_dict PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_maybe_unpair_preference_dataset PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_maybe_unpair_preference_dataset_dict PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_maybe_unpair_preference_dataset_already_paired PASSED
tests/test_data_utils.py::TestUnpairPreferenceDataset::test_maybe_unpair_preference_dataset_dict_already_paired PASSED

============================== 10 passed in 6.57s ===============================
```

I also ran the full `tests/test_data_utils.py` file to check for regressions (see PR discussion/CI for full output);
all tests pass.

`pre-commit run --files trl/data_utils.py tests/test_data_utils.py` passes (ruff check, ruff format, doc-builder
style check all green).

Fixes #6877

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in preference dataset preprocessing with a targeted regression test; behavior for Dataset, DatasetDict, and IterableDataset is unchanged.
> 
> **Overview**
> Fixes **`unpair_preference_dataset`** when the input is an **`IterableDatasetDict`**, which previously hit the wrong branch and passed a split→columns **dict** to `remove_columns` instead of a flat column list. That left `chosen`/`rejected` in place after unpairing and triggered a **column length mismatch** during `map` (issue #6877).
> 
> The change resolves column names the same way as for **`DatasetDict`**: take the first split, then read **`column_names`** from that split (with the existing iterable peek fallback). A regression test mirrors the existing dict test for iterable dict inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19696e992a7183971e311c86fb900c9c7389461d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->