### PR TITLE
Match hub kernels by repo id when checking the attention implementation

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1073,6 +1073,26 @@ class TestSFTTrainer(TrlTestCase):
                 model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
             )
 
+    @pytest.mark.parametrize(
+        "attn_implementation, expect_warning",
+        [
+            ("kernels-community/flash-attn2", False),
+            ("kernels-community/flash-attn2@v2", False),
+            ("eager", True),
+        ],
+    )
+    def test_padding_free_warns_only_for_unsupported_attention(self, attn_implementation, expect_warning, caplog):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train[:2]")
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
+        # Only the config value matters here: the warning is emitted at init, so no attention kernel is ever loaded.
+        model.config._attn_implementation = attn_implementation
+        training_args = SFTConfig(output_dir=self.tmp_dir, padding_free=True, max_length=None, report_to="none")
+
+        with caplog.at_level("WARNING", logger="trl.trainer.sft_trainer"):
+            SFTTrainer(model=model, args=training_args, train_dataset=dataset)
+
+        assert ("supported Flash Attention variant" in caplog.text) == expect_warning
+
     def test_train_with_iterable_dataset(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train", streaming=True)
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1168,7 +1168,10 @@ class SFTTrainer(_BaseTrainer):
         # BFD packing requires padding-free mode; otherwise, the collator outputs padded attention masks, causing
         # FlashAttention to ignore position_ids and recompute them incorrectly from the padded attention mask.
         self.padding_free = args.padding_free or (args.packing and args.packing_strategy in {"bfd", "bfd_split"})
-        use_flash_attention = model.config._attn_implementation in FLASH_ATTENTION_VARIANTS
+        # A hub kernel can be requested with a revision and/or a kernel name (`repo_id@revision:kernel_name`), while
+        # the variants above are bare repo ids, so compare against the repo id alone.
+        attn_implementation = model.config._attn_implementation.split("@")[0].split(":")[0]
+        use_flash_attention = attn_implementation in FLASH_ATTENTION_VARIANTS
         if self.padding_free:
             if data_collator is not None:
                 raise ValueError("Passing a custom data collator is not supported when using padding-free.")


### PR DESCRIPTION
This PR stops `SFTTrainer` from warning that a revision-pinned hub attention kernel is an unsupported attention implementation.

Fix #6984.

### Motivation

Transformers accepts a revision and a kernel name on a hub kernel spec (`repo_id@revision:kernel_name`) and keeps the full string in `config._attn_implementation`, while `FLASH_ATTENTION_VARIANTS` holds bare repo ids. A pinned kernel such as `kernels-community/flash-attn2@v2` therefore missed the lookup, and both the padding-free and the BFD packing checks warned that the attention implementation was not supported.

Pinning a revision is the current workaround for the flash-attn2 v3 stable-ABI backward crash on GQA models (huggingface/kernels-community#1085), it is the syntax recommended by the `kernels` maintainer (huggingface/kernels-community#1082), and it is what the invariant suite adopts in #6979. TRL was therefore warning users against its own workaround.

The impact is misleading output only: padding-free behavior is driven by a separate attribute, so no training behavior changes.

### Solution

Strip the revision and kernel name suffixes before the lookup, so a hub kernel is matched by its repo id.

### Changes

- Match the attention implementation against `FLASH_ATTENTION_VARIANTS` by repo id, so revision-pinned and kernel-name-suffixed hub kernels are recognized.
- Add a regression test covering the bare repo id, the revision-pinned form, and `eager` as a positive control, so the assertion cannot pass vacuously if the warning text changes.
- Leave `dpo_trainer.py` untouched: its copy of `FLASH_ATTENTION_VARIANTS` is unused, so removing that dead constant belongs in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time warning logic only; no changes to data collation or training paths.
> 
> **Overview**
> **SFTTrainer** no longer treats revision-pinned or kernel-named hub specs (e.g. `kernels-community/flash-attn2@v2`) as unsupported Flash Attention when **padding-free** is on. It normalizes `config._attn_implementation` to the repo id (strip `@revision` and `:kernel_name`) before checking membership in `FLASH_ATTENTION_VARIANTS`, so users stop getting the misleading “not set to a supported Flash Attention variant” warning while still using a supported kernel.
> 
> This is **warning-only** at trainer init; collator and training behavior are unchanged.
> 
> A new parametrized test asserts the padding-free Flash Attention warning is **absent** for bare and `@v2` flash-attn2 hub ids and **present** for `eager`, without loading any kernel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843fa5eddc76b0de8276380ee7215773b82d3f43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->