### PR TITLE
Read the Docker image version from the release tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "TRL version to build, for example 1.10.0"
+        required: true
 
 concurrency:
   group: docker-image-builds
@@ -21,19 +25,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Get TRL version from PyPI
-        run: |
-          set -euo pipefail
-          VERSION=$(curl --fail --silent --show-error https://pypi.org/pypi/trl/json | jq -r .info.version)
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9._-]*)?$ ]]; then
-            echo "Invalid version format: $VERSION"
-            exit 1
-          fi
-          if [[ ${#VERSION} -gt 50 ]]; then
-            echo "Version string too long: $VERSION"
-            exit 1
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Get TRL version
+        env:
+          TAG: ${{ inputs.version || github.event.release.tag_name }}
+        run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0


### PR DESCRIPTION
This PR takes the version of the released Docker image from the release tag instead of querying the PyPI API.

Part of #6989. Stacked on #6990.

### Motivation

The workflow asked PyPI for the latest published version, which made sense when it ran on every push to main and had no other way to know what to build. Now that it is triggered by the release itself (#6990), the version is already in the event payload, so the query and the validation it required are no longer needed.

Reading the tag also removes a race that the PyPI query had by construction: the API reports whatever is latest at the moment the workflow runs, not the release that triggered it.

### Solution

`github.event.release.tag_name` gives the tag being released, and the leading `v` is stripped to get the version. Manual runs take a required `version` input instead, since the release payload is empty there. The tag is passed through the step environment rather than interpolated into the script, which is the injection safe pattern for values coming from an event payload.

### Changes

- Derive the version from the release tag, or from a `version` input on manual runs
- Remove the PyPI query, along with the format and length validation it needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the build version is chosen; lowers risk of tagging images with the wrong PyPI “latest” during releases.
> 
> **Overview**
> The Docker build workflow no longer fetches the latest TRL version from PyPI (and drops the semver/length checks that step needed). **Release runs** set `VERSION` from `github.event.release.tag_name`, stripping a leading `v`. **Manual `workflow_dispatch` runs** require a new `version` input, since there is no release payload.
> 
> The tag/value is passed via a step `TAG` env var before `${TAG#v}` is written to `GITHUB_ENV`, avoiding interpolating event/input data directly into the shell script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13046ea936fc8f4ba10c45dd1925779e8d1c5948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->