### PR TITLE
Raise when SFTTrainer cannot infer a processor from an empty `_name_or_path`

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -31,6 +31,8 @@ from transformers import (
     AutoModelForImageTextToText,
     AutoTokenizer,
     BitsAndBytesConfig,
+    LlamaConfig,
+    LlamaForCausalLM,
     TrainingArguments,
 )
 from transformers.testing_utils import backend_device_count, backend_empty_cache, torch_device
@@ -1040,6 +1042,23 @@ class TestSFTTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_from_config_model_requires_processing_class(self):
+        # from_config leaves `_name_or_path` empty, so auto-loading the processor would hit the Hub with repo id "".
+        config = LlamaConfig(
+            vocab_size=32,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            max_position_embeddings=32,
+        )
+        model = LlamaForCausalLM(config)
+        dataset = Dataset.from_dict({"text": ["hello world"]})
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none", use_cpu=True)
+
+        with pytest.raises(ValueError, match=r"config\._name_or_path.*processing_class"):
+            SFTTrainer(model=model, args=training_args, train_dataset=dataset)
 
     def test_dataset_with_transform_requires_skip_prepare_dataset(self):
         dataset = Dataset.from_dict({"text": ["hello world"]})

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1000,9 +1000,13 @@ class SFTTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer a tokenizer/processor from the model: `config._name_or_path` is empty. This is "
+                    "expected for models initialized with `from_config`. Pass `processing_class` explicitly."
+                )
+            processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
 
         # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):


### PR DESCRIPTION
# What does this PR do?

When `processing_class` is omitted, `SFTTrainer` loads it with `AutoProcessor.from_pretrained(get_config_model_id(model.config))`. Models created with `from_config` have `_name_or_path=""`, so that call becomes `from_pretrained("")` and raises a Hub repo-id `OSError`.

This checks for an empty id first and raises a `ValueError` telling the caller to pass `processing_class`. Passing a tokenizer still works; this only changes the auto-load path.

Fixes #7071

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

@qgallouedec

Made with [Cursor](https://cursor.com)