### PR TITLE
Document the FlashAttention 2 backward failure on GQA models

### DIFF
--- a/docs/source/gkd_trainer.md
+++ b/docs/source/gkd_trainer.md
@@ -29,6 +29,7 @@ The authors find that on-policy data (high `lmbda`) performs better and the opti
 
 > [!WARNING]
 > Make sure that `attn_implementation="kernels-community/flash-attn2"` when training [Gemma models](https://huggingface.co/models?other=gemma2). Otherwise you will encounter NaNs in the logits due to the [soft capping technique](https://huggingface.co/blog/gemma2#soft-capping-and-attention-implementations) adopted by this architecture.
+> Gemma models use grouped-query attention, so this kernel currently needs to be pinned; see [FlashAttention 2 backward pass on GQA models](kernels_hub#flashattention-2-backward-pass-on-gqa-models).
 
 The basic API is as follows:
 

--- a/docs/source/kernels_hub.md
+++ b/docs/source/kernels_hub.md
@@ -46,6 +46,24 @@ trl sft ... --attn_implementation kernels-community/flash-attn2
 > [!TIP]
 > Now you can leverage faster attention backends with a pre-optimized kernel for your hardware configuration from the Hub, speeding up both development and training.
 
+## FlashAttention 2 backward pass on GQA models
+
+> [!WARNING]
+> Since Transformers v5.16, `kernels-community/flash-attn2` resolves to the kernel repository's `v3` branch, whose Torch stable ABI builds fail in the backward pass when `num_attention_heads != num_key_value_heads`, that is, on any model using grouped-query attention (most recent models). The forward pass is unaffected, so inference works and training fails at the first optimizer step with `RuntimeError: torch_call_dispatcher( "aten::sum", ... ) API call failed`.
+
+This also affects `attn_implementation="flash_attention_2"` when the `flash-attn` package is not installed, because Transformers then falls back to the same Hub kernel.
+
+Until [huggingface/kernels-community#1085](https://github.com/huggingface/kernels-community/issues/1085) is fixed, pin the kernel to the `v2` branch, whose builds cover Torch 2.11 to 2.13:
+
+```python
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(
+    "your-model-name",
+    attn_implementation="kernels-community/flash-attn2@v2",
+)
+```
+
 ## Comparing Attention Implementations
 
 We evaluated various attention implementations available in transformers, along with different kernel backends, using **TRL** and **SFT**.  

--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -204,6 +204,7 @@ Padding-free batching is an alternative approach for reducing memory usage. In t
 
 > [!WARNING]
 > It's highly recommended to use padding-free batching with **FlashAttention 2** or **FlashAttention 3**. Otherwise, you may encounter batch contamination issues.
+> If you use the `kernels-community/flash-attn2` Hub kernel, see [FlashAttention 2 backward pass on GQA models](kernels_hub#flashattention-2-backward-pass-on-gqa-models).
 
 <hfoptions id="padding-free">
 <hfoption id="DPO">

--- a/docs/source/speeding_up_training.md
+++ b/docs/source/speeding_up_training.md
@@ -133,6 +133,9 @@ training_args = SFTConfig(..., model_init_kwargs={"attn_implementation": "kernel
 
 Other options include `kernels-community/vllm-flash-attn3` and `kernels-community/paged-attention`.
 
+> [!WARNING]
+> Training a grouped-query attention model with `kernels-community/flash-attn2` currently fails in the backward pass; see [FlashAttention 2 backward pass on GQA models](kernels_hub#flashattention-2-backward-pass-on-gqa-models).
+
 Optimized attention works across all TRL trainers. For more details, see [Kernels Hub Integration](kernels_hub).
 
 </hfoption>


### PR DESCRIPTION
This PR documents the FlashAttention 2 Hub kernel failure on grouped-query attention models, and the revision pin that works around it.

### Motivation

Since Transformers v5.16, `kernels-community/flash-attn2` resolves to the kernel repository's `v3` branch, whose Torch stable ABI builds fail in the backward pass when `num_attention_heads != num_key_value_heads`, so fine-tuning any grouped-query attention model through this kernel crashes at the first optimizer step (huggingface/kernels-community#1085).

Two things make this hard on users. The error surfaces as an opaque `aten::sum` stable ABI dispatcher failure with no mention of attention, the kernel, or the model configuration. And it is not limited to users who request the kernel explicitly: `attn_implementation="flash_attention_2"` falls back to the same Hub kernel when the `flash-attn` package is not installed.

Several TRL pages recommend this kernel, including the padding-free section and the GKD page, which points Gemma users to it, so the docs currently route users into the failure with no warning.

### Solution

Describe the issue and the `@v2` pin once in the Kernels Hub guide, and point to it from the pages that recommend the kernel. The section is self-contained so it can be removed in one place once the upstream issue is fixed.

### Changes

- Add a section to the Kernels Hub guide describing the symptom, the affected models, the silent `flash_attention_2` fallback, and the `kernels-community/flash-attn2@v2` pin, with a link to the upstream issue.
- Point to that section from the padding-free recommendation in the memory usage guide.
- Point to that section from the Gemma recommendation on the GKD page, and from the attention kernel recommendation in the speeding up training guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or training logic modified.
> 
> **Overview**
> **Documents a training-breaking regression** when using the Hub `kernels-community/flash-attn2` kernel (and the `flash_attention_2` fallback without a local `flash-attn` install) on **grouped-query attention** models after Transformers v5.16.
> 
> Adds a dedicated **“FlashAttention 2 backward pass on GQA models”** section in `kernels_hub.md` that explains the v3 backward failure (`aten::sum` at the first optimizer step), who is affected, and the workaround **`kernels-community/flash-attn2@v2`**, with a link to [kernels-community#1085](https://github.com/huggingface/kernels-community/issues/1085).
> 
> **Cross-links** that section from other guides that already recommend the kernel: Gemma/GKD usage tips, padding-free + FlashAttention in the memory guide, and Hub kernels in the speeding-up-training guide—so users hit the warning before following those examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a86316d641366bb3a582948826893232a5e2623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->