### PR TITLE
Allow Liger with ServerDistillationTrainer

### DIFF
--- a/tests/experimental/test_server_distillation_trainer.py
+++ b/tests/experimental/test_server_distillation_trainer.py
@@ -74,9 +74,10 @@ def _variable_length_dataset():
     )
 
 
-def test_config_rejects_liger(tmp_path):
-    with pytest.raises(ValueError, match="use_liger_kernel=True is not supported by ServerDistillationTrainer"):
-        ServerDistillationConfig(**_make_server_config_kwargs(tmp_path), use_liger_kernel=True)
+def test_config_accepts_liger(tmp_path):
+    config = ServerDistillationConfig(**_make_server_config_kwargs(tmp_path), use_liger_kernel=True)
+
+    assert config.use_liger_kernel
 
 
 def test_config_rejects_reverse_kl_argmax(tmp_path):

--- a/trl/experimental/server_distillation/server_distillation_config.py
+++ b/trl/experimental/server_distillation/server_distillation_config.py
@@ -87,11 +87,6 @@ class ServerDistillationConfig(DistillationConfig):
 
         if self.reverse_kl_top_1_mode not in {"sampled", "argmax"}:
             raise ValueError("reverse_kl_top_1_mode must be one of: 'sampled', 'argmax'")
-        if self.use_liger_kernel:
-            raise ValueError(
-                "use_liger_kernel=True is not supported by ServerDistillationTrainer because the Liger loss path "
-                "requires a local teacher model."
-            )
         if self.teacher_model_server_url is None or not self.teacher_model_server_url.strip():
             raise ValueError("teacher_model_server_url must be set for ServerDistillationTrainer.")
         if self.beta == 0 and self.loss_top_k < 1:


### PR DESCRIPTION
# What does this PR do?

`ServerDistillationConfig` still rejected `use_liger_kernel=True` because the former fused distillation loss required a local teacher. After #7064 removed that loss path, server distillation uses its own sparse server loss while Transformers can apply the ordinary Liger model optimizations to the student.

This removes the obsolete validation and updates the focused configuration regression to require that the option is accepted. It follows the post-merge finding at https://github.com/huggingface/trl/pull/7064#discussion_r3937507852.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (not applicable).
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? (Not applicable; this is a focused follow-up to the linked review finding.)
- [ ] Did you make sure to update the documentation with your changes? (No documentation change is needed for removing an obsolete rejection.)
- [x] Did you write any new necessary tests?

## Tests

- Before the implementation change: `test_config_accepts_liger` failed with the obsolete `ValueError`.
- `python -m pytest tests/experimental/test_server_distillation_trainer.py -q` — 12 passed.
- `uvx ruff==0.13.3 check trl/experimental/server_distillation/server_distillation_config.py tests/experimental/test_server_distillation_trainer.py` — passed.
- `uvx ruff==0.13.3 format --check trl/experimental/server_distillation/server_distillation_config.py tests/experimental/test_server_distillation_trainer.py` — passed.
- `git diff --check` — passed.

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

@qgallouedec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change removing obsolete validation; no trainer or loss-path logic is modified in this diff.
> 
> **Overview**
> **Server distillation** no longer blocks `use_liger_kernel=True` on `ServerDistillationConfig`. The `__post_init__` check that raised because the old fused Liger distillation path needed a local teacher is removed, so Liger can apply to the student via the usual Transformers integration while teacher scoring stays on the remote server.
> 
> The regression test is flipped from expecting rejection to asserting that `use_liger_kernel=True` is accepted and stored on the config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164eaba47c5b26cace758799bc05b5892e400b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->