### PR TITLE
fix: score think_format_reward when <think> is prefilled in the prompt

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -37,9 +37,13 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>\nThis is\nmy reasoning.\n</think>\nThis is my answer.",  # Multiline reasoning
             "<think>\nThis is <some tag> my reasoning.</think>\nThis is my answer.",  # Reasoning including other tags
             "<think></think>\nThis is my answer.",  # Empty reasoning
+            # GRPO keeps generated tokens only; some templates already opened <think> in the prompt.
+            "This is my reasoning.</think>\nThis is my answer.",
+            "This is my reasoning.</think>This is my answer.",
+            "First, 2 plus 2.\n</think>\nThe answer is 4.",
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
+        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 
@@ -49,14 +53,12 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>This is my reasoning.\nThis is my answer.",  # No closing </think>
             "This is my reasoning. This is my answer.",  # No <think> tags
             "This is my reasoning.\nThis is my answer.",  # No <think> tags
-            "This is my reasoning.</think>\nThis is my answer.",  # No opening <think>
-            "This is my reasoning.</think>This is my answer.",  # No opening <think>
             "This<think>is my reasoning.</think>\nThis is my answer.",  # <think> tag in the middle
             "<think>This is<think>my reasoning.</think></think>This is my answer.",  # Nested <think> tags
             "<think>This is</think>\nmy\n<think>reasoning.</think>\nThis is my answer.",  # Multiline <think>
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
+        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -41,9 +41,12 @@ class TestThinkFormatReward(TrlTestCase):
             "This is my reasoning.</think>\nThis is my answer.",
             "This is my reasoning.</think>This is my answer.",
             "First, 2 plus 2.\n</think>\nThe answer is 4.",
+            # Accepted deliberately: a bare or mentioned </think> also scores 1.0.
+            "</think>",
+            "An answer that merely mentions </think>.",
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
+        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -20,6 +20,10 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
     Reward function that checks if the reasoning process is enclosed within `"<think>"` and `"</think>"` tags. The
     function returns a reward of 1.0 if the format is correct, otherwise 0.0.
 
+    The opening `"<think>"` tag is optional so that GRPO-style trainers still score well-formed completions when the
+    chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the
+    trainer only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
+
     Args:
         completions (`list[list[dict[str, str]]]`):
             List of completions to be evaluated. Each completion must be a list of one message, i.e. a dictionary
@@ -38,13 +42,16 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
 
     >>> completions = [
     ...     [{"content": "<think>\nThis is my reasoning.\n</think>\nThis is my answer."}],
+    ...     [{"content": "This is my reasoning.\n</think>\nThis is my answer."}],
     ...     [{"content": "<think>\nThis is my reasoning.\nThis is my answer."}],
     ... ]
     >>> think_format_reward(completions)
-    [1.0, 0.0]
+    [1.0, 1.0, 0.0]
     ```
     """
-    pattern = r"^<think>(?!.*<think>)(.*?)</think>.*$"
+    # Opening <think> is optional: GRPO decodes generated tokens only, and some chat templates already
+    # emit that tag in the prompt (DeepSeek-R1 distill, Qwen3.5/3.6 thinking).
+    pattern = r"^(?:<think>)?(?!.*<think>)(.*?)</think>.*$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -17,12 +17,15 @@ import re
 
 def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> list[float]:
     r"""
-    Reward function that checks if the reasoning process is enclosed within `"<think>"` and `"</think>"` tags. The
-    function returns a reward of 1.0 if the format is correct, otherwise 0.0.
+    Reward function that checks if the completion contains a `"</think>"` tag, with at most one optional leading
+    `"<think>"` tag. The function returns a reward of 1.0 if the format is correct, otherwise 0.0.
 
     The opening `"<think>"` tag is optional so that GRPO-style trainers still score well-formed completions when the
     chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the
     trainer only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
+
+    The relaxation is unconditional: completions that omit the opening tag also score 1.0 under templates that do not
+    prefill `"<think>"`.
 
     Args:
         completions (`list[list[dict[str, str]]]`):
@@ -50,7 +53,7 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
     ```
     """
     # Opening <think> is optional: GRPO decodes generated tokens only, and some chat templates already
-    # emit that tag in the prompt (DeepSeek-R1 distill, Qwen3.5/3.6 thinking).
+    # emit that tag in the prompt.
     pattern = r"^(?:<think>)?(?!.*<think>)(.*?)</think>.*$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]


### PR DESCRIPTION
# What does this PR do?

`think_format_reward` currently requires the completion to start with `<think>`. GRPO only decodes generated tokens (`grpo_trainer.py`), so models whose chat template already prefills that tag into the prompt — DeepSeek-R1 distill, and Qwen3.5/3.6 with thinking enabled — score `0.0` on every well-formed completion. A constant reward gives zero advantage, so the function contributes nothing for the whole run.

This PR makes the opening `<think>` tag optional, keeps the existing no-nested-`<think>` lookahead, and still requires `</think>`. Completions that already start with `<think>` (Qwen3) keep scoring 1.0.

Fixes #6966

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

Made with [Cursor](https://cursor.com)