### PR TITLE
Support bare --flag for bool | None dataclass fields in HfArgumentParser

### DIFF
--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -160,6 +160,24 @@ class TestTrlParser(TrlTestCase):
         assert isinstance(result_args[0], MyDataclass)
         assert result_args[0].arg1 == 42
 
+    def test_bare_flag_for_optional_bool_field(self):
+        """A `bool | None` field (e.g. `SFTConfig.bf16`) must accept a bare `--flag`, like a plain `bool` field."""
+
+        @dataclass
+        class OptionalBoolDataclass:
+            flag: bool | None = None
+
+        parser = TrlParser(dataclass_types=[OptionalBoolDataclass])
+
+        (result,) = parser.parse_args_and_config(["--flag"])
+        assert result.flag is True
+
+        (result,) = parser.parse_args_and_config([])
+        assert result.flag is None
+
+        (result,) = parser.parse_args_and_config(["--flag", "false"])
+        assert result.flag is False
+
     def test_parse_args_and_config_with_remaining_strings(self):
         parser = TrlParser(dataclass_types=[MyDataclass])
 

--- a/trl/scripts/_hf_argparser.py
+++ b/trl/scripts/_hf_argparser.py
@@ -234,7 +234,11 @@ class HfArgumentParser(ArgumentParser):
 
             # Hack because type=bool in argparse does not behave as we want.
             kwargs["type"] = string_to_bool
-            if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
+            if (
+                field.type is bool
+                or field.type == bool | None
+                or (field.default is not None and field.default is not dataclasses.MISSING)
+            ):
                 # Default value is False if we have no default when of type bool.
                 default = False if field.default is dataclasses.MISSING else field.default
                 # This is the value that will get picked if we don't include --{field.name} in any way


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI bug found via source reading (no GitHub issue exists for it) — full repro/root-cause in the commit message.

A dataclass field typed `bool | None` with default `None` (e.g. `bf16` in `_BaseConfig`, inherited by **every** trainer config — SFT, DPO, GRPO, RLOO, etc. — plus `SFTConfig.eval_packing`/`completion_only_loss`, `vllm_serve.py`'s `enable_prefix_caching`) cannot be used as a bare CLI flag, unlike every plain `bool` field (`--fp16` works fine):

```
$ python -m trl.scripts.sft --model_name_or_path ... --bf16
error: argument --bf16: expected one argument
```

**Root cause**: in `trl/scripts/_hf_argparser.py`, `_parse_dataclass_field`'s condition for setting `nargs="?", const=True` (which is what makes a bare `--flag` set the value to `True`) only fires when `field.type is bool`, or when `field.type is bool | None` **and** the default is not `None`. Since these fields are deliberately defaulted to `None` as an "unset" sentinel (per their own docstrings), the common case was broken.

**Fix**: extend the condition to also match `field.type == bool | None` regardless of default — consistent with how the existing negation-flag (`--no-*`) mechanism a few lines below already treats these two type forms identically.

## Test evidence

Added `test_bare_flag_for_optional_bool_field` to `tests/test_cli_utils.py`, covering the bare-flag, no-flag (stays `None`), and explicit-value cases.

- Before fix: `parser.parse_args_and_config(['--flag'])` raises `SystemExit` (`expected one argument`).
- After fix: `result.flag is True`.

```
$ python -m pytest tests/test_cli_utils.py::TestTrlParser -q
... 1 passed (new test) ...
$ python -m pytest tests/test_data_utils.py tests/test_cli_utils.py -q
631 passed in 989.32s
```

`ruff check` / `ruff format --check` on all changed files: clean.

## Disclosure

This fix was implemented with AI assistance (Claude), with the bug independently reproduced, the fix verified red→green, and the full related test suite run locally before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized argparse behavior change with a targeted regression test; no auth, data, or security impact.
> 
> **Overview**
> Fixes CLI parsing so **`bool | None`** dataclass fields (default **`None`**) accept a bare **`--flag`**, matching plain **`bool`** fields. Before this change, **`--bf16`** and similar flags failed with “expected one argument” because optional-bool fields only got **`nargs="?"`** / **`const=True`** when the default was non-**`None`**.
> 
> **`_parse_dataclass_field`** in **`_hf_argparser.py`** now treats **`bool | None`** like **`bool`** for that argparse setup, so **`--flag`** sets **`True`**, omission stays **`None`**, and **`--flag false`** still works.
> 
> Adds **`test_bare_flag_for_optional_bool_field`** in **`tests/test_cli_utils.py`** for those three behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bfe6057659244e711d20974fb04b35e3ba499f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->