### PR TITLE
Add padding_free packed forward for GRPO and RLOO per-token log-probs

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -338,6 +338,22 @@ training_args = GRPOConfig(
 
 For a full training example, see [`examples/grpo_continuous_batching/grpo_continuous_batching.py`](https://github.com/huggingface/trl/blob/main/examples/grpo_continuous_batching/grpo_continuous_batching.py).
 
+### Padding-free forward
+
+By default the per-token log-prob forward runs on a dense block: prompts are left-padded and completions right-padded to the longest sequence in the micro-batch, and the padding tokens are computed and then masked. With `padding_free=True`, each micro-batch's real tokens are packed into a single row with position ids that restart per sample and no attention mask, so a Flash Attention implementation separates the samples from the position resets and the padded compute is skipped. The per-token log-probs are scattered back into the padded layout, so every loss type and metric is unchanged.
+
+```python
+from transformers import AutoModelForCausalLM
+from trl import GRPOConfig
+
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct", attn_implementation="flash_attention_2")
+training_args = GRPOConfig(..., padding_free=True)
+```
+
+`padding_free=True` requires a Flash Attention `attn_implementation` (`flash_attention_2`, `flash_attention_3` or one of the `kernels-community` flash-attn kernels) and is not supported with `use_liger_kernel=True` or with vision-language models.
+
+The isolation depends on the model forwarding `position_ids` to the Flash Attention kernel and on every sequence-mixing layer being attention. A model whose Flash Attention path drops `position_ids` (OLMoE in transformers 4.56, for example) or a hybrid architecture with recurrent or state-space layers that read the whole row (Jamba, for example) is not separated by the position resets, and `padding_free=True` silently mixes samples on it. The same limit applies to the `padding_free` option of [`SFTTrainer`].
+
 ### GRPO at scale: train a 70B+ Model on multiple nodes
 
 When training large models like **Qwen2.5-72B**, you need several key optimizations to make the training efficient and scalable across multiple GPUs and nodes. These include:

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -222,6 +222,22 @@ In this mode, vLLM runs in a separate process (and using separate GPUs) and comm
 
 For more information, see [Speeding up training with vLLM](speeding_up_training#vllm-for-fast-generation-in-online-methods).
 
+### Padding-free forward
+
+By default the per-token log-prob forward runs on a dense block: prompts are left-padded and completions right-padded to the longest sequence in the micro-batch, and the padding tokens are computed and then masked. With `padding_free=True`, each micro-batch's real tokens are packed into a single row with position ids that restart per sample and no attention mask, so a Flash Attention implementation separates the samples from the position resets and the padded compute is skipped. The per-token log-probs are scattered back into the padded layout, so every loss type and metric is unchanged.
+
+```python
+from transformers import AutoModelForCausalLM
+from trl import RLOOConfig
+
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct", attn_implementation="flash_attention_2")
+training_args = RLOOConfig(..., padding_free=True)
+```
+
+`padding_free=True` requires a Flash Attention `attn_implementation` (`flash_attention_2`, `flash_attention_3` or one of the `kernels-community` flash-attn kernels) and is not supported with vision-language models.
+
+The isolation depends on the model forwarding `position_ids` to the Flash Attention kernel and on every sequence-mixing layer being attention. A model whose Flash Attention path drops `position_ids` (OLMoE in transformers 4.56, for example) or a hybrid architecture with recurrent or state-space layers that read the whole row (Jamba, for example) is not separated by the position resets, and `padding_free=True` silently mixes samples on it. The same limit applies to the `padding_free` option of [`SFTTrainer`].
+
 ### RLOO at scale: train a 70B+ Model on multiple nodes
 
 When training large models like **Qwen2.5-72B**, you need several key optimizations to make the training efficient and scalable across multiple GPUs and nodes. These include:

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import inspect
 import os
 import warnings
 from collections.abc import Callable
@@ -43,6 +44,7 @@ from .testing_utils import (
     TrlTestCase,
     is_ampere_or_newer,
     require_bitsandbytes,
+    require_kernels,
     require_liger_kernel,
     require_peft,
     require_response_parsing,
@@ -5015,3 +5017,163 @@ class TestGRPOTrainerSlow(TrlTestCase):
                 raise
 
         release_memory(trainer.model, trainer)
+
+
+def reward_length(completions, **kwargs):
+    return [float(len(completion)) for completion in completions]
+
+
+class TestGRPOTrainerPaddingFree(TrlTestCase):
+    def test_padding_free_matches_padded_forward(self):
+        # Eager attention ignores position-id resets, so packing two samples into one row would let them attend to
+        # each other. With one row per chunk the packed row is exactly that row without its padding, so the packed
+        # and padded forwards must agree token for token, which pins down the flatten, index and scatter logic.
+        torch.manual_seed(0)
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        ).eval()
+        model_kwarg_keys = set(inspect.signature(model.forward).parameters)
+        prompt_len, completion_len = 5, 4
+        prompt_ids = torch.randint(5, 100, (3, prompt_len))
+        prompt_mask = torch.ones(3, prompt_len, dtype=torch.long)
+        prompt_mask[0, :2] = 0  # left padding
+        prompt_mask[2, :3] = 0
+        completion_ids = torch.randint(5, 100, (3, completion_len))
+        completion_mask = torch.ones(3, completion_len, dtype=torch.long)
+        completion_mask[1, 2:] = 0  # right padding
+        completion_mask[2, :] = 0  # a fully masked completion, as `mask_truncated_completions` produces
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+
+        def forward(padding_free, keys):
+            trainer = SimpleNamespace(
+                model_kwarg_keys=keys, temperature=1.0, padding_free=padding_free, _entropy_bonus_enabled=False
+            )
+            return GRPOTrainer._get_per_token_logps_and_entropies(
+                trainer, model, input_ids, attention_mask, completion_len, batch_size=1, compute_entropy=True
+            )
+
+        with torch.no_grad():
+            dense_logps, dense_entropies, _ = forward(False, model_kwarg_keys)
+            packed_logps, packed_entropies, _ = forward(True, model_kwarg_keys)
+            # Models whose forward has no `logits_to_keep` take the full-logits path
+            sliced_logps, _, _ = forward(True, model_kwarg_keys - {"logits_to_keep"})
+
+        real = completion_mask.bool()
+        assert packed_logps.shape == dense_logps.shape == (3, completion_len)
+        torch.testing.assert_close(packed_logps[real], dense_logps[real])
+        torch.testing.assert_close(packed_entropies[real], dense_entropies[real])
+        torch.testing.assert_close(sliced_logps[real], dense_logps[real])
+        assert torch.all(packed_logps[~real] == 0)
+
+    def test_padding_free_backward(self):
+        # The scatter back to the padded layout must carry gradients to the model
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        )
+        trainer = SimpleNamespace(
+            model_kwarg_keys=set(inspect.signature(model.forward).parameters),
+            temperature=1.0,
+            padding_free=True,
+            _entropy_bonus_enabled=False,
+        )
+        input_ids = torch.randint(5, 100, (2, 6))
+        attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 0]])
+        logps, _, _ = GRPOTrainer._get_per_token_logps_and_entropies(
+            trainer, model, input_ids, attention_mask, 3, batch_size=1
+        )
+        logps.sum().backward()
+        assert model.get_input_embeddings().weight.grad is not None
+
+    def test_padding_free_requires_flash_attention(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="sdpa"
+        )
+        training_args = GRPOConfig(output_dir=self.tmp_dir, padding_free=True, report_to="none")
+        with pytest.raises(ValueError, match="requires a Flash Attention implementation, got 'sdpa'"):
+            GRPOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+    @require_liger_kernel
+    def test_padding_free_rejects_liger_kernel(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen3ForCausalLM")
+        model.config._attn_implementation = "flash_attention_2"  # pass the attention guard; no forward runs here
+        training_args = GRPOConfig(output_dir=self.tmp_dir, padding_free=True, use_liger_kernel=True, report_to="none")
+        with pytest.raises(ValueError, match="not supported with `use_liger_kernel=True`"):
+            GRPOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+    @require_vision
+    def test_padding_free_rejects_vision_language_models(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+        model = AutoModelForImageTextToText.from_pretrained(
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration"
+        )
+        model.config._attn_implementation = "flash_attention_2"  # pass the attention guard; no forward runs here
+        training_args = GRPOConfig(output_dir=self.tmp_dir, padding_free=True, report_to="none")
+        with pytest.raises(ValueError, match="not supported for vision-language models"):
+            GRPOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+    @pytest.mark.slow
+    @require_torch_accelerator
+    @require_kernels
+    @pytest.mark.skipif(
+        not is_ampere_or_newer() and torch_device != "xpu",
+        reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
+    )
+    @pytest.mark.xfail(
+        reason="kernels-community/flash-attn2 is currently unusable for training: no build variant for torch 2.13 "
+        "(https://github.com/huggingface/kernels-community/issues/1082), and the v3 stable-ABI build raises in the "
+        "backward pass for GQA models (https://github.com/huggingface/kernels-community/issues/1085)",
+    )
+    def test_train_padding_free(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        # A pretrained model: the tiny random-weight models give the same log-probs whether or not the samples in a
+        # packed row are separated, so they cannot tell the position resets apart from a plain causal row.
+        model = AutoModelForCausalLM.from_pretrained(
+            "Qwen/Qwen2.5-0.5B-Instruct", attn_implementation="kernels-community/flash-attn2", dtype=torch.bfloat16
+        )
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            padding_free=True,
+            bf16=True,
+            report_to="none",
+        )
+        trainer = GRPOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+        # Several samples in one packed row: the position-id resets must keep them apart, so the packed forward has to
+        # match the dense forward on every completion token.
+        tokenizer = trainer.processing_class
+        prompts = tokenizer(["The sky is", "One two three four five six"], padding=True, padding_side="left")
+        completions = tokenizer(["blue.", "seven eight nine"], padding=True, padding_side="right")
+        device = trainer.model.device
+        input_ids = torch.tensor(
+            [p + c for p, c in zip(prompts["input_ids"], completions["input_ids"], strict=True)], device=device
+        )
+        attention_mask = torch.tensor(
+            [p + c for p, c in zip(prompts["attention_mask"], completions["attention_mask"], strict=True)],
+            device=device,
+        )
+        logits_to_keep = len(completions["input_ids"][0])
+        with torch.no_grad():
+            packed_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+                trainer.model, input_ids, attention_mask, logits_to_keep, batch_size=2
+            )
+            trainer.padding_free = False
+            dense_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+                trainer.model, input_ids, attention_mask, logits_to_keep, batch_size=2
+            )
+            trainer.padding_free = True
+        completion_mask = attention_mask[:, -logits_to_keep:].bool()
+        torch.testing.assert_close(packed_logps[completion_mask], dense_logps[completion_mask], atol=5e-2, rtol=5e-2)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -5085,6 +5085,22 @@ class TestGRPOTrainerPaddingFree(TrlTestCase):
         logps.sum().backward()
         assert model.get_input_embeddings().weight.grad is not None
 
+    def test_padding_free_rejects_empty_prompt(self):
+        # A sample without a prompt token has no in-row predecessor for its first completion token
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        )
+        trainer = SimpleNamespace(
+            model_kwarg_keys=set(inspect.signature(model.forward).parameters),
+            temperature=1.0,
+            padding_free=True,
+            _entropy_bonus_enabled=False,
+        )
+        input_ids = torch.randint(5, 100, (2, 5))
+        attention_mask = torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]])
+        with pytest.raises(ValueError, match="at least one prompt token per sample"):
+            GRPOTrainer._get_per_token_logps_and_entropies(trainer, model, input_ids, attention_mask, 3, batch_size=2)
+
     def test_padding_free_requires_flash_attention(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         model = AutoModelForCausalLM.from_pretrained(

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -2312,6 +2312,22 @@ class TestRLOOTrainerPaddingFree(TrlTestCase):
         logps.sum().backward()
         assert model.get_input_embeddings().weight.grad is not None
 
+    def test_padding_free_rejects_empty_prompt(self):
+        # A sample without a prompt token has no in-row predecessor for its first completion token
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        )
+        trainer = SimpleNamespace(
+            model_kwarg_keys=set(inspect.signature(model.forward).parameters),
+            temperature=1.0,
+            padding_free=True,
+            _entropy_bonus_enabled=False,
+        )
+        input_ids = torch.randint(5, 100, (2, 5))
+        attention_mask = torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]])
+        with pytest.raises(ValueError, match="at least one prompt token per sample"):
+            RLOOTrainer._get_per_token_logps_and_entropies(trainer, model, input_ids, attention_mask, 3, batch_size=2)
+
     def test_padding_free_requires_flash_attention(self):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
         model = AutoModelForCausalLM.from_pretrained(

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -26,11 +28,21 @@ from transformers import (
     AutoTokenizer,
     BitsAndBytesConfig,
 )
+from transformers.testing_utils import torch_device
 from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
 
-from .testing_utils import TrlTestCase, require_bitsandbytes, require_peft, require_vision, require_vllm
+from .testing_utils import (
+    TrlTestCase,
+    is_ampere_or_newer,
+    require_bitsandbytes,
+    require_kernels,
+    require_peft,
+    require_torch_accelerator,
+    require_vision,
+    require_vllm,
+)
 
 
 if is_peft_available():
@@ -2232,3 +2244,154 @@ class TestRLOOTrainerVLM(TrlTestCase):
         )
         trainer.train()
         assert len(trainer._logs["images"]) == 0
+
+
+def reward_length(completions, **kwargs):
+    return [float(len(completion)) for completion in completions]
+
+
+class TestRLOOTrainerPaddingFree(TrlTestCase):
+    def test_padding_free_matches_padded_forward(self):
+        # Eager attention ignores position-id resets, so packing two samples into one row would let them attend to
+        # each other. With one row per chunk the packed row is exactly that row without its padding, so the packed
+        # and padded forwards must agree token for token, which pins down the flatten, index and scatter logic.
+        torch.manual_seed(0)
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        ).eval()
+        model_kwarg_keys = set(inspect.signature(model.forward).parameters)
+        prompt_len, completion_len = 5, 4
+        prompt_ids = torch.randint(5, 100, (3, prompt_len))
+        prompt_mask = torch.ones(3, prompt_len, dtype=torch.long)
+        prompt_mask[0, :2] = 0  # left padding
+        prompt_mask[2, :3] = 0
+        completion_ids = torch.randint(5, 100, (3, completion_len))
+        completion_mask = torch.ones(3, completion_len, dtype=torch.long)
+        completion_mask[1, 2:] = 0  # right padding
+        completion_mask[2, :] = 0  # a fully masked completion, as `mask_truncated_completions` produces
+        input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+        attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+
+        def forward(padding_free, keys):
+            trainer = SimpleNamespace(
+                model_kwarg_keys=keys, temperature=1.0, padding_free=padding_free, _entropy_bonus_enabled=False
+            )
+            return RLOOTrainer._get_per_token_logps_and_entropies(
+                trainer, model, input_ids, attention_mask, completion_len, batch_size=1, compute_entropy=True
+            )
+
+        with torch.no_grad():
+            dense_logps, dense_entropies, _ = forward(False, model_kwarg_keys)
+            packed_logps, packed_entropies, _ = forward(True, model_kwarg_keys)
+            # Models whose forward has no `logits_to_keep` take the full-logits path
+            sliced_logps, _, _ = forward(True, model_kwarg_keys - {"logits_to_keep"})
+
+        real = completion_mask.bool()
+        assert packed_logps.shape == dense_logps.shape == (3, completion_len)
+        torch.testing.assert_close(packed_logps[real], dense_logps[real])
+        torch.testing.assert_close(packed_entropies[real], dense_entropies[real])
+        torch.testing.assert_close(sliced_logps[real], dense_logps[real])
+        assert torch.all(packed_logps[~real] == 0)
+
+    def test_padding_free_backward(self):
+        # The scatter back to the padded layout must carry gradients to the model
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="eager"
+        )
+        trainer = SimpleNamespace(
+            model_kwarg_keys=set(inspect.signature(model.forward).parameters),
+            temperature=1.0,
+            padding_free=True,
+            _entropy_bonus_enabled=False,
+        )
+        input_ids = torch.randint(5, 100, (2, 6))
+        attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 0]])
+        logps, _, _ = RLOOTrainer._get_per_token_logps_and_entropies(
+            trainer, model, input_ids, attention_mask, 3, batch_size=1
+        )
+        logps.sum().backward()
+        assert model.get_input_embeddings().weight.grad is not None
+
+    def test_padding_free_requires_flash_attention(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        model = AutoModelForCausalLM.from_pretrained(
+            "trl-internal-testing/tiny-Qwen3ForCausalLM", attn_implementation="sdpa"
+        )
+        training_args = RLOOConfig(output_dir=self.tmp_dir, padding_free=True, report_to="none")
+        with pytest.raises(ValueError, match="requires a Flash Attention implementation, got 'sdpa'"):
+            RLOOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+    @require_vision
+    def test_padding_free_rejects_vision_language_models(self):
+        dataset = load_dataset("trl-internal-testing/zen-image", "conversational_prompt_only", split="train")
+        model = AutoModelForImageTextToText.from_pretrained(
+            "trl-internal-testing/tiny-Qwen2VLForConditionalGeneration"
+        )
+        model.config._attn_implementation = "flash_attention_2"  # pass the attention guard; no forward runs here
+        training_args = RLOOConfig(output_dir=self.tmp_dir, padding_free=True, report_to="none")
+        with pytest.raises(ValueError, match="not supported for vision-language models"):
+            RLOOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+    @pytest.mark.slow
+    @require_torch_accelerator
+    @require_kernels
+    @pytest.mark.skipif(
+        not is_ampere_or_newer() and torch_device != "xpu",
+        reason="Flash Attention 2 requires Ampere or newer GPU, or XPU",
+    )
+    @pytest.mark.xfail(
+        reason="kernels-community/flash-attn2 is currently unusable for training: no build variant for torch 2.13 "
+        "(https://github.com/huggingface/kernels-community/issues/1082), and the v3 stable-ABI build raises in the "
+        "backward pass for GQA models (https://github.com/huggingface/kernels-community/issues/1085)",
+    )
+    def test_train_padding_free(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+        # A pretrained model: the tiny random-weight models give the same log-probs whether or not the samples in a
+        # packed row are separated, so they cannot tell the position resets apart from a plain causal row.
+        model = AutoModelForCausalLM.from_pretrained(
+            "Qwen/Qwen2.5-0.5B-Instruct", attn_implementation="kernels-community/flash-attn2", dtype=torch.bfloat16
+        )
+        training_args = RLOOConfig(
+            output_dir=self.tmp_dir,
+            learning_rate=0.1,
+            per_device_train_batch_size=3,
+            num_generations=3,
+            max_completion_length=8,
+            padding_free=True,
+            bf16=True,
+            report_to="none",
+        )
+        trainer = RLOOTrainer(model=model, reward_funcs=reward_length, args=training_args, train_dataset=dataset)
+
+        # Several samples in one packed row: the position-id resets must keep them apart, so the packed forward has to
+        # match the dense forward on every completion token.
+        tokenizer = trainer.processing_class
+        prompts = tokenizer(["The sky is", "One two three four five six"], padding=True, padding_side="left")
+        completions = tokenizer(["blue.", "seven eight nine"], padding=True, padding_side="right")
+        device = trainer.model.device
+        input_ids = torch.tensor(
+            [p + c for p, c in zip(prompts["input_ids"], completions["input_ids"], strict=True)], device=device
+        )
+        attention_mask = torch.tensor(
+            [p + c for p, c in zip(prompts["attention_mask"], completions["attention_mask"], strict=True)],
+            device=device,
+        )
+        logits_to_keep = len(completions["input_ids"][0])
+        with torch.no_grad():
+            packed_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+                trainer.model, input_ids, attention_mask, logits_to_keep, batch_size=2
+            )
+            trainer.padding_free = False
+            dense_logps, _, _ = trainer._get_per_token_logps_and_entropies(
+                trainer.model, input_ids, attention_mask, logits_to_keep, batch_size=2
+            )
+            trainer.padding_free = True
+        completion_mask = attention_mask[:, -logits_to_keep:].bool()
+        torch.testing.assert_close(packed_logps[completion_mask], dense_logps[completion_mask], atol=5e-2, rtol=5e-2)
+
+        previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+        trainer.train()
+        assert trainer.state.log_history[-1]["train_loss"] is not None
+        for n, param in previous_trainable_params.items():
+            new_param = trainer.model.get_parameter(n)
+            assert not torch.equal(param, new_param), f"Parameter {n} has not changed."

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -275,6 +275,12 @@ class GRPOConfig(_BaseConfig):
             When enabled, truncated completions are excluded from the loss calculation, preventing them from being
             incorrectly penalized and introducing noise during training. According to the
             [DAPO](https://huggingface.co/papers/2503.14476) paper, this is a good practice for training stability.
+        padding_free (`bool`, *optional*, defaults to `False`):
+            Whether to run the per-token log-prob forward on a packed row: each micro-batch's real tokens are
+            concatenated into a single sequence with position ids that restart per sample and no attention mask, so a
+            Flash Attention implementation separates the samples from the position resets. Saves the padded compute.
+            Requires a Flash Attention `attn_implementation`; incompatible with `use_liger_kernel` and with
+            vision-language models.
         sync_ref_model (`bool`, *optional*, defaults to `False`):
             Whether to synchronize the reference model with the active model every `ref_model_sync_steps` steps, using
             the `ref_model_mixup_alpha` parameter. This synchronization originates from the
@@ -832,6 +838,16 @@ class GRPOConfig(_BaseConfig):
             "help": "When enabled, truncated completions are excluded from the loss calculation, preventing them from "
             "being incorrectly penalized and introducing noise during training. According to the DAPO paper, this is "
             "a good practice for training stability."
+        },
+    )
+    padding_free: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to run the per-token log-prob forward on a packed row: each micro-batch's real tokens are "
+            "concatenated into a single sequence with position ids that restart per sample and no attention mask, "
+            "so a Flash Attention implementation separates the samples from the position resets. Saves the padded "
+            "compute. Requires a Flash Attention `attn_implementation`; incompatible with `use_liger_kernel` and "
+            "with vision-language models."
         },
     )
     sync_ref_model: bool = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -1550,6 +1550,11 @@ class GRPOTrainer(_BaseTrainer):
                 mask = attention_mask_batch.bool()
                 completion_mask_batch = mask.clone()
                 completion_mask_batch[:, :-logits_to_keep] = False
+                if (mask.sum(dim=1) == completion_mask_batch.sum(dim=1)).any():
+                    raise ValueError(
+                        "`padding_free=True` needs at least one prompt token per sample: the first completion token "
+                        "of a sample without one has no predecessor in the packed row to take its logit from."
+                    )
                 keep_idx = completion_mask_batch[mask].nonzero(as_tuple=True)[0]
                 seq_lengths = mask.sum(dim=1).tolist()
                 model_inputs = {

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -118,6 +118,17 @@ if is_wandb_available():
 
 logger = get_logger(__name__)
 
+# Attention implementations that derive `cu_seqlens` from position-id resets, which the padding-free forward relies on.
+FLASH_ATTENTION_VARIANTS = {
+    "flash_attention_2",
+    "flash_attention_3",
+    "kernels-community/flash-attn",
+    "kernels-community/flash-attn2",
+    "kernels-community/flash-attn3",
+    "kernels-community/vllm-flash-attn3",
+    "kernels-community/aiter-flash-attn",
+}
+
 # A reward function can be a string, interpreted as a model ID and loaded as a pretrained model, a pretrained model, or
 # a callable that returns a list of floats (the rewards). The callable receives prompts, completions, and additional
 # arguments from the trainer (refer to the trainer's source for details). To ensure forward compatibility, it should
@@ -816,6 +827,23 @@ class GRPOTrainer(_BaseTrainer):
                     "`use_liger_kernel=False`."
                 )
         self.mask_truncated_completions = args.mask_truncated_completions
+        self.padding_free = args.padding_free
+        if self.padding_free:
+            attn_implementation = model.config._attn_implementation.split("@")[0].split(":")[0]
+            if attn_implementation not in FLASH_ATTENTION_VARIANTS:
+                raise ValueError(
+                    f"`padding_free=True` requires a Flash Attention implementation, got {attn_implementation!r}. The "
+                    "packed forward carries no attention mask and separates the samples through position-id resets, "
+                    f"which only these implementations honor: {sorted(FLASH_ATTENTION_VARIANTS)}. Set "
+                    "`attn_implementation` in the model configuration or disable `padding_free`."
+                )
+            if self.use_liger_kernel:
+                raise ValueError("`padding_free=True` is not supported with `use_liger_kernel=True`.")
+            if self._is_vlm:
+                raise ValueError(
+                    "`padding_free=True` is not supported for vision-language models: the multimodal inputs are "
+                    "indexed per sample and stay on the padded forward."
+                )
         self.top_entropy_quantile = args.top_entropy_quantile
         if self.use_liger_kernel and self.top_entropy_quantile < 1.0:
             raise NotImplementedError(
@@ -1513,8 +1541,26 @@ class GRPOTrainer(_BaseTrainer):
             if mm_token_type_ids is not None:
                 model_inputs["mm_token_type_ids"] = mm_token_type_ids[start:end]
 
-            # Only add logits_to_keep if the model supports it
-            if "logits_to_keep" in self.model_kwarg_keys:
+            if self.padding_free:
+                # Pack the chunk's real tokens into one row: position ids restart per sample and no attention mask is
+                # passed, so a Flash Attention implementation derives `cu_seqlens` from the resets (a mask would make
+                # it ignore the position ids). The completion tokens sit in the last `logits_to_keep` columns of the
+                # dense block; the logit that predicts token t is at t - 1, and every completion token's predecessor
+                # lies in its own row, so `keep_idx - 1` selects exactly the logits the dense path keeps.
+                mask = attention_mask_batch.bool()
+                completion_mask_batch = mask.clone()
+                completion_mask_batch[:, :-logits_to_keep] = False
+                keep_idx = completion_mask_batch[mask].nonzero(as_tuple=True)[0]
+                seq_lengths = mask.sum(dim=1).tolist()
+                model_inputs = {
+                    "input_ids": input_ids_batch[mask].unsqueeze(0),
+                    "position_ids": torch.cat(
+                        [torch.arange(n, device=input_ids.device) for n in seq_lengths]
+                    ).unsqueeze(0),
+                }
+                if "logits_to_keep" in self.model_kwarg_keys:
+                    model_inputs["logits_to_keep"] = keep_idx - 1
+            elif "logits_to_keep" in self.model_kwarg_keys:
                 # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
                 model_inputs["logits_to_keep"] = logits_to_keep + 1
 
@@ -1527,15 +1573,26 @@ class GRPOTrainer(_BaseTrainer):
 
             outputs = model(**model_inputs)
             logits = outputs.logits
-            # Exclude the last value: it corresponds to the next token pred
-            logits = logits[:, :-1, :]  # (B, L-1, H)
-            # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.
-            logits = logits[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
+            if self.padding_free:
+                if "logits_to_keep" not in self.model_kwarg_keys:
+                    logits = logits[:, keep_idx - 1, :]  # (1, K, H)
+                completion_ids = model_inputs["input_ids"][:, keep_idx]
+            else:
+                # Exclude the last value: it corresponds to the next token pred
+                logits = logits[:, :-1, :]  # (B, L-1, H)
+                # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.
+                logits = logits[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
+                completion_ids = input_ids_batch[:, -logits_to_keep:]
             # Divide logits by sampling temperature.
             # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
             logits = logits / self.temperature
-            completion_ids = input_ids_batch[:, -logits_to_keep:]
             logps = selective_log_softmax(logits, completion_ids)  # compute logprobs
+            if self.padding_free:
+                # Scatter the packed values back into the padded (b, logits_to_keep) layout the callers expect.
+                target_mask = completion_mask_batch[:, -logits_to_keep:]
+                packed_logps = logps
+                logps = torch.zeros(target_mask.shape, dtype=packed_logps.dtype, device=packed_logps.device)
+                logps[target_mask] = packed_logps[0]
             all_logps.append(logps)
 
             if compute_entropy:
@@ -1547,6 +1604,12 @@ class GRPOTrainer(_BaseTrainer):
                 else:
                     with torch.no_grad():
                         entropies = entropy_from_logits(logits)
+                if self.padding_free:
+                    packed_entropies = entropies
+                    entropies = torch.zeros(
+                        target_mask.shape, dtype=packed_entropies.dtype, device=packed_entropies.device
+                    )
+                    entropies[target_mask] = packed_entropies[0]
                 all_entropies.append(entropies)
 
             if compute_aux_loss:

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -192,6 +192,11 @@ class RLOOConfig(_BaseConfig):
             When enabled, truncated completions are excluded from the loss calculation, preventing them from being
             incorrectly penalized and introducing noise during training. According to the
             [DAPO](https://huggingface.co/papers/2503.14476) paper, this is a good practice for training stability.
+        padding_free (`bool`, *optional*, defaults to `False`):
+            Whether to run the per-token log-prob forward on a packed row: each micro-batch's real tokens are
+            concatenated into a single sequence with position ids that restart per sample and no attention mask, so a
+            Flash Attention implementation separates the samples from the position resets. Saves the padded compute.
+            Requires a Flash Attention `attn_implementation`; not supported with vision-language models.
         sync_ref_model (`bool`, *optional*, defaults to `False`):
             Whether to synchronize the reference model with the active model every `ref_model_sync_steps` steps, using
             the `ref_model_mixup_alpha` parameter. This synchronization originates from the
@@ -538,6 +543,15 @@ class RLOOConfig(_BaseConfig):
             "help": "When enabled, truncated completions are excluded from the loss calculation, preventing them from "
             "being incorrectly penalized and introducing noise during training. According to the DAPO paper, this is "
             "a good practice for training stability."
+        },
+    )
+    padding_free: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to run the per-token log-prob forward on a packed row: each micro-batch's real tokens are "
+            "concatenated into a single sequence with position ids that restart per sample and no attention mask, "
+            "so a Flash Attention implementation separates the samples from the position resets. Saves the padded "
+            "compute. Requires a Flash Attention `attn_implementation`; not supported with vision-language models."
         },
     )
     sync_ref_model: bool = field(

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -99,6 +99,17 @@ if is_wandb_available():
 
 logger = get_logger(__name__)
 
+# Attention implementations that derive `cu_seqlens` from position-id resets, which the padding-free forward relies on.
+FLASH_ATTENTION_VARIANTS = {
+    "flash_attention_2",
+    "flash_attention_3",
+    "kernels-community/flash-attn",
+    "kernels-community/flash-attn2",
+    "kernels-community/flash-attn3",
+    "kernels-community/vllm-flash-attn3",
+    "kernels-community/aiter-flash-attn",
+}
+
 # A reward function can be a string, interpreted as a model ID and loaded as a pretrained model, a pretrained model, or
 # a callable that returns a list of floats (the rewards). The callable receives prompts, completions, and additional
 # arguments from the trainer (refer to the trainer's source for details). To ensure forward compatibility, it should
@@ -522,6 +533,21 @@ class RLOOTrainer(_BaseTrainer):
         self.vllm_tensor_parallel_size = args.vllm_tensor_parallel_size  # only applies to colocation mode
         self.normalize_advantages = args.normalize_advantages
         self.mask_truncated_completions = args.mask_truncated_completions
+        self.padding_free = args.padding_free
+        if self.padding_free:
+            attn_implementation = model.config._attn_implementation.split("@")[0].split(":")[0]
+            if attn_implementation not in FLASH_ATTENTION_VARIANTS:
+                raise ValueError(
+                    f"`padding_free=True` requires a Flash Attention implementation, got {attn_implementation!r}. The "
+                    "packed forward carries no attention mask and separates the samples through position-id resets, "
+                    f"which only these implementations honor: {sorted(FLASH_ATTENTION_VARIANTS)}. Set "
+                    "`attn_implementation` in the model configuration or disable `padding_free`."
+                )
+            if isinstance(processing_class, ProcessorMixin):
+                raise ValueError(
+                    "`padding_free=True` is not supported for vision-language models: the multimodal inputs are "
+                    "indexed per sample and stay on the padded forward."
+                )
         self.reward_clip_range = args.reward_clip_range
 
         # Datasets
@@ -960,8 +986,26 @@ class RLOOTrainer(_BaseTrainer):
             if mm_token_type_ids is not None:
                 model_inputs["mm_token_type_ids"] = mm_token_type_ids[start:end]
 
-            # Only add logits_to_keep if the model supports it
-            if "logits_to_keep" in self.model_kwarg_keys:
+            if self.padding_free:
+                # Pack the chunk's real tokens into one row: position ids restart per sample and no attention mask is
+                # passed, so a Flash Attention implementation derives `cu_seqlens` from the resets (a mask would make
+                # it ignore the position ids). The completion tokens sit in the last `logits_to_keep` columns of the
+                # dense block; the logit that predicts token t is at t - 1, and every completion token's predecessor
+                # lies in its own row, so `keep_idx - 1` selects exactly the logits the dense path keeps.
+                mask = attention_mask_batch.bool()
+                completion_mask_batch = mask.clone()
+                completion_mask_batch[:, :-logits_to_keep] = False
+                keep_idx = completion_mask_batch[mask].nonzero(as_tuple=True)[0]
+                seq_lengths = mask.sum(dim=1).tolist()
+                model_inputs = {
+                    "input_ids": input_ids_batch[mask].unsqueeze(0),
+                    "position_ids": torch.cat(
+                        [torch.arange(n, device=input_ids.device) for n in seq_lengths]
+                    ).unsqueeze(0),
+                }
+                if "logits_to_keep" in self.model_kwarg_keys:
+                    model_inputs["logits_to_keep"] = keep_idx - 1
+            elif "logits_to_keep" in self.model_kwarg_keys:
                 # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
                 model_inputs["logits_to_keep"] = logits_to_keep + 1
 
@@ -974,20 +1018,37 @@ class RLOOTrainer(_BaseTrainer):
 
             outputs = model(**model_inputs)
             logits = outputs.logits
-            # Exclude the last value: it corresponds to the next token pred
-            logits = logits[:, :-1, :]  # (B, L-1, H)
-            # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.
-            logits = logits[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
+            if self.padding_free:
+                if "logits_to_keep" not in self.model_kwarg_keys:
+                    logits = logits[:, keep_idx - 1, :]  # (1, K, H)
+                completion_ids = model_inputs["input_ids"][:, keep_idx]
+            else:
+                # Exclude the last value: it corresponds to the next token pred
+                logits = logits[:, :-1, :]  # (B, L-1, H)
+                # Only keep the last logits_to_keep. For model that support logits_to_keep, this is a no-op.
+                logits = logits[:, -logits_to_keep:, :]  # (B, logits_to_keep, H)
+                completion_ids = input_ids_batch[:, -logits_to_keep:]
             # Divide logits by sampling temperature.
             # See https://huggingface.co/blog/the_n_implementation_details_of_rlhf_with_ppo#policy-training-implementation-details
             logits = logits / self.temperature
-            completion_ids = input_ids_batch[:, -logits_to_keep:]
             logps = selective_log_softmax(logits, completion_ids)  # compute logprobs
+            if self.padding_free:
+                # Scatter the packed values back into the padded (b, logits_to_keep) layout the callers expect.
+                target_mask = completion_mask_batch[:, -logits_to_keep:]
+                packed_logps = logps
+                logps = torch.zeros(target_mask.shape, dtype=packed_logps.dtype, device=packed_logps.device)
+                logps[target_mask] = packed_logps[0]
             all_logps.append(logps)
 
             if compute_entropy:
                 with torch.no_grad():
                     entropies = entropy_from_logits(logits)
+                if self.padding_free:
+                    packed_entropies = entropies
+                    entropies = torch.zeros(
+                        target_mask.shape, dtype=packed_entropies.dtype, device=packed_entropies.device
+                    )
+                    entropies[target_mask] = packed_entropies[0]
                 all_entropies.append(entropies)
 
             if compute_aux_loss:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -995,6 +995,11 @@ class RLOOTrainer(_BaseTrainer):
                 mask = attention_mask_batch.bool()
                 completion_mask_batch = mask.clone()
                 completion_mask_batch[:, :-logits_to_keep] = False
+                if (mask.sum(dim=1) == completion_mask_batch.sum(dim=1)).any():
+                    raise ValueError(
+                        "`padding_free=True` needs at least one prompt token per sample: the first completion token "
+                        "of a sample without one has no predecessor in the packed row to take its logit from."
+                    )
                 keep_idx = completion_mask_batch[mask].nonzero(as_tuple=True)[0]
                 seq_lengths = mask.sum(dim=1).tolist()
                 model_inputs = {


### PR DESCRIPTION
GRPO and RLOO log-probability forwards spent compute on padded tokens. I added optional padding-free forwards that pack real tokens, reset positions per sample, and restore the padded output layout, with checks for unsupported configurations. CPU tests cover output values, gradients, and guards, and GPU tests compare packed and dense outputs and train with finite loss. Prefix sharing remains open on #3549.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core log-prob forward path when enabled; incorrect packing or models that ignore position-id resets could silently mix samples or skew policy gradients, though defaults stay off and guards limit unsupported setups.
> 
> **Overview**
> Adds optional **`padding_free=True`** to **GRPO** and **RLOO** so per-token log-probability forwards pack each micro-batch’s non-padding tokens into one sequence with per-sample **position-id resets** (no attention mask), then **scatter** log-probs and entropies back into the usual padded `(batch, completion_len)` layout so losses and metrics stay the same.
> 
> **`GRPOConfig` / `RLOOConfig`** expose the flag; trainers validate **Flash Attention** on policy and reference models, reject **VLMs**, and GRPO also rejects **`use_liger_kernel`**. Docs describe usage, requirements, and models where position resets do not isolate samples.
> 
> New tests check packed vs dense agreement, backward grads, validation errors, and a slow GPU training path (xfail where flash kernels are broken).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9657bbb801db2acb0400fda919bbd9f1ab13084e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->