### PR TITLE
Align tiny Qwen3 Instruct-2507 config with Qwen/Qwen3-4B-Instruct-2507

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm_instruct_2507.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm_instruct_2507.py
@@ -34,12 +34,17 @@ MODEL_ID = "Qwen/Qwen3-4B-Instruct-2507"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen3Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=151936,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=262144,
+    rope_theta=5000000,
+    max_window_layers=36,
+    bos_token_id=151643,
+    eos_token_id=151645,
 )
 model = Qwen3ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-Qwen3ForCausalLM-Instruct-2507` generator config with its reference model, `Qwen/Qwen3-4B-Instruct-2507`, by mirroring the six non-size fields that diverge.

Part of #7093. Follows #7098 (Qwen2.5) and #7106 (Qwen3).

### Motivation

The script builds `Qwen3Config` from architecture arguments only, so the special token ids fall back to the class defaults, which are all `None`, while the generation config and the tokenizer come from the real model. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151645, 'bos_token_id': None, 'pad_token_id': 151643}.
```

### Solution

Mirror the reference values:

- `vocab_size=151936` (reference padded embedding size; previously `len(tokenizer.vocab) = 151669`)
- `bos_token_id=151643`, `eos_token_id=151645` (reference values; previously `None`)
- `rope_theta=5000000` (reference override; class default is `10000.0`)
- `max_position_embeddings=262144` (reference override; class default is `32768`)
- `max_window_layers=36` (reference override; class default is `28`)

`rope_theta` and `max_position_embeddings` differ from the values used for the base Qwen3 models in #7106, which is the point of this being a separate model: the 2507 release extends the context window and rescales RoPE accordingly. `max_position_embeddings` costs nothing at construction, since Qwen3 derives RoPE frequencies from `head_dim` alone; parameter and buffer counts are identical at 32768 and 262144.

`tie_word_embeddings` is deliberately left alone. The reference sets it to `True` while the tiny config has `False`, but tying changes the model structure rather than just its metadata, so it belongs with the size reductions rather than with this change. Same call as in #7106 for `small-Qwen3ForCausalLM`.

`pad_token_id` is left unset because the reference does not set it either.

The tiny architecture is untouched: `hidden_size`, `num_hidden_layers`, `num_attention_heads`, `num_key_value_heads` and `intermediate_size` stay as they are.

Once the fixture is regenerated, the warning above loses its `eos_token_id` key. The remaining `{'bos_token_id': None, 'pad_token_id': 151643}` is what any real Qwen3 model produces and cannot be fixed from here.

## Before

```
[config_diff] Qwen/Qwen3-4B-Instruct-2507 vs tiny (13 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151645                             → None
  hidden_size                                      2560                               → 8
  intermediate_size                                9728                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_position_embeddings                          262144                             → 32768
  max_window_layers                                36                                 → 28
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
  rope_theta                                       5000000                            → 10000.0
  tie_word_embeddings                              True                               → False
  vocab_size                                       151936                             → 151669
```

## After

```
[config_diff] Qwen/Qwen3-4B-Instruct-2507 vs tiny (7 differences)
  hidden_size                                      2560                               → 8
  intermediate_size                                9728                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                36                                 → 2
  num_key_value_heads                              8                                  → 2
  tie_word_embeddings                              True                               → False
```

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo still needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 151936
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta`, `max_position_embeddings` and `max_window_layers` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a tiny-model generation script and fixture metadata; no production training or inference paths.
> 
> **Overview**
> Updates the **tiny Qwen3-4B-Instruct-2507** hub generator so `Qwen3Config` matches `Qwen/Qwen3-4B-Instruct-2507` on metadata fields, not just the shrunk architecture.
> 
> **`vocab_size`** is pinned to **151936** instead of `len(tokenizer.vocab)`. **BOS/EOS** ids (**151643** / **151645**), **RoPE/context** settings (**`rope_theta=5000000`**, **`max_position_embeddings=262144`**, **`max_window_layers=36`**) are set from the reference so tokenizer, generation config, and model config stay aligned and `Trainer` stops rewriting config for **`eos_token_id`**. Tiny layer sizes are unchanged; **`tie_word_embeddings`** is still left as-is for structural reasons.
> 
> Regenerating the Hub fixture is required for tests to pick this up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57d871be89a531d2d81a879c7de417939538aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->