### PR TITLE
fix(sft): raise clear ValueError when config _name_or_path is empty

### DIFF
--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1000,8 +1000,14 @@ class SFTTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "The model configuration has an empty `_name_or_path`. When training a model instantiated "
+                    "from a config (e.g. `from_config`), `processing_class` must be passed explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
+                model_id, trust_remote_code=args.trust_remote_code
             )
 
         # Handle pad token for processors or tokenizers


### PR DESCRIPTION
AutoProcessor.from_pretrained('') fails with a confusing Hub repo-id error when training a model instantiated from a config. Fail fast with guidance to pass processing_class explicitly.

Fixes #7071

Reproduced locally with the exact script from the issue (OSError: Repo id must use alphanumeric chars...). After the fix it raises ValueError with a clear message. Existing test TestSFTTrainer::test_init_with_training_arguments still passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small init-path validation change with no impact on normal pretrained-model training flows.
> 
> **Overview**
> When `SFTTrainer` auto-loads a processor and the model was built from a config with no `_name_or_path`, it no longer calls `AutoProcessor.from_pretrained('')` and surfaces a confusing Hub repo-id error.
> 
> It now resolves the id via `get_config_model_id`, raises a **`ValueError`** if it is empty, and tells you to pass **`processing_class`** explicitly (e.g. after `from_config`). Otherwise behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a7fee0575873156210b174751b639c9cd25085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->