### PR TITLE
Document the TRL Docker image tags

### DIFF
--- a/docs/source/jobs_training.md
+++ b/docs/source/jobs_training.md
@@ -281,6 +281,52 @@ run_job(
 </hfoption>
 </hfoptions>
 
+The image is published under three kinds of tag:
+
+| Tag | Contents |
+| --- | --- |
+| `X.Y.Z` | The TRL release of that version, built when that version is released |
+| `latest` | The most recent release |
+| `dev` | The `main` branch, rebuilt on every merge |
+
+Use `dev` to run the development version, which is useful for trying a fix that has landed on `main` but is not released yet:
+
+<hfoptions id="script_type">
+<hfoption id="bash">
+
+```bash
+hf jobs run \
+    --flavor a100-large \
+    --secrets HF_TOKEN \
+    huggingface/trl:dev \
+    -- \
+    trl sft --model_name_or_path Qwen/Qwen2-0.5B-Instruct --dataset_name trl-lib/Capybara --output_dir Qwen2-0.5B-SFT
+```
+
+</hfoption>
+<hfoption id="python">
+
+```python
+from huggingface_hub import run_job
+
+run_job(
+    image="huggingface/trl:dev",
+    command=[
+        "trl", "sft",
+        "--model_name_or_path", "Qwen/Qwen2-0.5B-Instruct",
+        "--dataset_name", "trl-lib/Capybara",
+        "--output_dir", "Qwen2-0.5B-SFT",
+    ],
+    flavor="a100-large",
+    secrets={"HF_TOKEN": "hf_..."},
+)
+```
+
+</hfoption>
+</hfoptions>
+
+Tags only select what is installed in the image, so they matter for `hf jobs run`. With `hf jobs uv run` the version comes from the script header instead, and the tag makes no difference to which TRL is imported.
+
 Combining the two, so that `uv` resolves the script header while some imports still come from the image, needs extra flags. See [Reuse the image's packages and add dependencies with UV](https://huggingface.co/docs/hub/jobs-popular-images#reuse-the-images-packages-and-add-dependencies-with-uv) for that form and the paths it requires.
 
 Jobs runs on a Docker image from Hugging Face Spaces or Docker Hub, so you can also specify any custom image:


### PR DESCRIPTION
This PR documents the tags the TRL Docker image is published under, and shows how to use `dev` to run the development version.

Stacked on #7054.

### Motivation

The image has been published under three kinds of tag for a year, and none of them are documented. `dev` in particular has never been mentioned anywhere in the repository, so the only way to learn it exists is to browse Docker Hub. It came up in #6933, where the fact that it was undocumented was mistaken for it being unused.

The tags also only became meaningful recently. Before #6990, #6991 and #6992, a version tag was rewritten on every push to `main` and the installed version was not pinned to it, so `huggingface/trl:1.9.2` did not reliably contain 1.9.2. Now that it does, the tags are worth documenting.

Which tag you pick only matters for `hf jobs run`, since that is the form that runs what is installed in the image. #7054 covers that distinction, which is why this is stacked on it rather than standing alone.

### Verification

The published tags match what is documented here:

```
$ hf jobs run --flavor cpu-basic huggingface/trl python -c "import trl; print(trl.__version__)"
1.12.0
```

which is the current release, and the tag it was published under.

### Changes

- Document the `X.Y.Z`, `latest` and `dev` tags and what each contains
- Show running the development version with `huggingface/trl:dev`, in bash and Python
- Note that tags select what is installed in the image, so they are only relevant to `hf jobs run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `jobs_training.md` with no runtime, security, or API impact.
> 
> **Overview**
> The Jobs training guide now explains how **`huggingface/trl`** is tagged on Docker Hub: semver **`X.Y.Z`**, **`latest`**, and **`dev`** (main rebuilt on every merge), with a short table describing what each contains.
> 
> It adds **`hf jobs run`** examples (CLI and `run_job`) that pin **`huggingface/trl:dev`** so users can try fixes on main before a release, and clarifies that **image tags only affect `hf jobs run`**—with **`hf jobs uv run`**, TRL still comes from the script header, so the tag does not change which version is imported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff508830bf4143ef435510d8023b18ed6953d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->