### PR TITLE
Add multi-GPU precompute test coverage for KTO

### DIFF
--- a/tests/distributed/test_distributed.py
+++ b/tests/distributed/test_distributed.py
@@ -187,6 +187,45 @@ class TestDistributed(TrlTestCase):
         )
         # fmt: on
 
+    @pytest.mark.parametrize(
+        "config",
+        [
+            "ddp",
+            pytest.param(
+                "zero2",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.1.0"),
+                    reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
+                ),
+            ),
+            pytest.param(
+                "zero3",
+                marks=pytest.mark.xfail(
+                    Version(transformers.__version__) == Version("5.1.0"),
+                    reason="Upstream incompatibility: deepspeed and transformers==5.1.0 (see transformers#43780)",
+                ),
+            ),
+        ],
+    )
+    def test_kto_precompute_ref_log_probs(self, config, get_config_path):
+        # `--eval_strategy epoch` passes an eval dataset, so reference log-probs are precomputed for both the train and
+        # eval splits (two passes), which is what previously broke multi-GPU precompute (fingerprint cache mismatch, and
+        # a corrupted ZeRO-3 parameter coordinator from re-initializing DeepSpeed on the policy model per pass).
+        # fmt: off
+        run_command(
+            [
+                "accelerate", "launch", "--config_file", get_config_path(config), "trl/scripts/kto.py",
+                "--output_dir", self.tmp_dir,
+                "--model_name_or_path", "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                "--dataset_name", "trl-internal-testing/zen",
+                "--dataset_config", "standard_unpaired_preference",
+                "--precompute_ref_log_probs",
+                "--eval_strategy", "epoch",
+            ],
+            os.environ.copy(),
+        )
+        # fmt: on
+
     @require_liger_kernel
     @pytest.mark.parametrize(
         "config",


### PR DESCRIPTION
# What does this PR do?

#6403 already fixed reference-logprob precompute for both DPO and KTO, but only added a DPO distributed test. This adds the KTO mirror of `test_dpo_precompute_ref_log_probs` so the duplicated two-pass path (`--precompute_ref_log_probs --eval_strategy epoch`) cannot silently diverge.

The new test launches `trl/scripts/kto.py` on `trl-internal-testing/zen` (`standard_unpaired_preference`) over ddp / zero2 / zero3, with the same transformers 5.1.0 xfails as the DPO test. FSDP2 is excluded, as requested on the issue. `kto.py` already wires `eval_dataset` when `eval_strategy != "no"`.

Fixes #6471

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec (filed #6471)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modifications.
> 
> **Overview**
> Adds **`test_kto_precompute_ref_log_probs`** to `tests/distributed/test_distributed.py`, mirroring the existing DPO distributed test so KTO stays covered for the same fragile path.
> 
> The test runs `accelerate launch` with `trl/scripts/kto.py` on the tiny Qwen fixture and `standard_unpaired_preference`, with **`--precompute_ref_log_probs`** and **`--eval_strategy epoch`** so reference log-probs are precomputed on both train and eval (two passes)—the scenario that previously broke multi-GPU precompute. It is parametrized over **ddp**, **zero2**, and **zero3** (no FSDP2), with the same **transformers==5.1.0** xfail marks on DeepSpeed configs as the DPO test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f45184b7eac3042d41947b7de568d22d2c6911a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->