### PR TITLE
Add `log_entropy` to skip the per-token entropy metric in SFT, GRPO and RLOO

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -193,7 +193,7 @@ While training and evaluating, we record the following metrics:
 - `sampling/importance_sampling_ratio/mean`: The average constrained importance sampling ratio. Logged only when `use_vllm=True` and `vllm_importance_sampling_correction=True`.
 - `sampling/importance_sampling_ratio/max`: The largest constrained importance sampling ratio. Logged only when `use_vllm=True` and `vllm_importance_sampling_correction=True`.
 - `policy_loss`: The policy gradient loss value (before any entropy bonus). Logged when `entropy_coef` is nonzero or `use_adaptive_entropy=True`.
-- `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
+- `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.) Set `log_entropy=False` to skip computing it.
 - `entropy_coef`: The current entropy regularization coefficient. Logged when `entropy_coef` is nonzero or `use_adaptive_entropy=True`. Updated once per optimizer step when `use_adaptive_entropy=True`.
 - `aux_loss`: The load-balancing auxiliary loss of a Mixture-of-Experts model, before it is scaled by `router_aux_loss_coef` and added to the loss. Logged only when the model is a MoE model and `router_aux_loss_coef` is nonzero.
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -144,7 +144,7 @@ While training and evaluating, we record the following metrics:
 - `reward`: The overall average reward after summing rewards across functions (weighted by `reward_weights`).
 - `reward_std`: The standard deviation of summed rewards across functions (weighted by `reward_weights`), computed over the full batch.
 - `frac_reward_zero_std`: The fraction of samples in the generation batch with a reward std of zero, implying there is little diversity for that prompt (all answers are correct or incorrect).
-- `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.)
+- `entropy`: Average entropy of token predictions across generated completions. (If `mask_truncated_completions=True`, masked sequences tokens are excluded.) Set `log_entropy=False` to skip computing it.
 - `aux_loss`: The load-balancing auxiliary loss of a Mixture-of-Experts model, before it is scaled by `router_aux_loss_coef` and added to the loss. Logged only when the model is a MoE model and `router_aux_loss_coef` is nonzero.
 - `kl`: The average KL divergence between the model and the reference model, calculated over generated completions. Logged only if `beta` is nonzero.
 - `clip_ratio/region_mean`: The ratio of sequence probabilities where the RLOO objective is clipped to stay within the trust region:  \\( \text{clip}\left( r_{i}(\theta), 1 - \epsilon_\mathrm{low}, 1 + \epsilon_\mathrm{high} \right)\,, \quad r_{i}(\theta) = \frac{\pi_\theta(o_{i} \mid q)}{\pi_{\theta_{\text{old}}}(o_{i} \mid q)} \\). A higher value means more samples are clipped, which constrains how much the policy $\pi_\theta$ can change.

--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -126,7 +126,7 @@ While training and evaluating, we record the following metrics:
 * `epoch`: The current epoch number, based on dataset iteration.
 * `num_tokens`: The total number of tokens processed so far.
 * `loss`: The average cross-entropy loss computed over non-masked tokens in the current logging interval.
-* `entropy`: The average entropy of the model's predicted token distribution over non-masked tokens.
+* `entropy`: The average entropy of the model's predicted token distribution over non-masked tokens. Set `log_entropy=False` to skip computing it.
 * `mean_token_accuracy`: The proportion of non-masked tokens for which the model’s top-1 prediction matches the ground truth token.
 * `learning_rate`: The current learning rate, which may change dynamically if a scheduler is used.
 * `grad_norm`: The L2 norm of the gradients, computed before gradient clipping.

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -274,6 +274,35 @@ class TestTransformersContinuousBatchingContract:
 
 
 class TestGRPOTrainer(TrlTestCase):
+    @pytest.mark.parametrize("log_entropy", [False, True])
+    def test_log_entropy(self, log_entropy):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        # Leave the flag unset to exercise the default when entropy logging is enabled.
+        entropy_kwargs = {} if log_entropy else {"log_entropy": False}
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            max_steps=2,
+            logging_steps=1,
+            report_to="none",
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            **entropy_kwargs,
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda completions, **kwargs: [float(len(completion)) for completion in completions],
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+
+        assert any("loss" in entry for entry in trainer.state.log_history)
+        if log_entropy:
+            assert any("entropy" in entry for entry in trainer.state.log_history)
+        else:
+            assert all("entropy" not in entry for entry in trainer.state.log_history)
+
     def test_init_minimal(self):
         # Test that GRPOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -39,6 +39,35 @@ if is_peft_available():
 
 
 class TestRLOOTrainer(TrlTestCase):
+    @pytest.mark.parametrize("log_entropy", [False, True])
+    def test_log_entropy(self, log_entropy):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        # Leave the flag unset to exercise the default when entropy logging is enabled.
+        entropy_kwargs = {} if log_entropy else {"log_entropy": False}
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            max_steps=2,
+            logging_steps=1,
+            report_to="none",
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=8,
+            **entropy_kwargs,
+        )
+        trainer = RLOOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=lambda completions, **kwargs: [float(len(completion)) for completion in completions],
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+
+        assert any("loss" in entry for entry in trainer.state.log_history)
+        if log_entropy:
+            assert any("entropy" in entry for entry in trainer.state.log_history)
+        else:
+            assert all("entropy" not in entry for entry in trainer.state.log_history)
+
     def test_init_minimal(self):
         # Test that RLOOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -286,6 +286,33 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
 
 
 class TestSFTTrainer(TrlTestCase):
+    @pytest.mark.parametrize("log_entropy", [False, True])
+    @pytest.mark.parametrize("loss_type", ["nll", "chunked_nll"])
+    def test_log_entropy(self, log_entropy, loss_type):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+        # Leave the flag unset to exercise the default when entropy logging is enabled.
+        entropy_kwargs = {} if log_entropy else {"log_entropy": False}
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir,
+            max_steps=2,
+            logging_steps=1,
+            report_to="none",
+            loss_type=loss_type,
+            **entropy_kwargs,
+        )
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+        trainer.train()
+
+        assert any("loss" in entry for entry in trainer.state.log_history)
+        if log_entropy:
+            assert any("entropy" in entry for entry in trainer.state.log_history)
+        else:
+            assert all("entropy" not in entry for entry in trainer.state.log_history)
+
     def test_init_with_training_arguments(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
         args = TrainingArguments(output_dir=self.tmp_dir, report_to="none")

--- a/trl/experimental/gmpo/gmpo_trainer.py
+++ b/trl/experimental/gmpo/gmpo_trainer.py
@@ -55,7 +55,7 @@ class GMPOTrainer(GRPOTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            compute_entropy=True,
+            compute_entropy=self.top_entropy_quantile < 1.0 or self._entropy_bonus_enabled or self.args.log_entropy,
             pixel_values=inputs.get("pixel_values"),
             image_grid_thw=inputs.get("image_grid_thw"),
             num_images=inputs.get("num_images"),
@@ -138,7 +138,8 @@ class GMPOTrainer(GRPOTrainer):
         if self.beta != 0.0:
             self._metrics[mode]["kl"].append(global_masked_mean(per_token_kl))
 
-        self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
+        if self.args.log_entropy:
+            self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
 
         # Fraction of the tokens pushed into the clipped region, in log-space.
         is_low_clipped = (log_ratio < -self.epsilon_low) & (advantages_col < 0)

--- a/trl/experimental/gspo_token/grpo_trainer.py
+++ b/trl/experimental/gspo_token/grpo_trainer.py
@@ -34,7 +34,7 @@ class GRPOTrainer(_GRPOTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            compute_entropy=True,
+            compute_entropy=self.top_entropy_quantile < 1.0 or self._entropy_bonus_enabled or self.args.log_entropy,
             pixel_values=inputs.get("pixel_values"),
             image_grid_thw=inputs.get("image_grid_thw"),
             num_images=inputs.get("num_images"),
@@ -146,7 +146,8 @@ class GRPOTrainer(_GRPOTrainer):
         if self.beta != 0.0:
             self._metrics[mode]["kl"].append(global_masked_mean(per_token_kl))
 
-        self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
+        if self.args.log_entropy:
+            self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
 
         # Compute the clipped probability ratios
         is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -364,6 +364,8 @@ class GRPOConfig(_BaseConfig):
 
         > Parameters that control the logging
 
+        log_entropy (`bool`, *optional*, defaults to `True`):
+            Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training.
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
@@ -975,6 +977,12 @@ class GRPOConfig(_BaseConfig):
     )
 
     # Parameters that control the logging
+    log_entropy: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training."
+        },
+    )
     log_completions: bool = field(
         default=False,
         metadata={

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -3121,7 +3121,7 @@ class GRPOTrainer(_BaseTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            compute_entropy=True,
+            compute_entropy=self.top_entropy_quantile < 1.0 or self._entropy_bonus_enabled or self.args.log_entropy,
             compute_aux_loss=self.aux_loss_enabled,
             pixel_values=inputs.get("pixel_values"),
             image_grid_thw=inputs.get("image_grid_thw"),
@@ -3356,7 +3356,8 @@ class GRPOTrainer(_BaseTrainer):
         if self.beta != 0.0:
             self._metrics[mode]["kl"].append(global_masked_mean(per_token_kl))
 
-        self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
+        if self.args.log_entropy:
+            self._metrics[mode]["entropy"].append(global_masked_mean(entropies))
 
         if self.loss_type in ["grpo", "bnpo", "dr_grpo", "dapo", "luspo"]:
             # Compute the clipped probability ratios

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -208,6 +208,8 @@ class RLOOConfig(_BaseConfig):
 
         > Parameters that control the logging
 
+        log_entropy (`bool`, *optional*, defaults to `True`):
+            Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training.
         log_completions (`bool`, *optional*, defaults to `False`):
             Whether to log a sample of (prompt, completion) pairs every `logging_steps` steps. If `rich` is installed,
             it prints the sample. If `wandb` and/or `trackio` logging is enabled, it logs it to `wandb` and/or
@@ -564,6 +566,12 @@ class RLOOConfig(_BaseConfig):
     )
 
     # Parameters that control the logging
+    log_entropy: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training."
+        },
+    )
     log_completions: bool = field(
         default=False,
         metadata={

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1711,7 +1711,7 @@ class RLOOTrainer(_BaseTrainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            compute_entropy=True,
+            compute_entropy=self.args.log_entropy,
             compute_aux_loss=self.aux_loss_enabled,
             pixel_values=inputs.get("pixel_values"),
             image_grid_thw=inputs.get("image_grid_thw"),
@@ -1747,10 +1747,11 @@ class RLOOTrainer(_BaseTrainer):
             self._metrics[mode]["aux_loss"].append(self.accelerator.gather_for_metrics(aux_loss).mean().item())
 
         # Entropy
-        entropy_stats = self.accelerator.reduce(
-            torch.stack([(entropies * completion_mask).sum(), completion_mask.sum().float()]), reduction="sum"
-        )
-        self._metrics[mode]["entropy"].append((entropy_stats[0] / entropy_stats[1].clamp(min=1.0)).item())
+        if self.args.log_entropy:
+            entropy_stats = self.accelerator.reduce(
+                torch.stack([(entropies * completion_mask).sum(), completion_mask.sum().float()]), reduction="sum"
+            )
+            self._metrics[mode]["entropy"].append((entropy_stats[0] / entropy_stats[1].clamp(min=1.0)).item())
 
         # Compute the clipped probability ratios
         is_low_clipped = (coef_1 < 1 - self.epsilon_low) & (advantages < 0)

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -112,6 +112,8 @@ class SFTConfig(_BaseConfig):
               only (positions with `labels == -100` are dropped before the matmul) and the cross-entropy is processed
               in chunks of tokens to reduce peak activation memory. Not compatible with `use_liger_kernel`.
 
+        log_entropy (`bool`, *optional*, defaults to `True`):
+            Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training.
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
 
@@ -287,6 +289,12 @@ class SFTConfig(_BaseConfig):
             "processed in chunks of tokens to reduce peak activation memory; not compatible with `use_liger_kernel`; "
             "the patched `lm_head` path covers standard causal LMs and VLMs whose language model exposes a top-level "
             "`lm_head`, architectures with a non-standard head are not supported)."
+        },
+    )
+    log_entropy: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to log the per-token entropy metric. Disable to skip computing it unless needed for training."
         },
     )
     activation_offloading: bool = field(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -98,7 +98,7 @@ class _ChunkedCELMHeadOutput(CausalLMOutputWithPast):
     aux_loss: torch.Tensor | None = None
 
 
-def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
+def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping, compute_entropy):
     with maybe_gather_lm_head_ctx(w, b):
         # Project in the compute dtype and upcast only for the softmax, like `"nll"` and
         # `transformers`' own `ForCausalLMLoss` do. Matching the weight to the hidden-states dtype keeps the
@@ -115,7 +115,7 @@ def _chunk(h, w, b, lbl, logit_scale, final_logit_softcapping):
     chunk_loss = F.nll_loss(log_p, lbl, ignore_index=-100, reduction="sum")
     valid = lbl != -100
     chunk_correct = ((logits.argmax(dim=-1) == lbl) & valid).sum().float()
-    chunk_entropy = (-(log_p.exp() * log_p).sum(dim=-1) * valid).sum()
+    chunk_entropy = (-(log_p.exp() * log_p).sum(dim=-1) * valid).sum() if compute_entropy else None
     return chunk_loss, chunk_correct, chunk_entropy
 
 
@@ -129,7 +129,8 @@ def _chunked_cross_entropy_loss(
     logit_scale: float = 1.0,
     final_logit_softcapping: float | None = None,
     lm_head_bias: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    compute_entropy: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
     """
     Memory-efficient next-token cross-entropy over hidden states and an `lm_head` weight.
 
@@ -171,11 +172,14 @@ def _chunked_cross_entropy_loss(
             matching the `final_logit_softcapping` behavior of Gemma-style models. Applied after `logit_scale`.
         lm_head_bias (`torch.Tensor`, *optional*):
             Bias of the `lm_head` linear layer, shape `(V,)`. Added to each chunk's logits when provided.
+        compute_entropy (`bool`, *optional*, defaults to `True`):
+            Whether to compute per-token entropy. When disabled, the entropy sum is `None`.
 
     Returns:
-        `tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]`: scalar loss, number of correctly-predicted
-        tokens (count), sum of per-token Shannon entropy (in nats), and number of valid (non-`-100`) target tokens —
-        all over the local batch. Raw sums are returned so callers can reduce correctly across ranks.
+        `tuple[torch.Tensor, torch.Tensor, torch.Tensor or None, torch.Tensor]`: scalar loss, number of
+        correctly-predicted tokens (count), sum of per-token Shannon entropy (in nats, or `None` when disabled), and
+        number of valid (non-`-100`) target tokens, all over the local batch. Raw sums are returned so callers can
+        reduce correctly across ranks.
     """
     if labels is None and shift_labels is None:
         raise ValueError("At least one of `labels` or `shift_labels` must be provided.")
@@ -191,7 +195,7 @@ def _chunked_cross_entropy_loss(
     n_valid_tensor = valid.sum()
 
     correct = hidden.new_zeros((), dtype=torch.float32)
-    entropy_sum = hidden.new_zeros((), dtype=torch.float32)
+    entropy_sum = hidden.new_zeros((), dtype=torch.float32) if compute_entropy else None
 
     # Pack valid tokens to the front so masked positions form whole trailing chunks. `argsort` on the boolean mask is
     # a static-shape op (unlike `hidden[valid]`, whose output shape is data-dependent and poisons XLA compilation).
@@ -217,11 +221,13 @@ def _chunked_cross_entropy_loss(
             lbl_chunk,
             logit_scale,
             final_logit_softcapping,
+            compute_entropy,
             use_reentrant=False,
         )
         loss = loss + chunk_loss
         correct = correct + chunk_correct
-        entropy_sum = entropy_sum + chunk_entropy
+        if compute_entropy:
+            entropy_sum = entropy_sum + chunk_entropy
 
     if num_items_in_batch is None:
         # Clamped for the same reason: a fully-masked rank reduces to a finite zero rather than `0 / 0`.
@@ -233,7 +239,9 @@ def _chunked_cross_entropy_loss(
     return loss, correct, entropy_sum, n_valid_tensor
 
 
-def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: bool = False) -> None:
+def _patch_chunked_ce_lm_head(
+    model: torch.nn.Module, chunk_size: int, is_vlm: bool = False, compute_entropy: bool = True
+) -> None:
     """
     Patch `model.forward` to compute the LM loss via [`_chunked_cross_entropy_loss`].
 
@@ -258,6 +266,8 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             Set to `True` for VLMs. Only used for the transformers < 5.0.0 fallbacks: VLMs set `base_model_prefix = ""`
             there (so the backbone must be read off `model.model`), and they take the config-level MoE aux-loss
             parameters rather than the model-level ones.
+        compute_entropy (`bool`, *optional*, defaults to `True`):
+            Whether to compute per-token entropy. When disabled, the entropy sum is `None`.
     """
     # On VLMs the logit post-processing lives on `text_config`, so read it through `get_text_config()`. The MoE
     # `output_router_logits` flag lives there too, and is read off the same config below.
@@ -337,6 +347,7 @@ def _patch_chunked_ce_lm_head(model: torch.nn.Module, chunk_size: int, is_vlm: b
             logit_scale=logit_scale,
             final_logit_softcapping=final_logit_softcapping,
             lm_head_bias=lm_head_bias,
+            compute_entropy=compute_entropy,
         )
 
         aux_loss = None
@@ -1342,7 +1353,12 @@ class SFTTrainer(_BaseTrainer):
                             "`lm_head` from `target_modules`, or switch to `loss_type='nll'`. If this is a real use "
                             "case for you, please open an issue at https://github.com/huggingface/trl/issues."
                         )
-                _patch_chunked_ce_lm_head(target, chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE, is_vlm=self._is_vlm)
+                _patch_chunked_ce_lm_head(
+                    target,
+                    chunk_size=_CHUNKED_LM_HEAD_CHUNK_SIZE,
+                    is_vlm=self._is_vlm,
+                    compute_entropy=args.log_entropy,
+                )
             else:
                 raise ValueError(
                     f"Invalid `loss_type` {args.loss_type} passed. Supported values are 'nll', 'dft', and "
@@ -1812,9 +1828,10 @@ class SFTTrainer(_BaseTrainer):
             # forward, so the valid-token count over the padded labels can differ from the un-padded `labels[..., 1:]`
             # count by up to one per sequence; using the patched output keeps numerator and denominator aligned.
             num_valid = self.accelerator.gather_for_metrics(outputs.num_valid_tokens).sum()
-            entropy_sum = self.accelerator.gather_for_metrics(outputs.entropy_sum).sum()
-            entropy = (entropy_sum / num_valid).item() if num_valid > 0 else 0.0
-            self._metrics[mode]["entropy"].append(entropy)
+            if outputs.entropy_sum is not None:
+                entropy_sum = self.accelerator.gather_for_metrics(outputs.entropy_sum).sum()
+                entropy = (entropy_sum / num_valid).item() if num_valid > 0 else 0.0
+                self._metrics[mode]["entropy"].append(entropy)
         elif not self.args.use_liger_kernel:  # liger doesn't return logits
             with torch.no_grad():
                 if "shift_labels" in inputs:
@@ -1832,24 +1849,26 @@ class SFTTrainer(_BaseTrainer):
                 ):
                     shift_logits = shift_logits[:, self.num_virtual_tokens :, :]
 
-                per_token_entropy = entropy_from_logits(shift_logits)
                 predictions = shift_logits.argmax(dim=-1)
                 mask = shift_labels != -100
 
-                entropy_sum = (per_token_entropy * mask).sum()
                 total_tokens = mask.sum()
                 correct_predictions = (predictions == shift_labels) & mask
                 correct_tokens = correct_predictions.sum()
 
                 # Gather counts across ranks and weight-average
-                entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
                 total_tokens = self.accelerator.gather_for_metrics(total_tokens).sum()
                 correct_tokens = self.accelerator.gather_for_metrics(correct_tokens)
-                entropy = (entropy_sum / total_tokens).item() if total_tokens > 0 else 0.0
 
                 total_sum = total_tokens.sum()
                 accuracy = (correct_tokens.sum() / total_sum).item() if total_sum > 0 else 0.0
-            self._metrics[mode]["entropy"].append(entropy)
+
+                if self.args.log_entropy:
+                    per_token_entropy = entropy_from_logits(shift_logits)
+                    entropy_sum = (per_token_entropy * mask).sum()
+                    entropy_sum = self.accelerator.gather_for_metrics(entropy_sum).sum()
+                    entropy = (entropy_sum / total_tokens).item() if total_tokens > 0 else 0.0
+                    self._metrics[mode]["entropy"].append(entropy)
             self._metrics[mode]["mean_token_accuracy"].append(accuracy)
 
         if mode == "train":


### PR DESCRIPTION
# What does this PR do?

Adds `log_entropy` (default `True`) to `SFTConfig`, `GRPOConfig` and `RLOOConfig` so the per-token entropy metric can be switched off.

The metric is computed on every forward pass today, and it is not free: on the CPU measurement in the issue thread, `entropy_from_logits` over a `(6, 256, 151936)` logits tensor took 2342 ms against 1090 ms for `selective_log_softmax`, and fusing the two passes did not help because both are bandwidth-bound on the logits. The only way to avoid the cost is to not compute it.

With `log_entropy=False`:

- `SFTTrainer` skips `entropy_from_logits` on the `nll` path and skips the per-chunk entropy reduction on the `chunked_nll` path (`_chunked_cross_entropy_loss` and `_patch_chunked_ce_lm_head` take a `compute_entropy` argument; the entropy sum is `None` when disabled). `mean_token_accuracy` is unchanged.
- `GRPOTrainer`, `RLOOTrainer`, and the GMPO and GSPO-token copies of `_compute_loss` request entropies only when the loss needs them (`top_entropy_quantile < 1.0` or an active entropy bonus in GRPO; never in RLOO, which has no such option) and do not append the `entropy` metric. The four GRPO-family blocks are identical.
- DPO, KTO and TPO are out of scope; they compute entropy at their own loss sites and are left as they are.

Tests: `test_log_entropy` in `test_sft_trainer.py` (over `nll` and `chunked_nll`), `test_grpo_trainer.py` and `test_rloo_trainer.py` assert the `entropy` key is absent from every `log_history` entry when the flag is off and present by default. A mutant that appends the SFT metric unconditionally fails exactly the `nll-False` row. Docs for the three trainers name the flag next to the `entropy` metric.

This is shape 1 of the two offered on the issue on 2026-08-05 (a config flag, as the issue title asks). Shape 2 (derive the metric from need and drop it by default) would remove the metric for everyone, which loses a useful entropy-collapse signal, so the flag keeps the default behaviour unchanged.

Fixes #4184

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec @albertvillanova

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in performance optimization with default behavior unchanged; training paths that require entropy for regularization or masking still compute it.
> 
> **Overview**
> Adds **`log_entropy`** (default `True`) on `SFTConfig`, `GRPOConfig`, and `RLOOConfig` so training can avoid the expensive per-token entropy pass when you only care about loss and other metrics.
> 
> **SFT:** With `log_entropy=False`, the trainer skips `entropy_from_logits` on the `nll` path and passes `compute_entropy=False` through chunked CE (`_chunked_cross_entropy_loss` / `_patch_chunked_ce_lm_head`). `mean_token_accuracy` is unchanged.
> 
> **GRPO / RLOO (and GMPO / GSPO-token GRPO variants):** Entropy is still computed when the loss needs it (`top_entropy_quantile`, entropy bonus on GRPO); otherwise it follows `log_entropy`. The logged `entropy` metric is only recorded when `log_entropy` is true.
> 
> Docs for the three trainers note the flag next to the `entropy` metric; new parametrized tests assert presence/absence of `entropy` in `log_history`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd1cf9336dabae21a693f80dac5a14138ecfb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->