### PR TITLE
fix(grpo): add opt-in mask_zero_advantage_groups for zero-variance groups under beta>0

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -101,6 +101,9 @@ where the first term represents the scaled advantage and the second term penaliz
 > [!TIP]
 > Note that compared to the original formulation in [DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models](https://huggingface.co/papers/2402.03300), we use  \\( \beta = 0.0 \\) by default, meaning that the KL divergence term is not used. This choice is motivated by several recent studies (e.g., [Open-Reasoner-Zero: An Open Source Approach to Scaling Up Reinforcement Learning on the Base Model](https://huggingface.co/papers/2503.24290)) which have shown that the KL divergence term is not essential for training with GRPO. As a result, it has become common practice to exclude it (e.g. [Understanding R1-Zero-Like Training: A Critical Perspective](https://huggingface.co/papers/2503.20783), [DAPO: An Open-Source LLM Reinforcement Learning System at Scale](https://huggingface.co/papers/2503.14476)). If you wish to include the KL divergence term, you can set `beta` in [`GRPOConfig`] to a non-zero value.
 
+> [!TIP]
+> When  \\( \beta > 0 \\), a prompt group whose completions all receive the same reward has  \\( \hat{A}_{i,t} = 0 \\) for every token, so the first term above drops out — but the KL term still applies per-token regardless of the advantage, so that group still contributes a gradient. [Revisiting Group Relative Policy Optimization](https://huggingface.co/papers/2505.22257) proposes masking these zero-variance groups out of the loss entirely. You can enable this by setting `mask_zero_advantage_groups=True` in [`GRPOConfig`]; it's disabled by default to preserve the objective above exactly as written.
+
 In the original paper, this formulation is generalized to account for multiple updates after each generation (denoted  \\( \mu \\), can be set with `num_iterations` in [`GRPOConfig`]) by leveraging the **clipped surrogate objective**:
 
 $$

--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -235,6 +235,21 @@ training_args = GRPOConfig(
 )
 ```
 
+### Revisiting Group Relative Policy Optimization
+
+**📜 Paper**: https://huggingface.co/papers/2505.22257
+
+Section 3.2 ("On-Policy Clipped Objective with Zero Variance Masking à la DAPO") observes that when every completion in a group receives the same reward, the group's advantage is exactly zero, so the policy loss contributes no gradient — but a KL-regularized objective (`beta > 0`) still applies its per-token KL penalty to that group regardless, since it doesn't depend on the advantage. The paper proposes masking these zero-variance groups out of the objective entirely, hybridizing DAPO's oversampling-based zero-variance handling with a KL-regularized loss. Use [`GRPOConfig`]'s `mask_zero_advantage_groups` to reproduce this:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    beta=0.001,  # illustrative, not paper-specified: masking only matters when beta > 0 (it's a no-op at beta=0.0)
+    mask_zero_advantage_groups=True,
+)
+```
+
 ### Skywork-OR1: Open Reasoning Models
 
 **📜 Paper**: https://huggingface.co/papers/2505.22312

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -2681,6 +2681,49 @@ class TestGRPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert torch.equal(param, new_param), f"Parameter {n} has changed."
 
+    @pytest.mark.parametrize("mask_zero_advantage_groups", [False, True])
+    def test_train_with_mask_zero_advantage_groups(self, mask_zero_advantage_groups):
+        """
+        With beta > 0 and a reward function that returns the same value for every completion, every group has zero
+        reward std, so the advantage (and hence the policy loss) is exactly zero. With
+        mask_zero_advantage_groups=False (default), the per-token KL penalty still applies to these groups and
+        updates the model; with mask_zero_advantage_groups=True, those groups are masked out of the loss entirely
+        and the model does not update.
+        """
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        def constant_reward_func(completions, **kwargs):
+            return [1.0] * len(completions)
+
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            beta=0.1,  # KL regularization must be enabled for the spurious gradient to occur
+            learning_rate=0.1,  # use higher lr because gradients are tiny and default lr can stall updates
+            per_device_train_batch_size=3,  # reduce the batch size to reduce memory usage
+            num_generations=3,  # reduce the number of generations to reduce memory usage
+            max_completion_length=8,  # reduce the completion length to reduce memory usage
+            mask_zero_advantage_groups=mask_zero_advantage_groups,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            reward_funcs=constant_reward_func,
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+        trainer.train()
+
+        params_changed = any(
+            not torch.equal(param, trainer.model.get_parameter(n)) for n, param in previous_trainable_params.items()
+        )
+        if mask_zero_advantage_groups:
+            assert not params_changed, "Params should not change: zero-std groups were masked out of the loss."
+        else:
+            assert params_changed, "Params should change from the unmasked KL gradient on the zero-std groups."
+
     def test_warning_raised_all_rewards_none(self, caplog):
         """Test that a proper warning is raised when all rewards are None."""
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -240,6 +240,13 @@ class GRPOConfig(_BaseConfig):
             - `False` or `"none"`: no scaling is applied. The [Dr. GRPO
               paper](https://huggingface.co/papers/2503.20783) recommends not scaling rewards, as scaling by the
               standard deviation introduces a question-level difficulty bias.
+        mask_zero_advantage_groups (`bool`, *optional*, defaults to `False`):
+            Whether to zero out the completion mask for prompt groups whose reward std is zero (i.e.,
+            zero-variance/zero-advantage groups), so they contribute no gradient from either the policy loss or,
+            when `beta > 0`, the KL penalty term. This matches the zero-variance masking proposed in [Revisiting
+            Group Relative Policy Optimization](https://huggingface.co/papers/2505.22257), Section 3.2. Disabled by
+            default: the canonical GRPO objective applies the KL term per-token independently of the advantage, so a
+            zero-std group with `beta > 0` still contributes a KL gradient unless this is enabled.
         loss_type (`str`, *optional*, defaults to `"dapo"`):
             Specifies the loss formulation to use. Supported values are:
 
@@ -789,6 +796,17 @@ class GRPOConfig(_BaseConfig):
             "PPO Lite paper. "
             "`False` or `'none'`: no scaling is applied. The Dr. GRPO paper recommends not scaling rewards, as "
             "scaling by the standard deviation introduces a question-level difficulty bias."
+        },
+    )
+    mask_zero_advantage_groups: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to zero out the completion mask for prompt groups whose reward std is zero (i.e., "
+            "zero-variance/zero-advantage groups), so they contribute no gradient from either the policy loss or, "
+            "when `beta > 0`, the KL penalty term. This matches the zero-variance masking proposed in 'Revisiting "
+            "Group Relative Policy Optimization' (https://huggingface.co/papers/2505.22257), Section 3.2. Disabled by "
+            "default: the canonical GRPO objective applies the KL term per-token independently of the advantage, "
+            "so a zero-std group with `beta > 0` still contributes a KL gradient unless this is enabled."
         },
     )
     loss_type: str = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -816,6 +816,7 @@ class GRPOTrainer(_BaseTrainer):
                     "`use_liger_kernel=False`."
                 )
         self.mask_truncated_completions = args.mask_truncated_completions
+        self.mask_zero_advantage_groups = args.mask_zero_advantage_groups
         self.top_entropy_quantile = args.top_entropy_quantile
         if self.use_liger_kernel and self.top_entropy_quantile < 1.0:
             raise NotImplementedError(
@@ -2913,13 +2914,14 @@ class GRPOTrainer(_BaseTrainer):
                 nanmax(self.accelerator.gather(max_importance_sampling_ratio)).item()
             )
 
-        # When all completions in a reward group receive identical rewards, advantages
-        # are zero and the policy loss contributes no gradient. However, the per-token
-        # KL penalty (beta * per_token_kl in compute_loss) still fires because
-        # per_token_logps retains gradients while ref_per_token_logps is detached.
-        # Zeroing completion_mask for zero-std groups suppresses both the policy loss
-        # and the spurious KL gradient simultaneously. See issue #5588.
-        if self.beta != 0.0:
+        # Opt-in zero-variance masking (mask_zero_advantage_groups): when all completions in a reward
+        # group receive identical rewards, the group's advantage is already zero, so the policy loss
+        # contributes no gradient. If beta > 0, though, the per-token KL penalty in compute_loss still
+        # fires for that group, since per_token_logps retains gradients while ref_per_token_logps is
+        # detached. Zeroing completion_mask for zero-std groups suppresses both the (already-zero) policy
+        # loss and that KL gradient. Disabled by default: the canonical GRPO objective applies KL
+        # per-token independently of the advantage, so this is left opt-in rather than a default.
+        if self.mask_zero_advantage_groups:
             is_std_zero_local = is_std_zero[process_slice]  # shape: (local_completions,)
             completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2913,6 +2913,16 @@ class GRPOTrainer(_BaseTrainer):
                 nanmax(self.accelerator.gather(max_importance_sampling_ratio)).item()
             )
 
+        # When all completions in a reward group receive identical rewards, advantages
+        # are zero and the policy loss contributes no gradient. However, the per-token
+        # KL penalty (beta * per_token_kl in compute_loss) still fires because
+        # per_token_logps retains gradients while ref_per_token_logps is detached.
+        # Zeroing completion_mask for zero-std groups suppresses both the policy loss
+        # and the spurious KL gradient simultaneously. See issue #5588.
+        if self.beta != 0.0:
+            is_std_zero_local = is_std_zero[process_slice]  # shape: (local_completions,)
+            completion_mask = completion_mask * (~is_std_zero_local).unsqueeze(1).int()
+
         output = {
             "prompt_ids": prompt_ids,
             "prompt_mask": prompt_mask,


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

Follow-up to #5588 ("Zero-std reward groups produce spurious KL gradients when `beta > 0`"), which was closed by @qgallouedec as expected GRPO behavior rather than a bug — with a suggestion that if there's interest, it could be added as an opt-in flag (e.g. `mask_zero_advantage_groups: bool = False`) referencing the paper raised in that discussion. This PR implements exactly that.

**What it does:** when `beta > 0` and every completion in a reward group gets the same reward, the group's advantage is exactly zero, so the policy loss term drops out — but the per-token KL penalty still applies regardless of the advantage, so the group still contributes a gradient. `GRPOConfig.mask_zero_advantage_groups` (default `False`, per `CONTRIBUTING.md`'s opt-in-for-new-features guideline) masks the completion mask for these zero-std groups when enabled, matching the zero-variance masking proposed in [Revisiting Group Relative Policy Optimization](https://huggingface.co/papers/2505.22257), Section 3.2.

Also checked whether RLOO needs the same flag (the original issue's title mentioned both trainers): it doesn't. RLOO folds the KL penalty into the reward *before* computing `std_rewards`/advantages, so a genuinely zero-std group there already has zero gradient by construction — there's no separate KL loss term the way GRPO's `compute_loss` adds one. Left RLOO untouched rather than adding a no-op flag.

Updated `docs/source/paper_index.md` per `.ai/AGENTS.md`'s requirement for PRs implementing a paper's method, and added a matching `docs/source/grpo_trainer.md` tip next to the existing `beta` documentation.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #5588, see maintainer comment: https://github.com/huggingface/trl/issues/5588#issuecomment-3282898242
- [x] Did you make sure to update the documentation with your changes? `docs/source/grpo_trainer.md`, `docs/source/paper_index.md`
- [x] Did you write any new necessary tests? `tests/test_grpo_trainer.py::TestGRPOTrainer::test_train_with_mask_zero_advantage_groups`

## AI writing disclosure

- [x] AI-generated: the PR was mostly or fully generated by an AI tool (Claude Code), under my direction and review. I understand the change, engaged with the maintainer's original issue discussion in scoping it, and can discuss/iterate on it.

## Who can review?

@qgallouedec — tagging since you closed #5588 and suggested this exact opt-in approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in config defaulting to False; only affects loss masking when enabled, mainly relevant for KL-regularized GRPO runs.
> 
> **Overview**
> Adds **`GRPOConfig.mask_zero_advantage_groups`** (default `False`) so training can match zero-variance masking from [Revisiting GRPO](https://huggingface.co/papers/2505.22257) when **`beta > 0`**.
> 
> With identical rewards in a group, advantages are zero so the policy term vanishes, but the per-token KL penalty can still update weights. When the flag is enabled, **`GRPOTrainer`** zeros **`completion_mask`** for those zero–reward-std groups before loss, removing both policy and KL contributions from them. Default behavior is unchanged.
> 
> Docs add a tip in **`grpo_trainer.md`**, a **`paper_index.md`** entry, and **`test_train_with_mask_zero_advantage_groups`** checks that parameters move only from KL when masking is off and stay fixed when it is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ff0c8a0076a61d7d7b6ad58b50d3813884f577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->