### PR TITLE
Pin the TRL version installed in the Docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: docker/trl
+          build-args: |
+            VERSION=${{ env.VERSION }}
           push: true
           tags: |
             huggingface/trl:${{ env.VERSION }}

--- a/docker/trl/Dockerfile
+++ b/docker/trl/Dockerfile
@@ -1,4 +1,5 @@
 FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
+ARG VERSION
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip uv
-RUN uv pip install --system trl[liger,peft,vlm] kernels trackio
+RUN uv pip install --system trl[liger,peft,vlm]==${VERSION} kernels trackio


### PR DESCRIPTION
This PR pins the TRL version installed in the released Docker image to the version the image is tagged with.

Part of #6989. Stacked on #6991.

### Motivation

The Dockerfile installs `trl[liger,peft,vlm]` unpinned, while the image is tagged with a specific version. The tag is therefore a claim about the contents rather than a constraint on them, and the two can disagree: the build resolves whatever PyPI serves at build time, which is not necessarily the version being released.

With the image now built once per release (#6990) from the release tag (#6991), the version is known at build time and can be pinned.

### Changes

- Add a `VERSION` build argument to the Dockerfile and pin the TRL install to it
- Pass the version to the build as a build argument
- Add the missing trailing newline to the Dockerfile, on the line this PR already changes

### Note

`VERSION` has no default, so building the image locally now requires `--build-arg VERSION=...`. This is deliberate: without a value the build fails, rather than silently producing an image whose contents do not match its tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Docker packaging only; no runtime library or application logic changes, though incorrect VERSION wiring could ship an image with the wrong TRL version.
> 
> **Overview**
> Release Docker images now install **the same TRL version as the image tag**, instead of whatever unpinned `trl[liger,peft,vlm]` resolves on PyPI at build time.
> 
> The **Dockerfile** adds a required `VERSION` build arg and pins the install to `trl[...]==${VERSION}`. The **release workflow** passes `VERSION` from the release tag (or manual dispatch input) into `docker/build-push-action` as `build-args`.
> 
> Local builds must pass `--build-arg VERSION=...`; there is no default, so a missing version fails the build rather than producing a mismatched image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1329f9af25efab90584e84fa39c7f6c6be9f2012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->