### PR TITLE
Fix zero generation config validation

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -274,9 +274,10 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
-    def test_num_generations_must_be_at_least_two(self):
+    @pytest.mark.parametrize("num_generations", [0, 1])
+    def test_num_generations_must_be_at_least_two(self, num_generations):
         with pytest.raises(ValueError, match="GRPO requires at least 2 generations"):
-            GRPOConfig(output_dir=self.tmp_dir, num_generations=0)
+            GRPOConfig(output_dir=self.tmp_dir, num_generations=num_generations)
 
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -274,6 +274,10 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    def test_num_generations_must_be_at_least_two(self):
+        with pytest.raises(ValueError, match="GRPO requires at least 2 generations"):
+            GRPOConfig(output_dir=self.tmp_dir, num_generations=0)
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -39,9 +39,10 @@ if is_peft_available():
 
 
 class TestRLOOTrainer(TrlTestCase):
-    def test_num_generations_must_be_at_least_two(self):
+    @pytest.mark.parametrize("num_generations", [0, 1])
+    def test_num_generations_must_be_at_least_two(self, num_generations):
         with pytest.raises(ValueError, match="RLOO requires at least 2 generations"):
-            RLOOConfig(output_dir=self.tmp_dir, num_generations=0)
+            RLOOConfig(output_dir=self.tmp_dir, num_generations=num_generations)
 
     def test_init_minimal(self):
         # Test that RLOOTrainer can be instantiated with only model, reward_model and train_dataset

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -39,6 +39,10 @@ if is_peft_available():
 
 
 class TestRLOOTrainer(TrlTestCase):
+    def test_num_generations_must_be_at_least_two(self):
+        with pytest.raises(ValueError, match="RLOO requires at least 2 generations"):
+            RLOOConfig(output_dir=self.tmp_dir, num_generations=0)
+
     def test_init_minimal(self):
         # Test that RLOOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -1078,6 +1078,12 @@ class GRPOConfig(_BaseConfig):
                 "this invariant. Set auto_find_batch_size=False and lower per_device_train_batch_size instead."
             )
 
+        if self.num_generations < 2:
+            raise ValueError(
+                "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
+                f"{self.num_generations}."
+            )
+
         num_processes = self.world_size
         # The current default effective batch size
         if self.generation_batch_size is None and self.steps_per_generation is None:
@@ -1117,12 +1123,6 @@ class GRPOConfig(_BaseConfig):
             raise ValueError(
                 f"generation_batch_size ({self.generation_batch_size}) must be divisible by num_generations "
                 f"({self.num_generations})."
-            )
-
-        if self.num_generations < 2:
-            raise ValueError(
-                "GRPO requires at least 2 generations per prompt to calculate the advantages. You provided "
-                f"{self.num_generations}, which is less than the minimum required."
             )
 
         if self.vllm_importance_sampling_cap is not None:

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -630,7 +630,6 @@ class RLOOConfig(_BaseConfig):
                 "so Transformers' context-parallel / Ulysses sequence-parallel input sharding cannot be applied to the "
                 "raw generation batch. Set both `cp_size=1` and `sp_size=1`, or disable `parallelism_config`."
             )
-
         # `auto_find_batch_size` halves the train batch size on OOM, and the generation batch is derived from it. The
         # reduced batch is no longer guaranteed to hold full prompt groups, which breaks grouping the rewards by
         # prompt. There's no way to preserve the invariant while shrinking the batch, so reject it up front.
@@ -639,6 +638,12 @@ class RLOOConfig(_BaseConfig):
                 "auto_find_batch_size is not supported by RLOO, because the generation batch must contain full "
                 "prompt groups of num_generations completions, and reducing the batch size on out-of-memory breaks "
                 "this invariant. Set auto_find_batch_size=False and lower per_device_train_batch_size instead."
+            )
+
+        if self.num_generations < 2:
+            raise ValueError(
+                "RLOO requires at least 2 generations per prompt to calculate the advantages. You provided "
+                f"{self.num_generations}."
             )
 
         num_processes = self.world_size
@@ -680,10 +685,4 @@ class RLOOConfig(_BaseConfig):
             raise ValueError(
                 f"generation_batch_size ({self.generation_batch_size}) must be divisible by num_generations "
                 f"({self.num_generations})."
-            )
-
-        if self.num_generations < 2:
-            raise ValueError(
-                "RLOO requires at least 2 generations per prompt to calculate the advantages. You provided "
-                f"{self.num_generations}, which is less than the minimum required."
             )


### PR DESCRIPTION
## What does this PR do?

This PR fixes the validation order for `num_generations` in the GRPO and RLOO configuration classes.

Previously, setting `num_generations=0` caused a `ZeroDivisionError` during batch-size validation. The configuration now validates the minimum number of generations before performing batch-size arithmetic and raises a clear `ValueError` instead.

Regression tests were added for both `GRPOConfig` and `RLOOConfig`.

No new dependencies are required.

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [ ] I have read the contributor guideline and Pull Request section.
- [ ] This change was not discussed in a GitHub issue.
- [x] Documentation was reviewed; no documentation update was necessary.
- [x] Necessary regression tests were added.

## AI writing disclosure

We used AI tools to help identify the issue, suggest implementation details, and improve the wording of this PR. The changes and final description were reviewed and finalized by a human contributor.

- [ ] No AI usage
- [x] AI-assisted
- [ ] AI-generated
## Testing

- Python syntax checks passed.
- Focused tests were added but could not be run locally because `transformers` is not installed in the current environment.
- No new dependencies are required.

## Who can review?

Anyone in the community is welcome to review this PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reordering of existing validation logic plus tests; no change to training behavior for valid configs.
> 
> **Overview**
> Fixes a config validation ordering bug where `num_generations` of `0` or `1` could surface a **`ZeroDivisionError`** during `generation_batch_size % num_generations` checks instead of a clear configuration error.
> 
> **`GRPOConfig`** and **`RLOOConfig`** now enforce **`num_generations >= 2`** immediately after the `auto_find_batch_size` guard and before any batch-size arithmetic. The error message is slightly tightened to report the provided value only.
> 
> Parametrized regression tests in **`test_grpo_trainer.py`** and **`test_rloo_trainer.py`** assert that `num_generations` of `0` and `1` raise **`ValueError`** with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48790d392cc95a5ad7f15aae641a32779e59cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->