### PR TITLE
Remove the unused FLASH_ATTENTION_VARIANTS constant from the DPO trainer

### DIFF
--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -80,15 +80,6 @@ if is_peft_available():
 logger = get_logger(__name__)
 
 
-FLASH_ATTENTION_VARIANTS = {
-    "flash_attention_2",
-    "flash_attention_3",
-    "kernels-community/flash-attn2",
-    "kernels-community/flash-attn3",
-    "kernels-community/vllm-flash-attn3",
-}
-
-
 @dataclass
 class DataCollatorForPreference(DataCollatorMixin):
     """


### PR DESCRIPTION
This PR removes the `FLASH_ATTENTION_VARIANTS` constant from the DPO trainer, where it is never used.

Follow-up suggested in #6979 and #6985.

### Motivation

The constant mirrors the one in the SFT trainer, which uses it to warn when padding-free or BFD packing runs on an attention implementation that does not reliably support it. The DPO copy has no such check, because padding-free is currently disabled there: `DPOTrainer` warns and forces `padding_free=False` until the feature returns after the refactor.

Keeping the copy is not harmless. #6985 changes how the SFT trainer matches that set, so that a Hub kernel requested with a revision (`repo_id@revision`) is recognized. The DPO copy would silently keep the old shape, and whoever restores padding-free in DPO would likely copy it, reintroducing the bug that #6985 just fixed. Deleting it now means the check gets written once, from the current source, when the feature comes back.

### Solution

Delete the constant. Nothing else references it.

### Changes

- Remove the unused `FLASH_ATTENTION_VARIANTS` constant from the DPO trainer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion of an unused constant with no runtime behavior change.
> 
> **Overview**
> Removes the dead **`FLASH_ATTENTION_VARIANTS`** set from `dpo_trainer.py`. That list was a duplicate of the one in the SFT trainer and was never referenced in DPO code (padding-free is still disabled there with a warning).
> 
> The change avoids keeping a stale copy that could be pasted back when padding-free returns, instead of reusing the updated SFT matching logic (e.g. Hub kernel IDs with `@revision`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8144fcc1434746165373b48848fb8906af5fa160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->