### PR TITLE
Normalize VLM string content in RLOO prompt tokenization

### DIFF
--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 import torch
 import transformers
-from datasets import DatasetDict, IterableDatasetDict, load_dataset
+from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import (
     AutoModelForCausalLM,
@@ -2232,3 +2232,28 @@ class TestRLOOTrainerVLM(TrlTestCase):
         )
         trainer.train()
         assert len(trainer._logs["images"]) == 0
+
+    def test_tokenize_prompts_vlm_string_content(self):
+        # VLM processors may reject plain string content; _tokenize_prompts should normalize it.
+        prompts = [[{"role": "user", "content": "Describe the image."}]]
+        dataset = Dataset.from_dict({"prompt": prompts})
+
+        def reward_func(completions, **kwargs):
+            return [0.0] * len(completions)
+
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            report_to="none",
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+            reward_funcs=reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+        prompt_ids, images, _ = trainer._tokenize_prompts(prompts)
+        assert prompt_ids
+        assert images is None

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -311,8 +311,10 @@ class RLOOTrainer(_BaseTrainer):
         # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):
             self._tokenizer = processing_class.tokenizer
+            self._is_vlm = True
         elif isinstance(processing_class, PreTrainedTokenizerBase):
             self._tokenizer = processing_class
+            self._is_vlm = False
         else:
             raise TypeError("The `processing_class` must be either a `PreTrainedTokenizerBase` or a `ProcessorMixin`")
 
@@ -1171,6 +1173,10 @@ class RLOOTrainer(_BaseTrainer):
     def _tokenize_prompts(self, prompts: list):
         """Tokenize prompts and extract images/multimodal fields for generation."""
         if is_conversational({"prompt": prompts[0]}):
+            # Normalize string content to content blocks for VLM processors that don't handle plain strings.
+            if self._is_vlm:
+                prompts = [prepare_multimodal_messages(prompt) for prompt in prompts]
+
             # Extract images from messages for VLM support
             images = []
             has_images = False


### PR DESCRIPTION
# What does this PR do?

GRPO and Distillation normalize conversational string content with `prepare_multimodal_messages` before `apply_chat_template` when the policy is a VLM. `RLOOTrainer._tokenize_prompts` had the same image-extraction path but skipped that prefix, so VLM processors that reject plain strings would see unnormalized messages.

This copies GRPO's two-line normalize (and comment) into RLOO, and sets `self._is_vlm` in the same `ProcessorMixin` / tokenizer branch GRPO already uses. RLOO does not gain env/tool schema rendering.

Adds `test_tokenize_prompts_vlm_string_content` to cover a conversational VLM prompt whose user content is a plain string.

Fixes #7049

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parity fix on the VLM prompt tokenization path; behavior for text-only models is unchanged and a targeted test covers the regression.
> 
> **Overview**
> **RLOO VLM prompts** now match GRPO/Distillation: when the policy uses a `ProcessorMixin`, conversational messages with plain-string `content` are normalized via `prepare_multimodal_messages` inside `_tokenize_prompts` before `apply_chat_template`, so processors that require content blocks no longer fail.
> 
> `RLOOTrainer` also sets **`self._is_vlm`** from the processing-class type (`ProcessorMixin` vs tokenizer), gating that normalization.
> 
> Adds **`test_tokenize_prompts_vlm_string_content`** (tiny Qwen2.5-VL) to assert `_tokenize_prompts` succeeds for string user content with no images. Fixes #7049.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be96135e344da14f8311ba60d3640dedee1388d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->