### PR TITLE
Pin layer_types so the tiny Cohere2 model covers both attention types

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/cohere2_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/cohere2_for_causal_lm.py
@@ -38,6 +38,9 @@ config = Cohere2Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    # One of each attention type. Deriving the pattern from num_hidden_layers=2 gives two sliding
+    # layers (the reference is 3:1), so the full-attention NoPE path would never run.
+    layer_types=["sliding_attention", "full_attention"],
     logit_scale=1.0,
     rope_theta=50000,
     bos_token_id=2,


### PR DESCRIPTION
This PR pins `layer_types` in the tiny Cohere2 generation script so that the model has one layer of each attention type.

Related to:
- #6962

### Motivation

The tiny model has 2 layers, and Cohere2's period of 4 makes the derived pattern yield two sliding layers and no full-attention layer.

That matters more than it does for the other hybrid models, because Cohere2 applies RoPE only on sliding layers. From the [transformers docs](https://huggingface.co/docs/transformers/model_doc/cohere2):

> The model features three layers with sliding window attention and ROPE for efficient local context modeling and relative positional encoding. A fourth layer uses global attention without positional embeddings, enabling unrestricted token interactions across the entire sequence.

So the tiny model never exercised the NoPE global-attention path, which is the defining feature of the Command R7B architecture. Traced on the current model, `apply_rotary_pos_emb` runs on 2 of 2 layers; with the pinned pattern it runs on 1 of 2.

Unlike #6962, this emits no log line, so it is purely a test-coverage gap.

### Solution

Pin `layer_types` explicitly, as the Gemma4 and DiffusionGemma scripts already do, and as the Nemotron 3 scripts do for block types ("one of each block type"). The order is local first, matching the reference's `order_of_interleaved_layers="local_attn_first"`.

With 2 layers the reference 3:1 ratio cannot be represented at all, so the choice is not between a faithful and an unfaithful pattern, but between covering one attention type and covering both.

The Hub model has been regenerated in this PR:
- [x] https://huggingface.co/trl-internal-testing/tiny-Cohere2ForCausalLM/discussions/3, which needs to be merged for this change to take effect. 

Verified in this CI run (https://github.com/huggingface/trl/actions/runs/33179106731) with the revision pinned through `MODEL_REVISIONS`: 
- 38 Cohere2 tests pass in every job, including the `transformers` 4.56.2 floor, with the test totals unchanged (2369 passed, 149 skipped, 7 xfailed).

This was the last tiny model with an uncovered layer type. Sweeping all of them, only Gemma3, Olmo3 (both handled in #6962) and Cohere2 were missing one; the other 28 already cover every type their architecture can produce.

### Changes

- Pin `layer_types` to `["sliding_attention", "full_attention"]` in the tiny Cohere2 generation script

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only tiny-model generation script change with no runtime library impact until the Hub artifact is updated.
> 
> **Overview**
> The tiny **Cohere2** causal-LM generator now **explicitly sets** `layer_types` to `["sliding_attention", "full_attention"]` instead of letting the config derive the pattern from two layers—which previously produced **only sliding** layers and never ran the **full-attention / NoPE** path (RoPE on sliding only).
> 
> This aligns with other tiny scripts (e.g. Gemma4, DiffusionGemma) so CI and smoke tests exercise **both** attention types; the Hub tiny model must be regenerated separately for tests to pick up the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5221395f5ad196cd2485566385dae6234f1281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->