### PR TITLE
Pool PPO micro-batch statistics by token and sample counts

### DIFF
--- a/tests/experimental/test_ppo_trainer.py
+++ b/tests/experimental/test_ppo_trainer.py
@@ -767,7 +767,7 @@ def test_uneven_micro_batch_stats_are_pooled(tmp_path, monkeypatch):
 
     trainer.train()
 
-    assert [values.shape[0] for values, _ in masked_inputs] == [4, 4, 4, 4, 2, 2, 2, 2] * 2
+    assert [values.shape[0] for values, _ in masked_inputs] == [4] * 7 + [2] * 7 + [4] * 7 + [2] * 7
     assert [values.shape[0] for values in logprobs_diffs] == [4, 2, 4, 2]
     assert [values.shape[0] for values in entropy_logits] == [4, 2, 4, 2]
 
@@ -777,18 +777,15 @@ def test_uneven_micro_batch_stats_are_pooled(tmp_path, monkeypatch):
         return (numerator / denominator).item()
 
     metrics = trainer.state.log_history[-1]
-    logprobs_diff = torch.cat(logprobs_diffs)
-    logits = torch.cat(entropy_logits)
-    prob_dist = torch.nn.functional.softmax(logits, dim=-1)
-    entropy = torch.logsumexp(logits, dim=-1) - torch.sum(prob_dist * logits, dim=-1)
-    assert metrics["policy/approxkl_avg"] == pytest.approx(0.5 * logprobs_diff.square().mean().item(), abs=1e-7)
-    # masked_mean writes value loss, value clipfrac, policy loss, then policy clipfrac for every micro-batch.
-    assert metrics["loss/value_avg"] == pytest.approx(0.5 * pooled_mean(masked_inputs[0::4]), abs=1e-7)
-    assert metrics["val/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[1::4]), abs=1e-7)
-    assert metrics["loss/policy_avg"] == pytest.approx(pooled_mean(masked_inputs[2::4]), abs=1e-7)
-    assert metrics["policy/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[3::4]), abs=1e-7)
-    assert metrics["policy/entropy_avg"] == pytest.approx(entropy.mean().item(), abs=1e-7)
-    assert metrics["val/ratio"] == pytest.approx(logprobs_diff.exp().mean().item(), abs=1e-6)
+    # masked_mean writes value loss, value clipfrac, policy loss, policy clipfrac, approximate KL, entropy, then
+    # ratio for every micro-batch.
+    assert metrics["loss/value_avg"] == pytest.approx(0.5 * pooled_mean(masked_inputs[0::7]), abs=1e-7)
+    assert metrics["val/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[1::7]), abs=1e-7)
+    assert metrics["loss/policy_avg"] == pytest.approx(pooled_mean(masked_inputs[2::7]), abs=1e-7)
+    assert metrics["policy/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[3::7]), abs=1e-7)
+    assert metrics["policy/approxkl_avg"] == pytest.approx(0.5 * pooled_mean(masked_inputs[4::7]), abs=1e-7)
+    assert metrics["policy/entropy_avg"] == pytest.approx(pooled_mean(masked_inputs[5::7]), abs=1e-7)
+    assert metrics["val/ratio"] == pytest.approx(pooled_mean(masked_inputs[6::7]), abs=1e-6)
 
 
 def test_ratio_var_ignores_unwritten_stats(tmp_path):

--- a/tests/experimental/test_ppo_trainer.py
+++ b/tests/experimental/test_ppo_trainer.py
@@ -17,7 +17,7 @@ import os
 
 import pytest
 import torch
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForSeq2SeqLM,
@@ -32,6 +32,7 @@ from trl.experimental.ppo import (
     AutoModelForSeq2SeqLMWithValueHead,
     PPOConfig,
     PPOTrainer,
+    ppo_trainer,
 )
 from trl.experimental.ppo.ppo_trainer import batch_generation, masked_mean, masked_var, masked_whiten
 
@@ -685,6 +686,109 @@ class TestCore(TrlTestCase):
         whiten_masked = masked_whiten(self.test_input, self.test_mask)[1:3]
         diffs = (whiten_unmasked - whiten_masked).sum()
         assert abs(diffs.item()) < 0.00001
+
+
+def test_uneven_micro_batch_stats_are_pooled(tmp_path, monkeypatch):
+    model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+    ref_model = AutoModelForCausalLM.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
+    tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+    reward_model_id = "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5"
+    value_model = AutoModelForSequenceClassification.from_pretrained(reward_model_id, num_labels=1)
+    reward_model = AutoModelForSequenceClassification.from_pretrained(reward_model_id, num_labels=1)
+    tokenized = tokenizer("Hello world")
+    train_dataset = Dataset.from_dict(
+        {
+            "input_ids": [tokenized["input_ids"]] * 12,
+            "attention_mask": [tokenized["attention_mask"]] * 12,
+        }
+    )
+    training_args = PPOConfig(
+        output_dir=tmp_path,
+        per_device_train_batch_size=4,
+        gradient_accumulation_steps=3,
+        num_mini_batches=2,
+        num_ppo_epochs=1,
+        total_episodes=12,
+        response_length=4,
+        num_sample_generations=0,
+        use_cpu=True,
+        bf16=False,
+        gradient_checkpointing=False,
+        disable_tqdm=True,
+        save_strategy="no",
+        report_to="none",
+    )
+    masked_inputs = []
+    rollout_logprobs = {}
+    logprobs_diffs = []
+    entropy_logits = []
+
+    # Captures the four masked micro-batch statistics. The scalar reduction and sub-batch shape exclude setup calls.
+    def tracked_masked_mean(values, mask, axis=None):
+        if axis is None and values.shape[0] < 12:
+            masked_inputs.append((values.detach().clone(), mask.detach().clone()))
+        return masked_mean(values, mask, axis)
+
+    selective_log_softmax = ppo_trainer.selective_log_softmax
+
+    # Captures rollout logprobs and training inputs used by entropy, approx-KL, and ratio without global Torch patches.
+    # The response-length shape and gradient state distinguish training micro-batches from rollout/reference calls.
+    def tracked_selective_log_softmax(logits, index):
+        output = selective_log_softmax(logits, index)
+        if logits.ndim == 3 and logits.shape[1] == training_args.response_length:
+            if logits.requires_grad:
+                entropy_logits.append(logits.detach().clone())
+                old_logprobs = torch.stack([rollout_logprobs[tuple(response.tolist())] for response in index])
+                padding_mask = index == tokenizer.pad_token_id
+                new_logprobs = output.detach().masked_fill(padding_mask, ppo_trainer.INVALID_LOGPROB)
+                old_logprobs = old_logprobs.masked_fill(padding_mask, ppo_trainer.INVALID_LOGPROB)
+                logprobs_diffs.append(new_logprobs - old_logprobs)
+            elif not rollout_logprobs:
+                rollout_logprobs.update(
+                    (tuple(response.tolist()), logprob.detach().clone())
+                    for response, logprob in zip(index, output, strict=True)
+                )
+        return output
+
+    monkeypatch.setattr(ppo_trainer, "masked_mean", tracked_masked_mean)
+    monkeypatch.setattr(ppo_trainer, "selective_log_softmax", tracked_selective_log_softmax)
+    trainer = PPOTrainer(
+        args=training_args,
+        processing_class=tokenizer,
+        model=model,
+        ref_model=ref_model,
+        reward_model=reward_model,
+        value_model=value_model,
+        train_dataset=train_dataset,
+        eval_dataset=train_dataset,
+    )
+
+    trainer.train()
+
+    assert [values.shape[0] for values, _ in masked_inputs] == [4, 4, 4, 4, 2, 2, 2, 2] * 2
+    assert [values.shape[0] for values in logprobs_diffs] == [4, 2, 4, 2]
+    assert [values.shape[0] for values in entropy_logits] == [4, 2, 4, 2]
+
+    def pooled_mean(inputs):
+        numerator = sum((values * mask).sum() for values, mask in inputs)
+        denominator = sum(mask.sum() for _, mask in inputs)
+        return (numerator / denominator).item()
+
+    metrics = trainer.state.log_history[-1]
+    logprobs_diff = torch.cat(logprobs_diffs)
+    logits = torch.cat(entropy_logits)
+    prob_dist = torch.nn.functional.softmax(logits, dim=-1)
+    entropy = torch.logsumexp(logits, dim=-1) - torch.sum(prob_dist * logits, dim=-1)
+    assert metrics["policy/approxkl_avg"] == pytest.approx(0.5 * logprobs_diff.square().mean().item(), abs=1e-7)
+    # masked_mean writes value loss, value clipfrac, policy loss, then policy clipfrac for every micro-batch.
+    assert metrics["loss/value_avg"] == pytest.approx(0.5 * pooled_mean(masked_inputs[0::4]), abs=1e-7)
+    assert metrics["val/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[1::4]), abs=1e-7)
+    assert metrics["loss/policy_avg"] == pytest.approx(pooled_mean(masked_inputs[2::4]), abs=1e-7)
+    assert metrics["policy/clipfrac_avg"] == pytest.approx(pooled_mean(masked_inputs[3::4]), abs=1e-7)
+    assert metrics["policy/entropy_avg"] == pytest.approx(entropy.mean().item(), abs=1e-7)
+    assert metrics["val/ratio"] == pytest.approx(logprobs_diff.exp().mean().item(), abs=1e-6)
 
 
 class TestPPOTrainer(TrlTestCase):

--- a/tests/experimental/test_ppo_trainer.py
+++ b/tests/experimental/test_ppo_trainer.py
@@ -791,6 +791,55 @@ def test_uneven_micro_batch_stats_are_pooled(tmp_path, monkeypatch):
     assert metrics["val/ratio"] == pytest.approx(logprobs_diff.exp().mean().item(), abs=1e-6)
 
 
+def test_ratio_var_ignores_unwritten_stats(tmp_path):
+    model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
+    ref_model = AutoModelForCausalLM.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
+    tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+    reward_model_id = "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5"
+    value_model = AutoModelForSequenceClassification.from_pretrained(reward_model_id, num_labels=1)
+    reward_model = AutoModelForSequenceClassification.from_pretrained(reward_model_id, num_labels=1)
+    tokenized = tokenizer("Hello world")
+    train_dataset = Dataset.from_dict(
+        {
+            "input_ids": [tokenized["input_ids"]] * 12,
+            "attention_mask": [tokenized["attention_mask"]] * 12,
+        }
+    )
+    training_args = PPOConfig(
+        output_dir=tmp_path,
+        learning_rate=0.0,
+        per_device_train_batch_size=4,
+        gradient_accumulation_steps=3,
+        num_mini_batches=2,
+        num_ppo_epochs=1,
+        total_episodes=12,
+        response_length=4,
+        num_sample_generations=0,
+        use_cpu=True,
+        bf16=False,
+        gradient_checkpointing=False,
+        disable_tqdm=True,
+        save_strategy="no",
+        report_to="none",
+    )
+    trainer = PPOTrainer(
+        args=training_args,
+        processing_class=tokenizer,
+        model=model,
+        ref_model=ref_model,
+        reward_model=reward_model,
+        value_model=value_model,
+        train_dataset=train_dataset,
+        eval_dataset=train_dataset,
+    )
+
+    trainer.train()
+
+    assert trainer.state.log_history[-1]["val/ratio_var"] == pytest.approx(0.0, abs=1e-12)
+
+
 class TestPPOTrainer(TrlTestCase):
     def setup_method(self):
         # Set up the models and tokenizer using the test model

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -636,6 +636,10 @@ class PPOTrainer(_BaseTrainer):
         vf_clipfrac_stats = torch.zeros(stats_shape, device=device)
         entropy_stats = torch.zeros(stats_shape, device=device)
         ratio_stats = torch.zeros(stats_shape, device=device)
+        ratio_mean_stats = torch.zeros(stats_shape, device=device)
+        padding_count_stats = torch.zeros(stats_shape, device=device)
+        padding_p1_count_stats = torch.zeros(stats_shape, device=device)
+        micro_batch_size_stats = torch.zeros(stats_shape, device=device)
         model.train()
 
         # trainer state initialization
@@ -855,17 +859,42 @@ class PPOTrainer(_BaseTrainer):
                                 prob_dist = torch.nn.functional.softmax(logits, dim=-1)
                                 entropy = torch.logsumexp(logits, dim=-1) - torch.sum(prob_dist * logits, dim=-1)
                                 approxkl = 0.5 * (logprobs_diff**2).mean()
-                                approxkl_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = approxkl
+                                padding_count = (~padding_mask[micro_batch_inds]).sum()
+                                padding_p1_count = (~padding_mask_p1[micro_batch_inds]).sum()
+                                micro_batch_size = len(micro_batch_inds)
+                                approxkl_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    approxkl * micro_batch_size
+                                )
                                 pg_clipfrac_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    pg_clipfrac
+                                    pg_clipfrac * padding_count
                                 )
-                                pg_loss_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = pg_loss
-                                vf_loss_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = vf_loss
+                                pg_loss_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    pg_loss * padding_count
+                                )
+                                vf_loss_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    vf_loss * padding_p1_count
+                                )
                                 vf_clipfrac_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    vf_clipfrac
+                                    vf_clipfrac * padding_p1_count
                                 )
-                                entropy_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = entropy.mean()
-                                ratio_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = ratio.mean()
+                                entropy_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    entropy.mean() * micro_batch_size
+                                )
+                                ratio_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    ratio.mean() * micro_batch_size
+                                )
+                                ratio_mean_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    ratio.mean()
+                                )
+                                padding_count_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    padding_count
+                                )
+                                padding_p1_count_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    padding_p1_count
+                                )
+                                micro_batch_size_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
+                                    micro_batch_size
+                                )
                         gradient_accumulation_idx += 1
                     minibatch_idx += 1
                     # del everything and empty cache
@@ -875,6 +904,7 @@ class PPOTrainer(_BaseTrainer):
                         vf_losses1, vf_losses2, vf_loss, vf_clipfrac, logprobs_diff, ratio, pg_losses, pg_losses2, pg_loss_max,
                         pg_loss, loss, pg_clipfrac, prob_dist, entropy, approxkl, mb_return,
                         mb_advantage, mb_values, mb_responses, mb_query_responses, mb_logprobs,
+                        padding_count, padding_p1_count, micro_batch_size,
                     )
                     # fmt: on
                     empty_cache()
@@ -894,14 +924,31 @@ class PPOTrainer(_BaseTrainer):
                 )
                 metrics["objective/rlhf_reward"] = self.accelerator.gather_for_metrics(rlhf_reward).mean().item()
                 metrics["objective/scores"] = self.accelerator.gather_for_metrics(scores.mean()).mean().item()
-                metrics["policy/approxkl_avg"] = self.accelerator.gather_for_metrics(approxkl_stats).mean().item()
-                metrics["policy/clipfrac_avg"] = self.accelerator.gather_for_metrics(pg_clipfrac_stats).mean().item()
-                metrics["loss/policy_avg"] = self.accelerator.gather_for_metrics(pg_loss_stats).mean().item()
-                metrics["loss/value_avg"] = self.accelerator.gather_for_metrics(vf_loss_stats).mean().item()
-                metrics["val/clipfrac_avg"] = self.accelerator.gather_for_metrics(vf_clipfrac_stats).mean().item()
-                metrics["policy/entropy_avg"] = self.accelerator.gather_for_metrics(entropy_stats).mean().item()
-                metrics["val/ratio"] = self.accelerator.gather_for_metrics(ratio_stats).mean().item()
-                metrics["val/ratio_var"] = self.accelerator.gather_for_metrics(ratio_stats).var().item()
+                padding_count = self.accelerator.gather_for_metrics(padding_count_stats).sum()
+                padding_p1_count = self.accelerator.gather_for_metrics(padding_p1_count_stats).sum()
+                micro_batch_size = self.accelerator.gather_for_metrics(micro_batch_size_stats).sum()
+                metrics["policy/approxkl_avg"] = (
+                    self.accelerator.gather_for_metrics(approxkl_stats).sum() / micro_batch_size
+                ).item()
+                metrics["policy/clipfrac_avg"] = (
+                    self.accelerator.gather_for_metrics(pg_clipfrac_stats).sum() / padding_count
+                ).item()
+                metrics["loss/policy_avg"] = (
+                    self.accelerator.gather_for_metrics(pg_loss_stats).sum() / padding_count
+                ).item()
+                metrics["loss/value_avg"] = (
+                    self.accelerator.gather_for_metrics(vf_loss_stats).sum() / padding_p1_count
+                ).item()
+                metrics["val/clipfrac_avg"] = (
+                    self.accelerator.gather_for_metrics(vf_clipfrac_stats).sum() / padding_p1_count
+                ).item()
+                metrics["policy/entropy_avg"] = (
+                    self.accelerator.gather_for_metrics(entropy_stats).sum() / micro_batch_size
+                ).item()
+                metrics["val/ratio"] = (
+                    self.accelerator.gather_for_metrics(ratio_stats).sum() / micro_batch_size
+                ).item()
+                metrics["val/ratio_var"] = self.accelerator.gather_for_metrics(ratio_mean_stats).var().item()
                 metrics["val/num_eos_tokens"] = (responses == processing_class.eos_token_id).sum().item()
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = self.state.episode

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -926,7 +926,8 @@ class PPOTrainer(_BaseTrainer):
                 metrics["objective/scores"] = self.accelerator.gather_for_metrics(scores.mean()).mean().item()
                 padding_count = self.accelerator.gather_for_metrics(padding_count_stats).sum()
                 padding_p1_count = self.accelerator.gather_for_metrics(padding_p1_count_stats).sum()
-                micro_batch_size = self.accelerator.gather_for_metrics(micro_batch_size_stats).sum()
+                micro_batch_size_stats = self.accelerator.gather_for_metrics(micro_batch_size_stats)
+                micro_batch_size = micro_batch_size_stats.sum()
                 metrics["policy/approxkl_avg"] = (
                     self.accelerator.gather_for_metrics(approxkl_stats).sum() / micro_batch_size
                 ).item()
@@ -948,7 +949,8 @@ class PPOTrainer(_BaseTrainer):
                 metrics["val/ratio"] = (
                     self.accelerator.gather_for_metrics(ratio_stats).sum() / micro_batch_size
                 ).item()
-                metrics["val/ratio_var"] = self.accelerator.gather_for_metrics(ratio_mean_stats).var().item()
+                ratio_mean = self.accelerator.gather_for_metrics(ratio_mean_stats)
+                metrics["val/ratio_var"] = ratio_mean[micro_batch_size_stats > 0].var().item()
                 metrics["val/num_eos_tokens"] = (responses == processing_class.eos_token_id).sum().item()
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = self.state.episode

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -926,8 +926,8 @@ class PPOTrainer(_BaseTrainer):
                 metrics["objective/scores"] = self.accelerator.gather_for_metrics(scores.mean()).mean().item()
                 padding_count = self.accelerator.gather_for_metrics(padding_count_stats).sum()
                 padding_p1_count = self.accelerator.gather_for_metrics(padding_p1_count_stats).sum()
-                micro_batch_size_stats = self.accelerator.gather_for_metrics(micro_batch_size_stats)
-                micro_batch_size = micro_batch_size_stats.sum()
+                gathered_micro_batch_size_stats = self.accelerator.gather_for_metrics(micro_batch_size_stats)
+                micro_batch_size = gathered_micro_batch_size_stats.sum()
                 metrics["policy/approxkl_avg"] = (
                     self.accelerator.gather_for_metrics(approxkl_stats).sum() / micro_batch_size
                 ).item()
@@ -950,7 +950,7 @@ class PPOTrainer(_BaseTrainer):
                     self.accelerator.gather_for_metrics(ratio_stats).sum() / micro_batch_size
                 ).item()
                 ratio_mean = self.accelerator.gather_for_metrics(ratio_mean_stats)
-                metrics["val/ratio_var"] = ratio_mean[micro_batch_size_stats > 0].var().item()
+                metrics["val/ratio_var"] = ratio_mean[gathered_micro_batch_size_stats > 0].var().item()
                 metrics["val/num_eos_tokens"] = (responses == processing_class.eos_token_id).sum().item()
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = self.state.episode

--- a/trl/experimental/ppo/ppo_trainer.py
+++ b/trl/experimental/ppo/ppo_trainer.py
@@ -639,7 +639,6 @@ class PPOTrainer(_BaseTrainer):
         ratio_mean_stats = torch.zeros(stats_shape, device=device)
         padding_count_stats = torch.zeros(stats_shape, device=device)
         padding_p1_count_stats = torch.zeros(stats_shape, device=device)
-        micro_batch_size_stats = torch.zeros(stats_shape, device=device)
         model.train()
 
         # trainer state initialization
@@ -858,12 +857,12 @@ class PPOTrainer(_BaseTrainer):
                                 )
                                 prob_dist = torch.nn.functional.softmax(logits, dim=-1)
                                 entropy = torch.logsumexp(logits, dim=-1) - torch.sum(prob_dist * logits, dim=-1)
-                                approxkl = 0.5 * (logprobs_diff**2).mean()
-                                padding_count = (~padding_mask[micro_batch_inds]).sum()
+                                response_mask = ~padding_mask[micro_batch_inds]
+                                approxkl = 0.5 * masked_mean(logprobs_diff**2, response_mask)
+                                padding_count = response_mask.sum()
                                 padding_p1_count = (~padding_mask_p1[micro_batch_inds]).sum()
-                                micro_batch_size = len(micro_batch_inds)
                                 approxkl_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    approxkl * micro_batch_size
+                                    approxkl * padding_count
                                 )
                                 pg_clipfrac_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
                                     pg_clipfrac * padding_count
@@ -878,22 +877,18 @@ class PPOTrainer(_BaseTrainer):
                                     vf_clipfrac * padding_p1_count
                                 )
                                 entropy_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    entropy.mean() * micro_batch_size
+                                    masked_mean(entropy, response_mask) * padding_count
                                 )
+                                mean_ratio = masked_mean(ratio, response_mask)
                                 ratio_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    ratio.mean() * micro_batch_size
+                                    mean_ratio * padding_count
                                 )
-                                ratio_mean_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    ratio.mean()
-                                )
+                                ratio_mean_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = mean_ratio
                                 padding_count_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
                                     padding_count
                                 )
                                 padding_p1_count_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
                                     padding_p1_count
-                                )
-                                micro_batch_size_stats[ppo_epoch_idx, minibatch_idx, gradient_accumulation_idx] = (
-                                    micro_batch_size
                                 )
                         gradient_accumulation_idx += 1
                     minibatch_idx += 1
@@ -904,7 +899,7 @@ class PPOTrainer(_BaseTrainer):
                         vf_losses1, vf_losses2, vf_loss, vf_clipfrac, logprobs_diff, ratio, pg_losses, pg_losses2, pg_loss_max,
                         pg_loss, loss, pg_clipfrac, prob_dist, entropy, approxkl, mb_return,
                         mb_advantage, mb_values, mb_responses, mb_query_responses, mb_logprobs,
-                        padding_count, padding_p1_count, micro_batch_size,
+                        padding_count, padding_p1_count, response_mask, mean_ratio,
                     )
                     # fmt: on
                     empty_cache()
@@ -926,10 +921,8 @@ class PPOTrainer(_BaseTrainer):
                 metrics["objective/scores"] = self.accelerator.gather_for_metrics(scores.mean()).mean().item()
                 padding_count = self.accelerator.gather_for_metrics(padding_count_stats).sum()
                 padding_p1_count = self.accelerator.gather_for_metrics(padding_p1_count_stats).sum()
-                gathered_micro_batch_size_stats = self.accelerator.gather_for_metrics(micro_batch_size_stats)
-                micro_batch_size = gathered_micro_batch_size_stats.sum()
                 metrics["policy/approxkl_avg"] = (
-                    self.accelerator.gather_for_metrics(approxkl_stats).sum() / micro_batch_size
+                    self.accelerator.gather_for_metrics(approxkl_stats).sum() / padding_count
                 ).item()
                 metrics["policy/clipfrac_avg"] = (
                     self.accelerator.gather_for_metrics(pg_clipfrac_stats).sum() / padding_count
@@ -944,13 +937,12 @@ class PPOTrainer(_BaseTrainer):
                     self.accelerator.gather_for_metrics(vf_clipfrac_stats).sum() / padding_p1_count
                 ).item()
                 metrics["policy/entropy_avg"] = (
-                    self.accelerator.gather_for_metrics(entropy_stats).sum() / micro_batch_size
+                    self.accelerator.gather_for_metrics(entropy_stats).sum() / padding_count
                 ).item()
-                metrics["val/ratio"] = (
-                    self.accelerator.gather_for_metrics(ratio_stats).sum() / micro_batch_size
-                ).item()
+                metrics["val/ratio"] = (self.accelerator.gather_for_metrics(ratio_stats).sum() / padding_count).item()
                 ratio_mean = self.accelerator.gather_for_metrics(ratio_mean_stats)
-                metrics["val/ratio_var"] = ratio_mean[gathered_micro_batch_size_stats > 0].var().item()
+                gathered_padding_count_stats = self.accelerator.gather_for_metrics(padding_count_stats)
+                metrics["val/ratio_var"] = ratio_mean[gathered_padding_count_stats > 0].var().item()
                 metrics["val/num_eos_tokens"] = (responses == processing_class.eos_token_id).sum().item()
                 metrics["lr"] = self.lr_scheduler.get_last_lr()[0]
                 metrics["episode"] = self.state.episode


### PR DESCRIPTION
Fixes #7012.

### What

`PPOTrainer` reduced its per-update statistics with an unweighted mean over micro-batch slots. Each slot holds a `masked_mean` (or plain mean) of its own micro-batch, so with a short final micro-batch the reported number was a mean of means, not the token or sample mean it is documented as. Unwritten slots, when `stats_shape` is larger than the loop writes, also contributed zeros.

The seven means now store weighted numerators and reduce as total numerator over total count:

- `loss/policy_avg`, `policy/clipfrac_avg` weight by the active response-token count of the micro-batch.
- `loss/value_avg`, `val/clipfrac_avg` weight by the active value-token count (`padding_mask_p1`).
- `policy/approxkl_avg`, `policy/entropy_avg`, `val/ratio` are per-token statistics: each slot now stores a `masked_mean` over the response tokens times the response-token count, and the reduction divides by the gathered response-token count. Before, the plain `.mean()` in those three slots included pad positions, and the first version of this PR only reweighted that mean by micro-batch size (corrected in 42c71bff).
- `val/ratio_var` keeps its variance over slot means, on its own buffer, because the issue leaves that population undefined, but now only over the slots the loop wrote: the response-token count buffer marks them, and the unwritten zeros used to inflate it (with `learning_rate=0` under a 3-over-2 split every ratio is 1 and the logged variance was 0.2667 instead of 0).

### Test

`test_uneven_micro_batch_stats_are_pooled` runs one CPU update with `per_device_train_batch_size=4, gradient_accumulation_steps=3, num_mini_batches=2`, which splits each minibatch into micro-batches of 4 and 2 samples. It spies on the module-level `masked_mean` and `selective_log_softmax` to record the live tensors entering each statistic, pools them independently, and compares with the logged metrics.

### Verification

On a compute node (job 58032838):

- fixed tree: the test passes, and the full `tests/experimental/test_ppo_trainer.py` gives 57 passed, 2 skipped;
- base `ppo_trainer.py`: the test fails at the first pooled comparison;
- mutant dividing `loss/policy_avg` by the sample count instead of the token count: fails;
- mutant with the entropy weight off by one: fails;
- ruff 0.13.3 check and format: clean.

`test_ratio_var_ignores_unwritten_stats` trains with `learning_rate=0`, `gradient_accumulation_steps=3` and `num_mini_batches=2` and asserts `val/ratio_var` is 0; on the previous commit it reads 0.2667.

### Limits

- Multi-process aggregation was not run here. The count and numerator buffers go through the same `gather_for_metrics` path as before.
- This overlaps with #6861, which changes the same stat buffers (per-update allocation, NaN for unwritten slots). Whichever merges second needs a small conflict resolution; the count-based reduction here makes the unwritten-slot handling unnecessary for the seven means.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PPO training metrics are reduced across micro-batches, which affects monitoring and any logic keyed on those logs; training loss/backprop paths are unchanged but reported KL/entropy/ratio values will differ when batching is uneven.
> 
> **Overview**
> **PPO logged averages** no longer take an unweighted mean over micro-batch slots (which skewed uneven 4 vs 2 splits and let empty slots pull metrics toward zero). Each step now accumulates **weighted numerators**—policy-side stats (`loss/policy_avg`, clip fractions, approx KL, entropy, `val/ratio`) scale by active **response-token** count; value-side stats use **`padding_mask_p1`** counts—and divides by the gathered totals after `gather_for_metrics`.
> 
> **Per-micro-batch computation** also aligns with masking: approximate KL and entropy use `masked_mean` on the response mask instead of raw `.mean()`, and ratio logging uses masked means.
> 
> **`val/ratio_var`** is still variance across per-slot mean ratios, but only slots with `padding_count > 0`, so unwritten buffer zeros no longer inflate variance (e.g. LR=0 case).
> 
> **Tests** add `test_uneven_micro_batch_stats_are_pooled` (monkeypatched `masked_mean` / `selective_log_softmax` vs logged metrics) and `test_ratio_var_ignores_unwritten_stats`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c71bff9ee2485b88db2160ec56c03554165796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


