### PR TITLE
Add padding-free training for vision datasets in SFTTrainer

### DIFF
--- a/docs/source/sft_trainer.md
+++ b/docs/source/sft_trainer.md
@@ -339,6 +339,12 @@ trainer.train()
 >
 > Only use `max_length` when you've verified that truncation won't remove image tokens for the entire dataset.
 
+Vision datasets support `padding_free=True` in [`SFTConfig`]. Each example is processed individually, then the token
+sequences are concatenated without padding, with position IDs restarting at each example boundary. This requires a
+supported Flash Attention implementation, configured through the model's `attn_implementation`. The model must preserve
+these position resets when preparing its attention inputs, so models that use multimodal RoPE (such as the Qwen-VL
+family) are rejected for now. Example packing (`packing=True`) remains unsupported for vision datasets.
+
 ## SFTTrainer
 
 [[autodoc]] SFTTrainer

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -29,6 +29,7 @@ from packaging.version import Version
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
+    AutoProcessor,
     AutoTokenizer,
     BitsAndBytesConfig,
     TrainingArguments,
@@ -39,6 +40,7 @@ from transformers.utils import is_peft_available
 from trl import SFTConfig, SFTTrainer
 from trl.trainer.sft_trainer import (
     DataCollatorForLanguageModeling,
+    DataCollatorForVisionLanguageModeling,
     _chunked_cross_entropy_loss,
     _patch_chunked_ce_lm_head,
     dft_loss,
@@ -283,6 +285,71 @@ class TestDataCollatorForLanguageModeling(TrlTestCase):
         assert len(result) == 2
         assert torch.equal(result[0], torch.tensor([0, 1, 0, 1]))
         assert torch.equal(result[1], torch.arange(3))
+
+
+class TestDataCollatorForVisionLanguageModeling(TrlTestCase):
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration",
+            "trl-internal-testing/tiny-Idefics2ForConditionalGeneration",
+            "trl-internal-testing/tiny-Idefics3ForConditionalGeneration",
+        ],
+    )
+    @pytest.mark.parametrize("completion_only_loss", [None, False, True])
+    @pytest.mark.parametrize("image_counts", [(1, 1), (1, 2)])
+    @require_vision
+    def test_padding_free_vision(self, model_id, completion_only_loss, image_counts):
+        from PIL import Image
+
+        processor = AutoProcessor.from_pretrained(model_id)
+        # Keep image processing small enough for CPU tests, including Idefics image splitting.
+        if "Idefics2" in model_id:
+            processor.image_processor.size = {"longest_edge": 56, "shortest_edge": 56}
+        elif "Idefics3" in model_id:
+            processor.image_processor.size = {"longest_edge": 56}
+            processor.image_processor.max_image_size = {"longest_edge": 56}
+
+        examples = []
+        for index, image_count in enumerate(image_counts):
+            prompt = [{"role": "user", "content": "Describe these images."}]
+            completion = [{"role": "assistant", "content": "A red square." * (index + 1)}]
+            example = {
+                "images": [Image.new("RGB", (56 + 28 * index, 56), ("red", "blue")[index]) for _ in range(image_count)]
+            }
+            if completion_only_loss is None:
+                example["messages"] = prompt + completion
+            else:
+                example.update(prompt=prompt, completion=completion)
+            examples.append(example)
+
+        collator = DataCollatorForVisionLanguageModeling(processor, completion_only_loss=bool(completion_only_loss))
+        samples = [collator([copy.deepcopy(example)]) for example in examples]
+        batched = collator(copy.deepcopy(examples))
+        collator.padding_free = True
+        result = collator(copy.deepcopy(examples))
+
+        lengths = [sample["input_ids"].shape[1] for sample in samples]
+        assert lengths[0] != lengths[1]
+        assert result["input_ids"].shape == (1, sum(lengths))
+        assert "attention_mask" not in result
+        assert set(result) == (set(batched) - {"attention_mask"}) | {"position_ids"}
+        torch.testing.assert_close(result["position_ids"], torch.cat([torch.arange(n) for n in lengths]).unsqueeze(0))
+        for key in {"input_ids", "token_type_ids", "mm_token_type_ids"} & set(result):
+            torch.testing.assert_close(result[key], torch.cat([sample[key] for sample in samples], dim=1))
+        expected_labels = torch.cat([sample["labels"] for sample in samples], dim=1)
+        expected_labels[result["position_ids"] == 0] = -100
+        torch.testing.assert_close(result["labels"], expected_labels)
+        assert result["pixel_values"].shape[0] == sum(sample["pixel_values"].shape[0] for sample in samples)
+        for key in set(batched) - {"input_ids", "labels", "attention_mask", "token_type_ids", "mm_token_type_ids"}:
+            if isinstance(batched[key], torch.Tensor):
+                torch.testing.assert_close(result[key], batched[key])
+            else:
+                assert result[key] == batched[key]
+        if completion_only_loss:
+            for sample in samples:
+                assert (sample["labels"] == -100).any()
+                assert (sample["labels"] != -100).any()
 
 
 class TestSFTTrainer(TrlTestCase):
@@ -1092,6 +1159,58 @@ class TestSFTTrainer(TrlTestCase):
             SFTTrainer(model=model, args=training_args, train_dataset=dataset)
 
         assert ("supported Flash Attention variant" in caplog.text) == expect_warning
+
+    @pytest.mark.parametrize(
+        "attn_implementation, expect_warning",
+        [("kernels-community/flash-attn2", False), ("kernels-community/flash-attn2@v2", False), ("eager", True)],
+    )
+    @require_vision
+    def test_padding_free_vision_init(self, attn_implementation, expect_warning, caplog):
+        from PIL import Image
+
+        dataset = Dataset.from_dict(
+            {
+                "image": [Image.new("RGB", (56, 56), "red")],
+                "messages": [[{"role": "user", "content": "Describe this image."}]],
+            }
+        )
+        model = AutoModelForImageTextToText.from_pretrained(
+            "trl-internal-testing/tiny-Idefics3ForConditionalGeneration"
+        )
+        # Only the config value matters here: the warning is emitted at init, so no attention kernel is ever loaded.
+        model.config._attn_implementation = attn_implementation
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir, padding_free=True, max_length=None, bf16=False, report_to="none"
+        )
+
+        with caplog.at_level("WARNING", logger="trl.trainer.sft_trainer"):
+            trainer = SFTTrainer(model=model, args=training_args, train_dataset=dataset)
+
+        assert trainer._is_vision_dataset
+        assert trainer.padding_free
+        assert isinstance(trainer.data_collator, DataCollatorForVisionLanguageModeling)
+        assert trainer.data_collator.padding_free
+        assert ("supported Flash Attention variant" in caplog.text) == expect_warning
+
+    @require_vision
+    def test_padding_free_vision_rejects_multimodal_rope(self):
+        from PIL import Image
+
+        dataset = Dataset.from_dict(
+            {
+                "image": [Image.new("RGB", (56, 56), "red")],
+                "messages": [[{"role": "user", "content": "Describe this image."}]],
+            }
+        )
+        model = AutoModelForImageTextToText.from_pretrained(
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration"
+        )
+        training_args = SFTConfig(
+            output_dir=self.tmp_dir, padding_free=True, max_length=None, bf16=False, report_to="none"
+        )
+
+        with pytest.raises(ValueError, match="multimodal RoPE"):
+            SFTTrainer(model=model, args=training_args, train_dataset=dataset)
 
     def test_train_with_iterable_dataset(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train", streaming=True)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -343,7 +343,9 @@ class TestDataCollatorForVisionLanguageModeling(TrlTestCase):
         assert result["pixel_values"].shape[0] == sum(sample["pixel_values"].shape[0] for sample in samples)
         for key in set(batched) - {"input_ids", "labels", "attention_mask", "token_type_ids", "mm_token_type_ids"}:
             if isinstance(batched[key], torch.Tensor):
-                torch.testing.assert_close(result[key], batched[key])
+                # transformers 4.56 pads Idefics2's `pixel_attention_mask` as float64 when image counts differ, while
+                # each single example yields int64; the values are what matter here.
+                torch.testing.assert_close(result[key], batched[key], check_dtype=False)
             else:
                 assert result[key] == batched[key]
         if completion_only_loss:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -571,11 +571,13 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
 
     The collator outputs a dictionary including:
     - `"input_ids"`: Tensor of token IDs.
-    - `"attention_mask"`: Tensor indicating attention mask.
+    - `"attention_mask"`: Tensor indicating attention mask. Omitted when `padding_free=True`.
     - `"pixel_values"`: Tensor representing image pixel values.
     - `"labels"`: Tensor for training labels.
 
     Additional keys may be present depending on the processor, such as `"image_grid_thw"` or `"image_position_ids"`.
+    When `padding_free=True`, token sequences are flattened into a single sequence and `"position_ids"` restart at zero
+    for each example.
 
     Args:
         processor ([`~transformers.ProcessorMixin`]):
@@ -594,6 +596,9 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
             datasets format](dataset_formats#standard).
         return_tensors (`str`, *optional*, defaults to `"pt"`):
             Type of Tensor to return. Only `"pt"` is currently supported.
+        padding_free (`bool`, *optional*, defaults to `False`):
+            Whether to flatten the batch into a single sequence without padding. Requires a Flash Attention
+            implementation that uses position IDs to separate examples.
 
     Example:
     ```python
@@ -639,6 +644,7 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
     pad_to_multiple_of: int | None = None
     dataset_text_field: str = "text"
     return_tensors: str = "pt"
+    padding_free: bool = False
 
     def torch_call(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
         if "messages" in examples[0] or self.dataset_text_field in examples[0]:
@@ -646,11 +652,42 @@ class DataCollatorForVisionLanguageModeling(DataCollatorMixin):
                 raise ValueError(
                     "The `completion_only_loss` argument is not supported for language modeling datasets."
                 )
-            return self._collate_language_modeling(examples)
+            collate = self._collate_language_modeling
         elif "prompt" in examples[0] and "completion" in examples[0]:
-            return self._collate_prompt_completion(examples)
+            collate = self._collate_prompt_completion
         else:
             raise KeyError(f"Unexpected input keys in examples: {list(examples[0].keys())}.")
+
+        if not self.padding_free:
+            return collate(examples)
+
+        outputs = [collate([example]) for example in examples]
+        attention_masks = [output.pop("attention_mask").bool() for output in outputs]
+        seq_lengths = [int(mask.sum()) for mask in attention_masks]
+        output = {}
+        for key in dict.fromkeys(key for sample in outputs for key in sample):
+            if key in {"input_ids", "labels", "token_type_ids", "mm_token_type_ids"}:
+                output[key] = torch.cat(
+                    [sample[key][mask] for sample, mask in zip(outputs, attention_masks, strict=True)]
+                ).unsqueeze(0)
+            else:
+                values = [sample[key] for sample in outputs if key in sample]
+                if key == "pixel_attention_mask" or (key == "pixel_values" and values[0].ndim == 5):
+                    # Idefics processors pad the image count and spatial dimensions within a batch.
+                    output[key] = pad([row for value in values for row in value], padding_value=0)
+                elif isinstance(values[0], torch.Tensor):
+                    output[key] = torch.cat(values, dim=0)
+                else:
+                    output[key] = [item for value in values for item in value]
+
+        # For padding-free, we should NOT create attention_mask as it causes FlashAttention to ignore position_ids and
+        # compute wrong cu_seq_lens from the all-1s mask
+        output["position_ids"] = DataCollatorForLanguageModeling.get_position_ids_from_packed_seq_lengths(
+            [seq_lengths]
+        )[0].unsqueeze(0)
+        # The first token of each example would otherwise be predicted from the last token of the previous one.
+        output["labels"][output["position_ids"] == 0] = -100
+        return output
 
     def _collate_language_modeling(self, examples: list[dict[str, Any]]) -> dict[str, Any]:
         if "image" in examples[0]:
@@ -1048,10 +1085,15 @@ class SFTTrainer(_BaseTrainer):
             raise ValueError(
                 "Packing is not supported for vision datasets. Please set `packing=False` in the SFTConfig."
             )
-        if self._is_vision_dataset and args.padding_free:
+        if (
+            self._is_vision_dataset
+            and args.padding_free
+            and "mrope_section" in (model.config.get_text_config().rope_scaling or {})
+        ):
             raise ValueError(
-                "Padding-free training is yet not supported for vision datasets. Please set `padding_free=False` in "
-                "the `SFTConfig`."
+                "Padding-free training is not yet supported for vision datasets with models that use multimodal RoPE "
+                "(such as the Qwen-VL family): these models derive their 3D position ids from the batch and drop the "
+                "position ids that separate the packed examples. Please set `padding_free=False` in the `SFTConfig`."
             )
         if self._is_vision_dataset and args.assistant_only_loss:
             raise ValueError(
@@ -1232,6 +1274,7 @@ class SFTTrainer(_BaseTrainer):
                 completion_only_loss=self.completion_only_loss,
                 pad_to_multiple_of=args.pad_to_multiple_of,
                 dataset_text_field=args.dataset_text_field,
+                padding_free=self.padding_free,
             )
 
         if args.packing and args.packing_strategy in {"bfd", "bfd_split"} and not use_flash_attention:


### PR DESCRIPTION
SFT rejected padding-free training for vision datasets. I added per-example processing and concatenation with reset positions and masked boundary labels, while rejecting models that rebuild multimodal positions. CPU tests cover image layouts and trainer wiring, and a GPU check confirmed sample isolation and finite training losses with Idefics3.
Fixes #4339.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batching and attention boundaries for VLM training; incorrect packing could cause cross-example attention, though RoPE models are explicitly blocked and tests assert position resets and label masking.
> 
> **Overview**
> Enables **`padding_free=True`** on vision-language SFT: `SFTTrainer` wires it into `DataCollatorForVisionLanguageModeling`, which now processes each example separately, strips padding, concatenates token/image fields into one sequence, emits **`position_ids`** that restart per example (no **`attention_mask`**), and masks the first token of each segment in **`labels`**—matching the text padding-free / Flash Attention contract. Idefics-style batches get extra padding when image counts or sizes differ before concat.
> 
> The blanket ban on vision + padding-free is lifted; **`packing=True`** for vision stays unsupported. **`padding_free`** is rejected only when the model uses **multimodal RoPE** (e.g. Qwen-VL, detected via `mrope_section` in `rope_scaling`), because those models rebuild 3D positions and would break example boundaries.
> 
> Docs describe the feature, Flash Attention requirement, and RoPE limitation. Tests cover the VLM collator (Qwen2-VL, Idefics2/3), trainer init/warnings, and multimodal-RoPE rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef772ba3179107f9c65ebf2ab5b8dad03f6394d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->