### PR TITLE
Inject the model revision into concrete config loads too

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ def apply_model_revisions(monkeypatch):
         AutoConfig,
         AutoModelForCausalLM,
         AutoModelForSequenceClassification,
+        PretrainedConfig,
         PreTrainedModel,
         PreTrainedTokenizerBase,
         ProcessorMixin,
@@ -127,11 +128,12 @@ def apply_model_revisions(monkeypatch):
         # Re-wrap as classmethod
         return classmethod(wrapper)
 
-    # Patch all transformers Auto* classes
+    # Patch the transformers Auto* classes and the base classes they dispatch to
     for cls in [
         AutoConfig,
         AutoModelForCausalLM,
         AutoModelForSequenceClassification,
+        PretrainedConfig,
         PreTrainedModel,
         PreTrainedTokenizerBase,
         ProcessorMixin,


### PR DESCRIPTION
This PR makes the `MODEL_REVISIONS` override apply to concrete config classes as well, so a tiny model under test is read at the pinned revision everywhere.

### Motivation

`apply_model_revisions` patches `from_pretrained` on the `Auto*` classes and on `PreTrainedModel`, `PreTrainedTokenizerBase` and `ProcessorMixin`, but not on the base config class. `AutoConfig` is a factory and never appears in a concrete config's MRO:

```
Qwen2Config MRO: ['Qwen2Config', 'PreTrainedConfig', 'PushToHubMixin', 'RotaryEmbeddingConfigMixin']
```

so a caller that reaches for the concrete class slips past the override. `peft` does exactly that when deciding whether the embedding was resized:

```python
vocab_size != model.config.__class__.from_pretrained(model_id).vocab_size
```

The model is loaded at the revision under test while its base config is read from the default branch, so any fixture PR that changes `vocab_size` makes the two disagree and every PEFT test emits:

```
UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
```

That is 34 spurious warnings while validating #7098, and it also means `save_embedding_layers` is silently forced on in those tests.

### Solution

Add the base config class to the patched set. Concrete configs do not define their own `from_pretrained`, so they inherit the patched one.

`PretrainedConfig` is the spelling that works across the supported range: 4.56.2 exports only that name, while 5.x exports both it and `PreTrainedConfig` pointing at the same object.

### Verification

Ran the suite with `MODEL_REVISIONS` pinned to the #7098 fixture PRs, with and without this change:

| | without | with |
|---|---:|---:|
| `save_embedding_layers` warnings | 34 | **0** |
| passed / skipped / xfailed | 2385 / 149 / 5 | 2385 / 149 / 5 |
| distinct `PAD/BOS/EOS` variants | 22 | 22 |

https://github.com/huggingface/trl/actions/runs/34141451081/job/101804124860

The token realignment counts are the control and are unchanged, confirming the patch does not alter which revision the model itself loads from. Total lines differ by 3 (463 against 460) purely because the earlier run had 4 reruns and this one had none.

With `MODEL_REVISIONS` empty, which is its state on `main`, the fixture returns early and nothing is patched at all.

### Changes

- Patch `from_pretrained` on the base config class alongside the `Auto*` and other base classes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conftest change; no production code paths, and patching is skipped when `MODEL_REVISIONS` is empty on main.
> 
> **Overview**
> Extends the `apply_model_revisions` pytest fixture so `MODEL_REVISIONS` also applies when configs are loaded through **concrete** config classes (e.g. `Qwen2Config.from_pretrained`), not only `AutoConfig` and model/tokenizer loaders.
> 
> **`PretrainedConfig`** is added to the patched classes and imports (using the `PretrainedConfig` spelling for compatibility across transformers 4.x/5.x). Concrete configs inherit `from_pretrained` from that base, so pinned Hub revisions now apply consistently when libraries such as PEFT reload config by class.
> 
> This removes config-at-default-branch vs weights-at-pinned-revision mismatches during tiny-model PR CI (e.g. spurious `save_embedding_layers` warnings). When `MODEL_REVISIONS` is empty, the fixture still exits early and behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121979754830d22131f0a8a5351d39ad85a9b47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->