### PR TITLE
Show list lengths and mark truncation in the tiny-model config diff

### DIFF
--- a/scripts/generate_tiny_models/_common.py
+++ b/scripts/generate_tiny_models/_common.py
@@ -174,8 +174,22 @@ def check_dtype_pattern(reference_id, model):
         print(f"  {name}: reference={ref}, tiny={tiny}")
 
 
-def print_config_diff(reference_id, model):
-    """Print the flat, recursive diff between the reference Hub config and the tiny-model config."""
+def _format_diff_value(value, width):
+    """Render a config value for the diff table, tagging lists with their length and marking truncation."""
+    text = f"[{len(value)} items] {value}" if isinstance(value, list) else str(value)
+    if width is None or len(text) <= width:
+        return text
+    return text[: width - 1] + "\u2026"
+
+
+def print_config_diff(reference_id, model, full=None):
+    """Print the flat, recursive diff between the reference Hub config and the tiny-model config.
+
+    Values are truncated to keep the table aligned; pass `--full-diff` (or `full=True`) to print them in full.
+    """
+    if full is None:
+        full = _parse_args().full_diff
+    width = None if full else 34
     reference_config = AutoConfig.from_pretrained(reference_id)
     ref_flat = _flatten(reference_config.to_dict())
     tiny_flat = _flatten(model.config.to_dict())
@@ -191,7 +205,7 @@ def print_config_diff(reference_id, model):
 
     print(f"[config_diff] {reference_id} vs tiny ({len(rows)} differences)")
     for k, r, t in rows:
-        print(f"  {k:48s} {str(r)[:34]:34s} → {str(t)[:34]}")
+        print(f"  {k:48s} {_format_diff_value(r, width):34s} → {_format_diff_value(t, width)}")
 
 
 def _parse_args():
@@ -200,6 +214,11 @@ def _parse_args():
         "--create-pr",
         action="store_true",
         help="If the repo already exists, open a PR instead of skipping.",
+    )
+    parser.add_argument(
+        "--full-diff",
+        action="store_true",
+        help="Print untruncated values in the config diff.",
     )
     args, _ = parser.parse_known_args()
     return args


### PR DESCRIPTION
This PR makes list-valued rows in the tiny-model config diff readable, and adds a flag to print values in full.

### Motivation

`print_config_diff` truncates values at 34 characters with nothing to indicate it, so a 64-entry list and a 2-entry list render as the same string and the row looks like a false positive:

```
layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
```

### Solution

Tag lists with their length and mark truncation with an ellipsis, so a cut value is never mistaken for a complete one:

```
layer_types                                      [64 items] ['full_attention', 'fu… → [2 items] ['full_attention', 'ful…
```

Add a `--full-diff` flag, alongside the existing `--create-pr`, for the cases where the entries themselves matter, such as the heterogeneous `layer_types` of the Qwen3.5 and Gemma families:

```
$ python -m scripts.generate_tiny_models.for_causal_lm.qwen2_for_causal_lm_2_5 --full-diff
  layer_types                                      [64 items] ['full_attention', 'full_attention', ...] → [2 items] ['full_attention', 'full_attention']
```

The count is kept alongside the preview rather than replacing it, since for a list whose entries vary the preview still carries information a bare count would drop.

### Changes

- Tag list values with their length and mark truncated values with an ellipsis in `print_config_diff`
- Add a `--full-diff` flag, and a matching `full` parameter, to print values untruncated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only logging in tiny-model generation scripts; no runtime or production behavior changes.
> 
> **Overview**
> **Config diff output** for tiny-model generation scripts now shows list lengths (e.g. `[64 items]`) and uses an ellipsis when a value is cut at 34 characters, so truncated rows are not mistaken for full values—especially for long `layer_types` lists.
> 
> Adds **`--full-diff`** on the shared argparse helper (and optional `full=True` on `print_config_diff`) to print untruncated reference vs tiny values when the actual entries matter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7718f9ddf1c643d2b86380f71ddb825fa5120837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->