### PR TITLE
Fail fast for MoE auxiliary loss with Liger GRPO

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -935,6 +935,25 @@ class TestGRPOTrainer(TrlTestCase):
                 peft_config=lora_config,
             )
 
+    @require_liger_kernel
+    def test_init_fails_with_moe_aux_loss_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        # The MoE auxiliary loss is on by default; it is incompatible with the Liger fused loss.
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="does not support the Mixture-of-Experts load-balancing auxiliary loss"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_peft
     def test_liger_kernel_with_peft_non_lm_head_target_allowed(self):
         # The lm_head guard must only fire when the adapter actually wraps lm_head. An adapter that targets other

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -45,7 +45,8 @@ class GRPOConfig(_BaseConfig):
         router_aux_loss_coef (`float`, *optional*, defaults to `0.001`):
             Coefficient of the load-balancing auxiliary loss. Only has an effect when training a Mixture-of-Experts
             (MoE) model; for other models it does nothing. The auxiliary loss is added to the training loss with this
-            weight. Set to `0.0` to disable it.
+            weight. Set to `0.0` to disable it. The auxiliary loss is not supported with the Liger kernel; set this
+            value to `0.0` when `use_liger_kernel=True`.
         disable_dropout (`bool`, *optional*, defaults to `False`):
             Whether to disable dropout in the model. This is useful for training with a reference model, as it prevents
             the model from generating different logprobs for the same input.
@@ -444,7 +445,8 @@ class GRPOConfig(_BaseConfig):
         metadata={
             "help": "Coefficient of the load-balancing auxiliary loss. Only has an effect when training a "
             "Mixture-of-Experts (MoE) model; for other models it does nothing. The auxiliary loss is added to the "
-            "training loss with this weight. Set to `0.0` to disable it."
+            "training loss with this weight. Set to `0.0` to disable it. The auxiliary loss is not supported when "
+            "`use_liger_kernel=True`."
         },
     )
     disable_dropout: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -788,6 +788,12 @@ class GRPOTrainer(_BaseTrainer):
         is_moe = getattr(text_config, "output_router_logits", None) is not None
         self.aux_loss_enabled = is_moe and args.router_aux_loss_coef != 0.0
         self.router_aux_loss_coef = args.router_aux_loss_coef
+        if self.aux_loss_enabled and self.use_liger_kernel:
+            raise ValueError(
+                "Liger GRPO loss does not support the Mixture-of-Experts load-balancing auxiliary loss, because it "
+                "fuses the loss without materializing the router logits. Either set `router_aux_loss_coef` to `0.0` "
+                "to disable the auxiliary loss, or set `use_liger_kernel` to False."
+            )
         self.scale_rewards = args.scale_rewards
         self.importance_sampling_level = args.importance_sampling_level
         self.off_policy_mask_threshold = args.off_policy_mask_threshold


### PR DESCRIPTION
# What does this PR do?

`GRPOTrainer` now fails fast when a Mixture-of-Experts model enables the load-balancing auxiliary loss together with the Liger fused GRPO loss.

The Liger GRPO path does not materialize router logits, so the auxiliary loss cannot be included in the training objective. Before this change, the run proceeded without the auxiliary term and without a warning.

The guard matches the existing DPO/KTO behavior. The `GRPOConfig` documentation now explains the required `router_aux_loss_coef=0.0` setting, and a focused initialization regression test covers the incompatibility.

Fixes #7009

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? This change follows the reproducer and proposed direction in [#7009](https://github.com/huggingface/trl/issues/7009).
- [x] Did you make sure to update the documentation with your changes? The `GRPOConfig` parameter documentation now describes the Liger restriction.
- [x] Did you write any new necessary tests? Added `test_init_fails_with_moe_aux_loss_and_liger`.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool. The changed lines and validation results were reviewed before submission.

## Who can review?

Anyone in the community is welcome to review this focused GRPO/Liger compatibility change once the tests have passed.

## Tests

- `uvx ruff check trl/trainer/grpo_trainer.py trl/trainer/grpo_config.py tests/test_grpo_trainer.py` — passed
- `uvx ruff format --check trl/trainer/grpo_trainer.py trl/trainer/grpo_config.py tests/test_grpo_trainer.py` — passed
- `git diff --check` — passed
- `pytest tests/test_grpo_trainer.py::TestGRPOTrainer::test_init_fails_with_moe_aux_loss_and_liger` — skipped locally because `liger-kernel` is not installed
- Manual construction with `trl-internal-testing/tiny-Qwen3MoeForCausalLM` — confirmed the expected `ValueError` before the Liger dependency check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Initialization-only validation and documentation; no change to training loops unless the incompatible config was previously used silently.
> 
> **Overview**
> **GRPO** now raises at trainer init if a MoE model would use the default load-balancing auxiliary loss (`router_aux_loss_coef` non-zero) together with **`use_liger_kernel=True`**, instead of training without that term and no warning. The error message tells users to set **`router_aux_loss_coef=0.0`** or turn off the Liger kernel, matching the existing DPO/KTO guards.
> 
> **`GRPOConfig`** docs for **`router_aux_loss_coef`** note that the auxiliary loss is unsupported with the Liger kernel. A new **`test_init_fails_with_moe_aux_loss_and_liger`** test (behind **`@require_liger_kernel`**) asserts the **`ValueError`** on a tiny MoE model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 232b24647c2844999d11abd8b7d9c2dd79d0f202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->