### PR TITLE
Fix mixed precision in Liger DPO loss path

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -905,6 +905,37 @@ class TestDPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_liger_kernel
+    @pytest.mark.skipif(torch_device != "cuda", reason="test requires a CUDA or ROCm device")
+    def test_train_with_liger_uses_autocast(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            bf16=True,
+            max_steps=1,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        autocast_enabled = []
+
+        def record_autocast_state(*_):
+            autocast_enabled.append(torch.is_autocast_enabled("cuda"))
+
+        handle = trainer.model.base_model.register_forward_pre_hook(record_autocast_state)
+        try:
+            trainer.train()
+        finally:
+            handle.remove()
+
+        assert autocast_enabled
+        assert all(autocast_enabled)
+
+    @require_liger_kernel
     @require_peft
     def test_train_with_liger_kernel_and_peft(self):
         # A LoRA adapter that does not target lm_head leaves the head as a plain Linear, so Liger reads the real

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -1761,11 +1761,15 @@ class DPOTrainer(_BaseTrainer):
                 deepspeed_plugin = self.accelerator.state.deepspeed_plugin
                 is_zero3 = deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3
                 unwrapped_model = self.accelerator.unwrap_model(model)
-                if is_zero3 or self.is_fsdp_enabled:
-                    return self._forward_redirection(
-                        model, unwrapped_model, self._compute_loss_liger, unwrapped_model, inputs, return_outputs
-                    )
-                return self._compute_loss_liger(unwrapped_model, inputs, return_outputs)
+                # Accelerate normally enables mixed precision in a wrapper around the top-level model's forward.
+                # The Liger path calls the unwrapped backbone directly, so it must restore that autocast context or
+                # mixed-precision training silently executes the backbone and fused LM head in FP32.
+                with self.accelerator.autocast():
+                    if is_zero3 or self.is_fsdp_enabled:
+                        return self._forward_redirection(
+                            model, unwrapped_model, self._compute_loss_liger, unwrapped_model, inputs, return_outputs
+                        )
+                    return self._compute_loss_liger(unwrapped_model, inputs, return_outputs)
             return self._compute_loss(model, inputs, return_outputs)
         except ValueError as e:
             if "Image features and image tokens do not match" in str(e) and self.args.max_length is not None:


### PR DESCRIPTION
## What does this PR do?

The Liger DPO path unwraps the Accelerate model and calls its backbone directly. This bypasses Accelerate's mixed-precision forward wrapper, so BF16 training silently executes the backbone and fused LM head in FP32.

Run the unwrapped Liger path inside `self.accelerator.autocast()`. This covers the direct, FSDP, and ZeRO-3 redirection paths without changing native DPO execution.

## Why?

On an H100 BF16 LFM2 DPO workload, profiling a matched 2K-token optimizer step showed matrix multiplication consuming 225 ms in the Liger path versus 48 ms natively. The Liger kernels were not the cause; the Liger backbone GEMMs were FP32. Restoring autocast reduced the matched Liger step from about 0.37 s to 0.17 s.

## Testing

- Added a one-step BF16 regression test that records autocast state at the unwrapped backbone.
- H100: focused regression test passed.
- H100: Liger DPO/LFM2 correctness suite passed (830 tests).
- MI325X: Liger DPO/LFM2 correctness suite passed (830 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the Liger loss path with a targeted regression test; restores intended mixed-precision behavior without altering standard DPO training.
> 
> **Overview**
> Fixes **silent FP32 execution** when training DPO with **`use_liger_kernel=True`** and mixed precision (e.g. BF16). The Liger path unwraps the model and runs the backbone and fused LM head outside Accelerate’s usual forward wrapper, so autocast was not applied.
> 
> **`DPOTrainer.compute_loss`** now wraps the entire Liger branch—including ZeRO-3/FSDP `_forward_redirection`—in **`self.accelerator.autocast()`**. The non-Liger DPO path is unchanged.
> 
> Adds **`test_train_with_liger_uses_autocast`**: one-step BF16 CUDA training with a forward pre-hook on the unwrapped backbone that asserts CUDA autocast stays on during the step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c22162d823b7bb68d665944e33e334f319f356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->