### PR TITLE
Use ruff `select` instead of `extend-select` to keep the rule set explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,9 @@ ignore = [
     "C901", # function complexity
     "E501",
 ]
-extend-select = ["E", "F", "I", "W", "UP", "B", "T", "C"]
+# `select`, not `extend-select`: the rule set is explicit, so a ruff release that expands its default
+# selection (0.16 raised the defaults from 59 to 413 rules) does not silently enable new rules.
+select = ["E", "F", "I", "W", "UP", "B", "T", "C"]
 
 [tool.ruff.lint.per-file-ignores]
 # Allow prints in auxiliary scripts


### PR DESCRIPTION
This PR makes TRL's ruff lint rule set explicit and independent of ruff's own default rule selection.

### Motivation

Ruff 0.16 raised its default rule selection from 59 to 413 rules. `extend-select` adds onto those defaults, so TRL silently inherits every rule ruff enables by default, including whole families the project never opted into (`BLE`, `SIM`, `S`, `TRY`, `LOG`, `DTZ`, `PL*`, `PIE`, `FURB`, `RUF`, `PYI`, ...).

This has two consequences today:

- A contributor whose editor or local install runs ruff 0.16.4 sees 272 errors that CI never reports, since CI pins 0.13.3.
- Any ruff bump past 0.16 breaks the quality job and rewrites source through `--fix`. This is why #6957 is red.

### Solution

Use `select`, which replaces the default selection instead of extending it. The listed rule families stay exactly as they are, so the set of rules TRL enforces becomes a project decision rather than a function of the installed ruff version. Adopting any of the newly defaulted rules remains a separate, deliberate change.

At the pinned ruff 0.13.3 this is a no-op: both configurations resolve to byte-identical sets of 170 enabled rules, and `ruff check` on all tracked Python files reports `All checks passed!` before and after. It also passes under ruff 0.16.4 with this change applied.

### Changes

- Replace `extend-select` with `select` in the ruff lint configuration
- Add a comment recording why the rule set is pinned explicitly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to lint tooling; no runtime or application logic is affected.
> 
> **Overview**
> **Ruff linting is pinned to an explicit rule list** so newer Ruff releases cannot silently turn on hundreds of extra default rules.
> 
> In `pyproject.toml`, `[tool.ruff.lint]` now uses **`select`** (replacing **`extend-select`**) with the same families (`E`, `F`, `I`, `W`, `UP`, `B`, `T`, `C`). A short comment documents that this avoids inheriting Ruff 0.16+’s expanded defaults. Behavior at the pinned Ruff version should be unchanged; local/editor runs on newer Ruff should align with CI instead of surfacing rules the project never opted into.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1324eb0c559162a6dbe4b9886814e9b148428432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->