### PR TITLE
fix(sft): raise clear ValueError when config _name_or_path is empty

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1280,6 +1280,24 @@ class TestSFTTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
+    def test_init_with_empty_name_or_path_raises(self):
+        from transformers import LlamaConfig, LlamaForCausalLM
+
+        config = LlamaConfig(
+            vocab_size=32,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            max_position_embeddings=32,
+        )
+        model = LlamaForCausalLM(config)
+        assert model.config._name_or_path == ""
+        dataset = Dataset.from_dict({"text": ["hello world"]})
+        training_args = SFTConfig(output_dir=self.tmp_dir, report_to="none", use_cpu=True)
+        with pytest.raises(ValueError, match="processing_class"):
+            SFTTrainer(model=model, args=training_args, train_dataset=dataset)
+
     def test_train_assistant_only(self):
         dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1000,8 +1000,14 @@ class SFTTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "The model configuration has an empty `_name_or_path`. When training a model instantiated "
+                    "from a config (e.g. `from_config`), `processing_class` must be passed explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
+                model_id, trust_remote_code=args.trust_remote_code
             )
 
         # Handle pad token for processors or tokenizers


### PR DESCRIPTION
# What does this PR do?

When `SFTTrainer` is given a model instantiated from a config (e.g. `from_config`), the config's `_name_or_path` is `""`. The processing-class auto-load path called `AutoProcessor.from_pretrained("")`, which fails with a confusing Hub repo-id error (`OSError: Repo id must use alphanumeric chars...`).

This PR fails fast with a clear `ValueError` telling the user to pass `processing_class` explicitly, and adds a regression test.

Fixes #7071

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small init-time validation and clearer error handling; normal Hub/pretrained model paths are unchanged when a model id is present.
> 
> **Overview**
> **`SFTTrainer`** no longer auto-loads a processor when the model was built from a config and **`config._name_or_path`** is empty. In that case it **raises a `ValueError`** that tells you to pass **`processing_class`** explicitly, instead of calling **`AutoProcessor.from_pretrained("")`** and surfacing a misleading Hub repo-id **`OSError`**.
> 
> A regression test builds **`LlamaForCausalLM`** from **`LlamaConfig`** (empty **`_name_or_path`**) and checks that init fails with a message mentioning **`processing_class`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467b426af0364d4d1bf48e356af717acfe1abb78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->