### PR TITLE
Filter the benign torch DataParallel scalar-gather warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,4 +258,12 @@ filterwarnings = [
     # Upstream issue: https://github.com/pytorch/pytorch/issues/175484
     # Remove once: no supported torch version emits it
     "ignore:TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled:UserWarning",
+
+    # torch's DataParallel warns that it is gathering the per-replica scalar losses into a vector, since scalars have
+    # to be unsqueezed first (upstream, not actionable in TRL: the gather happens entirely inside nn.DataParallel)
+    # Triggered by the SFT slow tests since the multi-GPU CI job moved to a runner with two visible devices:
+    # transformers' Trainer wraps the model in nn.DataParallel whenever n_gpu > 1 and no distributed launcher is used
+    # Tracking issue: https://github.com/huggingface/trl/issues/7018
+    # Remove once: the multi-GPU CI no longer exercises nn.DataParallel (https://github.com/huggingface/trl/issues/6836)
+    "ignore:Was asked to gather along dimension 0, but all input tensors were scalars:UserWarning",
 ]


### PR DESCRIPTION
This PR silences the benign `torch` `nn.DataParallel` scalar-loss gather `UserWarning` emitted by the SFT tests in the multi-GPU CI job.

Fix #7018.

### Motivation

Since the multi-GPU slow tests job moved to a runner with two visible devices, `tests/test_sft_trainer.py` emits 16 warnings:

```
/__w/trl/trl/.venv/lib/python3.12/site-packages/torch/autograd/function.py:625: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.
  return super().apply(*args, **kwargs)  # type: ignore[misc]
```

`Trainer` wraps the model in `nn.DataParallel` whenever more than one accelerator is visible and no distributed launcher is used. `DataParallel` then gathers each replica's output, and since the `loss` field is a 0-dim scalar on every replica, `torch.nn.parallel._functions.Gather` unsqueezes them into a vector and warns about it. The gather happens entirely inside `DataParallel`, which also chooses the dimension, so there is nothing actionable on the TRL side. The tests pass.

Not reported upstream: `nn.DataParallel` is soft-deprecated in favour of `DistributedDataParallel` and the warning has been unchanged for years, identical at `v2.13.0` and on `pytorch/main`. It is also arguably intentional, since the gathered shape does differ from a plain gather along dimension 0. The two existing reports (huggingface/transformers#852 and huggingface/transformers#14128) were both closed with no code change.

### Solution

Suppress the warning through `filterwarnings` in `pyproject.toml`, documented like the other upstream warning filters. The entry is tied to #6836 rather than to a dependency version, since the warning disappears once the multi-GPU CI no longer exercises `nn.DataParallel`.

### Changes

- Add a `filterwarnings` entry for the `torch` `DataParallel` scalar-gather `UserWarning`, with a comment explaining the cause, what triggers it, and when the entry can be removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes pytest warning filters for CI; no library or training runtime behavior.
> 
> **Overview**
> Adds a **pytest `filterwarnings` ignore** in `pyproject.toml` for PyTorch’s benign `UserWarning` when `nn.DataParallel` gathers per-replica **scalar losses** (“Was asked to gather along dimension 0, but all input tensors were scalars…”).
> 
> This noise showed up after the **multi-GPU slow-test runner** gained two visible devices: Hugging Face `Trainer` wraps the model in `DataParallel` in that setup, and the gather happens inside PyTorch—not something TRL can fix. The entry is documented like other upstream filters, with tracking **#7018** and a note to drop it when CI no longer exercises `DataParallel` (**#6836**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb9e45b89a6bca85189c1c1141ca969ea323032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->