### PR TITLE
Fix config loading options when loading models

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 import transformers
 from datasets import IterableDataset
 from packaging.version import Version
-from transformers import AutoConfig, AutoModelForCausalLM, PretrainedConfig
+from transformers import AutoConfig, AutoModelForCausalLM, GPT2Config, GPT2LMHeadModel, PretrainedConfig
 from transformers.testing_utils import torch_device
 from transformers.utils import is_peft_available
 
@@ -36,6 +36,7 @@ from trl.trainer.utils import (
     adjusted_mfu,
     compute_flops_per_token,
     compute_mfu,
+    create_model_from_path,
     entropy_from_logits,
     flush_left,
     generate_model_card,
@@ -113,6 +114,26 @@ class TestUseAdapter(TrlTestCase):
 
         assert torch.equal(output_1, expected_1)
         assert torch.equal(output_2, expected_2)
+
+
+class TestCreateModelFromPathSubfolder:
+    @pytest.mark.parametrize("subfolder", ["", "checkpoint"])
+    def test_loads_model_and_config_from_same_directory(self, tmp_path, subfolder):
+        config = GPT2Config(
+            vocab_size=32, n_positions=16, n_embd=16, n_layer=1, n_head=2, bos_token_id=0, eos_token_id=1
+        )
+        model = GPT2LMHeadModel(config).eval()
+        model.save_pretrained(tmp_path / subfolder)
+
+        loaded_model = create_model_from_path(
+            str(tmp_path), subfolder=subfolder, local_files_only=True, device_map=None
+        )
+
+        input_ids = torch.tensor([[1, 2, 3]])
+        with torch.no_grad():
+            expected = model(input_ids).logits
+            actual = loaded_model(input_ids).logits
+        torch.testing.assert_close(actual, expected)
 
 
 class TestPad(TrlTestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,7 +116,7 @@ class TestUseAdapter(TrlTestCase):
         assert torch.equal(output_2, expected_2)
 
 
-class TestCreateModelFromPathSubfolder:
+class TestCreateModelFromPathSubfolder(TrlTestCase):
     @pytest.mark.parametrize("subfolder", ["", "checkpoint"])
     def test_loads_model_and_config_from_same_directory(self, tmp_path, subfolder):
         config = GPT2Config(
@@ -134,6 +134,56 @@ class TestCreateModelFromPathSubfolder:
             expected = model(input_ids).logits
             actual = loaded_model(input_ids).logits
         torch.testing.assert_close(actual, expected)
+
+    @pytest.mark.parametrize("subfolder", ["", "checkpoint"])
+    def test_loads_config_from_requested_cached_revision(self, tmp_path, subfolder):
+        model_id = "trl-offline-tests/tiny-gpt2"
+        revision = "b" * 40
+        snapshot = tmp_path / "models--trl-offline-tests--tiny-gpt2" / "snapshots" / revision
+        config = GPT2Config(
+            vocab_size=32, n_positions=16, n_embd=16, n_layer=1, n_head=2, bos_token_id=0, eos_token_id=1
+        )
+        model = GPT2LMHeadModel(config).eval()
+        model.save_pretrained(snapshot / subfolder)
+
+        # No default-revision snapshot exists, and the cache is outside the user's Hub cache.
+        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+            loaded_model = create_model_from_path(
+                model_id,
+                revision=revision,
+                cache_dir=str(tmp_path),
+                subfolder=subfolder,
+                local_files_only=True,
+                device_map=None,
+            )
+
+        input_ids = torch.tensor([[1, 2, 3]])
+        with torch.no_grad():
+            expected = model(input_ids).logits
+            actual = loaded_model(input_ids).logits
+        torch.testing.assert_close(actual, expected)
+
+    def test_forwards_config_loading_options_without_model_only_kwargs(self):
+        config = GPT2Config(architectures=["GPT2LMHeadModel"])
+        loading_kwargs = {
+            "subfolder": "checkpoint",
+            "revision": "custom-revision",
+            "cache_dir": "custom-cache",
+            "token": "test-token-not-a-credential",
+            "local_files_only": True,
+            "trust_remote_code": True,
+        }
+        with (
+            patch("trl.trainer.utils.AutoConfig.from_pretrained", return_value=config) as config_loader,
+            patch("transformers.GPT2LMHeadModel.from_pretrained") as model_loader,
+        ):
+            result = create_model_from_path("model-id", **loading_kwargs, device_map=None, attn_implementation="eager")
+
+        config_loader.assert_called_once_with("model-id", **loading_kwargs)
+        model_loader.assert_called_once_with(
+            "model-id", **loading_kwargs, device_map=None, attn_implementation="eager", dtype=torch.float32
+        )
+        assert result is model_loader.return_value
 
 
 class TestPad(TrlTestCase):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1179,7 +1179,11 @@ def create_model_from_path(
         kwargs["device_map"] = None if PartialState().device.type == "cpu" else "auto"
     if architecture is None:
         # Best effort to infer architecture from config, but we fall back to AutoModelForCausalLM if we can't find it
-        config = AutoConfig.from_pretrained(model_id, trust_remote_code=kwargs.get("trust_remote_code", False))
+        config = AutoConfig.from_pretrained(
+            model_id,
+            subfolder=kwargs.get("subfolder", ""),
+            trust_remote_code=kwargs.get("trust_remote_code", False),
+        )
         architecture = getattr(transformers, config.architectures[0], None)
         if architecture is None:
             # Remote-code checkpoint: the architecture name lives in the dynamic module, not in

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1182,6 +1182,10 @@ def create_model_from_path(
         config = AutoConfig.from_pretrained(
             model_id,
             subfolder=kwargs.get("subfolder", ""),
+            revision=kwargs.get("revision", "main"),
+            cache_dir=kwargs.get("cache_dir"),
+            token=kwargs.get("token"),
+            local_files_only=kwargs.get("local_files_only", False),
             trust_remote_code=kwargs.get("trust_remote_code", False),
         )
         architecture = getattr(transformers, config.architectures[0], None)


### PR DESCRIPTION
## What does this PR do?

Fixes #7025.

Forward `subfolder`, `revision`, `cache_dir`, `token`, and `local_files_only` to the configuration lookup in `create_model_from_path`, so architecture inference reads the same checkpoint directory as the model loader. Previously, a checkpoint saved only in a subdirectory failed during `AutoConfig.from_pretrained`, even though Transformers loaded it successfully with the same arguments.

The regression test saves a tiny GPT-2 locally and compares the loaded logits with the original for root-directory and subdirectory checkpoints. Before the fix, the subdirectory case fails and the root case passes; both pass after the fix. No Hub fixture or GPU is needed for these cases.

Following the collaborator review, the same lookup now also respects the checkpoint revision, cache location, authentication option, and offline-only setting. Two additional offline tests load a tiny GPT-2 from a temporary Hub-cache snapshot at a non-default revision, both at the root and in a subfolder. A forwarding test checks that model-only options stay out of the config lookup; the test class now inherits `TrlTestCase`.

This does not change the architecture fallback in #7008 or processor loading in #6978. The #7008/#7026 changes are semantically independent but touch adjacent lines: whichever lands second needs to preserve both changes. If #7008 lands first, I will merge the updated main into this branch without rewriting reviewed commits.

## Validation

Current head (Python 3.10, Transformers 5.14.1, CPU/offline):

- Three added cases fail before the loading-option fix; the two original subfolder cases still pass.
- After the fix: 66 passed, 174 deselected in the focused CPU utility selection, including all five model-loading cases. This is not the full test suite.
- Repository-pinned pre-commit hooks: Ruff check, Ruff format, and doc-builder style passed.
- `git diff --check` passed.
- Private Hub authentication and remote-code checkpoints were not exercised; `token` forwarding is checked with a dummy value and mocked loaders.

## Before submitting

- [x] Read the contributor guidelines.
- [x] Linked the current-main reproduction in #7025; no prior maintainer approval is claimed.
- [x] Added regression tests for the bug and unchanged root-directory behavior.
- [x] Documentation reviewed; this restores an existing model-loading argument and adds no new API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bugfix in model-loading helper with regression tests; no API changes beyond restoring correct argument forwarding.
> 
> **Overview**
> Fixes checkpoint loading when weights live in a **subfolder** by aligning config discovery with model loading in `create_model_from_path`.
> 
> When architecture is inferred, **`AutoConfig.from_pretrained`** now receives the same Hub/path kwargs as **`from_pretrained`** on the model (`subfolder`, `revision`, `cache_dir`, `token`, `local_files_only`, plus existing `trust_remote_code`). Previously config was read from the repo root while the model could load from a subdirectory, causing failures for subdirectory-only checkpoints.
> 
> Adds **`TestCreateModelFromPathSubfolder`** with local GPT-2 regression tests (root vs `checkpoint` subfolder, offline cached revision) and a mocked test that config kwargs are forwarded without leaking model-only options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e21e7166d95f780c72e9f6aaefd71716b5291f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
