### PR TITLE
Align tiny/small Qwen2.5 config with Qwen/Qwen2.5-32B-Instruct

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5.py
@@ -38,6 +38,8 @@ config = Qwen2Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    rope_theta=1000000.0,
+    max_window_layers=70,
     bos_token_id=151643,
     eos_token_id=151645,
 )

--- a/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5.py
@@ -32,12 +32,14 @@ MODEL_ID = "Qwen/Qwen2.5-32B-Instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen2Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=152064,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    bos_token_id=151643,
+    eos_token_id=151645,
 )
 model = Qwen2ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)

--- a/scripts/generate_tiny_models/for_causal_lm/small_qwen2_for_causal_lm_2_5.py
+++ b/scripts/generate_tiny_models/for_causal_lm/small_qwen2_for_causal_lm_2_5.py
@@ -27,12 +27,14 @@ MODEL_ID = "Qwen/Qwen2.5-32B-Instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen2Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=152064,
     hidden_size=128,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    bos_token_id=151643,
+    eos_token_id=151645,
 )
 model = Qwen2ForCausalLM(config).to(dtype=torch.bfloat16)
 smoke_test(model, tokenizer)

--- a/scripts/generate_tiny_models/for_causal_lm/small_qwen2_for_causal_lm_2_5.py
+++ b/scripts/generate_tiny_models/for_causal_lm/small_qwen2_for_causal_lm_2_5.py
@@ -33,6 +33,8 @@ config = Qwen2Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    rope_theta=1000000.0,
+    max_window_layers=70,
     bos_token_id=151643,
     eos_token_id=151645,
 )


### PR DESCRIPTION
This PR aligns the `tiny-Qwen2ForCausalLM-2.5` and `small-Qwen2ForCausalLM-2.5` generator configs with their reference model, `Qwen/Qwen2.5-32B-Instruct`, by mirroring the five non-size fields that diverge.

Part of #7093.

### Motivation

Both scripts build `Qwen2Config` from architecture arguments only, so the special token ids fall back to the class defaults, which are all `None`, while the generation config and the tokenizer come from the real model. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151645, 'bos_token_id': None, 'pad_token_id': 151643}.
```

### Solution

Mirror the reference values, as done for GLM-4.5 in #5638, Cohere in #5706, Cohere2 in #5707 and Qwen3 MoE in #5716:

- `vocab_size=152064` (reference padded embedding size; previously `len(tokenizer.vocab) = 151665`)
- `bos_token_id=151643`, `eos_token_id=151645` (reference values; previously `None`)
- `rope_theta=1000000.0` (reference override; class default is `10000.0`)
- `max_window_layers=70` (reference override; class default is `28`)

`vocab_size` and `len(tokenizer.vocab)` are different quantities: the tokenizer value counts tokens, while `config.vocab_size` is the embedding matrix dimension, which the reference pads up to a multiple of 128 so the embedding and `lm_head` tile cleanly. The 399 extra rows add 6.4 KB to the tiny model and 102 KB to the small one. Deriving it from the tokenizer also made the config depend on the reference tokenizer files at generation time.

`rope_theta` has no numerical effect on the tiny variant, whose `head_dim` of 2 leaves a single rotation pair with `inv_freq = 1.0` for any base, but it does change the small variant, whose `head_dim` is 32. `max_window_layers` is inert either way, since the reference sets `use_sliding_window: False`, and is mirrored only to zero the diff.

`pad_token_id` is left unset because the reference does not set it either.

The tiny architecture is untouched: `hidden_size`, `num_hidden_layers`, `num_attention_heads`, `num_key_value_heads` and `intermediate_size` stay as they are. Remaining diffs are the intentional size reductions plus `layer_types`, whose length tracks `num_hidden_layers` and therefore cannot match.

Once the fixtures are regenerated, the warning above loses its `eos_token_id` key. The remaining `{'bos_token_id': None, 'pad_token_id': 151643}` is what any real Qwen2.5 model produces and cannot be fixed from here.

## Before

```
[config_diff] Qwen/Qwen2.5-32B-Instruct vs tiny (11 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151645                             → None
  hidden_size                                      5120                               → 8
  intermediate_size                                27648                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_window_layers                                70                                 → 28
  num_attention_heads                              40                                 → 4
  num_hidden_layers                                64                                 → 2
  num_key_value_heads                              8                                  → 2
  rope_theta                                       1000000.0                          → 10000.0
  vocab_size                                       152064                             → 151665
```

```
[config_diff] Qwen/Qwen2.5-32B-Instruct vs small (11 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151645                             → None
  hidden_size                                      5120                               → 128
  intermediate_size                                27648                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_window_layers                                70                                 → 28
  num_attention_heads                              40                                 → 4
  num_hidden_layers                                64                                 → 2
  num_key_value_heads                              8                                  → 2
  rope_theta                                       1000000.0                          → 10000.0
  vocab_size                                       152064                             → 151665
```

## After

```
[config_diff] Qwen/Qwen2.5-32B-Instruct vs tiny (6 differences)
  hidden_size                                      5120                               → 8
  intermediate_size                                27648                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              40                                 → 4
  num_hidden_layers                                64                                 → 2
  num_key_value_heads                              8                                  → 2
```

```
[config_diff] Qwen/Qwen2.5-32B-Instruct vs small (6 differences)
  hidden_size                                      5120                               → 128
  intermediate_size                                27648                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              40                                 → 4
  num_hidden_layers                                64                                 → 2
  num_key_value_heads                              8                                  → 2
```

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repos still need regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 152064 in both Qwen2.5 generator scripts
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta` and `max_window_layers` from the reference config
