### PR TITLE
Validate repetition penalty n-gram size

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -99,6 +99,11 @@ class TestSoftOverlongPunishmentReward:
 
 
 class TestRepetitionPenaltyReward:
+    @pytest.mark.parametrize("ngram_size", [0, -1])
+    def test_non_positive_ngram_size_raises(self, ngram_size):
+        with pytest.raises(ValueError, match="ngram_size must be greater than 0"):
+            get_repetition_penalty_reward(ngram_size=ngram_size)
+
     def test_no_repetition_yields_zero(self):
         """A completion with only unique n-grams gets no penalty."""
         reward_fn = get_repetition_penalty_reward(ngram_size=2, max_penalty=-1.0)

--- a/trl/rewards/other_rewards.py
+++ b/trl/rewards/other_rewards.py
@@ -35,7 +35,7 @@ def get_repetition_penalty_reward(ngram_size: int = 3, max_penalty: float = -1.0
 
     Args:
         ngram_size (`int`, *optional*, defaults to `3`):
-            Size of the token n-grams to consider.
+            Size of the token n-grams to consider. Must be greater than `0`.
         max_penalty (`float`, *optional*, defaults to `-1.0`):
             Most negative penalty, applied to a fully repetitive completion. Must be non-positive.
 
@@ -54,6 +54,8 @@ def get_repetition_penalty_reward(ngram_size: int = 3, max_penalty: float = -1.0
     [0.0, -0.75]
     ```
     """
+    if ngram_size <= 0:
+        raise ValueError(f"ngram_size must be greater than 0, got {ngram_size}")
     if max_penalty > 0:
         raise ValueError(f"max_penalty {max_penalty} should not be positive")
     return _RepetitionPenalty(ngram_size, max_penalty)


### PR DESCRIPTION
# What does this PR do?

`get_repetition_penalty_reward` currently accepts non-positive `ngram_size` values. These values produce an empty n-gram list and result in a `ZeroDivisionError` only when the returned reward function is called.

This PR:

- validates `ngram_size` when constructing the reward function and raises an actionable `ValueError`;
- documents that `ngram_size` must be greater than zero;
- adds regression coverage for zero and negative values.

Fixes #7015

## Testing

- `pytest -q tests/test_rewards.py` — 20 passed, 20 skipped
- `ruff check trl/rewards/other_rewards.py tests/test_rewards.py`
- `ruff format --check trl/rewards/other_rewards.py tests/test_rewards.py`

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? See #7015.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small input validation on a reward factory; behavior for valid ngram_size is unchanged.
> 
> **Overview**
> **`get_repetition_penalty_reward`** now rejects non-positive **`ngram_size`** at construction time with a clear **`ValueError`**, instead of failing later with **`ZeroDivisionError`** when the returned reward runs on completions that produce no n-grams.
> 
> The **`ngram_size`** argument docs state it must be greater than zero. Regression tests cover **`ngram_size`** of **`0`** and **`-1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b5f54dc433efce530a46871d0426338665f2a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->