### PR TITLE
Fix processor inference for models with empty config paths

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -31,6 +31,8 @@ from transformers import (
     AutoModelForImageTextToText,
     AutoTokenizer,
     BitsAndBytesConfig,
+    LlamaConfig,
+    LlamaForCausalLM,
     TrainingArguments,
 )
 from transformers.testing_utils import backend_device_count, backend_empty_cache, torch_device
@@ -286,6 +288,26 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
 
 
 class TestSFTTrainer(TrlTestCase):
+    def test_empty_model_name_or_path_requires_processing_class(self):
+        model = LlamaForCausalLM(
+            LlamaConfig(
+                vocab_size=32,
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=4,
+                max_position_embeddings=32,
+            )
+        )
+        dataset = Dataset.from_dict({"text": ["hello world"]})
+
+        with pytest.raises(ValueError, match=r"`model\.config\._name_or_path` is empty"):
+            SFTTrainer(
+                model=model,
+                args=SFTConfig(output_dir=self.tmp_dir, report_to="none", use_cpu=True),
+                train_dataset=dataset,
+            )
+
     def test_init_with_training_arguments(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
         args = TrainingArguments(output_dir=self.tmp_dir, report_to="none")

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -843,9 +843,13 @@ class AsyncGRPOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoTokenizer.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
 

--- a/trl/experimental/bco/bco_trainer.py
+++ b/trl/experimental/bco/bco_trainer.py
@@ -603,9 +603,13 @@ class BCOTrainer(_BaseTrainer):
             self.ref_model = create_reference_model(model)
 
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoTokenizer.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if args.max_length is None:
             logger.warning(
                 "When using DPODataCollatorWithPadding, you should set `max_length` in the `BCOConfig`. "

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -287,9 +287,13 @@ class CPOTrainer(_BaseTrainer):
             self.pad_token_id = model.config.pad_token_id
 
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoTokenizer.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if args.max_length is None:
             logger.warning(
                 "`max_length` is not set in the CPOConfig's init"

--- a/trl/experimental/orpo/orpo_trainer.py
+++ b/trl/experimental/orpo/orpo_trainer.py
@@ -297,9 +297,13 @@ class ORPOTrainer(_BaseTrainer):
             self.pad_token_id = model.config.pad_token_id
 
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoTokenizer.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if args.max_length is None:
             logger.warning(
                 "`max_length` is not set in the ORPOConfig's init"

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -294,8 +294,14 @@ class SDFTTrainer(_BaseTrainer):
             model = prepare_peft_model(model, peft_config, args)
 
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config),
+                model_id,
                 truncation_side="left",
                 padding_side="left",
                 trust_remote_code=args.trust_remote_code,

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -411,8 +411,14 @@ class SDPOTrainer(_BaseTrainer):
             model = prepare_peft_model(model, peft_config, args)
 
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config),
+                model_id,
                 truncation_side="left",
                 padding_side="left",
                 trust_remote_code=args.trust_remote_code,

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -157,8 +157,14 @@ class SSDTrainer(_BaseTrainer):
             model = prepare_peft_model(model, peft_config, args)
 
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config),
+                model_id,
                 truncation_side="left",
                 padding_side="left",
                 trust_remote_code=args.trust_remote_code,

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -335,9 +335,13 @@ class TPOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if not isinstance(processing_class, PreTrainedTokenizerBase):
             raise TypeError(
                 "The `processing_class` must be a `PreTrainedTokenizerBase`. `TPOTrainer` does not currently "

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -457,6 +457,11 @@ class DistillationTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
+            if not model_name_or_path:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
                 model_name_or_path,
                 truncation_side="left",

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -582,9 +582,13 @@ class DPOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
 
         # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -364,8 +364,14 @@ class GRPOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config),
+                model_id,
                 truncation_side="left",
                 padding_side="left",
                 trust_remote_code=args.trust_remote_code,

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -642,9 +642,13 @@ class KTOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
         if isinstance(processing_class, ProcessorMixin):
             self._tokenizer = processing_class.tokenizer
             self._is_vlm = True

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -413,9 +413,13 @@ class RewardTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoTokenizer.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoTokenizer.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
 
         # Handle pad token for processors or tokenizers
         if args.eos_token is not None:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -296,8 +296,14 @@ class RLOOTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
             processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config),
+                model_id,
                 truncation_side="left",
                 padding_side="left",
                 trust_remote_code=args.trust_remote_code,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1000,9 +1000,13 @@ class SFTTrainer(_BaseTrainer):
 
         # Processing class
         if processing_class is None:
-            processing_class = AutoProcessor.from_pretrained(
-                get_config_model_id(model.config), trust_remote_code=args.trust_remote_code
-            )
+            model_id = get_config_model_id(model.config)
+            if not model_id:
+                raise ValueError(
+                    "Cannot infer the processing class because `model.config._name_or_path` is empty. "
+                    "Please pass `processing_class` explicitly."
+                )
+            processing_class = AutoProcessor.from_pretrained(model_id, trust_remote_code=args.trust_remote_code)
 
         # Handle pad token for processors or tokenizers
         if isinstance(processing_class, ProcessorMixin):


### PR DESCRIPTION
# What does this PR do?

Fixes #7071

Models created directly from a config have an empty
`model.config._name_or_path`. When `processing_class` was omitted, affected
trainers passed that empty value to `from_pretrained`, causing an unhelpful Hub
repository-ID error.

This PR raises a clear `ValueError` requiring an explicit
`processing_class` instead. The matching auto-load paths were updated
consistently in SFT, DPO, KTO, GRPO, RLOO, and Reward trainers.

A focused SFT regression test covers a model created from a tiny
`LlamaConfig`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? #7071
- [x] Did you make sure to update the documentation with your changes? No documentation change is needed for this bug fix.
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time validation only; behavior for models with a normal `_name_or_path` is unchanged, and the failure mode for config-only models becomes an explicit error instead of an obscure Hub load failure.
> 
> **Overview**
> When `processing_class` is omitted, TRL trainers infer a tokenizer or processor from `model.config._name_or_path`. Models built directly from a config leave that field empty, so `AutoTokenizer`/`AutoProcessor.from_pretrained` was called with an invalid repo id and failed with a confusing Hub error.
> 
> This PR adds the same guard everywhere that auto-load runs: resolve the id via `get_config_model_id` (or `model_name_or_path` in `DistillationTrainer`), and if it is empty, raise a **`ValueError`** telling callers to pass **`processing_class`** explicitly. The change is applied across core trainers (SFT, DPO, KTO, GRPO, RLOO, Reward, Distillation) and the experimental trainers touched in the diff.
> 
> A regression test on **`SFTTrainer`** builds a tiny **`LlamaForCausalLM`** from **`LlamaConfig`** and asserts the new error is raised at init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac4aa28fe16e9c236f8adee531fed51362b1de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->