### PR TITLE
fix: score think_format_reward when <think> is prefilled in the prompt

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -37,9 +37,13 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>\nThis is\nmy reasoning.\n</think>\nThis is my answer.",  # Multiline reasoning
             "<think>\nThis is <some tag> my reasoning.</think>\nThis is my answer.",  # Reasoning including other tags
             "<think></think>\nThis is my answer.",  # Empty reasoning
+            # GRPO keeps generated tokens only; some templates already opened <think> in the prompt.
+            "This is my reasoning.</think>\nThis is my answer.",
+            "This is my reasoning.</think>This is my answer.",
+            "First, 2 plus 2.\n</think>\nThe answer is 4.",
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
+        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 
@@ -49,14 +53,12 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>This is my reasoning.\nThis is my answer.",  # No closing </think>
             "This is my reasoning. This is my answer.",  # No <think> tags
             "This is my reasoning.\nThis is my answer.",  # No <think> tags
-            "This is my reasoning.</think>\nThis is my answer.",  # No opening <think>
-            "This is my reasoning.</think>This is my answer.",  # No opening <think>
             "This<think>is my reasoning.</think>\nThis is my answer.",  # <think> tag in the middle
             "<think>This is<think>my reasoning.</think></think>This is my answer.",  # Nested <think> tags
             "<think>This is</think>\nmy\n<think>reasoning.</think>\nThis is my answer.",  # Multiline <think>
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
+        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -20,6 +20,10 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
     Reward function that checks if the reasoning process is enclosed within `"<think>"` and `"</think>"` tags. The
     function returns a reward of 1.0 if the format is correct, otherwise 0.0.
 
+    The opening `"<think>"` tag is optional so that GRPO-style trainers still score well-formed completions when the
+    chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the
+    trainer only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
+
     Args:
         completions (`list[list[dict[str, str]]]`):
             List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
@@ -38,13 +42,16 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
 
     >>> completions = [
     ...     [{"content": "<think>\nThis is my reasoning.\n</think>\nThis is my answer."}],
+    ...     [{"content": "This is my reasoning.\n</think>\nThis is my answer."}],
     ...     [{"content": "<think>\nThis is my reasoning.\nThis is my answer."}],
     ... ]
     >>> think_format_reward(completions)
-    [1.0, 0.0]
+    [1.0, 1.0, 0.0]
     ```
     """
-    pattern = r"^<think>(?!.*<think>)(.*?)</think>.*$"
+    # Opening <think> is optional: GRPO decodes generated tokens only, and some chat templates already
+    # emit that tag in the prompt (DeepSeek-R1 distill, Qwen3.5/3.6 thinking).
+    pattern = r"^(?:<think>)?(?!.*<think>)(.*?)</think>.*$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]


### PR DESCRIPTION
## Summary
- `think_format_reward` required completions to start with `<think>`. GRPO only decodes generated tokens, so models whose chat template already prefills that tag (DeepSeek-R1 distill, Qwen3.5/3.6 thinking) scored `0.0` on every well-formed completion.
- Make the opening tag optional, keep the existing no-nested-`<think>` lookahead, and still require `</think>`.
- Add regression coverage for the DeepSeek-R1-style completion from #6966.

Fixes #6966

## Test plan
- [x] Existing `TestThinkFormatReward` cases still pass (full `<think>...</think>` remains 1.0; missing close / nested / mid-string open remain 0.0)
- [x] Prefill-style completions like `First, 2 plus 2.\n</think>\nThe answer is 4.` now score 1.0
- [ ] `python -m pytest -sv tests/test_rewards.py::TestThinkFormatReward` on CI

Made with [Cursor](https://cursor.com)