### PR TITLE
Fix variable reference in BCO docs

### DIFF
--- a/docs/source/bco_trainer.md
+++ b/docs/source/bco_trainer.md
@@ -66,7 +66,7 @@ def embed_prompt(input_ids, attention_mask, model):
     outputs = model(input_ids=input_ids, attention_mask=attention_mask)
     return outputs.last_hidden_state.mean(dim=1)
 
-embedding_model = Accelerator().prepare_model(self.embedding_model)
+embedding_model = Accelerator().prepare_model(embedding_model)
 embedding_func = partial(embed_prompt, model=embedding_model)
 ```
 
@@ -85,7 +85,7 @@ bco_trainer = BCOTrainer(
     train_dataset=train_dataset,
     processing_class=tokenizer,
     embedding_func=embedding_func,
-    embedding_tokenizer=self.embedding_tokenizer,
+    embedding_tokenizer=embedding_tokenizer,
 )
 
 bco_trainer.train()


### PR DESCRIPTION
Fix variable reference for embedding model and tokenizer in BCO docs.

This pull request makes minor fixes to the example code in `docs/source/bco_trainer.md` to improve clarity and correctness when using embedding models and tokenizers.

### Changes

- Updated usage of the embedding model and tokenizer to use the correct variable names instead of `self.embedding_model` and `self.embedding_tokenizer`, ensuring the code works as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example fixes with no runtime or API changes.
> 
> **Overview**
> Corrects the **UDM embedding setup** snippet in `bco_trainer.md` so it uses the local variables `embedding_model` and `embedding_tokenizer` instead of invalid `self.embedding_model` / `self.embedding_tokenizer` references.
> 
> The `Accelerator().prepare_model` call and `BCOTrainer(..., embedding_tokenizer=...)` argument now match the preceding example code, so copy-pasted docs run outside a class context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c751da5e962d564bcdcb79bc4b579079d05a5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->