### PR TITLE
Fix FP8 weight synchronization for colocated vLLM

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -283,6 +283,20 @@ training_args = RLOOConfig(
 </hfoption>
 </hfoptions>
 
+To store the colocated vLLM copy in FP8 without changing the training model's dtype, pass the FP8 quantization setting to vLLM:
+
+```python
+from trl import GRPOConfig
+
+training_args = GRPOConfig(
+    ...,
+    use_vllm=True,
+    vllm_llm_kwargs={"quantization": "fp8"},
+)
+```
+
+vLLM quantizes the checkpoint when the engine starts. During weight synchronization, TRL sends the current training weights through vLLM's reload path so vLLM recomputes the FP8 weights and scales. This affects the generation copy only. It does not enable FP8 training.
+
 #### Server Mode
 
 In **server mode**, vLLM runs as a separate process on dedicated GPUs and communicates with the trainer via HTTP.

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
+from types import SimpleNamespace
+
 import pytest
 from datasets import Dataset, DatasetDict, features, load_dataset
 from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
 from transformers.utils import is_peft_available, is_vision_available
 
 from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
+from trl.experimental.online_dpo import online_dpo_trainer as online_dpo_trainer_module
 
 from ..testing_utils import TrlTestCase, require_peft, require_torch_accelerator, require_vision, require_vllm
 
@@ -30,6 +34,208 @@ if is_vision_available():
     import numpy as np
     from PIL import Image
     from transformers import AutoModelForImageTextToText, AutoProcessor
+
+
+class TestOnlineDPOWeightReload(TrlTestCase):
+    @staticmethod
+    def _build(monkeypatch, quantization, fail_on=None):
+        events = []
+        model_config = SimpleNamespace(quantization=quantization)
+        parameter_data = [object(), object()]
+        parameters = [
+            ("layer.a", SimpleNamespace(data=parameter_data[0])),
+            ("layer.b", SimpleNamespace(data=parameter_data[1])),
+        ]
+        training_model = SimpleNamespace(named_parameters=lambda: parameters)
+
+        class RecordingModel:
+            def load_weights(self, weights):
+                [(name, actual_parameter)] = weights
+                events.append(("load", name, actual_parameter))
+                if name == fail_on:
+                    raise RuntimeError("load failed")
+
+        model = RecordingModel()
+
+        class RecordingModelRunner:
+            def get_model(self):
+                events.append(("get_model",))
+                return model
+
+        model_runner = RecordingModelRunner()
+        driver_worker = SimpleNamespace(model_runner=model_runner)
+        model_executor = SimpleNamespace(driver_worker=driver_worker)
+        llm_engine = SimpleNamespace(model_executor=model_executor)
+        llm = SimpleNamespace(
+            llm_engine=llm_engine,
+            model_config=model_config,
+            reset_prefix_cache=lambda: events.append(("reset",)),
+        )
+
+        monkeypatch.setattr(
+            online_dpo_trainer_module,
+            "initialize_layerwise_reload",
+            lambda actual: events.append(("initialize", actual)),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            online_dpo_trainer_module,
+            "finalize_layerwise_reload",
+            lambda actual, config: events.append(("finalize", actual, config)),
+            raising=False,
+        )
+        trainer = object.__new__(OnlineDPOTrainer)
+        trainer.vllm_mode = "colocate"
+        trainer.llm = llm
+        trainer.model = training_model
+        trainer.accelerator = SimpleNamespace(state=SimpleNamespace(deepspeed_plugin=None))
+        trainer.is_fsdp_enabled = False
+        trainer._fix_param_name_to_vllm = lambda name, extra_prefixes=None: name
+        monkeypatch.setattr(online_dpo_trainer_module, "is_peft_model", lambda actual: False)
+        return trainer, events, model, model_config, parameter_data
+
+    @staticmethod
+    def _build_specialized_path(monkeypatch, path):
+        trainer, events, model, model_config, parameter_data = TestOnlineDPOWeightReload._build(monkeypatch, "fp8")
+        parameters = [
+            ("layer.a", SimpleNamespace(data=parameter_data[0])),
+            ("layer.b", SimpleNamespace(data=parameter_data[1])),
+        ]
+        before_load = []
+        after_load = []
+
+        if path == "peft":
+            peft_parameters = [(f"base_model.model.{name}", parameter) for name, parameter in parameters]
+
+            class RecordingPeftModel:
+                prefix = "lora_"
+
+                def parameters(self):
+                    return [parameter for _, parameter in peft_parameters]
+
+                def named_parameters(self):
+                    return peft_parameters
+
+                def merge_adapter(self):
+                    events.append(("merge_adapter",))
+
+                def unmerge_adapter(self):
+                    events.append(("unmerge_adapter",))
+
+            trainer.model = RecordingPeftModel()
+            monkeypatch.setattr(online_dpo_trainer_module, "is_peft_model", lambda actual: actual is trainer.model)
+            before_load = [("merge_adapter",)]
+            after_load = [("unmerge_adapter",)]
+        elif path == "fsdp1":
+
+            class FakeFSDP:
+                def named_children(self):
+                    return []
+
+                def named_parameters(self):
+                    return parameters
+
+                @staticmethod
+                def summon_full_params(module, recurse, writeback):
+                    events.append(("summon_full_params", module, recurse, writeback))
+                    return nullcontext()
+
+            trainer.model = FakeFSDP()
+            trainer.is_fsdp_enabled = True
+            trainer.accelerator.state.fsdp_plugin = SimpleNamespace(fsdp_version=1)
+            monkeypatch.setattr(online_dpo_trainer_module, "FSDP", FakeFSDP)
+            before_load = [("summon_full_params", trainer.model, False, False)]
+        elif path == "fsdp2":
+
+            class FakeDTensor:
+                is_cpu = False
+
+                def __init__(self, data):
+                    self.data = data
+
+                def full_tensor(self):
+                    return self.data
+
+            state_dict = {name: FakeDTensor(parameter.data) for name, parameter in parameters}
+
+            class RecordingFSDP2Model:
+                def state_dict(self):
+                    events.append(("state_dict",))
+                    return state_dict
+
+            trainer.model = RecordingFSDP2Model()
+            trainer.is_fsdp_enabled = True
+            trainer.accelerator.state.fsdp_plugin = SimpleNamespace(fsdp_version=2)
+            trainer.accelerator.device = object()
+            before_load = [("state_dict",)]
+        else:
+            raise ValueError(f"Unknown path: {path}")
+
+        return trainer, events, model, model_config, parameter_data, before_load, after_load
+
+    def test_fp8_colocate_move_uses_one_reload_lifecycle(self, monkeypatch):
+        trainer, events, model, model_config, parameter_data = self._build(monkeypatch, quantization="fp8")
+
+        OnlineDPOTrainer._move_model_to_vllm(trainer)
+
+        assert events == [
+            ("get_model",),
+            ("initialize", model),
+            ("get_model",),
+            ("load", "layer.a", parameter_data[0]),
+            ("get_model",),
+            ("load", "layer.b", parameter_data[1]),
+            ("finalize", model, model_config),
+            ("reset",),
+        ]
+
+    def test_failed_fp8_colocate_move_does_not_finalize_or_reset_cache(self, monkeypatch):
+        trainer, events, model, _, parameter_data = self._build(monkeypatch, quantization="fp8", fail_on="layer.b")
+
+        with pytest.raises(RuntimeError, match="load failed"):
+            OnlineDPOTrainer._move_model_to_vllm(trainer)
+
+        assert events == [
+            ("get_model",),
+            ("initialize", model),
+            ("get_model",),
+            ("load", "layer.a", parameter_data[0]),
+            ("get_model",),
+            ("load", "layer.b", parameter_data[1]),
+        ]
+
+    def test_unquantized_colocate_move_uses_load_weights_fast_path(self, monkeypatch):
+        trainer, events, _, _, parameter_data = self._build(monkeypatch, quantization=None)
+
+        OnlineDPOTrainer._move_model_to_vllm(trainer)
+
+        assert events == [
+            ("get_model",),
+            ("load", "layer.a", parameter_data[0]),
+            ("get_model",),
+            ("load", "layer.b", parameter_data[1]),
+            ("reset",),
+        ]
+
+    @pytest.mark.parametrize("path", ["peft", "fsdp1", "fsdp2"])
+    def test_fp8_specialized_colocate_paths_share_one_reload_lifecycle(self, monkeypatch, path):
+        result = self._build_specialized_path(monkeypatch, path)
+        trainer, events, model, model_config, parameter_data, before_load, after_load = result
+
+        OnlineDPOTrainer._move_model_to_vllm(trainer)
+
+        assert events == [
+            ("get_model",),
+            ("initialize", model),
+            *before_load,
+            ("get_model",),
+            ("load", "layer.a", parameter_data[0]),
+            ("get_model",),
+            ("load", "layer.b", parameter_data[1]),
+            *after_load,
+            ("finalize", model, model_config),
+            ("reset",),
+        ]
 
 
 class TestOnlineDPOTrainer(TrlTestCase):

--- a/tests/test_vllm_client_server.py
+++ b/tests/test_vllm_client_server.py
@@ -200,7 +200,6 @@ class TestVLLMGenerationLLMKwargs(TrlTestCase):
         "enable_sleep_mode",
         "logprobs_mode",
         "model",
-        "quantization",
         "seed",
         "tensor_parallel_size",
     ]
@@ -228,6 +227,105 @@ class TestVLLMGenerationLLMKwargs(TrlTestCase):
         # the engine side would silently desynchronize the two.
         with pytest.raises(ValueError, match=f"`{key}` cannot be set in `vllm_llm_kwargs`"):
             self._build(monkeypatch, {key: 2})
+
+    def test_fp8_quantization_reaches_the_llm_constructor(self, monkeypatch):
+        captured = self._build(monkeypatch, {"quantization": "fp8"})
+
+        assert captured["quantization"] == "fp8"
+
+    @pytest.mark.parametrize("quantization", [None, "awq", "bitsandbytes", "gptq"])
+    def test_other_quantization_values_are_rejected(self, monkeypatch, quantization):
+        with pytest.raises(ValueError, match='only supports `"fp8"`'):
+            self._build(monkeypatch, {"quantization": quantization})
+
+
+class TestVLLMGenerationWeightReload(TrlTestCase):
+    def _build(self, quantization, fail_on=None):
+        events = []
+
+        class RecordingModel:
+            def load_weights(self, weights):
+                [(name, param)] = weights
+                events.append(("load", name, param))
+                if name == fail_on:
+                    raise RuntimeError("load failed")
+
+        model = RecordingModel()
+
+        class RecordingModelRunner:
+            def get_model(self):
+                events.append(("get_model",))
+                return model
+
+            def reload_weights(self, *, weights_iterator):
+                events.append(("reload",))
+                for name, param in weights_iterator:
+                    events.append(("load", name, param))
+                    if name == fail_on:
+                        raise RuntimeError("load failed")
+
+        model_runner = RecordingModelRunner()
+        driver_worker = SimpleNamespace(model_runner=model_runner)
+        model_executor = SimpleNamespace(driver_worker=driver_worker)
+        llm_engine = SimpleNamespace(model_executor=model_executor)
+        llm = SimpleNamespace(
+            llm_engine=llm_engine,
+            model_config=SimpleNamespace(quantization=quantization),
+            reset_prefix_cache=lambda: events.append(("reset",)),
+        )
+
+        generation = object.__new__(vllm_generation.VLLMGeneration)
+        generation.mode = "colocate"
+        generation.enable_sleep_mode = False
+        generation.accelerator = SimpleNamespace(is_main_process=True)
+        generation.llm = llm
+        params = [("layer.a", object()), ("layer.b", object())]
+
+        def iter_named_params():
+            events.append(("iterate",))
+            yield from params
+
+        generation._iter_named_params = iter_named_params
+        return generation, events, params
+
+    def test_sync_weights_reloads_then_resets_cache(self):
+        generation, events, params = self._build(quantization="fp8")
+
+        generation.sync_weights()
+
+        assert events == [
+            ("reload",),
+            ("iterate",),
+            ("load", *params[0]),
+            ("load", *params[1]),
+            ("reset",),
+        ]
+
+    def test_sync_weights_does_not_reset_cache_after_failed_reload(self):
+        generation, events, params = self._build(quantization="fp8", fail_on="layer.b")
+
+        with pytest.raises(RuntimeError, match="load failed"):
+            generation.sync_weights()
+
+        assert events == [
+            ("reload",),
+            ("iterate",),
+            ("load", *params[0]),
+            ("load", *params[1]),
+        ]
+
+    def test_sync_weights_unquantized_uses_load_weights_fast_path(self):
+        generation, events, params = self._build(quantization=None)
+
+        generation.sync_weights()
+
+        assert events == [
+            ("get_model",),
+            ("iterate",),
+            ("load", *params[0]),
+            ("load", *params[1]),
+            ("reset",),
+        ]
 
 
 @pytest.mark.slow

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -147,8 +147,8 @@ class GOLDConfig(SFTConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_sync_frequency (`int`, *optional*, defaults to `1`):
             Frequency (in training steps) to synchronize student model weights to vLLM engine. Set to 1 to sync after
             every step.
@@ -425,8 +425,9 @@ class GOLDConfig(SFTConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_structured_outputs_regex: str | None = field(

--- a/trl/experimental/iw_opd/iw_opd_config.py
+++ b/trl/experimental/iw_opd/iw_opd_config.py
@@ -145,8 +145,8 @@ class IWOPDConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_structured_outputs_regex (`str` or `None`, *optional*):
             Regex pattern for vLLM structured outputs.
         vllm_sync_frequency (`int`, *optional*, defaults to `1`):
@@ -383,8 +383,9 @@ class IWOPDConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_structured_outputs_regex: str | None = field(

--- a/trl/experimental/online_dpo/online_dpo_config.py
+++ b/trl/experimental/online_dpo/online_dpo_config.py
@@ -97,8 +97,8 @@ class OnlineDPOConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_mode (`str`, *optional*, defaults to `"colocate"`):
             Mode to use for vLLM integration when `use_vllm` is set to `True`. Must be one of `"server"` or
             `"colocate"`.
@@ -291,8 +291,9 @@ class OnlineDPOConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_structured_outputs_regex: str | None = field(

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -88,6 +88,7 @@ else:
 
 if is_vllm_available():
     from vllm import LLM, SamplingParams
+    from vllm.model_executor.model_loader.reload import finalize_layerwise_reload, initialize_layerwise_reload
     from vllm.sampling_params import StructuredOutputsParams
 
 
@@ -774,7 +775,7 @@ class OnlineDPOTrainer(_BaseTrainer):
             if self.vllm_mode == "server" and self.accelerator.is_main_process:
                 self.vllm_client.update_named_param(name, param)
             elif self.vllm_mode == "colocate":
-                llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.get_model()
                 llm_model.load_weights([(name, param)])
 
     def _move_model_to_vllm(self):
@@ -784,6 +785,13 @@ class OnlineDPOTrainer(_BaseTrainer):
             # the parameter gathers below.
             with self.vllm_client.weight_update():
                 self._move_model_to_vllm_inner()
+        elif self.vllm_mode == "colocate" and self.llm.model_config.quantization == "fp8":
+            model_runner = self.llm.llm_engine.model_executor.driver_worker.model_runner
+            llm_model = model_runner.get_model()
+            # Bracket every existing PEFT and FSDP load path with one FP8 reload lifecycle.
+            initialize_layerwise_reload(llm_model)
+            self._move_model_to_vllm_inner()
+            finalize_layerwise_reload(llm_model, self.llm.model_config)
         else:
             self._move_model_to_vllm_inner()
 
@@ -839,7 +847,7 @@ class OnlineDPOTrainer(_BaseTrainer):
                         if self.vllm_mode == "server" and self.accelerator.is_main_process:
                             self.vllm_client.update_named_param(name, param.data)
                         elif self.vllm_mode == "colocate":
-                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.get_model()
                             llm_model.load_weights([(name, param.data)])
                 # Unmerge adapters while parameters are still gathered
                 self.model.unmerge_adapter()
@@ -860,7 +868,7 @@ class OnlineDPOTrainer(_BaseTrainer):
                         if self.vllm_mode == "server" and self.accelerator.is_main_process:
                             self.vllm_client.update_named_param(name, param.data)
                         elif self.vllm_mode == "colocate":
-                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.get_model()
                             llm_model.load_weights([(name, param.data)])
 
     def _sync_fsdp1_params_to_vllm(self, module: nn.Module, prefix: str = "", visited=None):
@@ -887,7 +895,7 @@ class OnlineDPOTrainer(_BaseTrainer):
                     if self.vllm_mode == "server" and self.accelerator.is_main_process:
                         self.vllm_client.update_named_param(full_name, param.data)
                     elif self.vllm_mode == "colocate":
-                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.get_model()
                         llm_model.load_weights([(full_name, param.data)])
 
     def _fix_param_name_to_vllm(self, name, extra_prefixes: list[str] | None = None):

--- a/trl/experimental/sdft/sdft_config.py
+++ b/trl/experimental/sdft/sdft_config.py
@@ -145,8 +145,8 @@ class SDFTConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_enable_sleep_mode (`bool`, *optional*, defaults to `False`):
             Enable vLLM sleep mode to offload weights/cache during the optimizer step. Keeps GPU memory usage low, but
             waking the engine adds host–device transfer latency.
@@ -330,8 +330,9 @@ class SDFTConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_enable_sleep_mode: bool = field(

--- a/trl/experimental/sdpo/sdpo_config.py
+++ b/trl/experimental/sdpo/sdpo_config.py
@@ -202,8 +202,8 @@ class SDPOConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_enable_sleep_mode (`bool`, *optional*, defaults to `False`):
             Enable vLLM sleep mode to offload weights/cache during the optimizer step. Keeps GPU memory usage low, but
             waking the engine adds host–device transfer latency.
@@ -406,8 +406,9 @@ class SDPOConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_enable_sleep_mode: bool = field(

--- a/trl/experimental/ssd/ssd_config.py
+++ b/trl/experimental/ssd/ssd_config.py
@@ -79,8 +79,8 @@ class SSDConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_server_base_url (`str` or `None`, *optional*):
             Base URL for the vLLM server. If provided, `vllm_server_host` and `vllm_server_port` are ignored.
         vllm_server_host (`str`, *optional*, defaults to `"0.0.0.0"`):
@@ -198,8 +198,9 @@ class SSDConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_server_base_url: str | None = field(

--- a/trl/generation/vllm_generation.py
+++ b/trl/generation/vllm_generation.py
@@ -110,21 +110,20 @@ if is_bitsandbytes_available():
 
 # `LLM` constructor arguments that `vllm_llm_kwargs` may not override, each with the reason. TRL reads every one of
 # them back after the engine is built, or the weight sync relies on it, so overriding only the engine side would
-# silently desynchronize the two.
+# silently desynchronize the two. `quantization` is validated separately because FP8 is supported.
 RESERVED_LLM_KWARGS = {
     "model": "the weight sync pushes the training model's parameters into the engine",
     "tensor_parallel_size": "TRL builds the tensor-parallel process groups from `vllm_tensor_parallel_size`",
     "distributed_executor_backend": "TRL drives the colocated driver worker directly",
     "seed": "TRL seeds each tensor-parallel group identically so its workers sample the same completions",
     "logprobs_mode": "the importance-sampling correction expects processed log probabilities",
-    "quantization": "TRL derives it from the training model's own quantization",
     "enable_sleep_mode": "TRL drives the sleep/wake cycle from `vllm_enable_sleep_mode`",
 }
 
 
 def _check_llm_kwargs(llm_kwargs: dict | None) -> dict:
     """
-    Return the user-supplied `LLM` constructor arguments as a dict, refusing the keys in `RESERVED_LLM_KWARGS`.
+    Return the user-supplied `LLM` constructor arguments as a dict, refusing unsupported or reserved values.
 
     Args:
         llm_kwargs (`dict`, *optional*):
@@ -134,9 +133,11 @@ def _check_llm_kwargs(llm_kwargs: dict | None) -> dict:
         `dict`: `llm_kwargs`, or an empty dict when it is `None`.
 
     Raises:
-        `ValueError`: if any key of `llm_kwargs` is in `RESERVED_LLM_KWARGS`.
+        `ValueError`: if any key of `llm_kwargs` is in `RESERVED_LLM_KWARGS`, or if `quantization` is not `"fp8"`.
     """
     llm_kwargs = llm_kwargs or {}
+    if "quantization" in llm_kwargs and llm_kwargs["quantization"] != "fp8":
+        raise ValueError('`quantization` in `vllm_llm_kwargs` only supports `"fp8"`.')
     for key in sorted(llm_kwargs.keys() & RESERVED_LLM_KWARGS.keys()):
         raise ValueError(f"`{key}` cannot be set in `vllm_llm_kwargs`: {RESERVED_LLM_KWARGS[key]}.")
     return llm_kwargs
@@ -248,6 +249,7 @@ class VLLMGeneration:
             Additional keyword arguments for the vLLM `LLM` constructor, used only in colocate mode, where TRL builds
             the engine. Useful for engine arguments TRL does not expose, such as `hf_overrides`. Keys that conflict
             with the arguments TRL sets override them, except the keys in `RESERVED_LLM_KWARGS`, which raise.
+            `quantization` may only be set to `"fp8"`.
 
     """
 
@@ -551,8 +553,14 @@ class VLLMGeneration:
                 for _ in self._iter_named_params():  # take part in the gather collectives
                     pass
         elif self.mode == "colocate":
-            for name, param in self._iter_named_params():
-                self.llm.llm_engine.model_executor.driver_worker.model_runner.model.load_weights([(name, param)])
+            model_runner = self.llm.llm_engine.model_executor.driver_worker.model_runner
+            if self.llm.model_config.quantization == "fp8":
+                # vLLM rebuilds the FP8 weights and scales inside its reload lifecycle.
+                model_runner.reload_weights(weights_iterator=self._iter_named_params())
+            else:
+                llm_model = model_runner.get_model()
+                for name, param in self._iter_named_params():
+                    llm_model.load_weights([(name, param)])
 
         # Reset cache on vLLM
         if self.mode == "server" and accelerator.is_main_process:
@@ -627,9 +635,8 @@ class VLLMGeneration:
         repetition_penalty = self.repetition_penalty
         max_completion_length = self.max_completion_length
 
-        # Sleep level 2 discards the weights, so waking up isn't enough: they must be re-pushed from the training
-        # model. vLLM's `reload_weights` can't be used here, as it reloads the initial checkpoint from disk rather
-        # than the current training weights. See https://github.com/vllm-project/vllm/issues/29341
+        # Sleep level 2 discards the weights, so waking up isn't enough. `sync_weights()` pushes the current training
+        # parameters back to vLLM before generation.
         if self.mode == "colocate" and self.enable_sleep_mode and self._llm_weights_sleeping:
             self.sync_weights()
 

--- a/trl/trainer/distillation_config.py
+++ b/trl/trainer/distillation_config.py
@@ -106,8 +106,8 @@ class DistillationConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_enable_sleep_mode (`bool`, *optional*, defaults to `False`):
             Enable vLLM sleep mode to offload student weights during the optimizer step.
         vllm_structured_outputs_regex (`str`, *optional*):
@@ -319,8 +319,9 @@ class DistillationConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_enable_sleep_mode: bool = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -134,8 +134,8 @@ class GRPOConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_structured_outputs_regex (`str`, *optional*):
             Regex for vLLM structured outputs. If `None` (default), structured outputs is disabled.
 
@@ -617,8 +617,9 @@ class GRPOConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_enable_sleep_mode: bool = field(

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -129,8 +129,8 @@ class RLOOConfig(_BaseConfig):
             where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, such as
             `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys TRL reads
             back after building the engine (`model`, `tensor_parallel_size`, `distributed_executor_backend`, `seed`,
-            `logprobs_mode`, `quantization`, `enable_sleep_mode`), which raise. If you are using `vllm_mode="server"`,
-            pass these arguments when launching the server instead.
+            `logprobs_mode`, `enable_sleep_mode`), which raise. `quantization` may only be set to `"fp8"`. If you are
+            using `vllm_mode="server"`, pass these arguments when launching the server instead.
         vllm_structured_outputs_regex (`str`, *optional*):
             Regex for vLLM structured outputs. If `None` (default), structured outputs is disabled.
 
@@ -438,8 +438,9 @@ class RLOOConfig(_BaseConfig):
             "`colocate`, where TRL builds the engine. Useful for engine arguments TRL does not expose a field for, "
             "such as `hf_overrides`. Keys that conflict with the arguments TRL sets override them, except the keys "
             "TRL reads back after building the engine (`model`, `tensor_parallel_size`, "
-            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `quantization`, `enable_sleep_mode`), which "
-            "raise. If you are using `vllm_mode='server'`, pass these arguments when launching the server instead."
+            "`distributed_executor_backend`, `seed`, `logprobs_mode`, `enable_sleep_mode`), which raise. "
+            "`quantization` may only be set to `'fp8'`. If you are using `vllm_mode='server'`, pass these arguments "
+            "when launching the server instead."
         },
     )
     vllm_enable_sleep_mode: bool = field(


### PR DESCRIPTION
# What does this PR do?

I fixed FP8 weight synchronization for colocated vLLM engines. When `vllm_llm_kwargs={"quantization": "fp8"}` is set, TRL now uses vLLM's reload lifecycle so vLLM rebuilds the FP8 weights and scales from the current training weights during each synchronization. Non-FP8 colocate engines keep the existing direct `load_weights` path. I also applied the lifecycle to Online DPO's standard, PEFT, FSDP1, and FSDP2 paths.

This PR is stacked on #6816 and addresses the colocate part of #3399. It accepts only `"fp8"` as a user-provided quantization setting and documents that this changes only the vLLM generation copy, not the training dtype.

## Testing

- `26 passed` in the focused configuration and reload lifecycle tests.
- `31 passed, 35 deselected` in the broader non-slow vLLM tests. This run includes the focused cases.
- The repository's pinned Ruff check, Ruff format, and doc-builder hooks passed.
- On one NVIDIA GB10 with vLLM 0.27.1, the FP8 colocate run passed all 7 checks across 7 synchronization calls and 3 perturb and restore cycles.
- A two-step BF16 GRPO run with FP8 generation passed all 10 checks. Both reloads consumed BF16 weights, and the selected weight changed between reloads after an optimizer update.

I had one physical GPU available, so I could not run tensor parallelism or the two-GPU trainer-to-server matrix. This PR does not change the server-side transfer path. The PEFT, FSDP1, and FSDP2 cases are controlled unit tests, not live distributed runs.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone familiar with vLLM weight synchronization or online trainers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the colocated weight-sync path for all trainers using `VLLMGeneration` and Online DPO; incorrect FP8 reload behavior could desync generation from training, but scope is limited to optional FP8 colocate mode with added tests.
> 
> **Overview**
> Adds **FP8 colocated vLLM** support via `vllm_llm_kwargs={"quantization": "fp8"}` so the inference copy can run in FP8 while training stays in its original dtype. `quantization` is no longer fully blocked in `vllm_llm_kwargs`; only `"fp8"` is accepted—other values raise.
> 
> **Weight synchronization** now branches on FP8: colocated engines use vLLM’s reload path (`reload_weights` in `VLLMGeneration.sync_weights`, and `initialize_layerwise_reload` / `finalize_layerwise_reload` around Online DPO’s `_move_model_to_vllm`, including PEFT/FSDP1/FSDP2). Unquantized colocate still uses per-parameter `load_weights` via `model_runner.get_model()`. Prefix cache is reset only after a successful sync; failed loads skip finalize/reset.
> 
> Trainer config help text is updated across GRPO, RLOO, Online DPO, and related configs. Docs describe the FP8 colocate setup. Unit tests cover kwargs validation, `VLLMGeneration.sync_weights`, and Online DPO reload ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf61f76ee698bf97fb64ead1f4f0a5c4fdbcd5a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->