### PR TITLE
Correct what the TRL Docker image provides in the Jobs guide

### DIFF
--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -245,7 +245,7 @@ run_uv_job(
 </hfoption>
 </hfoptions>
 
-To run the TRL that is installed in the image, use `hf jobs run` instead. It runs a command in the image directly, with no script header to resolve, so the image's own TRL is what executes:
+To run the TRL that is installed in the image, use `hf jobs run` instead. It runs a command in the image directly, with no script header to resolve, so the image's own TRL is what executes. The `--` separates the command from the Jobs options, which is needed whenever the command itself takes options:
 
 <hfoptions id="script_type">
 <hfoption id="bash">
@@ -255,6 +255,7 @@ hf jobs run \
     --flavor a100-large \
     --secrets HF_TOKEN \
     huggingface/trl \
+    -- \
     trl sft --model_name_or_path Qwen/Qwen2-0.5B-Instruct --dataset_name trl-lib/Capybara --output_dir Qwen2-0.5B-SFT
 ```
 
@@ -280,7 +281,7 @@ run_job(
 </hfoption>
 </hfoptions>
 
-Combining the two, so that `uv` resolves the script header while some imports still come from the image, needs extra flags. See [Popular Jobs images](https://huggingface.co/docs/hub/jobs-popular-images) for that form and the paths it requires.
+Combining the two, so that `uv` resolves the script header while some imports still come from the image, needs extra flags. See [Reuse the image's packages and add dependencies with UV](https://huggingface.co/docs/hub/jobs-popular-images#reuse-the-images-packages-and-add-dependencies-with-uv) for that form and the paths it requires.
 
 Jobs runs on a Docker image from Hugging Face Spaces or Docker Hub, so you can also specify any custom image:
 

--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -213,7 +213,9 @@ Every `.py` example in the [Examples Index](example_overview#index) declares its
 
 ### Docker Images
 
-An up-to-date Docker image with all TRL dependencies is available at [huggingface/trl](https://hub.docker.com/r/huggingface/trl) and can be used directly with Hugging Face Jobs:
+Jobs runs your script with `uv`, which installs the dependencies declared in its `# /// script` header into a fresh environment. The TRL your script imports therefore comes from that header, not from the image, and the examples above need no `--image` at all.
+
+A Docker image with TRL preinstalled is available at [huggingface/trl](https://hub.docker.com/r/huggingface/trl). Passing it gives the job the image's system layer, such as its CUDA toolchain, which matters for dependencies that compile against it:
 
 <hfoptions id="script_type">
 <hfoption id="bash">
@@ -243,6 +245,8 @@ run_uv_job(
 </hfoption>
 </hfoptions>
 
+To import the TRL installed in the image instead of the one `uv` resolves from the header, extra flags are needed. See [Popular Jobs images](https://huggingface.co/docs/hub/jobs-popular-images) for that form and the paths it requires.
+
 Jobs runs on a Docker image from Hugging Face Spaces or Docker Hub, so you can also specify any custom image:
 
 <hfoptions id="script_type">
@@ -253,7 +257,6 @@ hf jobs uv run \
     --flavor a100-large \
     --secrets HF_TOKEN \
     --image <docker-image> \
-    --secrets HF_TOKEN \
     train.py
 ```
 

--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -215,7 +215,7 @@ Every `.py` example in the [Examples Index](example_overview#index) declares its
 
 Jobs runs your script with `uv`, which installs the dependencies declared in its `# /// script` header into a fresh environment. The TRL your script imports therefore comes from that header, not from the image, and the examples above need no `--image` at all.
 
-A Docker image with TRL preinstalled is available at [huggingface/trl](https://hub.docker.com/r/huggingface/trl). Passing it gives the job the image's system layer, such as its CUDA toolchain, which matters for dependencies that compile against it:
+A Docker image with TRL preinstalled is available at [huggingface/trl](https://hub.docker.com/r/huggingface/trl). Passing it to `hf jobs uv run` gives the job the image's system layer, such as its CUDA toolchain, which matters for dependencies that compile against it:
 
 <hfoptions id="script_type">
 <hfoption id="bash">
@@ -245,7 +245,42 @@ run_uv_job(
 </hfoption>
 </hfoptions>
 
-To import the TRL installed in the image instead of the one `uv` resolves from the header, extra flags are needed. See [Popular Jobs images](https://huggingface.co/docs/hub/jobs-popular-images) for that form and the paths it requires.
+To run the TRL that is installed in the image, use `hf jobs run` instead. It runs a command in the image directly, with no script header to resolve, so the image's own TRL is what executes:
+
+<hfoptions id="script_type">
+<hfoption id="bash">
+
+```bash
+hf jobs run \
+    --flavor a100-large \
+    --secrets HF_TOKEN \
+    huggingface/trl \
+    trl sft --model_name_or_path Qwen/Qwen2-0.5B-Instruct --dataset_name trl-lib/Capybara --output_dir Qwen2-0.5B-SFT
+```
+
+</hfoption>
+<hfoption id="python">
+
+```python
+from huggingface_hub import run_job
+
+run_job(
+    image="huggingface/trl",
+    command=[
+        "trl", "sft",
+        "--model_name_or_path", "Qwen/Qwen2-0.5B-Instruct",
+        "--dataset_name", "trl-lib/Capybara",
+        "--output_dir", "Qwen2-0.5B-SFT",
+    ],
+    flavor="a100-large",
+    secrets={"HF_TOKEN": "hf_..."},
+)
+```
+
+</hfoption>
+</hfoptions>
+
+Combining the two, so that `uv` resolves the script header while some imports still come from the image, needs extra flags. See [Popular Jobs images](https://huggingface.co/docs/hub/jobs-popular-images) for that form and the paths it requires.
 
 Jobs runs on a Docker image from Hugging Face Spaces or Docker Hub, so you can also specify any custom image:
 


### PR DESCRIPTION
This PR corrects what the Jobs guide says the TRL Docker image provides, and documents the entry point that does use the image's TRL.

Fixes #7028.

### Motivation

The guide states that "an up-to-date Docker image with all TRL dependencies" can be "used directly with Hugging Face Jobs", one paragraph after stating that every example declares its dependencies in a `# /// script` header. Those two statements pull in opposite directions, and the second one wins.

The two Jobs entry points behave in opposite ways here:

| entry point | runs the image's Python packages |
| --- | --- |
| `hf jobs run` / `run_job` | yes, the command runs in the image directly |
| `hf jobs uv run` / `run_uv_job` | no, `uv` resolves the script header into its own environment |

Verified on a small image rather than argued from the source. An image with `packaging==23.2` installed system wide, and two scripts run in it with `uv run`:

| script header | imported |
| --- | --- |
| `dependencies = ["packaging==24.0"]` | `24.0`, from `/root/.cache/uv/environments-v2/...` |
| `dependencies = []` | `ImportError: No module named 'packaging'` |

The second case is the conclusive one: the environment `uv` builds does not see the image's site-packages at all, so a package present in the image is not importable unless the header asks for it.

The `run` side is verified too, with an actual Job rather than by reading the source:

```
$ hf jobs run --flavor cpu-basic huggingface/trl python -c "import sys, trl; print('TRL_VERSION', trl.__version__); print('ARGV', sys.argv)" --model_name_or_path Qwen/Qwen2-0.5B-Instruct
TRL_VERSION 1.12.0
ARGV ['-c', '--model_name_or_path', 'Qwen/Qwen2-0.5B-Instruct']
```

`TRL_VERSION` is the TRL installed in the image, so `hf jobs run` really does execute the image's own build. It also matches the tag the image was published under, which is the consumer side of the pinning added in #6992. `ARGV` shows that flags the wrapper does not recognise are passed through to the command untouched, which is what the example below relies on.

One sharp edge worth knowing, since it is not obvious: `hf jobs run` is declared with `ignore_unknown_options` but not `allow_interspersed_args=False`, so options it *does* recognise are still consumed wherever they appear. `hf jobs run <image> trl --help` prints the wrapper's help rather than TRL's. No `trl sft` flag collides with the wrapper's options, so the example below is unaffected.

The guide only documented the `uv run` form, while describing a benefit that only the `run` form delivers. `trl-jobs` already uses the `run` form, calling `run_job(image="huggingface/trl", command=["trl", "sft", ...])`, so the image's TRL is genuinely what executes there.

This was raised in #7028 and confirmed there by @sergiopaniego and @davanstrien, who is correcting the equivalent text in the Hub guide in https://github.com/huggingface/hub-docs/pull/2758.

### Solution

Say what each entry point actually gives you, and point to the Hub guide for the expert form that mixes the two, rather than restating those flags and paths here where they would drift.

### Changes

- Explain that with `hf jobs uv run` the imported TRL comes from the script header, not from the image, and that the preceding examples need no `--image`
- Describe what passing `--image` to `hf jobs uv run` does give you, which is the image's system layer
- Document `hf jobs run` as the way to run the TRL installed in the image, with bash and Python examples
- Link to the Hub guide on popular Jobs images for the form that mixes header resolution with the image's own builds
- Remove a duplicated `--secrets HF_TOKEN` flag in the custom image example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the Jobs training guide; no runtime or API behavior is modified.
> 
> **Overview**
> **Corrects the Jobs training guide** so it no longer implies the `huggingface/trl` image supplies the TRL version used by `hf jobs uv run`.
> 
> The **Docker Images** section now states that `uv` installs packages from the script’s `# /// script` header into a fresh environment, so earlier `uv run` examples do not need `--image`. It explains that `--image` on `uv run` mainly provides the image’s system layer (e.g. CUDA toolchain).
> 
> It **adds** documentation for **`hf jobs run` / `run_job`**, including bash and Python examples with `--` before the command, as the path that runs TRL preinstalled in the image (e.g. `trl sft`).
> 
> A **link** points to the Hub guide for mixing image packages with UV-resolved script headers. A **duplicate** `--secrets HF_TOKEN` in the custom-image `uv run` bash example is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cc695ba11d4b0c4b84e2fc04f052ccb2c888d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->