### PR TITLE
Document that padding_free is currently disabled in DPO

### DIFF
--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -208,6 +208,9 @@ Padding-free batching is an alternative approach for reducing memory usage. In t
 <hfoptions id="padding-free">
 <hfoption id="DPO">
 
+> [!WARNING]
+> Padding-free is temporarily unavailable in DPO since the refactor in [#3906](https://github.com/huggingface/trl/pull/3906). Setting `padding_free=True` in [`DPOConfig`] logs a warning and falls back to standard padding. It is planned to return in a future update, tracked in [#2469](https://github.com/huggingface/trl/issues/2469).
+
 ```python
 from trl import DPOConfig
 

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -62,6 +62,9 @@ class DPOConfig(_BaseConfig):
             Whether to perform forward passes without padding by flattening all sequences in the batch into a single
             continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
             supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch structure.
+            Temporarily unavailable since the DPO refactor in [#3906](https://github.com/huggingface/trl/pull/3906):
+            setting it to `True` logs a warning and falls back to standard padding. It is planned to return in a future
+            update.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
         precompute_ref_log_probs (`bool`, *optional*, defaults to `False`):
@@ -207,7 +210,8 @@ class DPOConfig(_BaseConfig):
             "help": "Whether to perform forward passes without padding by flattening all sequences in the batch into "
             "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this "
             "is only supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch "
-            "structure."
+            "structure. Temporarily unavailable since the DPO refactor in #3906: setting it to `True` logs a warning "
+            "and falls back to standard padding. It is planned to return in a future update."
         },
     )
     pad_to_multiple_of: int | None = field(


### PR DESCRIPTION
DPO documents `padding_free` as available even though the trainer warns and falls back to standard padding. I documented that behavior in the configuration docstring, CLI help, and memory usage guide. A trainer probe confirmed the fallback before and after the edit, and lint, format, and documentation style checks pass.
Refs #2469.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to config help and the memory-usage guide; training behavior is unchanged.
> 
> **Overview**
> Aligns **DPO** `padding_free` documentation with current trainer behavior after [#3906](https://github.com/huggingface/trl/pull/3906): the option still exists on [`DPOConfig`], but setting `padding_free=True` only triggers a warning and standard padding is used.
> 
> Adds matching notes in the **`DPOConfig.padding_free`** class docstring and CLI **`help`** text, plus a **WARNING** on the DPO tab in `reducing_memory_usage.md` (with a link to [#2469](https://github.com/huggingface/trl/issues/2469)). The DPO example snippet is kept for when the feature returns. **No runtime or default changes**—SFT padding-free docs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8123a245d19ec33eb0892022efd4b5d453a976e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->