### PR TITLE
Stop dependabot from opening ruff pre-commit bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,14 @@ updates:
       local-actions:
         patterns: ["*"]
 
-  # Not grouped, so that a ruff bump, which reformats code, stays separate from a doc-builder bump
+  # Not grouped, so that each hook bump stays reviewable on its own
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      # Ruff is frozen on purpose: a bump reformats code and rewrites source through `--fix`, without
+      # reporting anything new under our own rule selection. Bump it by hand when there is a reason.
+      - dependency-name: "https://github.com/astral-sh/ruff-pre-commit"


### PR DESCRIPTION
This PR stops dependabot from opening ruff pre-commit bumps, while leaving the rest of the pre-commit hooks on their weekly schedule.

### Motivation

Ruff bumps are pure cost for us. They reformat code and rewrite source through `--fix`, and they report nothing new under our own rule selection: ruff 0.13.3 and 0.16.4 both pass on every tracked Python file once the rule set is explicit. #6957 is the current example, red on the quality job and rewriting 42 files.

Freezing ruff is a deliberate choice rather than neglect, so it belongs in the config next to the reason, not in dependabot's per-repo dismissal state.

doc-builder bumps stay valuable and must keep flowing. #6956 is a live example.

### Solution

Add an `ignore` entry naming the ruff hook, taken verbatim from the `dependency-name` that dependabot writes in its own commit trailers. `ignore` is per dependency, so doc-builder and both github-actions ecosystems are unaffected.

The entry carries no `versions` or `update-types` filter, which ignores every update for that dependency. A semver filter would be the natural way to allow patch releases only, but it is not usable here: dependabot does not report an update type for pre-commit hooks, and ruff 0.13.3 is in any case the last release of the 0.13 line, so a patch-only rule would never match anything.

The comment above the entry no longer describes reality once ruff is ignored, so it is reworded to state the remaining rationale for not grouping.

### Changes

- Ignore all updates for the ruff pre-commit hook, with a comment recording why
- Reword the stale comment about keeping ruff and doc-builder bumps in separate pull requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency automation only; no runtime or application code changes.
> 
> **Overview**
> Dependabot’s **pre-commit** ecosystem entry now **ignores** all updates for `https://github.com/astral-sh/ruff-pre-commit`, with an inline comment that ruff is frozen on purpose (bumps reformat and `--fix` without new findings under the project’s rules) and should be bumped manually when needed.
> 
> The comment above the ungrouped pre-commit block is **reworded** so it no longer cites keeping ruff separate from doc-builder; it now says each remaining hook bump should stay reviewable on its own. Weekly pre-commit updates for other hooks (e.g. doc-builder) and github-actions entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c17f2f7a7022730f6a9a9ee3bce907e7cda3bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->