### PR TITLE
[AsyncGRPO] Gather FSDP2 weights before NCCL send to vLLM

### DIFF
--- a/tests/experimental/test_async_grpo_trainer.py
+++ b/tests/experimental/test_async_grpo_trainer.py
@@ -39,7 +39,10 @@ from trl.experimental.async_grpo.async_grpo_trainer import (
     TokenBudgetBatcher,
     _balance_by_squared_length,
     _reduce_metric,
+    _sync_weight_dtype,
+    _vllm_param_name,
 )
+from trl.experimental.async_grpo.vllm_client import VLLMClient
 from trl.experimental.async_grpo.async_rollout_worker import (
     AsyncRolloutWorker,
     DriftKind,
@@ -382,7 +385,7 @@ class TestAsyncGRPOTrainerVLM(TrlTestCase):
         # `*ForConditionalGeneration` architecture (`model.language_model.*`), not the text tower alone
         # (`model.*`). Frozen vision weights never change, so they are not streamed at all.
         trainer = self._trainer(model_id)
-        streamed = dict(trainer._streaming_iter())
+        streamed = dict(trainer._gather_weight_items())
 
         assert streamed
         assert streamed.keys() == {n for n, p in trainer.model.named_parameters() if p.requires_grad}
@@ -1188,3 +1191,27 @@ class TestEpochStop(TrlTestCase):
         # steps for the same 2 epochs. If forks leaked into the epoch count, the forked run would instead
         # stop in FEWER prompt-passes (the pre-fix bug).
         assert forked.state.global_step > no_fork.state.global_step
+
+
+class TestFSDP2WeightSyncHelpers:
+    def test_vllm_param_name_strips_wrappers(self):
+        assert _vllm_param_name("module.model.layers.0.self_attn.q_proj.weight") == (
+            "model.layers.0.self_attn.q_proj.weight"
+        )
+        assert _vllm_param_name("model.layers.0._checkpoint_wrapped_module.self_attn.q_proj.weight") == (
+            "model.layers.0.self_attn.q_proj.weight"
+        )
+        assert _vllm_param_name("model.layers.0.self_attn.q_proj.weight") == "model.layers.0.self_attn.q_proj.weight"
+
+    def test_sync_weight_dtype_follows_mixed_precision(self):
+        assert _sync_weight_dtype(AsyncGRPOConfig(output_dir="out", bf16=True, report_to="none")) is torch.bfloat16
+        assert _sync_weight_dtype(AsyncGRPOConfig(output_dir="out", fp16=True, bf16=False, report_to="none")) is (
+            torch.float16
+        )
+
+    def test_start_weight_update_is_not_checkpoint_format(self):
+        client = VLLMClient("http://localhost:8000")
+        with patch("trl.experimental.async_grpo.vllm_client.requests.post") as post:
+            post.return_value.status_code = 200
+            client.start_weight_update(timeout=5)
+        assert post.call_args.kwargs["json"] == {"is_checkpoint_format": False}

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -70,6 +70,24 @@ RewardFunc = Callable[..., list[float]]
 MetricValue = float | tuple[float, float]
 
 
+def _vllm_param_name(name: str) -> str:
+    """Strip DDP / FSDP / activation-checkpoint wrappers so the name matches vLLM's module tree."""
+    return (
+        name.removeprefix("module.")
+        .replace("._checkpoint_wrapped_module", "")
+        .replace("_checkpoint_wrapped_module.", "")
+    )
+
+
+def _sync_weight_dtype(args: Any) -> torch.dtype:
+    """Dtype vLLM should receive. FSDP2 mixed-precision often upcasts params to fp32."""
+    if getattr(args, "bf16", False):
+        return torch.bfloat16
+    if getattr(args, "fp16", False):
+        return torch.float16
+    return torch.float32
+
+
 def _reduce_metric(key: str, values: list[MetricValue]) -> float:
     """Reduce one logging window into the number that gets logged.
 
@@ -219,6 +237,8 @@ class _TrainBeginCallback(TrainerCallback):
         self._fired = True
         if self._trainer.accelerator.is_main_process and self._trainer.weight_transfer is not None:
             self._trainer.weight_transfer.init_weight_transfer()
+        # init_weight_transfer is rank-0 only; other ranks must not enter `_sync_weight` first.
+        self._trainer.accelerator.wait_for_everyone()
         self._trainer._sync_weight()
         if self._trainer.accelerator.is_main_process and self._trainer.rollout_worker is not None:
             self._trainer.rollout_worker.start()
@@ -977,9 +997,10 @@ class AsyncGRPOTrainer(_BaseTrainer):
                     if not param.requires_grad:
                         continue
                     # DDP/FSDP1 wrapping and gradient checkpointing, avoids vllm module not exist error
-                    name = name.removeprefix("module.").replace("_checkpoint_wrapped_module.", "")
+                    name = _vllm_param_name(name)
                     weight_names.append(name)
-                    weight_dtype_names.append(str(param.dtype).split(".")[-1])
+                    # Advertise the dtype we will cast to before send, not the FSDP-upcast storage dtype.
+                    weight_dtype_names.append(str(_sync_weight_dtype(self.args)).split(".")[-1])
                     weight_shapes.append(list(param.shape))
                 self.weight_transfer = WeightTransferClient(
                     vllm_client=self.vllm_client,
@@ -1330,19 +1351,28 @@ class AsyncGRPOTrainer(_BaseTrainer):
         super().log(logs, start_time)
         self._metrics[mode].clear()
 
-    def _streaming_iter(self):
-        # Iterate parameters one at a time. For FSDP2 (DTensor), full_tensor() all-gathers just this parameter across
-        # FSDP ranks, then frees it once the generator advances — avoiding materializing the full model in memory.
+    def _gather_weight_items(self) -> list[tuple[str, torch.Tensor]]:
+        # All ranks run `full_tensor()` here and only here. `send_weights()` talks to vLLM NCCL and can
+        # block rank 0 for a long time; if that is interleaved with FSDP all-gathers (the old streaming
+        # iterator), non-0 ranks race ahead and the default process group hangs.
         device = self.accelerator.device
+        target_dtype = _sync_weight_dtype(self.args)
+        gathered: list[tuple[str, torch.Tensor]] = []
         for name, param in self.model.named_parameters():
             if not param.requires_grad:
                 continue
-            # DDP/FSDP1 wrapping and gradient checkpointing, avoids vllm module not exist error
-            name = name.removeprefix("module.").replace("_checkpoint_wrapped_module.", "")
+            name = _vllm_param_name(name)
             full = param.full_tensor() if isinstance(param, DTensor) else param.detach()
             if full.device != device:
                 full = full.to(device)
-            yield name, full
+            if full.dtype != target_dtype:
+                full = full.to(target_dtype)
+            if self.accelerator.is_main_process:
+                gathered.append((name, full))
+            else:
+                del full
+        self.accelerator.wait_for_everyone()
+        return gathered
 
     def _sync_weight(self):
         t0 = time.time()
@@ -1355,18 +1385,18 @@ class AsyncGRPOTrainer(_BaseTrainer):
         self.accelerator.wait_for_everyone()
         t_barrier = time.time()
 
-        logger.info(f"Weight sync: transferring weights... (barrier took {t_barrier - t_pause:.1f}s)")
+        logger.info(f"Weight sync: gathering FSDP shards... (barrier took {t_barrier - t_pause:.1f}s)")
+        gathered = self._gather_weight_items()
+        t_gather = time.time()
+
+        logger.info(f"Weight sync: transferring weights... (gather took {t_gather - t_barrier:.1f}s)")
         if self.accelerator.is_main_process and self.weight_transfer:
-            self.weight_transfer.send_weights(self._streaming_iter())
-        else:
-            # Non-rank-0 processes must still participate in full_tensor() collectives for FSDP2.
-            for _ in self._streaming_iter():
-                pass
+            self.weight_transfer.send_weights(iter(gathered))
         t_transfer = time.time()
 
         self.accelerator.wait_for_everyone()
 
-        logger.info(f"Weight sync: resuming vLLM... (transfer took {t_transfer - t_barrier:.1f}s)")
+        logger.info(f"Weight sync: resuming vLLM... (transfer took {t_transfer - t_gather:.1f}s)")
         if self.accelerator.is_main_process:
             if self.weight_transfer:
                 self.weight_transfer.resume()
@@ -1374,11 +1404,11 @@ class AsyncGRPOTrainer(_BaseTrainer):
             if self.rollout_worker:
                 self.rollout_worker.update_model_version(self.model_version)
         weight_sync_s = time.time() - t0
-        # log the three phases  of weight sync
         self._metrics["train"]["perf/weight_sync_s"].append(weight_sync_s)
         self._metrics["train"]["perf/weight_sync_pause_s"].append(t_pause - t0)
         self._metrics["train"]["perf/weight_sync_barrier_s"].append(t_barrier - t_pause)
-        self._metrics["train"]["perf/weight_sync_transfer_s"].append(t_transfer - t_barrier)
+        self._metrics["train"]["perf/weight_sync_gather_s"].append(t_gather - t_barrier)
+        self._metrics["train"]["perf/weight_sync_transfer_s"].append(t_transfer - t_gather)
         logger.info(f"Weight sync: done. Total {weight_sync_s:.1f}s")
 
     def _save_checkpoint(self, model, trial):

--- a/trl/experimental/async_grpo/vllm_client.py
+++ b/trl/experimental/async_grpo/vllm_client.py
@@ -109,8 +109,10 @@ class VLLMClient:
 
     def start_weight_update(self, timeout: int = 1800) -> None:
         """Prepare the workers for a weight reload; must complete before any weights are sent."""
+        # NCCL streaming is not a checkpoint-file reload. True makes workers wait for a
+        # checkpoint path that never arrives and hangs `/update_weights` after the broadcast.
         response = requests.post(
-            f"{self.server_url}/start_weight_update", json={"is_checkpoint_format": True}, timeout=timeout
+            f"{self.server_url}/start_weight_update", json={"is_checkpoint_format": False}, timeout=timeout
         )
         if response.status_code != 200:
             raise Exception(f"Request failed: {response.status_code}, {response.text}")

--- a/trl/experimental/async_grpo/weight_transfer.py
+++ b/trl/experimental/async_grpo/weight_transfer.py
@@ -130,9 +130,13 @@ class WeightTransferClient:
 
         def trainer_send_weights():
             try:
+                send_kwargs = {"group": self.model_update_group, "packed": True}
+                # Default 1 GiB pack buffer is smaller than Qwen3 embed/lm_head rows (and 32B layers).
+                if hasattr(NCCLTrainerSendWeightsArgs, "packed_buffer_size_bytes"):
+                    send_kwargs["packed_buffer_size_bytes"] = 4 * 1024**3
                 NCCLWeightTransferEngine.trainer_send_weights(
                     iterator=iterator,
-                    trainer_args=NCCLTrainerSendWeightsArgs(group=self.model_update_group, packed=True),
+                    trainer_args=NCCLTrainerSendWeightsArgs(**send_kwargs),
                 )
             except BaseException as exc:  # noqa: BLE001
                 error.append(exc)


### PR DESCRIPTION
## Summary
- Gather every FSDP2 shard with `full_tensor()` on all trainer ranks **before** rank 0 talks to vLLM. The previous streaming iterator interleaved default-PG all-gathers with rank-0 NCCL/HTTP, so non-0 ranks raced ahead and the trainer process group hung (NCCL watchdog, `last enqueued` on rank 0 far behind).
- Send `is_checkpoint_format=False` on `/start_weight_update`. NCCL streaming is not a checkpoint reload; `True` leaves workers waiting for a path that never arrives and hangs `/update_weights`.
- Cast gathered parameters to the mixed-precision dtype (bf16/fp16) and strip `_checkpoint_wrapped_module` so packed NCCL names/dtypes match the server. Raise the packed buffer to 4 GiB when the vLLM API exposes it.
- Barrier after rank-0-only `init_weight_transfer()` so other ranks do not enter the first gather during the NCCL handshake.

Fixes #7103. Related: #6797 (offload / missing timeout; different root cause).

Verified on 16 trainer + 16 sampler H200 (Qwen3-1.7B and Qwen3-32B FSDP2). After this path, 32B weight sync is ~2.3s and training proceeds past the first step.

## Test plan
- [x] `pytest tests/experimental/test_async_grpo_trainer.py::TestFSDP2WeightSyncHelpers`
- [ ] Existing `test_weight_sync_streams_the_text_tower_only` still passes (now uses `_gather_weight_items`)
- [ ] Multi-rank FSDP2 + `vllm serve` smoke: first weight sync completes, no default-PG NCCL timeout


Made with [Cursor](https://cursor.com)