### PR TITLE
Drop fused JSD from DistillationTrainer

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -93,7 +93,7 @@ While training and evaluating, we record the following metrics:
 - `completions/clipped_ratio`: The ratio of truncated (clipped) completions.
 - `tools/call_frequency`: The average number of tool calls per completion in the generation batch. Logged only when `tools` are provided.
 - `tools/failure_frequency`: The fraction of tool calls that failed (the tool was not found, raised an exception, or the call type is unsupported). It is `0.0` when no tool was called. Logged only when `tools` are provided.
-- `entropy`: Average entropy of token predictions across generated completions (in nats). Not logged on the Liger fast path.
+- `entropy`: Average entropy of token predictions across generated completions (in nats).
 
 ## Customization
 

--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -176,15 +176,6 @@ trainer.train()
 > [!WARNING]
 > The distillation loss reads `lm_head.weight` directly and runs the student backbone without going through `PeftModel.forward()`. Adapters on `lm_head` (via `target_modules`) and prompt-learning methods (PromptTuning, PrefixTuning, P-Tuning) are therefore rejected, since they would be silently ignored. To train the head, use `modules_to_save=["lm_head"]` instead.
 
-### Train with Liger Kernel
-
-Liger Kernel is a collection of Triton kernels for LLM training that boosts multi-GPU throughput, cuts memory use, and works seamlessly with tools like FlashAttention, PyTorch FSDP, and DeepSpeed. For more information, see [Liger Kernel Integration](liger_kernel_integration).
-
-Set `use_liger_kernel=True` in the [`DistillationConfig`] to compute the JSD with the fused Liger kernel instead of the chunked path.
-
-> [!WARNING]
-> The fused Liger kernel cannot apply per-model `logit_scale` (e.g. Cohere) or `final_logit_softcapping` (e.g. Gemma), so it is rejected for models that set them — use the default chunked path for those.
-
 ## Agent Training
 
 [`DistillationTrainer`] supports **agent training**: the student calls tools during generation and is distilled on the resulting trajectory. Tool-result tokens are masked out of the loss, so the student is only trained on the tokens it generated itself.

--- a/tests/test_distillation_trainer.py
+++ b/tests/test_distillation_trainer.py
@@ -31,7 +31,6 @@ from trl.trainer.distillation_trainer import _chunked_divergence_loss
 from .testing_utils import (
     TrlTestCase,
     require_bitsandbytes,
-    require_liger_kernel,
     require_peft,
     require_response_parsing,
     require_torch_accelerator,
@@ -1236,102 +1235,6 @@ class TestDistillationTrainer(TrlTestCase):
             reference = jsd.sum() / num_valid
 
         torch.testing.assert_close(loss, reference, rtol=1e-4, atol=1e-6)
-
-    @require_liger_kernel
-    @require_torch_accelerator
-    def test_liger_loss_agrees_with_chunked(self):
-        # The Liger fused path and the default chunked path compute the same JSD objective (they share the hidden-state
-        # extraction and differ only in the final loss call), so they must agree on a fixed batch. Toggling
-        # `use_liger_kernel` on one trainer keeps the same (un-patched) model, so only the loss kernel differs.
-        from trl.losses import FusedLinearJSDLoss
-
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        trainer = DistillationTrainer(
-            model="trl-internal-testing/tiny-Qwen3ForCausalLM",
-            teacher_model="trl-internal-testing/small-Qwen3ForCausalLM",
-            args=DistillationConfig(output_dir=self.tmp_dir, beta=0.5, report_to="none"),
-            train_dataset=dataset,
-        )
-
-        # The tiny models are randomly initialized, so their next-token distributions are nearly uniform over the
-        # ~150k vocab. At that scale the JSD sits at the float32 noise floor, where the chunked and fused paths' matmul
-        # reduction orders diverge by ~2x — a conditioning artifact, not a real objective difference. Scale the LM heads
-        # to peak the distributions so the two paths are compared on a well-conditioned batch.
-        with torch.no_grad():
-            trainer.model.get_output_embeddings().weight.mul_(50.0)
-            trainer.teacher_model.get_output_embeddings().weight.mul_(50.0)
-
-        device = trainer.accelerator.device
-        vocab_size = trainer.model.config.vocab_size
-        gen = torch.Generator().manual_seed(1)
-        prompt_length, completion_length = 4, 3
-        batch = {
-            "prompt_ids": torch.randint(0, vocab_size, (2, prompt_length), generator=gen).to(device),
-            "prompt_mask": torch.ones(2, prompt_length, dtype=torch.long, device=device),
-            "completion_ids": torch.randint(0, vocab_size, (2, completion_length), generator=gen).to(device),
-            "completion_mask": torch.ones(2, completion_length, dtype=torch.long, device=device),
-        }
-        num_valid = batch["completion_mask"].sum()
-
-        trainer.model.eval()
-        with torch.no_grad():
-            chunked_loss = trainer.compute_loss(trainer.model, batch, num_items_in_batch=num_valid)
-            trainer.use_liger_kernel = True
-            trainer.liger_loss = FusedLinearJSDLoss(
-                beta=trainer.beta,
-                ignore_index=-100,
-                temperature=trainer.temperature,
-                compiled=False,
-                weight_hard_loss=0.0,
-                weight_soft_loss=1.0,
-            )
-            liger_loss = trainer.compute_loss(trainer.model, batch, num_items_in_batch=num_valid)
-
-        torch.testing.assert_close(liger_loss, chunked_loss, rtol=1e-3, atol=1e-4)
-
-    @require_liger_kernel
-    def test_liger_incompatible_with_logit_softcapping_raises(self):
-        # The Liger fused JSD kernel can't apply Cohere `logit_scale` / Gemma `final_logit_softcapping`, so unlike the
-        # chunked path it would optimize a different objective than the model's real forward. Reject rather than train
-        # silently wrong.
-        student = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen3ForCausalLM")
-        student.config.final_logit_softcapping = 30.0
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        with pytest.raises(ValueError, match="final_logit_softcapping"):
-            DistillationTrainer(
-                model=student,
-                teacher_model="trl-internal-testing/small-Qwen3ForCausalLM",
-                args=DistillationConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none"),
-                train_dataset=dataset,
-            )
-
-    @require_liger_kernel
-    def test_liger_allows_none_logit_scale(self):
-        # `logit_scale = None` (e.g. MPT) means unscaled, like `1.0`; the Liger guard must not reject it.
-        student = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen3ForCausalLM")
-        student.config.logit_scale = None
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        DistillationTrainer(  # must not raise
-            model=student,
-            teacher_model="trl-internal-testing/small-Qwen3ForCausalLM",
-            args=DistillationConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none"),
-            train_dataset=dataset,
-        )
-
-    @require_liger_kernel
-    def test_liger_rejects_zero_logit_scale(self):
-        # `logit_scale = 0.0` is a real (degenerate) scale, not "unscaled" — it zeroes the logits. The Liger kernel
-        # can't apply it, so like any other non-1.0 scale it must be rejected, not silently read as 1.0.
-        student = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5")
-        student.config.logit_scale = 0.0
-        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
-        with pytest.raises(ValueError, match="logit_scale"):
-            DistillationTrainer(
-                model=student,
-                teacher_model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
-                args=DistillationConfig(output_dir=self.tmp_dir, use_liger_kernel=True, report_to="none"),
-                train_dataset=dataset,
-            )
 
 
 @require_vision

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -45,7 +45,7 @@ from transformers import (
     is_trackio_available,
     is_wandb_available,
 )
-from transformers.utils import is_liger_kernel_available, is_peft_available, is_rich_available
+from transformers.utils import is_peft_available, is_rich_available
 
 from ..chat_template_utils import (
     _SUPPORTS_RESPONSE_TEMPLATE,
@@ -60,7 +60,6 @@ from ..distributed import DistributedBackend
 from ..extras.profiling import profiling_context, profiling_decorator
 from ..generation.vllm_generation import VLLMGeneration
 from ..import_utils import is_jmespath_available, is_vllm_available
-from ..losses import FusedLinearJSDLoss
 from ..models import prepare_deepspeed
 from ..models.utils import _ForwardRedirection, unwrap_model_for_generation
 from .base_trainer import _BaseTrainer
@@ -638,27 +637,9 @@ class DistillationTrainer(_BaseTrainer):
                     "adapter such as LoRA instead."
                 )
 
-        # The chunked JSD loss (and the Liger path) call the student backbone directly, bypassing the DDP/FSDP
-        # wrapper's forward; route them through `_forward_redirection` so `prepare_for_backward()` still fires.
+        # The chunked JSD loss calls the student backbone directly, bypassing the DDP/FSDP wrapper's forward; route it
+        # through `_forward_redirection` so `prepare_for_backward()` still fires.
         self._forward_redirection = _ForwardRedirection()
-
-        # Liger fused JSD loss
-        self.use_liger_kernel = False
-        if args.use_liger_kernel:
-            if not is_liger_kernel_available():
-                raise ImportError(
-                    "Liger is required to use `use_liger_kernel` as the distillation loss. Run "
-                    "`pip install liger-kernel`."
-                )
-            self.liger_loss = FusedLinearJSDLoss(
-                beta=args.beta,
-                ignore_index=-100,
-                temperature=args.temperature,
-                compiled=False,
-                weight_hard_loss=0.0,
-                weight_soft_loss=1.0,
-            )
-            self.use_liger_kernel = True
 
         # Teacher model setup
         # `teacher_model` may be None: subclasses (e.g. ServerDistillationTrainer) supply the teacher another way.
@@ -749,28 +730,6 @@ class DistillationTrainer(_BaseTrainer):
                     f"requires a shared vocabulary. Use a teacher with the same vocab_size, or GOLD for "
                     f"cross-tokenizer distillation."
                 )
-            # The Liger fused JSD kernel projects `h @ Wᵀ` directly and has no `logit_scale` /
-            # `final_logit_softcapping` parameters, so (unlike the chunked path) it cannot reproduce Cohere
-            # `logit_scale` or Gemma `final_logit_softcapping`. Refuse rather than silently optimize a different
-            # objective than the model's real forward.
-            if self.use_liger_kernel:
-                for name, model in [("student", self.model), ("teacher", teacher_model)]:
-                    # On VLMs the logit post-processing lives on `text_config`, so read it through
-                    # `get_text_config()`. Muse Glimmer names its pre-softcap multiplier `output_multiplier`.
-                    config = model.config.get_text_config()
-                    logit_scale = getattr(config, "logit_scale", None)
-                    if logit_scale is None:
-                        logit_scale = getattr(config, "output_multiplier", None)
-                    scaled = logit_scale not in (None, 1.0)
-                    softcapped = getattr(config, "final_logit_softcapping", None) is not None
-                    if scaled or softcapped:
-                        raise ValueError(
-                            f"`use_liger_kernel=True` is incompatible with the {name} model's `logit_scale` / "
-                            f"`final_logit_softcapping` (e.g. Cohere / Gemma models): the Liger fused JSD loss reads "
-                            f"`lm_head.weight` directly and cannot apply them, so it would optimize a different "
-                            f"objective than the model's real forward. Set `use_liger_kernel=False` to use the chunked "
-                            f"loss, which applies both."
-                        )
             if self.is_deepspeed_enabled:
                 self.teacher_model = prepare_deepspeed(teacher_model, self.accelerator)
             else:
@@ -1913,53 +1872,11 @@ class DistillationTrainer(_BaseTrainer):
         student_lm_head = unwrapped_student.get_output_embeddings()
         teacher_lm_head = unwrapped_teacher.get_output_embeddings()
 
-        if self.use_liger_kernel:
-            # Fused JSD over the same hidden states as the chunked path. `true_labels` only masks positions (the
-            # hard-loss weight is 0), so any non-ignore id marks a valid completion token; `_get_last_hidden_state`
-            # already returns the completion-aligned positions, so no shift is needed.
-            true_labels = torch.where(
-                loss_mask.bool(), inputs["completion_ids"], torch.full_like(inputs["completion_ids"], -100)
-            ).reshape(-1)
-            # Under FSDP2 the heads are DTensors; materialize them once with full_tensor() for the fused kernel, as the
-            # chunked path does. No-op off FSDP2; the ZeRO-3 (non-DTensor) case is handled by maybe_gather_lm_head_ctx.
-            student_weight, student_bias = student_lm_head.weight, student_lm_head.bias
-            teacher_weight, teacher_bias = teacher_lm_head.weight, teacher_lm_head.bias
-            if isinstance(student_weight, torch.distributed.tensor.DTensor):
-                student_weight = student_weight.full_tensor()
-                if student_bias is not None:
-                    student_bias = student_bias.full_tensor()
-            if isinstance(teacher_weight, torch.distributed.tensor.DTensor):
-                teacher_weight = teacher_weight.full_tensor()
-                if teacher_bias is not None:
-                    teacher_bias = teacher_bias.full_tensor()
-            # ZeRO-3 shards the heads and the fused kernel reads them directly, so gather them for the call.
-            with maybe_gather_lm_head_ctx(
-                student_lm_head.weight, student_lm_head.bias, teacher_lm_head.weight, teacher_lm_head.bias
-            ):
-                loss = self.liger_loss(
-                    student_input=student_hidden_states.reshape(-1, student_hidden_states.size(-1)),
-                    student_weight=student_weight,
-                    teacher_input=teacher_hidden_states.reshape(-1, teacher_hidden_states.size(-1)),
-                    teacher_weight=teacher_weight,
-                    true_labels=true_labels,
-                    student_bias=student_bias,
-                    teacher_bias=teacher_bias,
-                )
-            # Liger normalizes by the local valid-token count; rescale to the global count for grad-accum correctness.
-            if num_items_in_batch is not None:
-                num_valid_local = (true_labels != -100).sum().clamp_min(1)
-                if isinstance(num_items_in_batch, torch.Tensor):
-                    num_items_in_batch = num_items_in_batch.to(loss.device)
-                loss = loss * num_valid_local / num_items_in_batch
-            # The fused kernel produces no entropy; `compute_loss` logs none for the Liger path.
-            return loss, None, None
-
         # On VLMs the logit post-processing lives on `text_config`, so read it through `get_text_config()`.
         student_config = unwrapped_student.config.get_text_config()
         teacher_config = unwrapped_teacher.config.get_text_config()
         # `logit_scale` is None on models that don't scale (e.g. MPT); read that as unscaled (1.0). A real 0.0 is kept
-        # as-is: the Liger guard rejects it, and the chunked path applies it faithfully. Muse Glimmer applies the same
-        # pre-softcap multiplier under the name `output_multiplier`.
+        # as-is. Muse Glimmer applies the same pre-softcap multiplier under the name `output_multiplier`.
         student_logit_scale = getattr(student_config, "logit_scale", None)
         if student_logit_scale is None:
             student_logit_scale = getattr(student_config, "output_multiplier", None)

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -612,7 +612,7 @@ class DistillationTrainer(_BaseTrainer):
                 if param.requires_grad:
                     param.data = param.data.to(torch.bfloat16)
 
-        # Both loss paths (chunked and Liger) read `lm_head.weight` directly and run the backbone via
+        # The chunked JSD loss reads `lm_head.weight` directly and runs the backbone via
         # `_get_last_hidden_state`, bypassing `PeftModel.forward()` — so PEFT setups that live outside the backbone
         # weights are silently ignored. Fail loudly rather than train on a silently-wrong objective.
         if is_peft_model(model):
@@ -1815,13 +1815,12 @@ class DistillationTrainer(_BaseTrainer):
 
         # Log the mean per-token student entropy (in nats). The reduction runs here, after `_forward_redirection`
         # returns, so the `gather_for_metrics` collective does not run inside the DDP/FSDP-wrapped forward (a hang/
-        # ordering risk). The Liger path produces no entropy, so it logs none. Mirrors `SFTTrainer.compute_loss`.
-        if entropy_sum is not None:
-            mode = "train" if self.model.training else "eval"
-            num_valid_tokens = self.accelerator.gather_for_metrics(num_valid_tokens).sum()
-            entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
-            entropy = (entropy_sum / num_valid_tokens).item() if num_valid_tokens > 0 else 0.0
-            self._metrics[mode]["entropy"].append(entropy)
+        # ordering risk). Mirrors `SFTTrainer.compute_loss`.
+        mode = "train" if self.model.training else "eval"
+        num_valid_tokens = self.accelerator.gather_for_metrics(num_valid_tokens).sum()
+        entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
+        entropy = (entropy_sum / num_valid_tokens).item() if num_valid_tokens > 0 else 0.0
+        self._metrics[mode]["entropy"].append(entropy)
 
         return (loss, None) if return_outputs else loss
 


### PR DESCRIPTION
# What does this PR do?

Always uses the existing token-chunked JSD path in `DistillationTrainer` and removes the duplicated fused-JSD branch. Part of #7063.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes an alternate loss implementation that some configs may have relied on for speed; default chunked distillation behavior is unchanged but anyone still passing `use_liger_kernel` needs to migrate.
> 
> **Overview**
> **`DistillationTrainer` no longer supports the optional Liger fused Jensen–Shannon divergence kernel** (`use_liger_kernel` / `FusedLinearJSDLoss`). Training always goes through the existing memory-efficient **chunked JSD** path in `_compute_loss`.
> 
> Related cleanup drops Liger-only setup (import/availability checks, `self.liger_loss`, and guards that rejected models with `logit_scale` or `final_logit_softcapping` on the fused path). **Entropy** is now **always** aggregated and logged in `compute_loss` (the fused path previously skipped it).
> 
> Documentation removes the “Train with Liger Kernel” section and the note that entropy is omitted on the Liger fast path. Tests drop `require_liger_kernel` and all Liger parity/compatibility cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fbe2e5e2eee9941f7c6f665f605d186ddbb120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->