### PR TITLE
Cast the lm_head weight in the chunked backward, as the forward already does

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1298,6 +1298,37 @@ class TestChunkedLogProbFunction:
         torch.testing.assert_close(grad_hidden_chunked, hidden.grad, atol=1e-2, rtol=1e-2)
         torch.testing.assert_close(grad_weight_chunked, weight.grad, atol=1e-2, rtol=1e-2)
 
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_backward_half_hidden_with_full_precision_weight(self, dtype):
+        """Autocast leaves the lm_head weight in float32 while the hidden states are half.
+
+        That is the case the cast in forward exists for; backward recomputes the same logits and
+        has to make the same cast, or `torch.mm` rejects the mismatched operands.
+        """
+        torch.manual_seed(42)
+        hidden = torch.randn(self.N, self.H).to(dtype).requires_grad_(True)
+        weight = torch.randn(self.V, self.H, requires_grad=True)  # float32, as autocast leaves it
+        labels = torch.randint(0, self.V, (self.N,))
+
+        logprobs_chunked, _ = _ChunkedLogProbFunction.apply(hidden, weight, labels, 1.0, self.CHUNK_SIZE)
+        logprobs_chunked.sum().backward()
+        grad_hidden_chunked = hidden.grad.clone()
+        grad_weight_chunked = weight.grad.clone()
+
+        hidden.grad = None
+        weight.grad = None
+
+        # The shared reference helper matmuls the two operands directly, so it needs the same
+        # cast autocast applies before the lm_head; only the weight side differs here.
+        logits_ref = (hidden @ weight.to(dtype).t()).to(torch.float32)
+        logprobs_ref = F.log_softmax(logits_ref, dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
+        logprobs_ref.sum().backward()
+
+        assert grad_hidden_chunked.dtype == hidden.dtype
+        assert grad_weight_chunked.dtype == weight.dtype
+        torch.testing.assert_close(grad_hidden_chunked, hidden.grad, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(grad_weight_chunked, weight.grad, atol=1e-2, rtol=1e-2)
+
     @pytest.mark.parametrize("temperature", [1.0, 0.7])
     def test_backward_entropy(self, temperature):
         """Backprop through the `entropy` output alone (as opposed to `logprobs`, covered above)."""

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1427,7 +1427,11 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
                 C = end - start
                 w_chunk = weight[start:end]  # [C, H]
 
-                torch.mm(hidden, w_chunk.t(), out=mm_buf[:, :C])
+                # Same cast as in forward: under autocast the hidden states are half precision while
+                # the lm_head weight is not, and `torch.mm` needs both operands and `out` in one dtype.
+                # Only the logit recompute is cast; the gradient accumulation below keeps the full
+                # precision weight.
+                torch.mm(hidden, w_chunk.to(hidden.dtype).t(), out=mm_buf[:, :C])
                 if bias is not None:
                     mm_buf[:, :C].add_(bias[start:end].to(hidden.dtype))
                 logits_chunk = logits_buf[:, :C]


### PR DESCRIPTION
# What does this PR do?

`_ChunkedLogProbFunction` recomputes the logits chunk by chunk in `backward`, but unlike `forward` it does not cast the lm_head weight to the hidden dtype before the matmul, while writing into an `out` buffer allocated with the hidden dtype:

```python
# forward
w_chunk = weight[start:end].to(last_hidden.dtype)   # [C, H]
torch.mm(last_hidden, w_chunk.t(), out=mm_buf[:, :C])

# backward
w_chunk = weight[start:end]                          # [C, H]
torch.mm(hidden, w_chunk.t(), out=mm_buf[:, :C])
```

The comment above the forward cast names the case it exists for: *"using fp16=True, the model's hidden states get cast to float16 by autocast, but the mm_buf is allocated with last_hidden.dtype (float16) while w_chunk (the lm_head weights) is not auto casted"*. Backward hits the same case and has no cast, so a forward that succeeds cannot be backpropagated:

```python
hidden = torch.randn(6, 8, dtype=torch.bfloat16, requires_grad=True)
weight = torch.randn(32, 8, requires_grad=True)          # float32, as autocast leaves it
logprobs, _ = _ChunkedLogProbFunction.apply(hidden, weight, targets, 1.0, 7, None, 1.0)
logprobs.sum().backward()
# RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float
```

| hidden / weight | forward | backward before | backward after |
| --- | --- | --- | --- |
| float32 / float32 (control) | OK | OK | OK |
| bfloat16 / bfloat16 (control) | OK | OK | OK |
| bfloat16 / float32 | OK | `RuntimeError` | OK |
| float16 / float32 | OK | `RuntimeError` | OK |

## The fix

Cast inside the matmul rather than rebinding `w_chunk`, because the gradient accumulation a few lines down (`grad_hidden.add_(grad_logits @ w_chunk.float())`) should keep the full precision weight rather than one that has been round-tripped through half. `.to()` on an already matching dtype returns the same tensor, so the float32 and bfloat16 paths are untouched.

## Test

`TestChunkedLogProbFunction` already has `test_backward_bfloat16`, but it makes *both* operands bfloat16, which is the case that works. Added `test_backward_half_hidden_with_full_precision_weight`, parametrized over bfloat16 and float16 hidden states against a float32 weight, asserting the returned gradient dtypes and comparing both gradients against a reference that applies the same cast.

```
# this branch
12 passed

# against main
2 failed, 10 passed
E  RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float
E  RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::Half != float
```

The 10 pre-existing tests in the class pass on both sides. `ruff check` and `ruff format --check` report the identical findings on both files before and after.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @aminediro (author of the chunked lm_head)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow dtype-alignment fix in chunked backward; uniform-dtype paths are unchanged and new regression tests cover the autocast mixed-precision case.
> 
> **Overview**
> Fixes **`_ChunkedLogProbFunction.backward`** so chunked logit recomputation matches **forward** when autocast gives half-precision hidden states but leaves **`lm_head` weights in float32**. The backward path now uses `w_chunk.to(hidden.dtype)` in the `torch.mm` call (not by rebinding `w_chunk`), so operands align with the `out` buffer dtype without changing full-precision weight gradient accumulation.
> 
> Adds **`test_backward_half_hidden_with_full_precision_weight`** (bfloat16 and float16) to assert backward runs, gradient dtypes stay correct, and grads match a reference that applies the same weight cast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b307aa70dfe02f77086ce1fab37f6f9b6b7eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->