### PR TITLE
Reformat lambda functions for code clarity

### DIFF
--- a/trl/experimental/a2po/a2po_trainer.py
+++ b/trl/experimental/a2po/a2po_trainer.py
@@ -269,8 +269,9 @@ class A2POTrainer(_BaseTrainer):
         # so evaluation can still look up their V*.
         if self.args.filter_all_incorrect:
             self.train_dataset = self.train_dataset.filter(
-                lambda example: maybe_apply_chat_template(example, self.processing_class)["prompt"]
-                not in all_incorrect
+                lambda example: (
+                    maybe_apply_chat_template(example, self.processing_class)["prompt"] not in all_incorrect
+                )
             )
         logger.info(f"Stage 1 complete: estimated V* for {len(self._optimal_values)} prompts.")
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -699,8 +699,10 @@ class RewardTrainer(_BaseTrainer):
                 if isinstance(dataset, Dataset):  # `IterableDataset.map` does not support `desc`
                     map_kwargs["desc"] = f"Filtering {dataset_name} >{args.max_length} tokens"
                 dataset = dataset.filter(
-                    lambda example: len(example["chosen_ids"]) <= args.max_length
-                    and len(example["rejected_ids"]) <= args.max_length,
+                    lambda example: (
+                        len(example["chosen_ids"]) <= args.max_length
+                        and len(example["rejected_ids"]) <= args.max_length
+                    ),
                     **map_kwargs,
                 )
 


### PR DESCRIPTION
This pull request makes minor improvements to the codebase by reformatting lambda functions for better readability in dataset filtering logic. No functional changes are introduced, only formatting adjustments to improve code clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only edits to filter predicates; no logic, data, or training-path changes.
> 
> **Overview**
> This PR only reformats two `Dataset.filter` lambdas; behavior is unchanged.
> 
> In **`A2POTrainer`** (`a2po_trainer.py`), the predicate that drops training prompts whose reference rollouts all scored zero is written as a parenthesized multi-line lambda instead of a single-line expression.
> 
> In **`RewardTrainer`** (`reward_trainer.py`), the `max_length` filter that keeps examples where both `chosen_ids` and `rejected_ids` fit within the limit gets the same parenthesized layout and a trailing comma after the lambda argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a081cf02177d926e1ff44f7855c9671a7d35b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->