### PR TITLE
Pin layer_types so the tiny Gemma3 and Olmo3 models cover both attention types

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/olmo3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/olmo3_for_causal_lm.py
@@ -39,6 +39,9 @@ config = Olmo3Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    # One of each attention type. Deriving the pattern from num_hidden_layers=2 gives two
+    # sliding layers (the reference is 3:1 over 32 layers), so the global RoPE path would never run.
+    layer_types=["sliding_attention", "full_attention"],
     # Non-size fields kept aligned with the reference so the tiny config only differs in what we scale down.
     max_position_embeddings=65536,
     rms_norm_eps=1e-06,

--- a/scripts/generate_tiny_models/for_conditional_generation/gemma3_for_conditional_generation.py
+++ b/scripts/generate_tiny_models/for_conditional_generation/gemma3_for_conditional_generation.py
@@ -34,7 +34,9 @@ text_config = {
     "hidden_size": 16,
     "num_attention_heads": 4,
     "num_key_value_heads": 2,
-    "layer_types": None,  # Set it automatically from num_hidden_layers
+    # One of each attention type. Deriving the pattern from num_hidden_layers=2 gives two
+    # sliding layers (the reference is 5:1 over 34 layers), so the global RoPE path would never run.
+    "layer_types": ["sliding_attention", "full_attention"],
     "intermediate_size": 32,
 }
 vision_config = {


### PR DESCRIPTION
This PR pins `layer_types` in the tiny Gemma3 and Olmo3 generation scripts so that each model has one layer of each attention type.

Fix #6961.

### Motivation

Both tiny models have 2 layers, and their sliding-window periods (6 for Gemma3, 4 for Olmo3) make the derived pattern yield two sliding layers and no full-attention layer. Two consequences:

- The global RoPE path is never built or executed, so `_compute_linear_scaling_rope_parameters` (Gemma3) and `_compute_yarn_parameters` (Olmo3) are dead code in our fixtures, even though both configs still carry the reference's global rope settings.
- `transformers` logs `Unrecognized keys in rope_parameters for 'rope_type'='default': {'full_attention', 'sliding_attention'}` on every config load, up to 104 times per CI job, because it classifies the nested per-layer rope dict against the layer types the model actually instantiates. Reported upstream as huggingface/transformers#48392.

### Solution

Pin `layer_types` explicitly, as the Gemma4 and DiffusionGemma scripts already do, and as the Nemotron 3 scripts do for block types ("one of each block type").

With 2 layers the reference ratios (5:1 for Gemma3, 3:1 for Olmo3) cannot be represented at all, so the choice is not between a faithful and an unfaithful pattern, but between covering one attention type and covering both.

The Hub models have been regenerated. Verified in [this CI run](https://github.com/huggingface/trl/actions/runs/33168783898): the log line drops from 104 to 0 in every job, no other `transformers` log line changes, and the test totals are unchanged (2369 passed, 149 skipped, 7 xfailed).

### Changes

- Pin `layer_types` to `["sliding_attention", "full_attention"]` in the tiny Gemma3 generation script, replacing the previous `None` that derived the pattern from `num_hidden_layers`
- Pin the same `layer_types` in the tiny Olmo3 generation script

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects tiny test fixture generation scripts and regenerated Hub weights; no runtime TRL or production model behavior changes.
> 
> **Overview**
> Pins **`layer_types`** to `["sliding_attention", "full_attention"]` in the tiny **Gemma3** and **Olmo3** Hub generation scripts so each 2-layer fixture includes one sliding and one full-attention block.
> 
> With only two layers, the auto-derived pattern from production ratios would use sliding attention everywhere, so global RoPE paths never ran in tests and `transformers` spammed unrecognized `rope_parameters` warnings on config load. This matches how other tiny generators (e.g. Gemma4, DiffusionGemma) already pin one of each attention type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2290673cb131a1d2198eed97f3c1a67001b82d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->