### PR TITLE
Document how to choose and pin a Hub kernel version

### DIFF
--- a/docs/source/kernels_hub.md
+++ b/docs/source/kernels_hub.md
@@ -46,6 +46,29 @@ trl sft ... --attn_implementation kernels-community/flash-attn2
 > [!TIP]
 > Now you can leverage faster attention backends with a pre-optimized kernel for your hardware configuration from the Hub, speeding up both development and training.
 
+## Choosing and Pinning a Kernel Version
+
+Kernel repositories on the Hub are versioned as branches (`v1`, `v2`, `v3`, ...), and Transformers selects a default version for each repository. That default can change from one Transformers release to the next, so the same `attn_implementation` value does not always resolve to the same build.
+
+To control which build is loaded, append a revision to the repository id, either a version branch or a commit SHA:
+
+```python
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(
+    "your-model-name",
+    attn_implementation="kernels-community/flash-attn2@v2",  # or a commit SHA to pin an exact build
+)
+```
+
+Pinning is useful to make a training run reproducible, and to stay on a known-good build when a newer one regresses. Keep in mind that each version only ships builds for a range of Torch and CUDA versions, so a pinned version may have no variant for your environment.
+
+> [!TIP]
+> `attn_implementation="flash_attention_2"` falls back to the `kernels-community/flash-attn2` Hub kernel when the `flash-attn` package is not installed, so you may be using a Hub kernel without having asked for one explicitly.
+
+> [!WARNING]
+> The `v3` builds for CUDA 12.8 currently fail in the backward pass for models using grouped-query attention. If your environment uses that CUDA version, pin `@v2` until [huggingface/kernels-community#1085](https://github.com/huggingface/kernels-community/issues/1085) is closed.
+
 ## Comparing Attention Implementations
 
 We evaluated various attention implementations available in transformers, along with different kernel backends, using **TRL** and **SFT**.  


### PR DESCRIPTION
This PR documents how a Hub kernel version is selected and how to pin it.

Supersedes #6986.

### Motivation

Kernel repositories are versioned as branches, and Transformers selects a default version for each repository, so the same `attn_implementation` value can resolve to a different build after a Transformers upgrade. That is documented nowhere in TRL, and it is how the recent flash-attn2 regression (huggingface/kernels-community#1085) reached users who had changed nothing on their side, including users who only ever asked for `flash_attention_2` and silently got the Hub kernel through the fallback.

Pinning a revision is the general remedy: it is what the invariant test suite uses in #6979, and what #6985 stops TRL warning about. It is worth documenting as a mechanism rather than only as a workaround for one incident.

#6986 documented that incident instead. Since then the upstream fix has landed and been rebuilt for most CUDA versions, so the incident-shaped note was both inaccurate and about to expire, while the underlying mechanism stays useful. This PR keeps the durable half and reduces the transient part to a single scoped warning that can be deleted on its own.

### Solution

Add a section to the Kernels Hub guide covering version resolution, the `repo_id@revision` syntax with either a version branch or a commit SHA, the fact that each version only ships builds for a range of Torch and CUDA versions, and the silent `flash_attention_2` fallback.

### Changes

- Add a "Choosing and Pinning a Kernel Version" section to the Kernels Hub guide.
- Note that `flash_attention_2` falls back to the Hub kernel when the `flash-attn` package is absent.
- Note the CUDA 12.8 regression and the `@v2` pin, scoped to that CUDA version and linked to the upstream issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or training code impact.
> 
> **Overview**
> Adds a **Choosing and Pinning a Kernel Version** section to the Kernels Hub guide so users understand that Hub kernels are versioned as branches and Transformers may change the default build between releases.
> 
> The doc explains pinning via `attn_implementation="kernels-community/flash-attn2@v2"` (or a commit SHA), why that helps reproducibility and known-good builds, and that each version only covers certain Torch/CUDA combos. It also calls out that **`flash_attention_2` can silently use the Hub kernel** when `flash-attn` is not installed, and includes a **scoped warning** to pin `@v2` on CUDA 12.8 until the grouped-query attention backward issue in `v3` is fixed upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7351dc5c9d6141632ffeb948339dc884cf97d0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->