### PR TITLE
Fix SFTConfig example: pass attn_implementation via model_init_kwargs

### DIFF
--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -294,7 +294,7 @@ training_args = SFTConfig(
     # to get the most out of SP
     max_length=4096,
     packing=True,
-    attn_implementation="flash_attention_2",
+    model_init_kwargs={"attn_implementation": "flash_attention_2"},
     per_device_train_batch_size=1,
     ...
 )


### PR DESCRIPTION
# What does this PR do?

Fixes the `SFTConfig` example in the sequence parallelism guide (`docs/source/distributing_training.md`, Training Configuration block): `attn_implementation` was passed as a direct kwarg, but neither `SFTConfig`, `_BaseConfig`, nor `transformers.TrainingArguments` defines such a field (dataclasses accept no `**kwargs`), so copying the example raises `TypeError: __init__() got an unexpected keyword argument 'attn_implementation'`.

The fix passes it via `model_init_kwargs={"attn_implementation": "flash_attention_2"}`, matching the official script (`trl/scripts/sft.py`), which explicitly carries `attn_implementation` inside `model_init_kwargs`.

Fixes # (no existing issue; docs-only fix)

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (not applicable — docs-only fix, no prior issue)
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? (not applicable — docs-only change)

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone in the community is free to review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a code example; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **ALST/Ulysses** training snippet in `distributing_training.md` so Flash Attention 2 is configured correctly when building `SFTConfig`.
> 
> The example no longer passes `attn_implementation` as a top-level `SFTConfig` argument (that raises `TypeError` because the config dataclass has no such field). It now uses `model_init_kwargs={"attn_implementation": "flash_attention_2"}`, consistent with `trl/scripts/sft.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b60b5a03f922454d3a8f06482d2aa897b2b783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->