### PR TITLE
Drop vLLM 0.19.0 support

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.19.0` to `0.27.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.19.1` to `0.27.1`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "tabulate"  # test report rendering in scripts/log_reports.py
 ]
 vllm = [
-    "vllm>=0.19.0,<=0.27.1",
+    "vllm>=0.19.1,<=0.27.1",
     "aiohttp>=3.13.3",
     "requests",
 ]

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -104,9 +104,9 @@ def is_vllm_available(min_version: str | None = None) -> bool:
         # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
         # above the plain release and would otherwise fail the upper-bound check.
         _vllm_base_version = Version(Version(_vllm_version).base_version)
-        if not (Version("0.19.0") <= _vllm_base_version <= Version("0.27.1")):
+        if not (Version("0.19.1") <= _vllm_base_version <= Version("0.27.1")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.19.0 to 0.27.1. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.19.1 to 0.27.1. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
As per the plan, and following #6844 (which dropped 0.18), this raises the minimum supported vLLM version from `0.19.0` to `0.19.1`. The upper bound stays `0.27.1` (the 0.28.0 bump is in its own PR; whichever merges second needs a one-line rebase).

vLLM 0.19.0 was released on 3 Apr 2026, so it reaches the 5-month support window on **3 Sep 2026**. Ready to merge from that date. 0.19.1 (18 Apr 2026) follows on 18 Sep.

<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/8e614d54-bf79-4c08-9a9f-9ce4d6673848" />

## Changes

The supported range is updated in the same three places as #6844:

- `docs/source/vllm_integration.md` — the vLLM integration doc warning
- `pyproject.toml` — the `trl[vllm]` optional dependency (`vllm>=0.19.1,<=0.27.1`)
- `trl/import_utils.py` — the version check and warning text in `is_vllm_available()`

No version gate becomes dead: the only remaining `min_version` gates are `>=0.21.0` in `trl/generation/vllm_client.py` and `>=0.22.0` in the experimental async trainers, all still above the floor.

Users on vLLM 0.19.0 will see the compatibility warning, and `pip install "trl[vllm]"` will no longer resolve to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-range and messaging only; no trainer or vLLM client logic changes.
> 
> **Overview**
> Raises TRL’s minimum supported vLLM release from **0.19.0** to **0.19.1**; the upper cap stays **0.27.1**.
> 
> The floor is updated in the vLLM integration doc warning, the `trl[vllm]` extra in `pyproject.toml` (`vllm>=0.19.1,<=0.27.1`), and the supported-range check and warning text in `is_vllm_available()`. Users on 0.19.0 get the compatibility warning; fresh `pip install "trl[vllm]"` will not pin 0.19.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2cc1186b1c3f962db5907787a7aaa7037eeb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->