### PR TITLE
Document that padding-free is temporarily unavailable in DPO

### DIFF
--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -208,6 +208,9 @@ Padding-free batching is an alternative approach for reducing memory usage. In t
 <hfoptions id="padding-free">
 <hfoption id="DPO">
 
+> [!WARNING]
+> Padding-free is temporarily unavailable in [`DPOTrainer`]: since the DPO refactor, setting `padding_free=True` warns and falls back to standard padding. It is planned to return in a future update.
+
 ```python
 from trl import DPOConfig
 

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -62,6 +62,8 @@ class DPOConfig(_BaseConfig):
             Whether to perform forward passes without padding by flattening all sequences in the batch into a single
             continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
             supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch structure.
+            Temporarily unavailable: since the DPO refactor, setting it to `True` warns and falls back to standard
+            padding. It is planned to return in a future update.
         pad_to_multiple_of (`int`, *optional*):
             If set, the sequences will be padded to a multiple of this value.
         precompute_ref_log_probs (`bool`, *optional*, defaults to `False`):
@@ -207,7 +209,8 @@ class DPOConfig(_BaseConfig):
             "help": "Whether to perform forward passes without padding by flattening all sequences in the batch into "
             "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this "
             "is only supported with the FlashAttention 2 or 3, which can efficiently handle the flattened batch "
-            "structure."
+            "structure. Temporarily unavailable: since the DPO refactor, setting it to True warns and falls back to "
+            "standard padding. It is planned to return in a future update."
         },
     )
     pad_to_multiple_of: int | None = field(


### PR DESCRIPTION
This PR documents that padding-free is currently disabled in `DPOTrainer`.

### Motivation

`DPOTrainer` warns and forces `padding_free=False` since the DPO refactor (#3906), but nothing outside the trainer says so. The memory usage guide still presents `DPOConfig(..., padding_free=True, ...)` as a way to reduce memory, and both the `DPOConfig.padding_free` docstring and its CLI help describe the feature as if it worked. A user following the guide gets no memory saving and only finds out from a runtime warning, if they read the logs.

### Solution

State the current status where the option is presented, without removing the example, since the feature is planned to return.

### Changes

- Flag the DPO example in the padding-free section of the memory usage guide as temporarily unavailable.
- Say the same in the `DPOConfig.padding_free` docstring and in the matching CLI help text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and help-text only; no training or config runtime behavior changes.
> 
> **Overview**
> **Documents that DPO `padding_free` is not active today**, aligning public docs with existing `DPOTrainer` behavior (warn and force standard padding after the DPO refactor).
> 
> Adds a **warning callout** above the DPO padding-free example in `reducing_memory_usage.md`, while keeping the `DPOConfig(..., padding_free=True, ...)` snippet for when the feature returns. The same **temporarily unavailable** note is added to the `DPOConfig.padding_free` class docstring and to the field’s CLI/`metadata` help text so users see it before training, not only from logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a7caf3ebf938b90c32df678ea3ee6c30e6f0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->