### PR TITLE
Remove the flash-attn2 xfail markers now that the padding-free tests pass

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -1091,11 +1091,6 @@ class TestDPOTrainer(TrlTestCase):
         not is_ampere_or_newer() and torch_device != "xpu",
         reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
     )
-    @pytest.mark.xfail(
-        reason="kernels-community/flash-attn2 is currently unusable for training: no build variant for torch 2.13 "
-        "(https://github.com/huggingface/kernels-community/issues/1082), and the v3 stable-ABI build raises in the "
-        "backward pass for GQA models (https://github.com/huggingface/kernels-community/issues/1085)",
-    )
     def test_train_padding_free(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1117,11 +1117,6 @@ class TestSFTTrainer(TrlTestCase):
         not is_ampere_or_newer() and torch_device != "xpu",
         reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
     )
-    @pytest.mark.xfail(
-        reason="kernels-community/flash-attn2 is currently unusable for training: no build variant for torch 2.13 "
-        "(https://github.com/huggingface/kernels-community/issues/1082), and the v3 stable-ABI build raises in the "
-        "backward pass for GQA models (https://github.com/huggingface/kernels-community/issues/1085)",
-    )
     def test_train_padding_free(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
 


### PR DESCRIPTION
This PR removes the `xfail` markers from the `test_train_padding_free` tests in SFT and DPO, which have been passing since the upstream kernel was rebuilt.

### Motivation

The markers were added in #6741 for two reasons, and neither holds in CI any more: there is no torch 2.13 build gap (the v3 stable ABI builds cover torch >= 2.9, and v2 has since gained torch 2.13 builds), and the GQA backward crash (huggingface/kernels-community#1085) was fixed by huggingface/kernels-community#1125 and rebuilt on 2026-08-31.

The `Tests with latest dependencies` job brackets the change precisely:

| run | result |
| --- | --- |
| 2026-08-31 13:51 UTC | `7 xfailed` |
| 2026-08-31 22:38 UTC | `5 xfailed, 2 xpassed` |
| every run since | `5 xfailed, 2 xpassed` |

The cu130 and cu132 builds were uploaded between 17:16 and 18:17 UTC that day, inside that window, and nothing changed in TRL. CI installs torch 2.14 with CUDA 13 wheels, so it resolves one of the rebuilt binaries. The test model is genuinely affected by the bug (`tiny-Qwen2ForCausalLM-2.5` has 4 query heads and 2 KV heads), so this is a real pass, not an accidental one.

The markers are not strict, so today the suite reports these as `xpassed` and a genuine regression would silently show up as `xfailed` again, which nobody reads. Removing them restores the signal.

### Changes

- Remove the flash-attn2 `xfail` marker from `test_train_padding_free` in the SFT and DPO test suites.

### Notes

The same marker on the GRPO `test_vlm_training` is already gone, since that test was removed in #6912.

This does not affect the invariant suite, which runs elsewhere on a cu128 environment where the kernel is still the pre-fix build, and which is protected by the `@v2` pin from #6979 rather than by any marker. If CI ever resolves a cu128 torch wheel before those builds are rebuilt, these tests will fail, which is the correct outcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that tightens CI expectations for two integration tests; no production code paths are modified.
> 
> **Overview**
> Removes the `@pytest.mark.xfail` decorators on **`test_train_padding_free`** in the DPO and SFT trainer test modules so those cases are enforced as normal passes again.
> 
> The tests still use `kernels-community/flash-attn2` with `padding_free=True` and keep the existing `@require_kernels` and Ampere/XPU skip guards; only the expected-failure marking is gone. That restores a clear CI signal now that upstream kernel rebuilds fixed the torch 2.13 build gap and GQA backward issues that motivated the markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee40c60ba002706ff734d46abf9fbdbf1d91e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->