### PR TITLE
Merge the two Dependabot github-actions entries into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,10 @@ multi-ecosystem-groups:
       interval: "weekly"
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    cooldown:
-      default-days: 7
-    patterns: ["*"]
-    multi-ecosystem-group: "github-actions-and-pre-commit"
-
-  # Actions pinned inside our local composite actions. The "/" directory above
-  # does not cover them: it only scans .github/workflows and the root action.yml.
+  # "/" only covers .github/workflows and the root action.yml, hence the composite actions glob.
   - package-ecosystem: "github-actions"
     directories:
+      - "/"
       - "/.github/actions/*"
     cooldown:
       default-days: 7


### PR DESCRIPTION
This PR merges the two Dependabot `github-actions` update entries into a single one.

### Motivation

The two entries were kept separate in #6897 only to avoid touching the entry that was already working, since a malformed `dependabot.yml` stops all updates for the repository without reporting anything. They have carried identical `cooldown`, `patterns` and group settings ever since, and every policy change has to be applied twice.

Since #7088 both entries feed the same pull request, as confirmed by #7089, so the split no longer has any observable effect.

### Solution

Keep one `github-actions` entry listing both locations in `directories`: `/` for the workflows and the root `action.yml`, and the `/.github/actions/*` glob for the actions pinned inside our local composite actions.

### Changes

- Merge the `/.github/actions/*` entry into the `/` entry, listing both under `directories`
- Drop the duplicated `cooldown`, `patterns` and `multi-ecosystem-group` settings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependabot config-only change with no application code impact; main risk is a YAML mistake that could silently stop updates, but the merged layout matches the prior dual-entry coverage.
> 
> **Overview**
> Consolidates the two identical **Dependabot `github-actions`** update blocks into a **single** entry so cooldown, patterns, and `multi-ecosystem-group` only need to be maintained once.
> 
> That entry now uses **`directories`** with **`/`** (workflows and root `action.yml`) and **`/.github/actions/*`** (pins inside local composite actions), replacing the previous split where each path had its own block. Behavior should stay the same now that both paths already shared the same grouped PR policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c218cac2e16cb3181308dc8602d6596cc544b0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->