### PR TITLE
Fix the input metadata of the post-slack composite action

### DIFF
--- a/.github/actions/post-slack/action.yml
+++ b/.github/actions/post-slack/action.yml
@@ -4,14 +4,14 @@ description: 'Send results to slack'
 author: 'Hugging Face'
 inputs:
   slack_channel:
+    description: 'Slack channel id, channel name, or user id to post the message to'
     required: true
-    type: string
   title:
+    description: 'Title shown in the message and in the notification summary'
     required: true
-    type: string
   slack_token:
+    description: 'Slack bot token used to call the chat.postMessage API'
     required: true
-    type: string
 
 runs:
   using: "composite"


### PR DESCRIPTION
This PR fixes the input metadata of the `post-slack` composite action, which does not follow the schema for composite action inputs.

### Motivation

The three inputs declare `type: string` and no `description`. For composite actions, an input accepts `description`, `required`, `default` and `deprecationMessage`. There is no `type` key, that one belongs to `workflow_call` inputs, and `description` is required.

GitHub tolerates this today, so nothing is broken at runtime, but `actionlint` cannot parse the action metadata and gives up on every workflow that uses it:

```
.github/workflows/docker-build.yml:55:15: could not parse action metadata in ".github/actions/post-slack": line 6: unexpected key "type" for definition of input "slack_token" [action]
.github/workflows/slow-tests.yml:124:15: could not parse action metadata in ".github/actions/post-slack": line 6: unexpected key "type" for definition of input "slack_token" [action]
```

That affects the seven workflows calling the action: `tests.yml`, `slow-tests.yml`, `tests_latest.yml`, `tests_python_versions.yml`, `tests_transformers_branch.yml`, `docker-build.yml` and `docker-build-dev.yml`. Since the failure is on the action metadata, the call sites are never checked at all, so genuine mistakes in how the action is called would go unreported.

### Changes

- Replace the invalid `type` key with the required `description` on the three inputs of the `post-slack` action

### Verification

`actionlint` 1.7.12, run on a worktree of `main` and on this branch:

- before: the finding above, reproduced on every workflow that uses the action
- after: no findings

The action's behavior is unchanged: the removed key was never read, and descriptions are documentation only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI action metadata only; no application or secret-handling logic changes.
> 
> **Overview**
> Updates **`.github/actions/post-slack/action.yml`** so its inputs match the composite-action schema: removes invalid `type: string` on `slack_channel`, `title`, and `slack_token`, and adds the required `description` for each.
> 
> This is metadata-only—call sites and runtime behavior are unchanged—but it lets **`actionlint`** parse the action and lint the workflows that reference it (e.g. `tests.yml`, `docker-build.yml`, `slow-tests.yml`) instead of failing on the action definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6414395b03cf6f8f3d673bb17e8c0d1c4ca08961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->