### PR TITLE
fix: validate dataset mixture fractions

### DIFF
--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -385,6 +385,23 @@ class TestGetDataset:
         with pytest.raises(ValueError, match="must be set for either all datasets"):
             get_dataset(mixture_config)
 
+    @pytest.mark.parametrize(
+        ("fractions", "error_message"),
+        [
+            ([0.0, 0.0], "must be greater than zero"),
+            ([-0.5, 1.5], "must be non-negative"),
+        ],
+    )
+    def test_dataset_fraction_invalid_raises_error_before_loading(self, fractions, error_message):
+        mixture_config = DatasetMixtureConfig(
+            datasets=[DatasetConfig(path="unused", fraction=fraction) for fraction in fractions]
+        )
+
+        with patch("datasets.load_dataset") as load_dataset_mock, pytest.raises(ValueError, match=error_message):
+            get_dataset(mixture_config)
+
+        load_dataset_mock.assert_not_called()
+
     def test_dataset_fraction_streaming_raises_error(self):
         mixture_config = DatasetMixtureConfig(
             datasets=[DatasetConfig(path="trl-internal-testing/zen", name="standard_language_modeling", fraction=0.5)],

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -390,6 +390,7 @@ class TestGetDataset:
         [
             ([0.0, 0.0], "must be greater than zero"),
             ([-0.5, 1.5], "must be non-negative"),
+            ([1.5, -0.5], "must be non-negative"),
         ],
     )
     def test_dataset_fraction_invalid_raises_error_before_loading(self, fractions, error_message):

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -442,6 +442,20 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
     import datasets
 
     logger.info(f"Creating dataset mixture with {len(mixture_config.datasets)} datasets")
+
+    # Validate fractions before loading any datasets so invalid configurations fail with an actionable error.
+    fractions = [dataset_config.fraction for dataset_config in mixture_config.datasets]
+    if any(fraction is not None for fraction in fractions):
+        if any(fraction is None for fraction in fractions):
+            raise ValueError("`fraction` must be set for either all datasets in the mixture or none of them.")
+        if any(fraction < 0 for fraction in fractions):
+            raise ValueError("Dataset `fraction` values must be non-negative.")
+        total_fraction = sum(fractions)
+        if total_fraction <= 0:
+            raise ValueError("The sum of dataset `fraction` values must be greater than zero.")
+        if mixture_config.streaming:
+            raise ValueError("Using a dataset `fraction` is not supported with streaming datasets.")
+
     datasets_list = []
     for dataset_config in mixture_config.datasets:
         logger.info(f"Loading dataset for mixture: {dataset_config.path} (config name: {dataset_config.name})")
@@ -460,13 +474,8 @@ def get_dataset(mixture_config: DatasetMixtureConfig) -> "DatasetDict":
     # If `fraction` is set, treat the values as target shares of the final mixture. They are normalized to sum to one,
     # and the mixture size is capped so that no dataset is oversampled: we keep the first `round(weight * total)` rows of
     # each dataset, where `total` is the largest mixture size such that no dataset contributes more rows than it has.
-    fractions = [dataset_config.fraction for dataset_config in mixture_config.datasets]
     if any(fraction is not None for fraction in fractions):
-        if any(fraction is None for fraction in fractions):
-            raise ValueError("`fraction` must be set for either all datasets in the mixture or none of them.")
-        if mixture_config.streaming:
-            raise ValueError("Using a dataset `fraction` is not supported with streaming datasets.")
-        weights = [fraction / sum(fractions) for fraction in fractions]
+        weights = [fraction / total_fraction for fraction in fractions]
         total = min(
             len(dataset) / weight for dataset, weight in zip(datasets_list, weights, strict=False) if weight > 0
         )

--- a/trl/scripts/utils.py
+++ b/trl/scripts/utils.py
@@ -65,7 +65,7 @@ class DatasetConfig:
             datasets, and the mixture size is capped so that no dataset is oversampled: the first `round(fraction * N)`
             rows of each dataset are kept, where `N` is the largest mixture size that avoids oversampling. Must be set
             for either all datasets in the mixture or none of them. Not supported for streaming datasets. When unset,
-            the full datasets are concatenated.
+            the full datasets are concatenated. Values must be non-negative and their sum must be greater than zero.
     """
 
     path: str


### PR DESCRIPTION
# What does this PR do?

Fixes #6981.

This change validates dataset mixture fractions before loading any datasets. It rejects negative fractions and zero-sum fractions with actionable `ValueError` messages, while preserving mixtures that include individual zero fractions when the total is positive.

The regression tests also verify that invalid configurations fail before `datasets.load_dataset` is called.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? The existing fraction documentation remains accurate, so no documentation change is needed.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation and ordering change in dataset loading; behavior for valid mixtures is unchanged aside from earlier errors for invalid configs.
> 
> **Overview**
> **`get_dataset`** now checks mixture **`fraction`** settings **before** any **`datasets.load_dataset`** calls, so bad configs fail fast with clear **`ValueError`** messages instead of after expensive I/O.
> 
> New rules: each fraction must be **non-negative**, and the **sum must be > 0** (all-zero sums are rejected; individual zeros remain OK when the total is positive). Existing checks—fraction on all-or-none datasets and no fractions with streaming—are part of the same upfront block. **`DatasetConfig`** docs note the non-negative / positive-sum requirement.
> 
> Tests add a parametrized case that mocks **`load_dataset`** and asserts it is **never** called when fractions are invalid (zero sum or negatives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb3079b80c7c84f8f0c022c0d7a0d6af245dbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->