### PR TITLE
Fail fast for MoE auxiliary loss with Liger GRPO

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -935,6 +935,25 @@ class TestGRPOTrainer(TrlTestCase):
                 peft_config=lora_config,
             )
 
+    @require_liger_kernel
+    def test_init_fails_with_moe_aux_loss_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        # The MoE auxiliary loss is on by default; it is incompatible with the Liger fused loss.
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="does not support the Mixture-of-Experts load-balancing auxiliary loss"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_peft
     def test_liger_kernel_with_peft_non_lm_head_target_allowed(self):
         # The lm_head guard must only fire when the adapter actually wraps lm_head. An adapter that targets other

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -788,6 +788,12 @@ class GRPOTrainer(_BaseTrainer):
         is_moe = getattr(text_config, "output_router_logits", None) is not None
         self.aux_loss_enabled = is_moe and args.router_aux_loss_coef != 0.0
         self.router_aux_loss_coef = args.router_aux_loss_coef
+        if self.aux_loss_enabled and self.use_liger_kernel:
+            raise ValueError(
+                "Liger GRPO loss does not support the Mixture-of-Experts load-balancing auxiliary loss, because it "
+                "fuses the loss without materializing the router logits. Either set `router_aux_loss_coef` to `0.0` "
+                "to disable the auxiliary loss, or set `use_liger_kernel` to False."
+            )
         self.scale_rewards = args.scale_rewards
         self.importance_sampling_level = args.importance_sampling_level
         self.off_policy_mask_threshold = args.off_policy_mask_threshold


### PR DESCRIPTION
## What does this PR do?

This PR makes `GRPOTrainer` fail fast when a Mixture-of-Experts model enables the load-balancing auxiliary loss together with the Liger fused GRPO loss.

The Liger GRPO path does not materialize router logits, so the auxiliary loss cannot be included in the training objective. Before this change, the run proceeded without the auxiliary term and without a warning.

The guard matches the existing DPO/KTO behavior and includes a focused initialization regression test.

Closes #7009

## Tests

- `uvx ruff check trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py` — passed
- `uvx ruff format --check trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py` — passed
- `git diff --check` — passed
- `pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_init_fails_with_moe_aux_loss_and_liger` — skipped locally because `liger-kernel` is not installed
- Manual construction with `trl-internal-testing/tiny-Qwen3MoeForCausalLM` — confirmed the expected `ValueError` before the Liger dependency check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Initialization-only validation with no change to training math when the incompatible combo is not used.
> 
> **Overview**
> **`GRPOTrainer` now raises at init** when a MoE model would use the default load-balancing auxiliary loss (`router_aux_loss_coef` ≠ 0) together with `use_liger_kernel=True`. The fused Liger GRPO path does not materialize router logits, so the aux term could not be applied; training previously continued without that loss and without warning.
> 
> The error message tells users to set `router_aux_loss_coef` to `0.0` or disable the Liger kernel, consistent with the existing DPO/KTO guards. A regression test (`test_init_fails_with_moe_aux_loss_and_liger`) asserts the `ValueError` for a tiny MoE model under `@require_liger_kernel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6654bb01614cfbf472fd3f9271f043c6cd813b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->