### PR TITLE
Fix extract_prompt off-by-one when chosen/rejected never diverge

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1195,6 +1195,39 @@ class TestExtractPrompt(TrlTestCase):
         example_extracted_prompt = maybe_extract_prompt(self.example_explicit_prompt_standard)
         assert example_extracted_prompt == self.example_explicit_prompt_standard, "The prompt should remain unchanged."
 
+    def test_extract_prompt_conversational_chosen_is_prefix_of_rejected(self):
+        # When "chosen" is a strict prefix of "rejected" (no divergence within the compared range), the whole of
+        # "chosen" is the common prompt, and it must not be duplicated into either output.
+        example = {
+            "chosen": [{"role": "user", "content": "What color is the sky?"}],
+            "rejected": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+        }
+        example_extracted_prompt = extract_prompt(example)
+        assert example_extracted_prompt == {
+            "prompt": [{"role": "user", "content": "What color is the sky?"}],
+            "chosen": [],
+            "rejected": [{"role": "assistant", "content": "It is blue."}],
+        }
+
+    def test_extract_prompt_conversational_chosen_equals_rejected(self):
+        # When "chosen" and "rejected" are identical (no divergence at all), the whole conversation is the common
+        # prompt, and "chosen"/"rejected" must both end up empty.
+        example = {
+            "chosen": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+            "rejected": [
+                {"role": "user", "content": "What color is the sky?"},
+                {"role": "assistant", "content": "It is blue."},
+            ],
+        }
+        example_extracted_prompt = extract_prompt(example)
+        assert example_extracted_prompt == {"prompt": example["chosen"], "chosen": [], "rejected": []}
+
 
 class TestPackDatasetWrapped(TrlTestCase):
     def test_with_dataset(self):

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -629,11 +629,16 @@ def extract_prompt(example: dict[str, Sequence]) -> dict[str, Sequence]:
      'rejected': [{'role': 'assistant', 'content': 'It is green.'}]}
     ```
     """
-    for idx in range(min(len(example["chosen"]), len(example["rejected"]))):
+    common_length = min(len(example["chosen"]), len(example["rejected"]))
+    for idx in range(common_length):
         if example["chosen"][idx] != example["rejected"][idx]:
             if example["chosen"][idx - 1] == " ":  # remove space before the prompt
                 idx -= 1
             break
+    else:
+        # No divergence found within the compared range: one of "chosen"/"rejected" is a prefix of the other, so
+        # the whole compared range is the common prompt.
+        idx = common_length
     return {
         "prompt": example["chosen"][:idx],
         "chosen": example["chosen"][idx:],


### PR DESCRIPTION
## What does this PR do?

Fixes a data-corruption bug found via source reading (no GitHub issue exists for it) — full repro/root-cause in the commit message.

`extract_prompt` (used by `maybe_extract_prompt`, relied on by `DPOTrainer` and friends for preference-dataset preprocessing) finds the first index where `chosen` and `rejected` diverge:

```python
for idx in range(min(len(chosen), len(rejected))):
    if chosen[idx] != rejected[idx]:
        ...
        break
```

**Root cause**: if the two never diverge within the compared range — one is a full prefix of the other, or they're entirely identical, both realistic inputs — the loop completes without `break`ing, and Python leaves `idx` at its last-iterated value (`min(len)-1`), not `min(len)`. The last common message is then wrongly excluded from `"prompt"` and duplicated verbatim into **both** `"chosen"` and `"rejected"`.

Example: with identical `chosen`/`rejected` conversations, the last message ends up duplicated into both outputs instead of being part of the prompt.

**Fix**: use a `for...else` so a fully-exhausted loop sets `idx = min(len(chosen), len(rejected))` — the true common-prefix length — instead of leaving it one short.

## Test evidence

Added two regression tests to `tests/test_data_utils.py::TestExtractPrompt`:
- `test_extract_prompt_conversational_chosen_is_prefix_of_rejected`
- `test_extract_prompt_conversational_chosen_equals_rejected`

Both fail on `main` (assert the last common message is NOT duplicated into chosen/rejected) and pass with the fix.

```
$ python -m pytest tests/test_data_utils.py::TestExtractPrompt -q
... 2 new + existing all passed ...
$ python -m pytest tests/test_data_utils.py tests/test_cli_utils.py -q
631 passed in 989.32s
```

`ruff check` / `ruff format --check` on all changed files: clean.

## Disclosure

This fix was implemented with AI assistance (Claude), with the bug independently reproduced, the fix verified red→green, and the full related test suite run locally before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes preference-dataset preprocessing used by DPO/KTO trainers; wrong splits could corrupt training data, but the change is narrow and regression-tested.
> 
> **Overview**
> Fixes an off-by-one bug in **`extract_prompt`** when `chosen` and `rejected` share a full common prefix (one is a prefix of the other, or they are identical). The divergence loop used to finish with `idx` at `common_length - 1`, so the last shared turn was left out of **`prompt`** and copied into both **`chosen`** and **`rejected`**.
> 
> The change adds a **`for`…`else`** branch so that when no mismatch is found, **`idx`** is set to **`common_length`**, i.e. the true shared prefix length. **`maybe_extract_prompt`** and DPO/KTO dataset preprocessing that call **`extract_prompt`** get the corrected split.
> 
> Two conversational regression tests cover the prefix and identical-conversation cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb7f3c7f1195edcec8ea90f6c05ac0088698ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->