### PR TITLE
Fix zero generation config validation

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -274,6 +274,10 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    def test_num_generations_must_be_at_least_two(self):
+        with pytest.raises(ValueError, match="GRPO requires at least 2 generations"):
+            GRPOConfig(output_dir=self.tmp_dir, num_generations=0)
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -39,6 +39,10 @@ if is_peft_available():
 
 
 class TestRLOOTrainer(TrlTestCase):
+    def test_num_generations_must_be_at_least_two(self):
+        with pytest.raises(ValueError, match="RLOO requires at least 2 generations"):
+            RLOOConfig(output_dir=self.tmp_dir, num_generations=0)
+
     def test_init_minimal(self):
         # Test that RLOOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -1078,6 +1078,12 @@ class GRPOConfig(_BaseConfig):
                 "this invariant. Set auto_find_batch_size=False and lower per_device_train_batch_size instead."
             )
 
+        if self.num_generations < 2:
+            raise ValueError(
+                "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
+                f"{self.num_generations}."
+            )
+
         num_processes = self.world_size
         # The current default effective batch size
         if self.generation_batch_size is None and self.steps_per_generation is None:
@@ -1117,12 +1123,6 @@ class GRPOConfig(_BaseConfig):
             raise ValueError(
                 f"generation_batch_size ({self.generation_batch_size}) must be divisible by num_generations "
                 f"({self.num_generations})."
-            )
-
-        if self.num_generations < 2:
-            raise ValueError(
-                "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
-                f"{self.num_generations}, which is less than the minimum required."
             )
 
         if self.vllm_importance_sampling_cap is not None:

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -630,7 +630,6 @@ class RLOOConfig(_BaseConfig):
                 "so Transformers' context-parallel / Ulysses sequence-parallel input sharding cannot be applied to the "
                 "raw generation batch. Set both `cp_size=1` and `sp_size=1`, or disable `parallelism_config`."
             )
-
         # `auto_find_batch_size` halves the train batch size on OOM, and the generation batch is derived from it. The
         # reduced batch is no longer guaranteed to hold full prompt groups, which breaks grouping the rewards by
         # prompt. There's no way to preserve the invariant while shrinking the batch, so reject it up front.
@@ -639,6 +638,12 @@ class RLOOConfig(_BaseConfig):
                 "auto_find_batch_size is not supported by RLOO, because the generation batch must contain full "
                 "prompt groups of num_generations completions, and reducing the batch size on out-of-memory breaks "
                 "this invariant. Set auto_find_batch_size=False and lower per_device_train_batch_size instead."
+            )
+
+        if self.num_generations < 2:
+            raise ValueError(
+                "RLOO requires at least 2 generations per prompt to calculate the advantages. You provided "
+                f"{self.num_generations}."
             )
 
         num_processes = self.world_size
@@ -680,10 +685,4 @@ class RLOOConfig(_BaseConfig):
             raise ValueError(
                 f"generation_batch_size ({self.generation_batch_size}) must be divisible by num_generations "
                 f"({self.num_generations})."
-            )
-
-        if self.num_generations < 2:
-            raise ValueError(
-                "RLOO requires at least 2 generations per prompt to calculate the advantages. You provided "
-                f"{self.num_generations}, which is less than the minimum required."
             )


### PR DESCRIPTION
Description:

What does this PR do?
This PR fixes the validation order for num_generations in the GRPO and RLOO configurations.

Previously, setting num_generations=0 caused a ZeroDivisionError during batch-size validation. It now raises the intended ValueError explaining that at least two generations are required.

Changes
Move the minimum-generation validation before batch-size calculations.
Add regression tests for both GRPOConfig and RLOOConfig.
Testing
Python syntax checks passed.
Focused pytest execution was blocked because transformers is not installed in the current environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config validation ordering and messaging only; no training or runtime behavior change for valid settings.
> 
> **Overview**
> **Fixes misleading failures when `num_generations` is 0 or 1** in `GRPOConfig` and `RLOOConfig`.
> 
> Validation that at least two generations are required now runs **before** generation-batch and divisibility logic that uses `num_generations` as a divisor. With `num_generations=0`, users previously hit a `ZeroDivisionError` instead of the intended `ValueError`; they now get a clear message that GRPO/RLOO need at least two generations per prompt.
> 
> The error text is slightly shortened (drops the redundant “less than the minimum required” clause). Regression tests assert `num_generations=0` raises the expected `ValueError` for both trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4bf0cc0f4ffa39320f8fcd562a35180e619a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->