### PR TITLE
Fix BEMACallback parameter alignment when some parameters are frozen

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -16,6 +16,7 @@ import json
 import os
 from unittest.mock import call, patch
 
+import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig, Trainer, TrainingArguments
 
@@ -236,3 +237,35 @@ class TestBEMACallback(TrlTestCase):
             callbacks=[bema_callback],
         )
         trainer.train()
+
+    def test_frozen_parameters(self):
+        """Test that BEMACallback writes the BEMA weights to the right parameters when some are frozen."""
+        self.model.model.embed_tokens.weight.requires_grad_(False)
+        training_args = TrainingArguments(output_dir=self.tmp_dir, report_to="none")
+        bema_callback = BEMACallback(update_freq=1)
+        trainer = Trainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=self.dataset["train"],
+            processing_class=self.tokenizer,
+            callbacks=[bema_callback],
+        )
+        trainer.train()
+
+        # Total 9 steps, updated at every step: the running model must hold the BEMA weights of the last update for
+        # each trainable parameter, matched by name, and the frozen parameter must be left untouched.
+        running_params = dict(bema_callback.running_model.named_parameters())
+        alpha = bema_callback._bema_alpha(9)
+        for name, thetat, theta0, ema in zip(
+            bema_callback.param_names,
+            bema_callback.thetat_params,
+            bema_callback.theta0_params,
+            bema_callback.ema_params,
+            strict=True,
+        ):
+            torch.testing.assert_close(
+                running_params[name], ema + alpha * (thetat.detach() - theta0), check_dtype=False
+            )
+        torch.testing.assert_close(
+            running_params["model.embed_tokens.weight"], self.model.model.embed_tokens.weight, check_dtype=False
+        )

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -665,6 +665,7 @@ class BEMACallback(TrainerCallback):
         self.theta0_params = []  # θ₀ buffers (on self.device)
         self.ema_params = []  # EMA buffers (on self.device)
         self.running_model = None  # a copy of the model to run BEMA on
+        self.running_params = []  # references to running model params, matched by name with thetat_params
 
     @staticmethod
     def _unwrap_model(model):
@@ -698,12 +699,15 @@ class BEMACallback(TrainerCallback):
         self.running_model = type(model)(model.config).to(self.device)
         self.running_model.load_state_dict(model.state_dict())
 
-        # Cache trainable parameters once in a fixed order
+        # Cache trainable parameters once in a fixed order, along with their counterparts in the running model. Frozen
+        # parameters are skipped, so the two must be matched by name rather than by position.
+        running_params = dict(self.running_model.named_parameters())
         for name, param in model.named_parameters():
             if not param.requires_grad:
                 continue
             self.param_names.append(name)
             self.thetat_params.append(param)
+            self.running_params.append(running_params[name])
 
             # Clone θ₀ and EMA on the same device as model
             theta0 = param.detach().clone().to(self.device)
@@ -725,7 +729,7 @@ class BEMACallback(TrainerCallback):
 
         # Compute EMA + BEMA in-place and write directly to running_model
         for thetat, theta0, ema, run_param in zip(
-            self.thetat_params, self.theta0_params, self.ema_params, self.running_model.parameters(), strict=True
+            self.thetat_params, self.theta0_params, self.ema_params, self.running_params, strict=True
         ):
             thetat = thetat.detach().to(self.device)
             ema.mul_(1 - beta).add_(thetat, alpha=beta)  # EMA update: ema = (1 - beta) * ema + beta * θₜ


### PR DESCRIPTION
# What does this PR do?

`BEMACallback` caches only the trainable parameters of the trained model in `on_train_begin` (it skips `requires_grad=False`), but `_bema_update` writes the BEMA weights by zipping that list against `self.running_model.parameters()`, which yields every parameter. As soon as any parameter is frozen the two sequences are positionally misaligned: `zip(..., strict=True)` raises on the length mismatch, and without `strict` each BEMA tensor would be written into the wrong parameter of the running model.

Repro: freeze the embedding matrix (`model.model.embed_tokens.weight.requires_grad_(False)`) and train with `BEMACallback(update_freq=1)`:

    RuntimeError: The size of tensor a (151665) must match the size of tensor b (8) at non-singleton dimension 0

This PR caches the matching running-model parameters by name in `on_train_begin` (`self.running_params`) and zips against that list, so frozen parameters are skipped consistently on both sides.

Test: `TestBEMACallback::test_frozen_parameters` freezes the embedding matrix, trains for 9 steps, and checks every trainable parameter of the running model against `ema + alpha * (theta_t - theta_0)` matched by name, while the frozen embedding is left equal to the trained model's. Fails on `main` with the error above, passes here. `check_dtype=False` because `running_model` is built from the config and may carry a different dtype than the trained model (pre-existing, unrelated to this fix).

Fixes # (none filed; found while reading `trl/trainer/callbacks.py`)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? (not needed: behavior fix only)
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training callback weight-update logic; incorrect alignment could corrupt saved BEMA checkpoints, though the fix is narrow and covered by a regression test.
> 
> **Overview**
> **Fixes `BEMACallback` when some weights are frozen** (`requires_grad=False`). Trainable tensors were tracked in a filtered list, but BEMA updates were applied by zipping against every parameter in `running_model`, which misaligned or crashed (`strict=True` length mismatch / wrong tensor shapes).
> 
> **`on_train_begin`** now builds `running_params` by **parameter name** for each trainable weight, and **`_update_bema_weights`** writes only into those tensors. Frozen weights in the running copy are no longer touched by the BEMA loop.
> 
> Adds **`test_frozen_parameters`**: freezes `embed_tokens`, trains with `update_freq=1`, checks trainable running weights match `ema + alpha * (θₜ - θ₀)` and the frozen embedding stays equal to the training model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71dc9f0485f1c4aa3cca7dd8be6b1ee2f096e418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->