### PR TITLE
Align tiny and small Qwen3 configs with their reference models

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm.py
@@ -34,12 +34,17 @@ REVISION = "refs/pr/14"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, revision=REVISION)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID, revision=REVISION)
 config = Qwen3Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=151936,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=40960,
+    rope_theta=1000000,
+    max_window_layers=36,
+    bos_token_id=151643,
+    eos_token_id=151645,
 )
 model = Qwen3ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)

--- a/scripts/generate_tiny_models/for_causal_lm/small_qwen3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/small_qwen3_for_causal_lm.py
@@ -27,12 +27,17 @@ MODEL_ID = "Qwen/Qwen3-4B"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen3Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=151936,
     hidden_size=128,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=40960,
+    rope_theta=1000000,
+    max_window_layers=36,
+    bos_token_id=151643,
+    eos_token_id=151645,
 )
 model = Qwen3ForCausalLM(config).to(dtype=torch.bfloat16)
 smoke_test(model, tokenizer)


### PR DESCRIPTION
This PR aligns the `tiny-Qwen3ForCausalLM` and `small-Qwen3ForCausalLM` generator configs with their reference models, `Qwen/Qwen3-8B` and `Qwen/Qwen3-4B`, by mirroring the six non-size fields that diverge.

Part of #7093. Follows #7098, which did the same for Qwen2.5.

### Motivation

Both scripts build `Qwen3Config` from architecture arguments only, so the special token ids fall back to the class defaults, which are all `None`, while the generation config and the tokenizer come from the real model. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151645, 'bos_token_id': None, 'pad_token_id': 151643}.
```

### Solution

Mirror the reference values. Both references agree on every one of them:

- `vocab_size=151936` (reference padded embedding size; previously `len(tokenizer.vocab) = 151669`)
- `bos_token_id=151643`, `eos_token_id=151645` (reference values; previously `None`)
- `rope_theta=1000000` (reference override; class default is `10000.0`)
- `max_position_embeddings=40960` (reference override; class default is `32768`)
- `max_window_layers=36` (reference override; class default is `28`)

The two fixtures are changed together because `DistillationTrainer` rejects a student/teacher `vocab_size` mismatch, and `small-Qwen3ForCausalLM` is the teacher for 29 tests whose student is `tiny-Qwen3ForCausalLM`. Moving one without the other would break them.

`tie_word_embeddings` is deliberately left alone. `Qwen/Qwen3-4B` sets it to `True` while the tiny config has `False`, but tying changes the model structure rather than just its metadata, so it belongs with the size reductions rather than with this change.

`pad_token_id` is left unset because neither reference sets it.

The tiny architecture is untouched: `hidden_size`, `num_hidden_layers`, `num_attention_heads`, `num_key_value_heads` and `intermediate_size` stay as they are.

Once the fixtures are regenerated, the warning above loses its `eos_token_id` key. The remaining `{'bos_token_id': None, 'pad_token_id': 151643}` is what any real Qwen3 model produces and cannot be fixed from here.

## Before

```
[config_diff] Qwen/Qwen3-8B vs tiny (12 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151645                             → None
  hidden_size                                      4096                               → 8
  intermediate_size                                12288                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_position_embeddings                          40960                              → 32768
  max_window_layers                                36                                 → 28
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
  rope_theta                                       1000000                            → 10000.0
  vocab_size                                       151936                             → 151669
```

```
[config_diff] Qwen/Qwen3-4B vs small (13 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151645                             → None
  hidden_size                                      2560                               → 128
  intermediate_size                                9728                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_position_embeddings                          40960                              → 32768
  max_window_layers                                36                                 → 28
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
  rope_theta                                       1000000                            → 10000.0
  tie_word_embeddings                              True                               → False
  vocab_size                                       151936                             → 151669
```

## After

```
[config_diff] Qwen/Qwen3-8B vs tiny (6 differences)
  hidden_size                                      4096                               → 8
  intermediate_size                                12288                              → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
```

```
[config_diff] Qwen/Qwen3-4B vs small (7 differences)
  hidden_size                                      2560                               → 128
  intermediate_size                                9728                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
  tie_word_embeddings                              True                               → False
```

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repos still need regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 151936 in both Qwen3 generator scripts
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta`, `max_position_embeddings` and `max_window_layers` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes tiny-model generation scripts and config metadata; no runtime library or production model behavior until fixtures are regenerated on the Hub.
> 
> **Overview**
> Updates the **tiny** (`Qwen/Qwen3-8B`) and **small** (`Qwen/Qwen3-4B`) Qwen3 fixture generator scripts so `Qwen3Config` matches the reference models on metadata that was previously left at class defaults or derived from `len(tokenizer.vocab)`.
> 
> Both scripts now set **`vocab_size=151936`**, **`bos_token_id` / `eos_token_id`**, **`max_position_embeddings=40960`**, **`rope_theta=1000000`**, and **`max_window_layers=36`**. Architecture shrink fields (`hidden_size`, layer counts, etc.) are unchanged. Tiny and small are updated together so distillation tests keep matching **`vocab_size`** between student and teacher.
> 
> After regenerating Hub fixtures, `print_config_diff` vs the references should only show intentional size/architecture deltas (and `tie_word_embeddings` on small), and training should stop rewriting config for the aligned token/ROPE/window fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5531195de28c2ea83fd00501e72e242b10a1df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->