### PR TITLE
GRPO: honor every EOS id declared in generation_config

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2682,6 +2682,85 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert torch.equal(param, new_param), f"Parameter {n} has changed."
 
+    def test_eos_token_ids_from_generation_config(self):
+        """
+        Models such as Phi-3.5, Qwen3 or Gemma-3-it declare several EOS ids in `generation_config.eos_token_id`, and
+        their chat template ends a turn with one of the secondary ids. The trainer must treat all of them as EOS.
+        """
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model = AutoModelForCausalLM.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        extra_eos_id = 151644  # <|im_start|>; any id other than tokenizer.eos_token_id (151645) works here
+        model.generation_config.eos_token_id = [tokenizer.eos_token_id, extra_eos_id]
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = GRPOTrainer(
+            model=model,
+            processing_class=tokenizer,
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        assert trainer.eos_token_ids == [tokenizer.eos_token_id, extra_eos_id]
+        # The transformers generation path must stop on any of them as well
+        assert trainer.generation_config.eos_token_id == [tokenizer.eos_token_id, extra_eos_id]
+
+    @patch("transformers.generation.utils.GenerationMixin.generate")
+    def test_train_completions_ending_on_secondary_eos_are_not_truncated(self, mock_generate):
+        """
+        A completion that ends on a secondary EOS id (declared in `generation_config.eos_token_id` but different from
+        `tokenizer.eos_token_id`) must be masked after that token and must not be counted as truncated.
+        """
+        extra_eos_id = 151644  # <|im_start|>; tokenizer.eos_token_id = 151645, pad_token_id = 151643
+
+        def fake_generate(input_ids, **kwargs):
+            completion_ids = torch.tensor(
+                [
+                    [9, 10, 11, extra_eos_id, 12, 13, 14, 15],  # ends on the secondary EOS, then garbage
+                    [9, 10, 11, 12, 13, 14, 15, extra_eos_id],  # secondary EOS generated just within the limit
+                    [9, 10, 11, 151645, 151643, 151643, 151643, 151643],  # ends on the tokenizer's EOS
+                ],
+                device=input_ids.device,
+            )
+            return torch.cat([input_ids, completion_ids], dim=1)
+
+        mock_generate.side_effect = fake_generate
+
+        model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+        model = AutoModelForCausalLM.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model.generation_config.eos_token_id = [tokenizer.eos_token_id, extra_eos_id]
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            max_steps=2,
+            logging_steps=1,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model=model,
+            processing_class=tokenizer,
+            reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        trainer.train()
+
+        logs = [log for log in trainer.state.log_history if "completions/clipped_ratio" in log]
+        assert logs, "no completion metrics were logged"
+        for log in logs:
+            # None of the completions is truncated: they all end on one of the EOS ids
+            assert log["completions/clipped_ratio"] == 0.0
+            # Everything after the (secondary) EOS is masked out: lengths are 4, 8 and 4 tokens
+            assert log["completions/mean_length"] == pytest.approx((4 + 8 + 4) / 3)
+
     def test_warning_raised_all_rewards_none(self, caplog):
         """Test that a proper warning is raised when all rewards are None."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -397,6 +397,14 @@ class GRPOTrainer(_BaseTrainer):
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
+        # Some models declare several end-of-sequence tokens in `generation_config.eos_token_id` (e.g. Phi-3.5:
+        # [32007, 32001, 32000], Qwen3: [151645, 151643], Gemma-3-it: [1, 106]) and their chat template ends a turn
+        # with one of the secondary ids (`<|end|>`, `<end_of_turn>`, ...) rather than with `tokenizer.eos_token_id`.
+        # Generation stops on any of them, so the EOS mask, the truncation metric and `mask_truncated_completions`
+        # must accept all of them. Otherwise a completion that ends on a secondary EOS is reported as truncated and
+        # everything generated after that stop token is kept in the loss.
+        self.eos_token_ids = self._get_eos_token_ids(model)
+
         # Resolve vision placeholder token IDs once. Used by the forward pass to rebuild mm_token_type_ids
         # when tool responses inject images into the completion (see _generate forward_kwargs block).
         self._image_pad_token_id = None
@@ -1128,7 +1136,7 @@ class GRPOTrainer(_BaseTrainer):
                 "do_sample": True,
                 "pad_token_id": self._tokenizer.pad_token_id,
                 "bos_token_id": self._tokenizer.bos_token_id,
-                "eos_token_id": self._tokenizer.eos_token_id,
+                "eos_token_id": self.eos_token_ids or None,
                 "temperature": self.temperature,
                 "top_p": self.top_p,
                 "top_k": self.top_k,
@@ -1248,6 +1256,19 @@ class GRPOTrainer(_BaseTrainer):
             sampler_fn=self._get_train_sampler,
             is_training=True,
         )
+
+    def _get_eos_token_ids(self, model) -> list[int]:
+        """
+        EOS token ids used for EOS masking and truncation detection: the tokenizer's EOS id followed by any extra
+        EOS id declared in the model's generation config (Phi-3.5, Qwen3, Gemma-3-it, ...).
+        """
+        eos_token_ids = [] if self._tokenizer.eos_token_id is None else [self._tokenizer.eos_token_id]
+        generation_config_eos = getattr(getattr(model, "generation_config", None), "eos_token_id", None)
+        if generation_config_eos is not None:
+            if isinstance(generation_config_eos, int):
+                generation_config_eos = [generation_config_eos]
+            eos_token_ids.extend(token_id for token_id in generation_config_eos if token_id not in eos_token_ids)
+        return eos_token_ids
 
     def _get_train_sampler(self, dataset: Dataset | None = None) -> Sampler:
         # Returns a sampler that
@@ -1917,8 +1938,8 @@ class GRPOTrainer(_BaseTrainer):
             prompt_length = generate_inputs["input_ids"].size(1)
             completion_ids = prompt_completion_ids[:, prompt_length:]
 
-            # Mask everything after the first EOS token
-            is_eos = completion_ids == self._tokenizer.eos_token_id
+            # Mask everything after the first EOS token (any of the model's EOS ids)
+            is_eos = torch.isin(completion_ids, torch.tensor(self.eos_token_ids, device=completion_ids.device))
             eos_idx = torch.full((is_eos.size(0),), is_eos.size(1), dtype=torch.long, device=device)
             eos_idx[is_eos.any(dim=1)] = is_eos.int().argmax(dim=1)[is_eos.any(dim=1)]
             sequence_indices = torch.arange(is_eos.size(1), device=device).expand(is_eos.size(0), -1)
@@ -1974,7 +1995,7 @@ class GRPOTrainer(_BaseTrainer):
         # When we compute `suffix_ids` by slicing `full_ids`, we must align the slicing boundary to
         # EOS (not EOS + newline). Templates that don't use EOS as end-of-turn (e.g. Gemma uses
         # <turn|>) skip this trimming.
-        eos_positions = [i for i, tok_id in enumerate(prefix_ids) if tok_id == self._tokenizer.eos_token_id]
+        eos_positions = [i for i, tok_id in enumerate(prefix_ids) if tok_id in self.eos_token_ids]
         if eos_positions:
             prefix_ids = prefix_ids[: eos_positions[-1] + 1]
 
@@ -2321,7 +2342,7 @@ class GRPOTrainer(_BaseTrainer):
         self._metrics[mode]["completions/max_length"].append(agg_completion_lengths.float().max().item())
 
         # Identify sequences that terminated with EOS and log their lengths
-        eos_and_pad = [self._tokenizer.eos_token_id, self._tokenizer.pad_token_id]
+        eos_and_pad = self.eos_token_ids + [self._tokenizer.pad_token_id]
         is_truncated = torch.tensor([ids[-1] not in eos_and_pad for ids in completion_ids], device=device)
         agg_is_truncated = self.accelerator.gather(is_truncated)
         self._metrics[mode]["completions/clipped_ratio"].append(agg_is_truncated.float().mean().item())
@@ -2508,7 +2529,7 @@ class GRPOTrainer(_BaseTrainer):
 
         # If mask_truncated_completions is enabled, zero out truncated completions for attention and loss masking
         if self.mask_truncated_completions:
-            eos_and_pad = [self._tokenizer.eos_token_id, self._tokenizer.pad_token_id]
+            eos_and_pad = self.eos_token_ids + [self._tokenizer.pad_token_id]
             is_truncated = torch.tensor([ids[-1] not in eos_and_pad for ids in completion_ids_list], device=device)
             # Mask completion_mask for attention masking
             completion_mask = completion_mask * (~is_truncated).unsqueeze(1).int()


### PR DESCRIPTION
## What does this PR do?

`GRPOTrainer` treats only `tokenizer.eos_token_id` as end-of-sequence. Several models declare more than one EOS id in `generation_config.eos_token_id`, and their chat template ends an assistant turn with one of the *secondary* ids:

| model | `generation_config.eos_token_id` | `tokenizer.eos_token_id` | turn terminator |
|---|---|---|---|
| Phi-3.5-mini-instruct | `[32007, 32001, 32000]` | 32000 `<\|endoftext\|>` | 32007 `<\|end\|>` |
| Qwen3 | `[151645, 151643]` | 151645 | 151645 (151643 also stops) |
| gemma-3-*-it | `[1, 106]` | 1 `<eos>` | 106 `<end_of_turn>` |

Generation (both `transformers` via the model's generation config and vLLM via `generation_config="auto"`) already stops on any of these ids, but the trainer then compares the completion against the single `tokenizer.eos_token_id`:

- `_generate_single_turn` (transformers path): the EOS mask only cuts after `tokenizer.eos_token_id`, so a completion that stopped on `<|end|>` keeps whatever follows it (padding / continued sampling) in the loss;
- `completions/clipped_ratio` and `completions/mean_terminated_length`: a completion ending on a secondary EOS is counted as truncated. On Phi-3.5 we observed `clipped_ratio ≈ 0.97` at step 1 with `max_completion_length=2048` while almost every completion had actually ended on `<|end|>`;
- `mask_truncated_completions=True`: those completions are masked out entirely, so for Phi-3.5 / Gemma-3-it the trainer sees no learning signal;
- `_get_tool_suffix_ids`: the prefix trimming looks for the single EOS id.

This PR collects `tokenizer.eos_token_id` plus every id in `generation_config.eos_token_id` into `self.eos_token_ids` (a list, tokenizer id first) and uses it at all four sites. On the transformers generation path the full list is also passed as `eos_token_id` in the `GenerationConfig`, so generation and masking agree.

Behaviour is unchanged for models whose generation config declares a single EOS id equal to the tokenizer's.

Verified on our side with Phi-3.5-mini-instruct and Gemma-3-4B-it GRPO runs (vLLM colocate and transformers generation): `clipped_ratio` goes from ~0.97 / 1.0 to the expected <0.1, `mean_terminated_length` becomes non-zero, and training proceeds normally.

## Tests

- `test_eos_token_ids_from_generation_config`: `self.eos_token_ids` and the transformers `GenerationConfig` contain both ids.
- `test_train_completions_ending_on_secondary_eos_are_not_truncated`: with a mocked `generate`, completions ending on the secondary EOS are masked after it and `completions/clipped_ratio == 0`.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Did you write any new necessary tests?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GRPO completion masking, truncation metrics, and loss masking; wrong EOS handling would skew training signal for multi-EOS chat models.
> 
> **Overview**
> **GRPOTrainer** now treats every EOS id listed in the model’s `generation_config.eos_token_id` (plus the tokenizer’s EOS) as a valid stop token, not only `tokenizer.eos_token_id`.
> 
> A new `_get_eos_token_ids` builds `self.eos_token_ids` at init. That list drives transformers `GenerationConfig.eos_token_id`, completion masking after the first matching EOS, `completions/clipped_ratio` / terminated-length metrics, `mask_truncated_completions`, and EOS-aware prefix trimming in `_get_tool_suffix_ids`. Models whose chat templates end turns on secondary EOS ids (e.g. Phi-3.5, Qwen3, Gemma-3-it) should no longer be misclassified as truncated or keep post-stop tokens in the loss.
> 
> Tests cover id collection on the trainer/generation config and a mocked training step where secondary-EOS completions get zero `clipped_ratio` and correct mean lengths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1dab09d475546d939d45b2619ceff47be01e532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->