### PR TITLE
Split the released and dev Docker image builds into separate workflows

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -1,38 +1,26 @@
-name: Build TRL Docker image
+name: Build TRL dev Docker image
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
-  group: docker-image-builds
+  group: docker-image-build-dev
   cancel-in-progress: false
 
 env:
   CI_SLACK_CHANNEL: ${{ secrets.CI_PUSH_MAIN_CHANNEL }}
 
 jobs:
-  trl:
-    name: "Build and push TRL Docker image"
+  trl-dev:
+    name: "Build and push TRL Dev Docker image"
     runs-on:
       group: aws-general-8-plus
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Get TRL version from PyPI
-        run: |
-          VERSION=$(curl -s https://pypi.org/pypi/trl/json | jq -r .info.version)
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9._-]*)?$ ]]; then
-            echo "Invalid version format: $VERSION"
-            exit 1
-          fi
-          if [[ ${#VERSION} -gt 50 ]]; then
-            echo "Version string too long: $VERSION"
-            exit 1
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
@@ -46,16 +34,15 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
-          context: docker/trl
+          context: docker/trl-dev
           push: true
           tags: |
-            huggingface/trl:${{ env.VERSION }}
-            huggingface/trl
+            huggingface/trl:dev
 
       - name: Post to Slack
         if: always()
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
-          title: Build and push TRL Docker image
+          title: Build and push TRL Dev Docker image
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR splits the Docker image builds into two workflows, so that the released image is built once per release instead of on every push to main, while the dev image keeps building on every push to main.

Part of #6989.

### Motivation

Both images were built from a single workflow triggered on every push to main. That is correct for `huggingface/trl:dev`, which tracks main and is meant to be mutable, but wrong for the released image: it rewrites `huggingface/trl:${VERSION}` on every merge until the next release, so a version tag does not identify what is inside it. #6989 has the details, including `huggingface/trl:1.9.2` being rebuilt on all 65 pushes to main between its release and 1.10.0.

The two images now have genuinely different release cadences, so a single trigger cannot serve both. Splitting the workflows lets each declare its own, which is also how the test workflows are already organized in this repository: one file per trigger, from `tests.yml` to `tests_latest.yml` and `tests_python_versions.yml`.

GitHub releases are published after the PyPI upload (v1.10.0 at `01:36:04` versus PyPI at `01:26:35`), so the release trigger does not race the index.

Removing the dev image was considered and rejected in #6933: it has consumers, and per-push builds are the behavior its users expect. This PR leaves it untouched.

### Changes

- Trigger `docker-build.yml` on `release: published` instead of on push to main, and keep only the released image job
- Add `docker-build-dev.yml` with the dev image job, triggered on push to main as before
- Give the dev workflow its own concurrency group, so a release build does not queue behind an in-flight dev build

### Note

The `release: published` trigger cannot be exercised before merging, since `workflow_dispatch` runs the job but not the trigger. I will dispatch the workflow manually once this is merged to confirm the job still builds and pushes, and the trigger itself is confirmed by the next release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow split with no application or auth changes; main operational risk is release Docker builds not running until the next published release unless manually dispatched.
> 
> **Overview**
> **Splits TRL Docker CI so release tags are built on publish, while `huggingface/trl:dev` still tracks `main`.**
> 
> Adds **`.github/workflows/docker-build-dev.yml`**, which runs on every push to `main` (and `workflow_dispatch`) and only builds/pushes `huggingface/trl:dev`, with its own concurrency group `docker-image-build-dev`.
> 
> Updates **`docker-build.yml`** to drop the `trl-dev` job and change the trigger from `push` to `main` to **`release: published`** (still allows manual dispatch). The remaining job keeps building the versioned image from PyPI plus the `huggingface/trl` tag, so versioned Docker images are no longer rebuilt on every merge to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca448cc53e85c4cadf8628e59fa7c38509fc60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->