### PR TITLE
Harden chunked log probabilities

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1226,8 +1226,11 @@ class TestChunkedLogProbFunction:
     N, H, V = 64, 32, 128
     CHUNK_SIZE = 32
 
-    def _reference_logprobs_and_entropy(self, hidden, weight, labels, temperature):
-        logits = (hidden @ weight.t()).to(torch.float32) / temperature  # [N, V]
+    def _reference_logprobs_and_entropy(self, hidden, weight, labels, temperature, bias=None):
+        logits = hidden @ weight.t()
+        if bias is not None:
+            logits = logits + bias
+        logits = logits.to(torch.float32) / temperature  # [N, V]
         log_p = F.log_softmax(logits, dim=-1)
         logprobs = log_p.gather(-1, labels.unsqueeze(-1)).squeeze(-1)
         p = torch.softmax(logits, dim=-1)
@@ -1242,7 +1245,7 @@ class TestChunkedLogProbFunction:
         labels = torch.randint(0, self.V, (self.N,))
 
         logprobs_chunked, entropy_chunked = _ChunkedLogProbFunction.apply(
-            hidden, weight, labels, temperature, self.CHUNK_SIZE
+            hidden, weight, None, labels, temperature, self.CHUNK_SIZE
         )
         logprobs_ref, entropy_ref = self._reference_logprobs_and_entropy(hidden, weight, labels, temperature)
 
@@ -1257,7 +1260,7 @@ class TestChunkedLogProbFunction:
         labels = torch.randint(0, self.V, (self.N,))
 
         # Chunked backward
-        logprobs_chunked, _ = _ChunkedLogProbFunction.apply(hidden, weight, labels, temperature, self.CHUNK_SIZE)
+        logprobs_chunked, _ = _ChunkedLogProbFunction.apply(hidden, weight, None, labels, temperature, self.CHUNK_SIZE)
         logprobs_chunked.sum().backward()
         grad_hidden_chunked = hidden.grad.clone()
         grad_weight_chunked = weight.grad.clone()
@@ -1280,7 +1283,7 @@ class TestChunkedLogProbFunction:
         labels = torch.randint(0, self.V, (self.N,))
 
         # Chunked backward
-        logprobs_chunked, _ = _ChunkedLogProbFunction.apply(hidden, weight, labels, temperature, self.CHUNK_SIZE)
+        logprobs_chunked, _ = _ChunkedLogProbFunction.apply(hidden, weight, None, labels, temperature, self.CHUNK_SIZE)
         logprobs_chunked.sum().backward()
         grad_hidden_chunked = hidden.grad.clone()
         grad_weight_chunked = weight.grad.clone()
@@ -1304,7 +1307,7 @@ class TestChunkedLogProbFunction:
         labels = torch.randint(0, self.V, (self.N,))
 
         # Chunked backward
-        _, entropy_chunked = _ChunkedLogProbFunction.apply(hidden, weight, labels, temperature, self.CHUNK_SIZE)
+        _, entropy_chunked = _ChunkedLogProbFunction.apply(hidden, weight, None, labels, temperature, self.CHUNK_SIZE)
         entropy_chunked.sum().backward()
         grad_hidden_chunked = hidden.grad.clone()
         grad_weight_chunked = weight.grad.clone()
@@ -1330,7 +1333,7 @@ class TestChunkedLogProbFunction:
 
         # Chunked backward
         logprobs_chunked, entropy_chunked = _ChunkedLogProbFunction.apply(
-            hidden, weight, labels, temperature, self.CHUNK_SIZE
+            hidden, weight, None, labels, temperature, self.CHUNK_SIZE
         )
         (2.0 * logprobs_chunked + 0.5 * entropy_chunked).sum().backward()
         grad_hidden_chunked = hidden.grad.clone()
@@ -1345,6 +1348,30 @@ class TestChunkedLogProbFunction:
 
         torch.testing.assert_close(grad_hidden_chunked, hidden.grad, atol=1e-4, rtol=1e-4)
         torch.testing.assert_close(grad_weight_chunked, weight.grad, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_bias(self, dtype):
+        torch.manual_seed(42)
+        hidden = torch.randn(self.N, self.H, dtype=dtype, requires_grad=True)
+        weight = torch.randn(self.V, self.H, dtype=dtype, requires_grad=True)
+        bias = torch.randn(self.V, dtype=dtype, requires_grad=True)
+        labels = torch.randint(0, self.V, (self.N,))
+
+        logprobs_chunked, entropy_chunked = _ChunkedLogProbFunction.apply(
+            hidden, weight, bias, labels, 0.7, self.CHUNK_SIZE
+        )
+        (2.0 * logprobs_chunked + 0.5 * entropy_chunked).sum().backward()
+        chunked_grads = hidden.grad.clone(), weight.grad.clone(), bias.grad.clone()
+
+        hidden.grad = weight.grad = bias.grad = None
+        logprobs_ref, entropy_ref = self._reference_logprobs_and_entropy(hidden, weight, labels, 0.7, bias)
+        (2.0 * logprobs_ref + 0.5 * entropy_ref).sum().backward()
+
+        atol, rtol = (5e-2, 2e-2) if dtype == torch.bfloat16 else (1e-4, 1e-4)
+        torch.testing.assert_close(logprobs_chunked, logprobs_ref, atol=atol, rtol=rtol)
+        torch.testing.assert_close(entropy_chunked, entropy_ref, atol=atol, rtol=rtol)
+        for actual, expected in zip(chunked_grads, (hidden.grad, weight.grad, bias.grad), strict=True):
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
 class _FakeTransformerModel(nn.Module):

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -193,10 +193,10 @@ def maybe_gather_lm_head_ctx(*params: torch.nn.Parameter):
     Fused losses (e.g. Liger) read `lm_head.weight` directly and hand it to the kernel without ever calling the
     `lm_head` module. Under DeepSpeed ZeRO-3 every parameter is sharded to `numel 0` and only re-materialized inside
     its owning module's forward hook, so the head's gather hook never fires and the kernel receives an empty weight.
-    This gathers the given parameters for the duration of the forward, so the fused matmul sees the full weight. The
-    weight gradient is computed and stashed during this forward, so the parameters need not stay gathered for the
-    backward — but the backward's gradient reduction relies on the ZeRO-3 pre-forward hooks being armed, so the caller
-    must run the fused loss inside the model's forward (e.g. via `_ForwardRedirection`).
+    This gathers the given parameters for the duration of a direct access, so the matmul sees the full weight. Fused
+    losses compute and stash their gradients during the forward; custom autograd functions that recompute during the
+    backward must enter this context again. The backward's gradient reduction relies on the ZeRO-3 pre-forward hooks
+    being armed, so the caller must run the loss inside the model's forward (e.g. via `_ForwardRedirection`).
 
     Returns a null context when ZeRO-3 is not enabled, or when the parameters are already gathered — with tied
     embeddings `embed_tokens` keeps the weight `AVAILABLE`, and re-partitioning it on exit would collide with
@@ -1324,6 +1324,7 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
         ctx,
         last_hidden: torch.Tensor,  # [N, H]
         weight: torch.Tensor,  # [V, H]
+        bias: torch.Tensor | None,  # [V]
         targets: torch.Tensor,  # [N]
         temperature: float,
         chunk_size: int,
@@ -1356,6 +1357,8 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
             # with last_hidden.dtype (float16) while w_chunk (the lm_head weights) is not auto casted
             w_chunk = weight[start:end].to(last_hidden.dtype)  # [C, H]
             torch.mm(last_hidden, w_chunk.t(), out=mm_buf[:, :C])
+            if bias is not None:
+                mm_buf[:, :C].add_(bias[start:end].to(last_hidden.dtype))
             logits_chunk = logits_buf[:, :C]
             logits_chunk.copy_(mm_buf[:, :C])
 
@@ -1385,7 +1388,7 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
         logprobs = target_logit - log_z
         entropy = log_z - x_sum_exp / sum_exp
 
-        ctx.save_for_backward(last_hidden, weight, targets, log_z, entropy)
+        ctx.save_for_backward(last_hidden, weight, bias, targets, log_z, entropy)
         ctx.temperature = temperature
         ctx.chunk_size = chunk_size
         ctx.logit_scale = logit_scale
@@ -1395,7 +1398,7 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_logprobs: torch.Tensor | None, grad_entropy: torch.Tensor | None):  # type: ignore
-        hidden, weight, labels, log_z, entropy = ctx.saved_tensors
+        hidden, weight, bias, labels, log_z, entropy = ctx.saved_tensors
         temperature: float = ctx.temperature
         chunk_size: int = ctx.chunk_size
         logit_scale: float = ctx.logit_scale
@@ -1403,63 +1406,78 @@ class _ChunkedLogProbFunction(torch.autograd.Function):
         inv_t = 1 / temperature
 
         N, _ = hidden.shape
-        vocab = weight.shape[0]
+        with maybe_gather_lm_head_ctx(weight, bias):
+            vocab = weight.shape[0]
 
-        # NOTE(@aminediro): always acc in fp32 even if input is not
-        grad_hidden = torch.zeros(hidden.shape, device=hidden.device, dtype=torch.float32)
-        grad_weight = torch.zeros(weight.shape, device=weight.device, dtype=torch.float32)
+            # NOTE(@aminediro): always acc in fp32 even if input is not
+            grad_hidden = torch.zeros(hidden.shape, device=hidden.device, dtype=torch.float32)
+            grad_weight = torch.zeros(weight.shape, device=weight.device, dtype=torch.float32)
+            grad_bias = torch.zeros(bias.shape, device=bias.device, dtype=torch.float32) if bias is not None else None
 
-        # Pre-allocate reusable buffers to avoid per-chunk allocation
-        mm_buf = torch.empty((N, chunk_size), device=hidden.device, dtype=hidden.dtype)
-        logits_buf = torch.empty((N, chunk_size), device=hidden.device, dtype=torch.float32)
+            # Pre-allocate reusable buffers to avoid per-chunk allocation
+            mm_buf = torch.empty((N, chunk_size), device=hidden.device, dtype=hidden.dtype)
+            logits_buf = torch.empty((N, chunk_size), device=hidden.device, dtype=torch.float32)
 
-        g = grad_logprobs.to(torch.float32) if grad_logprobs is not None else None  # [N]
-        g_entropy = grad_entropy.to(torch.float32) if grad_entropy is not None else None  # [N]
-        row_idx = torch.arange(N, device=hidden.device)
+            g = grad_logprobs.to(torch.float32) if grad_logprobs is not None else None  # [N]
+            g_entropy = grad_entropy.to(torch.float32) if grad_entropy is not None else None  # [N]
+            row_idx = torch.arange(N, device=hidden.device)
 
-        for start in range(0, vocab, chunk_size):
-            end = min(start + chunk_size, vocab)
-            C = end - start
-            w_chunk = weight[start:end]  # [C, H]
+            for start in range(0, vocab, chunk_size):
+                end = min(start + chunk_size, vocab)
+                C = end - start
+                w_chunk = weight[start:end]  # [C, H]
 
-            torch.mm(hidden, w_chunk.t(), out=mm_buf[:, :C])
-            logits_chunk = logits_buf[:, :C]
-            logits_chunk.copy_(mm_buf[:, :C])
+                torch.mm(hidden, w_chunk.t(), out=mm_buf[:, :C])
+                if bias is not None:
+                    mm_buf[:, :C].add_(bias[start:end].to(hidden.dtype))
+                logits_chunk = logits_buf[:, :C]
+                logits_chunk.copy_(mm_buf[:, :C])
 
-            logits_chunk.mul_(logit_scale)
-            if final_logit_softcapping is not None:
-                tanh_scaled = torch.tanh(logits_chunk / final_logit_softcapping)
-                logits_chunk.copy_(tanh_scaled * final_logit_softcapping)
+                logits_chunk.mul_(logit_scale)
+                if final_logit_softcapping is not None:
+                    tanh_scaled = torch.tanh(logits_chunk / final_logit_softcapping)
+                    logits_chunk.copy_(tanh_scaled * final_logit_softcapping)
 
-            logits_chunk.mul_(inv_t)  # [N, C]
-            probs = torch.exp(logits_chunk - log_z.unsqueeze(-1))  # [N, C]
+                logits_chunk.mul_(inv_t)  # [N, C]
+                probs = torch.exp(logits_chunk - log_z.unsqueeze(-1))  # [N, C]
 
-            if g is not None:
-                # dL/d(logits) = g * (1_[label] - p)
-                grad_logits = (-g).unsqueeze(-1) * probs  # [N, C]
+                if g is not None:
+                    # dL/d(logits) = g * (1_[label] - p)
+                    grad_logits = (-g).unsqueeze(-1) * probs  # [N, C]
 
-                in_chunk_cond = (labels >= start) & (labels < end)
-                local_idx = torch.clamp(labels - start, 0, end - start - 1)
-                # If label in chunk add g to grad else it stays the same
-                grad_logits[row_idx, local_idx] += g * in_chunk_cond
-            else:
-                grad_logits = torch.zeros_like(probs)
+                    in_chunk_cond = (labels >= start) & (labels < end)
+                    local_idx = torch.clamp(labels - start, 0, end - start - 1)
+                    # If label in chunk add g to grad else it stays the same
+                    grad_logits[row_idx, local_idx] += g * in_chunk_cond
+                else:
+                    grad_logits = torch.zeros_like(probs)
 
-            if g_entropy is not None:
-                # d(entropy)/d(logits_j) = -p_j * (log_p_j + entropy), entropy = -sum_k p_k * log_p_k
-                log_p_chunk = logits_chunk - log_z.unsqueeze(-1)  # [N, C]
-                grad_logits += (-g_entropy).unsqueeze(-1) * probs * (log_p_chunk + entropy.unsqueeze(-1))
+                if g_entropy is not None:
+                    # d(entropy)/d(logits_j) = -p_j * (log_p_j + entropy), entropy = -sum_k p_k * log_p_k
+                    log_p_chunk = logits_chunk - log_z.unsqueeze(-1)  # [N, C]
+                    grad_logits += (-g_entropy).unsqueeze(-1) * probs * (log_p_chunk + entropy.unsqueeze(-1))
 
-            grad_logits = grad_logits * inv_t
-            if final_logit_softcapping is not None:
-                grad_logits.mul_(1 - tanh_scaled.pow(2))
+                grad_logits = grad_logits * inv_t
+                if final_logit_softcapping is not None:
+                    grad_logits.mul_(1 - tanh_scaled.pow(2))
 
-            grad_logits = grad_logits * logit_scale
+                grad_logits = grad_logits * logit_scale
 
-            grad_hidden.add_(grad_logits @ w_chunk.float())
-            grad_weight[start:end].add_(grad_logits.t() @ hidden.float())
+                grad_hidden.add_(grad_logits @ w_chunk.float())
+                grad_weight[start:end].add_(grad_logits.t() @ hidden.float())
+                if grad_bias is not None:
+                    grad_bias[start:end].add_(grad_logits.sum(dim=0))
 
-        return grad_hidden.to(hidden.dtype), grad_weight.to(weight.dtype), None, None, None, None, None
+        return (
+            grad_hidden.to(hidden.dtype),
+            grad_weight.to(weight.dtype),
+            grad_bias.to(bias.dtype) if grad_bias is not None else None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 def patch_chunked_lm_head(
@@ -1506,6 +1524,7 @@ def patch_chunked_lm_head(
         logprobs_valid, entropy_valid = _ChunkedLogProbFunction.apply(
             hidden_flat,
             self.lm_head.weight,
+            self.lm_head.bias,
             targets_flat,
             temperature,
             chunk_size,


### PR DESCRIPTION
# What does this PR do?

Adds LM-head bias support and re-gathers partitioned weights during `_ChunkedLogProbFunction.backward`. Includes full-logit loss and gradient parity tests. Part of #7063.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RL/training loss math and gradients for chunked LM-head log-probs, including ZeRO-3 backward gathering; incorrect bias or gather behavior would skew policy gradients, though tests cover bias parity and existing backward paths.
> 
> **Overview**
> Extends the memory-efficient **`_ChunkedLogProbFunction`** path so chunked per-token log-probs and entropy match models whose **`lm_head` has bias**, and so backward stays correct under **DeepSpeed ZeRO-3** when weights are read outside a normal `lm_head` forward.
> 
> **`_ChunkedLogProbFunction`** now takes an optional **`bias`** argument (inserted after `weight`). Forward adds the bias slice per vocab chunk; backward accumulates **`grad_bias`** and wraps the recomputation loop in **`maybe_gather_lm_head_ctx(weight, bias)`** so partitioned head parameters are gathered during backward like fused losses need on forward. **`patch_chunked_lm_head`** passes **`self.lm_head.bias`** into `apply`.
> 
> Tests pass **`None`** for the new bias slot on existing cases and add **`test_bias`** (float32 and bfloat16) comparing forward, combined loss, and gradients to a reference that includes bias. **`maybe_gather_lm_head_ctx`** docs are updated to note that custom autograd functions must re-enter the context on backward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd259e0c46018a8d941dc563a7174703ff8e9373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->