### PR TITLE
Fix DPO and KTO Liger loss gaps

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -905,6 +905,23 @@ class TestDPOTrainer(TrlTestCase):
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
     @require_liger_kernel
+    def test_liger_loss_forwards_config(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        training_args = DPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            loss_type="robust",
+            label_smoothing=0.1,
+            discopop_tau=0.2,
+            report_to="none",
+        )
+        trainer = DPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        assert trainer.liger_loss.label_smoothing == 0.1
+        assert trainer.liger_loss.discopop_tau == 0.2
+
     @require_peft
     def test_train_with_liger_kernel_and_peft(self):
         # A LoRA adapter that does not target lm_head leaves the head as a plain Linear, so Liger reads the real

--- a/tests/test_kto_loss.py
+++ b/tests/test_kto_loss.py
@@ -147,6 +147,7 @@ class FusedLMHeadKTO(torch.nn.Module):
         ref_bias: bool = False,
         ignore_index: int = -100,
         beta: float = 0.1,
+        chunk_size: int = 2,
     ):
         super().__init__()
         self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=bias, dtype=dtype)
@@ -156,6 +157,7 @@ class FusedLMHeadKTO(torch.nn.Module):
             beta=beta,
             use_ref_model=True,
             average_log_prob=True,
+            chunk_size=chunk_size,
         )
 
     def forward(self, x, ref_x, y, preference_labels, kl=None):

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -937,6 +937,7 @@ class TestKTOTrainer(TrlTestCase):
             train_dataset=dataset,
             peft_config=LoraConfig(target_modules=["q_proj", "v_proj"]),
         )
+        assert trainer.liger_loss.use_ref_model
         previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
         trainer.train()
         assert trainer.state.log_history[-1]["train_loss"] is not None
@@ -1002,6 +1003,24 @@ class TestKTOTrainer(TrlTestCase):
                 args=training_args,
                 train_dataset=dataset,
                 compute_metrics=lambda _: {},
+            )
+
+    @require_liger_kernel
+    @pytest.mark.parametrize("weight", ["desirable_weight", "undesirable_weight"])
+    def test_init_fails_with_weighted_liger_loss(self, weight):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_unpaired_preference", split="train")
+        training_args = KTOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+            **{weight: 2.0},
+        )
+
+        with pytest.raises(ValueError, match=weight):
+            KTOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                args=training_args,
+                train_dataset=dataset,
             )
 
     @require_liger_kernel

--- a/trl/losses/fused_linear_unpaired_preference.py
+++ b/trl/losses/fused_linear_unpaired_preference.py
@@ -261,11 +261,11 @@ class FusedLinearUnpairedPreferenceBase(torch.autograd.Function):
         else:
             log_probs = (per_token_logps_chunk * loss_mask_chunk).sum(-1)
 
-        chosen_logps_sum = (log_probs * preference_labels_chunk.unsqueeze(1)).sum()
-        rejected_logps_sum = (log_probs * (~preference_labels_chunk).unsqueeze(1)).sum()
+        chosen_logps_sum = (log_probs * preference_labels_chunk).sum()
+        rejected_logps_sum = (log_probs * ~preference_labels_chunk).sum()
 
-        chosen_logits_sum = (logits_chunk * preference_labels_chunk.unsqueeze(1)).sum()
-        rejected_logits_sum = (logits_chunk * (~preference_labels_chunk).unsqueeze(1)).sum()
+        chosen_logits_sum = (logits_chunk * preference_labels_chunk.view(-1, 1, 1)).sum()
+        rejected_logits_sum = (logits_chunk * (~preference_labels_chunk).view(-1, 1, 1)).sum()
 
         return (
             log_probs,

--- a/trl/losses/kto_loss.py
+++ b/trl/losses/kto_loss.py
@@ -82,8 +82,8 @@ class FusedLinearKTOFunction(FusedLinearUnpairedPreferenceBase):
             losses = 1 - F.sigmoid(beta * logratios_chunk * multiplier_chunk)
 
         rewards = beta * logratios_chunk
-        chosen_rewards_sum = (rewards * preference_labels_chunk.unsqueeze(1)).sum()
-        rejected_rewards_sum = (rewards * (~preference_labels_chunk).unsqueeze(1)).sum()
+        chosen_rewards_sum = (rewards * preference_labels_chunk).sum()
+        rejected_rewards_sum = (rewards * ~preference_labels_chunk).sum()
 
         return losses.sum() / (full_target.shape[0]), chosen_rewards_sum, rejected_rewards_sum
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -845,7 +845,12 @@ class DPOTrainer(_BaseTrainer):
                         "wrong sequence. Use a weight-based adapter such as LoRA instead, or set "
                         "`use_liger_kernel=False`."
                     )
-            self.liger_loss = FusedLinearDPOLoss(beta=args.beta, loss_type=self.loss_types[0])
+            self.liger_loss = FusedLinearDPOLoss(
+                beta=args.beta,
+                loss_type=self.loss_types[0],
+                label_smoothing=self.label_smoothing,
+                discopop_tau=args.discopop_tau,
+            )
             # Redirect the model.module forward to the model forward to ensure pre-forward hooks are called, so that
             # under ZeRO-3 the parameter coordinator gathers/reduces `lm_head.weight` around the fused loss.
             self._forward_redirection = _ForwardRedirection()

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -832,6 +832,11 @@ class KTOTrainer(_BaseTrainer):
                     "compute_metrics is not supported with the Liger kernel. compute_metrics requires to be able to "
                     "recover the logits from the forward pass, but Liger kernel does not materialize logits."
                 )
+            if self.desirable_weight != 1.0 or self.undesirable_weight != 1.0:
+                raise ValueError(
+                    "The Liger KTO loss does not support `desirable_weight` or `undesirable_weight` other than 1.0. "
+                    "Either keep the default weights or set `use_liger_kernel` to False."
+                )
             if self.precompute_ref_logps:
                 raise ValueError(
                     "Liger KTO loss does not support precomputing reference log probabilities. Either disable "
@@ -982,7 +987,7 @@ class KTOTrainer(_BaseTrainer):
 
         # The Liger loss is built here, because it needs `self.ref_model`
         if self.use_liger_kernel:
-            self.liger_loss = FusedLinearKTOLoss(beta=self.beta, use_ref_model=(self.ref_model is not None))
+            self.liger_loss = FusedLinearKTOLoss(beta=self.beta, use_ref_model=True)
             # Redirect the model.module forward to the model forward to ensure pre-forward hooks are called, so that
             # under ZeRO-3 the parameter coordinator gathers/reduces `lm_head.weight` around the fused loss.
             self._forward_redirection = _ForwardRedirection()


### PR DESCRIPTION
# What does this PR do?

Fixes DPO and KTO Liger loss gaps found while reviewing #7059:

- forwards DPO label smoothing and DiscoPOP tau;
- fixes KTO metrics for multi-example chunks;
- raises for non-default KTO class weights instead of silently ignoring them;
- keeps the KTO reference path enabled for PEFT, where `ref_model=None` means the disabled adapter is the reference (#5876).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training loss and logged metrics for Liger DPO/KTO (including PEFT reference handling); incorrect behavior was fixed, but runs may differ from before.
> 
> **Overview**
> Closes gaps in **Liger fused losses** for DPO and KTO so training behavior matches the non-Liger paths and chunked batches report metrics correctly.
> 
> **DPO:** `DPOTrainer` now passes `label_smoothing` and `discopop_tau` into `FusedLinearDPOLoss` when `use_liger_kernel=True` (they were previously ignored).
> 
> **KTO:** Non-default `desirable_weight` / `undesirable_weight` with the Liger kernel now **fail at init** with a clear error instead of being silently dropped. Liger KTO is always built with `use_ref_model=True` so PEFT setups where `ref_model=None` still use the disabled-adapter reference path. In fused unpaired/KTO code, chosen/rejected **log-prob, logit, and reward sums** fix label broadcasting when `log_probs` is per-sequence and `chunk_size` > 1.
> 
> Tests cover DPO Liger config forwarding, KTO Liger + PEFT `use_ref_model`, weighted KTO + Liger errors, and smaller `chunk_size` in KTO loss correctness tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d7e85d0c17e2738859dc05bc50c9390328ed62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->