### PR TITLE
Fix compute_flops_per_token for the MoE configs it claims to support

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 import transformers
 from datasets import IterableDataset
 from packaging.version import Version
-from transformers import AutoConfig, AutoModelForCausalLM, PretrainedConfig
+from transformers import AutoConfig, AutoModelForCausalLM, MixtralConfig, PretrainedConfig, Qwen2MoeConfig
 from transformers.testing_utils import torch_device
 from transformers.utils import is_peft_available
 
@@ -1635,10 +1635,44 @@ class TestComputeFlopsPerToken(TrlTestCase):
         f_lo = compute_flops_per_token(cfg, 16384)
         cfg.num_experts_per_tok = 2
         f_hi = compute_flops_per_token(cfg, 16384)
-        moe_layers = sum(1 for i in range(cfg.num_hidden_layers) if i % cfg.decoder_sparse_step == 0)
+        moe_layers = sum(1 for i in range(cfg.num_hidden_layers) if (i + 1) % cfg.decoder_sparse_step == 0)
         per_expert_per_layer = 2 * 3 * cfg.hidden_size * cfg.moe_intermediate_size
         expected_delta = 3 * moe_layers * (2 - 1) * per_expert_per_layer
         assert f_hi - f_lo == expected_delta
+
+    def test_moe_config_attribute_spellings(self):
+        # MoE families spell the expert count and size differently: Mixtral uses `num_local_experts`
+        # with `intermediate_size`, Qwen2-MoE uses `num_experts` with `moe_intermediate_size`. Both
+        # must be counted, not raise.
+        mixtral = MixtralConfig(hidden_size=64, num_hidden_layers=2, intermediate_size=128, vocab_size=100)
+        qwen2_moe = Qwen2MoeConfig(hidden_size=64, num_hidden_layers=2, moe_intermediate_size=32, vocab_size=100)
+        assert compute_flops_per_token(mixtral, 512) > 0
+        assert compute_flops_per_token(qwen2_moe, 512) > 0
+
+    def test_moe_expert_size_from_intermediate_size(self):
+        # Mixtral has no `moe_intermediate_size`; its experts are `intermediate_size` wide. Doubling
+        # that must double the routed-expert term.
+        cfg = MixtralConfig(hidden_size=64, num_hidden_layers=2, intermediate_size=128, vocab_size=100)
+        f_lo = compute_flops_per_token(cfg, 512)
+        cfg.intermediate_size = 256
+        f_hi = compute_flops_per_token(cfg, 512)
+        per_layer = cfg.num_experts_per_tok * 2 * 3 * cfg.hidden_size * 128
+        assert f_hi - f_lo == 3 * cfg.num_hidden_layers * per_layer
+
+    def test_moe_sparse_step_and_mlp_only_layers(self):
+        # transformers puts the sparse block on layer `i` when `(i + 1) % decoder_sparse_step == 0`
+        # and `i` is not in `mlp_only_layers`, so both settings change how many layers are MoE.
+        cfg = Qwen2MoeConfig(
+            hidden_size=64, num_hidden_layers=4, intermediate_size=128, moe_intermediate_size=32, vocab_size=100
+        )
+        all_moe = compute_flops_per_token(cfg, 512)
+        cfg.decoder_sparse_step = 2
+        half_moe = compute_flops_per_token(cfg, 512)
+        cfg.decoder_sparse_step = 1
+        cfg.mlp_only_layers = [0, 1]
+        two_dense = compute_flops_per_token(cfg, 512)
+        assert half_moe < all_moe
+        assert half_moe == two_dense
 
     def test_config_without_head_dim(self):
         # `head_dim` is optional on configs: Qwen2 doesn't declare it. Falling back to `hidden_size //

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -1615,17 +1615,30 @@ def compute_flops_per_token(config: PretrainedConfig, seq_len: int) -> int:
         mlp_flops = 2 * 3 * h * config.intermediate_size
         total_layer_flops = L * (attn_flops + mlp_flops)
     else:
-        # Routed experts (gate + up + down, 3 matmuls each) + router.
-        if Version(transformers.__version__) >= Version("5.1.0"):
-            num_experts = config.num_local_experts
-        else:
+        # Routed experts (gate + up + down, 3 matmuls each) + router. MoE families spell these
+        # differently: Mixtral counts experts in `num_local_experts` and sizes them with
+        # `intermediate_size`, Qwen2-MoE counts them in `num_experts` and sizes them with
+        # `moe_intermediate_size`. Read whichever the config declares.
+        num_experts = getattr(config, "num_local_experts", None)
+        if num_experts is None:
             num_experts = config.num_experts
-        moe_mlp_flops = num_experts_per_tok * 2 * 3 * h * config.moe_intermediate_size
+        expert_intermediate_size = getattr(config, "moe_intermediate_size", None) or config.intermediate_size
+        moe_mlp_flops = num_experts_per_tok * 2 * 3 * h * expert_intermediate_size
         moe_mlp_flops += 2 * h * num_experts
         dense_mlp_flops = 2 * 3 * h * config.intermediate_size  # interspersed dense layers
-        sparse_step = config.decoder_sparse_step
+        # transformers puts the sparse block on layer `i` when `(i + 1) % decoder_sparse_step == 0`
+        # and `i` is not in `mlp_only_layers`; a config declaring neither (Mixtral) is sparse in
+        # every layer.
+        sparse_step = getattr(config, "decoder_sparse_step", 1)
+        mlp_only_layers = getattr(config, "mlp_only_layers", None) or []
         total_layer_flops = sum(
-            attn_flops + (moe_mlp_flops if layer_idx % sparse_step == 0 else dense_mlp_flops) for layer_idx in range(L)
+            attn_flops
+            + (
+                moe_mlp_flops
+                if layer_idx not in mlp_only_layers and (layer_idx + 1) % sparse_step == 0
+                else dense_mlp_flops
+            )
+            for layer_idx in range(L)
         )
 
     embed_flops = 2 * V * h


### PR DESCRIPTION
## What does this PR do?

`compute_flops_per_token` raises `AttributeError` on two of the three MoE families its own docstring names.

```
transformers 5.5.0
Mixtral    -> AttributeError: 'MixtralConfig' object has no attribute 'moe_intermediate_size'
Qwen2-MoE  -> AttributeError: 'Qwen2MoeConfig' object has no attribute 'num_local_experts'
Qwen3-MoE  -> 12,982,419,456
```

Two causes:

1. **Expert count and expert width are spelled differently per family.** Mixtral counts experts in `num_local_experts` and sizes them with `intermediate_size`; Qwen2-MoE counts them in `num_experts` and sizes them with `moe_intermediate_size`. The transformers-version switch picked `num_local_experts` on 5.1+, which Qwen2-MoE never declares. Now read whichever spelling the config carries.

2. **The MoE-layer rule was off by one and ignored `mlp_only_layers`.** transformers uses `(layer_idx not in config.mlp_only_layers) and (layer_idx + 1) % config.decoder_sparse_step == 0`; this used `layer_idx % sparse_step == 0`.

Qwen3-MoE is unchanged by this PR (12,982,419,456 before and after), so the fix is a no-op on the path that already worked.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Test

Three new tests in `TestComputeFlopsPerToken`, plus the existing `test_moe_active_vs_total_experts` mirror expression updated to the corrected layer rule.

```
pytest tests/test_utils.py -k "moe_config_attribute_spellings or moe_expert_size_from_intermediate_size or moe_sparse_step_and_mlp_only_layers"
before: 3 failed
pytest tests/test_utils.py -k "ComputeFlopsPerToken or ComputeMfu"
after: 8 passed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only FLOPs/MFU estimation helpers and tests; training forward/backward paths are untouched, though reported MFU for some MoE configs may shift slightly where the layer rule was wrong.
> 
> **Overview**
> **Fixes `compute_flops_per_token` for Mixtral and Qwen2-MoE** so MFU-style metrics no longer crash with `AttributeError` and layer counts match transformers.
> 
> MoE expert count and width are read from whichever config fields exist (`num_local_experts` / `num_experts`, `moe_intermediate_size` / `intermediate_size`) instead of assuming one naming scheme or a transformers version gate. Routed-expert FLOPs and which layers count as sparse now follow transformers: `(layer_idx + 1) % decoder_sparse_step == 0`, respect `mlp_only_layers`, and default sparse step to 1 when unset.
> 
> **Tests** add coverage for both config spellings, Mixtral expert sizing via `intermediate_size`, and sparse-step / MLP-only layering; the existing active-experts test is updated to the corrected layer rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e09c1d29b4a8546ce995447668ee3c1bea214e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->