### PR TITLE
Fix the invariant suite recording instructions

### DIFF
--- a/tests/invariant/README.md
+++ b/tests/invariant/README.md
@@ -6,7 +6,7 @@ Catches silent training bugs that don't fail unit tests but shift the training t
 
 Configs are grouped into **equivalence classes**: configs in the same class must produce the same trajectory (e.g. PDB=1×GAS=8 must equal PDB=8×GAS=1, FA2 must equal eager). Each class has one **canonical** config (the first one) that owns the class's reference snapshot. Every config in the class — canonical included — is asserted to match the saved reference. This catches both invariant breakage (a non-canonical config drifting away from the canonical's pinned trajectory) and numerical regressions (the canonical itself drifting from its committed snapshot across versions).
 
-Recording the references is a separate concern from testing them, so it's a separate entry point (`python tests/invariant/test_invariant.py`).
+Recording the references is a separate concern from testing them, so it's a separate entry point (`python -m tests.invariant.test_invariant`).
 
 Each config is a `trl <method>` CLI invocation with a fixed set of args. The harness shells out (`subprocess.run(["trl", method, ...])`), the CLI runs end to end, writes `trainer_state.json` to its `--output_dir`, and the harness parses the `log_history` into a `Trajectory`.
 
@@ -50,8 +50,8 @@ Reference snapshots are recorded on **H100 80GB**, except `sft_fa2.json` (**H200
 pytest tests/invariant/ -m invariant
 
 # record references
-python tests/invariant/test_invariant.py      # all classes
-python tests/invariant/test_invariant.py sft  # one class
+python -m tests.invariant.test_invariant      # all classes
+python -m tests.invariant.test_invariant sft  # one class
 ```
 
 Snapshot updates must be justified in the PR description.

--- a/tests/invariant/test_invariant.py
+++ b/tests/invariant/test_invariant.py
@@ -198,9 +198,10 @@ def _build(
 
 # Equivalence classes: each maps to a `members` list plus per-field `tol` (max |Δ|) and `residual_tol` (mean Δ)
 # dicts. The first member is the canonical config — it owns the class's reference snapshot and is the only one
-# re-recorded under `--update-references`. Every other member is asserted to match that snapshot.
-# Tuning tip: run `python tests/invariant/test_invariant.py <klass> --report` to see actual Δs and set tolerances
-# to ~1.5–2× the observed noise.
+# re-recorded by `python -m tests.invariant.test_invariant <klass>`. Every other member is asserted to match that
+# snapshot.
+# Tuning tip: `pytest tests/invariant/ -m invariant -k <klass>` reports the observed max |Δ| per field when it
+# exceeds the tolerance; set tolerances to ~1.5-2x that noise.
 EQUIVALENCE_CLASSES: dict[str, dict] = {
     "sft": {
         "tol": {"loss": 1e-3, "grad_norm": 1e-1},


### PR DESCRIPTION
This PR fixes the documented commands for recording invariant reference snapshots, which do not work.

### Motivation

The README tells you to record references with `python tests/invariant/test_invariant.py`. That has raised an error since #6036 added a relative import to the module:

```
File "tests/invariant/test_invariant.py", line 29, in <module>
    from ..testing_utils import is_bf16_supported
ImportError: attempted relative import with no known parent package
```

The working invocation is `python -m tests.invariant.test_invariant`.

The comment above the equivalence classes has the same problem, and additionally points at two options that do not exist: `--update-references` and `--report`. The recording entry point only accepts an optional class name and `--allow-dirty`.

This is the documented path for regenerating snapshots, and the README requires snapshot updates to be justified in the PR description, so it is worth having the commands actually run.

### Changes

- Use the module form of the recording command in the README, in both the Running section and the description of the entry point.
- Point the equivalence-class comment at the same command, replacing the non-existent `--update-references`.
- Reword the tolerance-tuning tip to describe what the suite actually reports, replacing the non-existent `--report`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes with no runtime or test logic modifications.
> 
> **Overview**
> Updates **training invariant** docs and inline comments so reference snapshot recording uses **`python -m tests.invariant.test_invariant`** instead of running `test_invariant.py` as a script, which breaks on the module’s relative imports.
> 
> The **README** “Running” section and the equivalence-class comment now describe the same working entry point (optional class name, e.g. `sft`). Stale references to **`--update-references`** and **`--report`** are removed; tolerance tuning is documented as using **`pytest tests/invariant/ -m invariant -k <klass>`**, which reports max |Δ| when assertions fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f067994db605f6b0b7a34dcd1e8e0318e9d06c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->