### PR TITLE
Fix Gemma 3 pan-and-scan crop batching in GRPO, RLOO, and Distillation

### DIFF
--- a/docs/source/distillation_trainer.md
+++ b/docs/source/distillation_trainer.md
@@ -295,6 +295,8 @@ trl distillation \
     --lora_alpha 16
 ```
 
+Gemma 3 pan-and-scan crops are kept with their source sample when splitting training microbatches. Enable it with `AutoProcessor.from_pretrained(model_id, do_pan_and_scan=True)` and pass that processor as `processing_class`. Additional crops increase memory use.
+
 ## DistillationTrainer
 
 [[autodoc]] DistillationTrainer

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -1039,6 +1039,19 @@ Each training sample should include:
 
 The trainer automatically handles image-to-tensor conversion via the model’s image processor.
 
+For Gemma 3, pan-and-scan can be enabled when loading the processor:
+
+```python
+processor = AutoProcessor.from_pretrained(model_id, do_pan_and_scan=True)
+trainer = GRPOTrainer(
+    model=model_id,
+    processing_class=processor,
+    # ...
+)
+```
+
+Pan-and-scan may expand an image into the original image plus several crops. GRPO keeps these crops together when splitting rollout batches into training microbatches. Crops increase memory use, so consider reducing the per-device batch size.
+
 ## GRPOTrainer
 
 [[autodoc]] GRPOTrainer

--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -597,6 +597,8 @@ Each training sample should include:
 
 The trainer automatically handles image-to-tensor conversion via the model’s image processor.
 
+Gemma 3 pan-and-scan crops are kept with their source sample when splitting training microbatches. Enable it with `AutoProcessor.from_pretrained(model_id, do_pan_and_scan=True)` and pass that processor as `processing_class`. Additional crops increase memory use.
+
 ## RLOOTrainer
 
 [[autodoc]] RLOOTrainer

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -26,6 +26,7 @@ from accelerate.utils.memory import release_memory
 from datasets import Dataset, DatasetDict, IterableDatasetDict, load_dataset
 from packaging.version import Version
 from transformers import (
+    AutoConfig,
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
     AutoModelForSequenceClassification,
@@ -4017,6 +4018,69 @@ class TestGRPOTrainerVLM(TrlTestCase):
                 assert torch.equal(param, new_param), f"Param {n} expected frozen by LLaVA design, but changed"
             else:
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    @pytest.mark.parametrize("pan_and_scan", [False, True])
+    def test_train_gemma_pan_and_scan(self, pan_and_scan):
+        from PIL import Image
+
+        model_id = "trl-internal-testing/tiny-Gemma3ForConditionalGeneration"
+        crop_options = {
+            "do_pan_and_scan": pan_and_scan,
+            "pan_and_scan_min_crop_size": 32,
+            "pan_and_scan_max_num_crops": 4,
+            "pan_and_scan_min_ratio_to_activate": 1.2,
+        }
+        processor = AutoProcessor.from_pretrained(model_id, image_seq_length=4, **crop_options)
+        processor.image_processor.size = {"height": 28, "width": 28}
+        config = AutoConfig.from_pretrained(model_id)
+        config.vision_config.image_size = 28
+        config.mm_tokens_per_image = 4
+        config.text_config.head_dim = 8
+        config.text_config.query_pre_attn_scalar = 8
+        model = AutoModelForImageTextToText.from_config(config, attn_implementation="eager")
+        dataset = Dataset.from_dict(
+            {
+                "prompt": [[{"role": "user", "content": "Describe the image."}]] * 4,
+                "image": [
+                    Image.new("RGB", size, color)
+                    for size, color in [
+                        ((128, 32), "red"),
+                        ((32, 32), "blue"),
+                        ((32, 128), "green"),
+                        ((32, 32), "white"),
+                    ]
+                ],
+            }
+        )
+
+        def reward_func(completions, **kwargs):
+            return [float(i % 2) for i in range(len(completions))]
+
+        args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            bf16=False,
+            fp16=False,
+            gradient_checkpointing=False,
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=2,
+            generation_batch_size=4,
+            num_generations=2,
+            max_completion_length=2,
+            max_steps=2,
+            learning_rate=0.01,
+            report_to="none",
+            save_strategy="no",
+            mask_truncated_completions=False,
+            seed=42,
+        )
+        trainer = GRPOTrainer(
+            model=model, processing_class=processor, args=args, train_dataset=dataset, reward_funcs=reward_func
+        )
+        before = model.model.multi_modal_projector.mm_input_projection_weight.detach().clone()
+        result = trainer.train()
+        assert trainer.state.global_step == 2
+        assert torch.isfinite(torch.tensor(result.training_loss))
+        assert not torch.equal(before, model.model.multi_modal_projector.mm_input_projection_weight.detach())
 
     def test_train_vlm_with_pad_to_multiple_of(self):
         # Models like Gemma3 use other forward keyword arguments like token_type_ids that also need to be padded when

--- a/tests/test_vlm_pan_and_scan.py
+++ b/tests/test_vlm_pan_and_scan.py
@@ -1,0 +1,87 @@
+import copy
+
+import pytest
+import torch
+from datasets import Dataset
+from PIL import Image
+from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+from trl import DistillationConfig, DistillationTrainer, RLOOConfig, RLOOTrainer
+
+
+@pytest.mark.parametrize("pan_and_scan", [False, True])
+@pytest.mark.parametrize("trainer_kind", ["rloo", "distillation"])
+def test_train_gemma_pan_and_scan(tmp_path, pan_and_scan, trainer_kind):
+    model_id = "trl-internal-testing/tiny-Gemma3ForConditionalGeneration"
+    processor = AutoProcessor.from_pretrained(
+        model_id,
+        image_seq_length=4,
+        do_pan_and_scan=pan_and_scan,
+        pan_and_scan_min_crop_size=32,
+        pan_and_scan_max_num_crops=4,
+        pan_and_scan_min_ratio_to_activate=1.2,
+    )
+    processor.image_processor.size = {"height": 28, "width": 28}
+    config = AutoConfig.from_pretrained(model_id)
+    config.vision_config.image_size = 28
+    config.mm_tokens_per_image = 4
+    config.text_config.head_dim = 8
+    config.text_config.query_pre_attn_scalar = 8
+    model = AutoModelForImageTextToText.from_config(config, attn_implementation="eager")
+    dataset = Dataset.from_dict(
+        {
+            "prompt": [[{"role": "user", "content": "Describe the image."}]] * 4,
+            "image": [
+                Image.new("RGB", size, color)
+                for size, color in [
+                    ((128, 32), "red"),
+                    ((32, 32), "blue"),
+                    ((32, 128), "green"),
+                    ((32, 32), "white"),
+                ]
+            ],
+        }
+    )
+    config_kwargs = dict(
+        output_dir=str(tmp_path),
+        bf16=False,
+        fp16=False,
+        gradient_checkpointing=False,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=2,
+        max_completion_length=2,
+        max_steps=2,
+        learning_rate=0.01,
+        report_to="none",
+        save_strategy="no",
+        seed=42,
+    )
+    if trainer_kind == "rloo":
+        initial_model_path = tmp_path / "initial_model"
+        model.save_pretrained(initial_model_path)
+        model.config._name_or_path = str(initial_model_path)
+
+        def reward_func(completions, **kwargs):
+            return [float(i % 2) for i in range(len(completions))]
+
+        trainer = RLOOTrainer(
+            model=model,
+            processing_class=processor,
+            args=RLOOConfig(**config_kwargs, generation_batch_size=4, num_generations=2),
+            train_dataset=dataset,
+            reward_funcs=reward_func,
+        )
+    else:
+        trainer = DistillationTrainer(
+            model=model,
+            teacher_model=copy.deepcopy(model),
+            processing_class=processor,
+            args=DistillationConfig(**config_kwargs),
+            train_dataset=dataset,
+        )
+    before = model.model.multi_modal_projector.mm_input_projection_weight.detach().clone()
+    result = trainer.train()
+    assert trainer.state.global_step == 2
+    assert torch.isfinite(torch.tensor(result.training_loss))
+    if trainer_kind == "rloo":
+        assert not torch.equal(before, model.model.multi_modal_projector.mm_input_projection_weight.detach())

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -1639,15 +1639,21 @@ class DistillationTrainer(_BaseTrainer):
             if self.processing_class.image_processor.use_thumbnail:
                 tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(tiles_per_image.dtype)
             num_tiles = [group.sum().item() for group in torch.split(tiles_per_image, num_images)]
-        # Same for InternVL, whose pixel_values is tile-indexed ([total_tiles, channels, height, width]).
+        # Recover counts for crop/tile-indexed pixels (Gemma pan-and-scan and InternVL).
         elif (
             images is not None
             and forward_kwargs["pixel_values"].ndim == 4
             and forward_kwargs["pixel_values"].size(0) != sum(num_images)
         ):
-            num_patches = self.processing_class.image_processor(
-                images=images, crop_to_patches=True, return_tensors="pt"
-            )["num_patches"]
+            if "num_crops" in self.processing_class.image_processor.model_input_names and hasattr(
+                self.processing_class.image_processor, "do_pan_and_scan"
+            ):
+                image_info = self.processing_class.image_processor(images=images, return_tensors="pt")
+                num_patches = torch.as_tensor(image_info["num_crops"]) + 1
+            else:
+                num_patches = self.processing_class.image_processor(
+                    images=images, crop_to_patches=True, return_tensors="pt"
+                )["num_patches"]
             num_tiles = [group.sum().item() for group in torch.split(num_patches, num_images)]
 
         # If token_type_ids are used, extend them with zeros for the completion part

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -2557,15 +2557,21 @@ class GRPOTrainer(_BaseTrainer):
             if self.processing_class.image_processor.use_thumbnail:
                 tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(tiles_per_image.dtype)
             num_tiles = [group.sum().item() for group in torch.split(tiles_per_image, num_images)]
-        # Same for InternVL, whose pixel_values is tile-indexed ([total_tiles, channels, height, width]).
+        # Recover counts for crop/tile-indexed pixels (Gemma pan-and-scan and InternVL).
         elif (
             images is not None
             and forward_kwargs["pixel_values"].ndim == 4
             and forward_kwargs["pixel_values"].size(0) != sum(num_images)
         ):
-            num_patches = self.processing_class.image_processor(
-                images=images, crop_to_patches=True, return_tensors="pt"
-            )["num_patches"]
+            if "num_crops" in self.processing_class.image_processor.model_input_names and hasattr(
+                self.processing_class.image_processor, "do_pan_and_scan"
+            ):
+                image_info = self.processing_class.image_processor(images=images, return_tensors="pt")
+                num_patches = torch.as_tensor(image_info["num_crops"]) + 1
+            else:
+                num_patches = self.processing_class.image_processor(
+                    images=images, crop_to_patches=True, return_tensors="pt"
+                )["num_patches"]
             num_tiles = [group.sum().item() for group in torch.split(num_patches, num_images)]
 
         # If token_type_ids are used, extend them with zeros for the completion part

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1456,15 +1456,21 @@ class RLOOTrainer(_BaseTrainer):
             if self.processing_class.image_processor.use_thumbnail:
                 tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(tiles_per_image.dtype)
             num_tiles = [group.sum().item() for group in torch.split(tiles_per_image, num_images)]
-        # Same for InternVL, whose pixel_values is tile-indexed ([total_tiles, channels, height, width]).
+        # Recover counts for crop/tile-indexed pixels (Gemma pan-and-scan and InternVL).
         elif (
             images is not None
             and forward_kwargs["pixel_values"].ndim == 4
             and forward_kwargs["pixel_values"].size(0) != sum(num_images)
         ):
-            num_patches = self.processing_class.image_processor(
-                images=images, crop_to_patches=True, return_tensors="pt"
-            )["num_patches"]
+            if "num_crops" in self.processing_class.image_processor.model_input_names and hasattr(
+                self.processing_class.image_processor, "do_pan_and_scan"
+            ):
+                image_info = self.processing_class.image_processor(images=images, return_tensors="pt")
+                num_patches = torch.as_tensor(image_info["num_crops"]) + 1
+            else:
+                num_patches = self.processing_class.image_processor(
+                    images=images, crop_to_patches=True, return_tensors="pt"
+                )["num_patches"]
             num_tiles = [group.sum().item() for group in torch.split(num_patches, num_images)]
 
         # If token_type_ids are used, extend them with zeros for the completion part


### PR DESCRIPTION
# What does this PR do?

Fix Gemma 3 pan-and-scan crop batching in GRPO, RLOO, and DistillationTrainer.

These trainers treat a four-dimensional `pixel_values` tensor with more entries than source images as an InternVL tiled-image batch. When Gemma 3 pan-and-scan expands an image into multiple crops, that branch passes an unsupported keyword to its image processor:

```text
TypeError: Gemma3ImageProcessorKwargs.__init__() got an unexpected keyword argument 'crop_to_patches'
```

The fix recovers each original image's count as `num_crops + 1` for processors exposing crop metadata and pan-and-scan capability. It groups those counts per sample and uses the existing `num_tiles` batching path, preserving image/crop ownership through shuffling and microbatch splitting. Both the capability and output name are checked because Aria also exposes `num_crops` with different semantics; this does not add Aria support. Existing InternVL and LFM2-VL branches are preserved.

The identical preprocessing block is updated in all three trainers, following TRL's duplicated-code consistency policy. Regression tests cover pan-and-scan off/on, mixed image aspect ratios, real generation and training, finite loss, and GRPO/RLOO vision-projector updates. Distillation uses a self-distillation teacher and checks completed training and finite loss rather than claiming a nonzero teacher signal. Public processor configuration is documented for all three trainers.

## Validation

- Before the fix, all three trainers reproduce the unsupported `crop_to_patches` failure with pan-and-scan on; off controls pass.
- The original GRPO patch passed 34 focused CPU checks covering real training, processor save/reload, environment tokenization parity, crop ownership, capability discrimination, and existing batch utilities.
- The two additional trainers passed four actual-training CPU tests and four GPU tests (pan-and-scan off/on for each).
- GRPO GPU checks: four passed, covering Gemma off/on and InternVL/Qwen2.5-VL regressions.
- Separate integration with #6699: two additional Gemma crop off/on GPU tests passed using actual Liger loss/backward. The #6699 changes are not included here.
- Ruff lint/format, `git diff --check`, and exact equality of the three crop-count blocks passed.

The submission is based on TRL main `1ecae07b`; the previously GPU-tested GRPO source and regression test are unchanged. Tests use tiny models and Transformers main `c93057d4`. GPU runs disable cuDNN for a local Conv3d limitation; no environment workaround is added to the source. These results do not claim production-scale, distributed, live-vLLM, or arbitrary tool-image coverage.

This is separate from #6699 (Liger token-type forwarding) and #6906 (tool-image token identification). The bug also affects the regular loss path before loss selection.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared VLM batching in three online trainers on the loss path; logic is gated on processor capabilities but incorrect detection could mis-split tiles for other models.
> 
> **Overview**
> Fixes **Gemma 3 pan-and-scan** training in **GRPO**, **RLOO**, and **DistillationTrainer** when `do_pan_and_scan=True` expands images into multiple `pixel_values` rows. Those trainers previously treated extra rows like **InternVL** tiles and called the image processor with `crop_to_patches`, which Gemma does not support.
> 
> The shared VLM preprocessing block now detects Gemma-style processors (`num_crops` in `model_input_names` and `do_pan_and_scan`) and derives per-sample counts as **`num_crops + 1`**, then feeds the existing **`num_tiles`** microbatch-splitting path so crops stay with their source sample. The InternVL branch is unchanged.
> 
> Docs for all three trainers describe enabling pan-and-scan via `AutoProcessor.from_pretrained(..., do_pan_and_scan=True)` and the memory tradeoff. **Regression tests** cover pan-and-scan on/off for GRPO (in `test_grpo_trainer.py`) and RLOO/distillation (new `test_vlm_pan_and_scan.py`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f2cdbcefeb9d484c30376bafea509569896f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->