### PR TITLE
feat: add optional k3 KL estimator to RLOO

### DIFF
--- a/docs/source/rloo_trainer.md
+++ b/docs/source/rloo_trainer.md
@@ -69,6 +69,17 @@ $$
 \mathbb{D}_{\mathrm{KL}}\!\left[\pi_\theta\|\pi_{\mathrm{ref}}\right] = \sum_{t=1}^T \log \frac{\pi_\theta(o_{i,t} \mid q, o_{i,<t})}{\pi_{\mathrm{ref}}(o_{i,t} \mid q, o_{i,<t})}.
 $$
 
+This is the `k1` estimator from the RLOO paper, and the default (`kl_estimator="k1"`). Set
+`kl_estimator="k3"` in [`RLOOConfig`] to use the [Schulman et al. (2020)](http://joschu.net/blog/kl-approx.html)
+estimator, as in [`GRPOTrainer`]:
+
+$$
+\mathbb{D}_{\mathrm{KL}}\left[\pi_\theta \|\pi_{\mathrm{ref}}\right] = \sum_{t=1}^T \left( \frac{\pi_{\mathrm{ref}}(o_{i,t} \mid q, o_{i,<t})}{\pi_\theta(o_{i,t} \mid q, o_{i,<t})} - \log \frac{\pi_{\mathrm{ref}}(o_{i,t} \mid q, o_{i,<t})}{\pi_\theta(o_{i,t} \mid q, o_{i,<t})} - 1 \right).
+$$
+
+`k3` is unbiased, has lower variance, and is always non-negative. In either case the KL term is
+applied as a detached reward penalty; it does not backpropagate into the policy.
+
 The final reward assigned to sequence  \\( o_i \\) is then:
 
 $$

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -29,6 +29,7 @@ from transformers import (
 from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
+from trl.trainer.rloo_trainer import _compute_per_token_kl
 
 from .testing_utils import TrlTestCase, require_bitsandbytes, require_peft, require_vision, require_vllm
 
@@ -36,6 +37,30 @@ from .testing_utils import TrlTestCase, require_bitsandbytes, require_peft, requ
 if is_peft_available():
     import peft
     from peft import LoraConfig, get_peft_model
+
+
+class TestRLOOKLEstimator(TrlTestCase):
+    def test_config_defaults_to_k1(self):
+        assert RLOOConfig(output_dir=self.tmp_dir).kl_estimator == "k1"
+
+    def test_k1_is_log_ratio(self):
+        old = torch.tensor([[0.0, -1.0], [0.5, 2.0]])
+        ref = torch.tensor([[0.2, 0.0], [0.5, 0.0]])
+        torch.testing.assert_close(_compute_per_token_kl(old, ref, "k1"), old - ref)
+
+    def test_k3_matches_schulman_estimator_and_is_non_negative(self):
+        old = torch.tensor([[0.0, -1.0], [0.5, 2.0]])
+        ref = torch.tensor([[0.2, 0.0], [0.5, 0.0]])
+        log_ratio = ref - old
+        expected = log_ratio.exp() - log_ratio - 1
+        kl = _compute_per_token_kl(old, ref, "k3")
+        torch.testing.assert_close(kl, expected)
+        assert torch.all(kl >= 0)
+        assert torch.any(_compute_per_token_kl(old, ref, "k1") < 0)
+
+    def test_invalid_estimator_raises(self):
+        with pytest.raises(ValueError, match="k1"):
+            _compute_per_token_kl(torch.zeros(1, 1), torch.zeros(1, 1), "k2")
 
 
 class TestRLOOTrainer(TrlTestCase):

--- a/trl/trainer/rloo_config.py
+++ b/trl/trainer/rloo_config.py
@@ -14,7 +14,7 @@
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from .base_config import _BaseConfig
 
@@ -173,6 +173,10 @@ class RLOOConfig(_BaseConfig):
         beta (`float`, *optional*, defaults to `0.05`):
             KL coefficient. If `0.0`, the reference model is not loaded, reducing memory usage and improving training
             speed.
+        kl_estimator (`Literal["k1", "k3"]`, *optional*, defaults to `"k1"`):
+            Estimator for the KL penalty applied to rewards. `"k1"` is the first-order log ratio from the RLOO paper
+            (unbiased, can be negative per token). `"k3"` is the Schulman estimator used by [`GRPOTrainer`] (unbiased,
+            lower variance, always ≥ 0). See [Approximating KL Divergence](http://joschu.net/blog/kl-approx.html).
         num_iterations (`int`, *optional*, defaults to `1`):
             Number of iterations per batch (denoted as μ in the algorithm).
         epsilon (`float`, *optional*, defaults to `0.2`):
@@ -497,6 +501,14 @@ class RLOOConfig(_BaseConfig):
         metadata={
             "help": "KL coefficient. If `0.0`, the reference model is not loaded, reducing memory usage and improving "
             "training speed."
+        },
+    )
+    kl_estimator: Literal["k1", "k3"] = field(
+        default="k1",
+        metadata={
+            "help": "Estimator for the KL penalty applied to rewards. 'k1' is the first-order log ratio from the RLOO "
+            "paper (unbiased, can be negative per token). 'k3' is the Schulman estimator used by GRPOTrainer "
+            "(unbiased, lower variance, always >= 0). See http://joschu.net/blog/kl-approx.html."
         },
     )
     num_iterations: int = field(

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -106,6 +106,22 @@ logger = get_logger(__name__)
 RewardFunc = str | PreTrainedModel | Callable[..., list[float | None]]
 
 
+def _compute_per_token_kl(
+    old_per_token_logps: torch.Tensor,
+    ref_per_token_logps: torch.Tensor,
+    kl_estimator: str,
+) -> torch.Tensor:
+    """Per-token KL from old/current policy log-probs vs the reference, using k1 or k3."""
+    if kl_estimator == "k1":
+        # First-order log ratio from Ahmadian et al. (2024). Unbiased; can be negative per token.
+        return old_per_token_logps - ref_per_token_logps
+    if kl_estimator == "k3":
+        # Schulman estimator (http://joschu.net/blog/kl-approx.html), same form as GRPOTrainer.
+        log_ratio = ref_per_token_logps - old_per_token_logps
+        return log_ratio.exp() - log_ratio - 1
+    raise ValueError(f"kl_estimator must be 'k1' or 'k3', got {kl_estimator!r}.")
+
+
 class RLOOTrainer(_BaseTrainer):
     """
     Trainer for the Reinforce Leave One Out (RLOO) method. This algorithm was initially proposed in the paper [Back to
@@ -256,6 +272,9 @@ class RLOOTrainer(_BaseTrainer):
             model_name = model if isinstance(model, str) else get_config_model_id(model.config)
             model_name = model_name.split("/")[-1]
             args = RLOOConfig(f"{model_name}-RLOO")
+
+        if args.kl_estimator not in {"k1", "k3"}:
+            raise ValueError(f"kl_estimator must be either 'k1' or 'k3', got {args.kl_estimator!r}.")
 
         # Model
         if isinstance(model, str):
@@ -1569,11 +1588,10 @@ class RLOOTrainer(_BaseTrainer):
 
         # Include the KL penalty in the reward
         if self.beta != 0.0:
-            # RLOO uses the first-order log ratio for the per-token KL estimate, following the original RLOO paper
-            # (Ahmadian et al., 2024, https://huggingface.co/papers/2405.14782). Unlike GRPOTrainer's Schulman
-            # approximation (always >= 0), this can be negative per token. The divergence is intentional: RLOO applies
-            # KL as a reward penalty (summed across tokens per sequence), while GRPO adds it to the per-token loss.
-            per_token_kl = old_per_token_logps - ref_per_token_logps
+            # k1 matches the RLOO paper (log ratio, can be negative). k3 is the Schulman estimator used by
+            # GRPOTrainer (always >= 0, lower variance). Either way KL is a sequence-level reward penalty, not a
+            # per-token loss term.
+            per_token_kl = _compute_per_token_kl(old_per_token_logps, ref_per_token_logps, self.args.kl_estimator)
             # Apply sequence-level KL penalty to rewards (sum KL across tokens first, then apply to each sequence)
             kl = (per_token_kl * completion_mask).sum(-1)
             kl = gather(kl)  # rewards are gathered, so kl must be too


### PR DESCRIPTION
# What does this PR do?

RLOO currently estimates the KL reward penalty with the first-order log ratio (`k1`). GRPO uses the lower-variance Schulman `k3` estimator, and PPO already exposes both via `kl_estimator` (#3240).

This PR adds the same choice to RLOO without changing the default:

- `kl_estimator="k1"` (default): log ratio from the RLOO paper. Unbiased, can be negative per token.
- `kl_estimator="k3"`: Schulman estimator, same formula as GRPO. Unbiased, lower variance, always ≥ 0.

KL is still a detached sequence-level reward penalty in both cases; it does not backpropagate into the policy.

Replacing `k1` in place would change every `beta>0` run and go against #5889 / #6096, which treated the paper log-ratio as intentional. If maintainers prefer `k3` as the default, that can be a follow-up.

Fixes #7086

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Choosing `k3` changes KL reward penalties for `beta > 0` runs and can alter training dynamics, though the default `k1` preserves backward compatibility.
> 
> **Overview**
> Adds **`kl_estimator`** to [`RLOOConfig`] so the KL term in the sequence-level reward can use either the existing paper **log-ratio (`k1`, default)** or the **Schulman `k3`** estimator (same as [`GRPOTrainer`]). Reward shaping is unchanged: KL is still summed over tokens, subtracted with **`beta`**, and does not backprop into the policy.
> 
> Implementation introduces **`_compute_per_token_kl`** in `rloo_trainer.py`, wires it into the reward path when **`beta != 0`**, and validates **`k1`/`k3`** at trainer init. Docs in `rloo_trainer.md` describe both formulas and the config knob; **`TestRLOOKLEstimator`** covers defaults, formulas, non-negativity of `k3`, and invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b4a3cb17e562fff660900f91f1884154b6eb72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->