### PR TITLE
Group Dependabot GitHub Actions and pre-commit updates in a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,35 @@
 version: 2
+
+# Single PR for all CI pins: doc-builder is pinned both in .github/workflows and in pre-commit.
+multi-ecosystem-groups:
+  github-actions-and-pre-commit:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      actions:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: "github-actions-and-pre-commit"
 
   # Actions pinned inside our local composite actions. The "/" directory above
   # does not cover them: it only scans .github/workflows and the root action.yml.
   - package-ecosystem: "github-actions"
     directories:
       - "/.github/actions/*"
-    schedule:
-      interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      local-actions:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: "github-actions-and-pre-commit"
 
-  # Not grouped, so that each hook bump stays reviewable on its own
   - package-ecosystem: "pre-commit"
     directory: "/"
-    schedule:
-      interval: "weekly"
     cooldown:
       default-days: 7
+    patterns: ["*"]
+    multi-ecosystem-group: "github-actions-and-pre-commit"
     ignore:
       # Ruff is frozen on purpose: a bump reformats code and rewrites source through `--fix`, without
       # reporting anything new under our own rule selection. Bump it by hand when there is a reason.


### PR DESCRIPTION
This PR makes Dependabot open a single pull request for all our CI pins, instead of one per package ecosystem.

### Motivation

`doc-builder` is pinned twice: as reusable workflows in `.github/workflows` and as the hook `rev` in `.pre-commit-config.yaml`. Since these live in two different Dependabot ecosystems (`github-actions` and `pre-commit`), each bump arrived as two separate pull requests that had to be merged together, as in #7078 and #7079.

### Solution

Dependabot multi-ecosystem groups combine updates from several ecosystems into one pull request. The three update entries (workflow actions, composite action actions, and pre-commit hooks) now belong to a single group, so both `doc-builder` pins always move together.

The per-entry `schedule` keys are dropped because the group provides the schedule. The `cooldown` and `ignore` settings stay per entry, as they are not supported at group level.

### Changes

- Add a `github-actions-and-pre-commit` multi-ecosystem group with a weekly schedule
- Assign the `github-actions` and `pre-commit` update entries to that group
- Remove the now redundant `actions` and `local-actions` single-ecosystem groups

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/dependabot.yml` changes how update PRs are grouped; no application or workflow logic is modified.
> 
> **Overview**
> Dependabot will now open **one weekly PR** for CI dependency bumps instead of separate PRs per ecosystem.
> 
> The config adds a `multi-ecosystem-groups` entry (`github-actions-and-pre-commit`) and wires all three update blocks—root workflows, `/.github/actions/*`, and pre-commit—to that group. Per-entry **weekly `schedule`** keys and the old single-ecosystem **`groups`** (`actions`, `local-actions`) are removed in favor of top-level **`patterns`** and **`multi-ecosystem-group`**. **Cooldown** and the **Ruff pre-commit ignore** are unchanged on each entry.
> 
> This keeps paired pins (e.g. `doc-builder` in workflows and `.pre-commit-config.yaml`) on the same bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef73d9633aaf31ca3381b5b2b56af674aa8bcfe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->