### PR TITLE
Align tiny GptOss config with openai/gpt-oss-20b

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/gpt_oss_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/gpt_oss_for_causal_lm.py
@@ -32,7 +32,7 @@ MODEL_ID = "openai/gpt-oss-20b"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = GptOssConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=201088,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
@@ -40,6 +40,8 @@ config = GptOssConfig(
     intermediate_size=32,
     num_local_experts=4,
     num_experts_per_tok=2,
+    eos_token_id=200002,
+    pad_token_id=199999,
 )
 model = GptOssForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-GptOssForCausalLM` generator config with its reference model, `openai/gpt-oss-20b`.

Part of #7093. Follows #7098 (Qwen2.5), #7106 (Qwen3) and #7107 (Qwen3 Instruct-2507).

### Motivation

The script builds `GptOssConfig` from architecture arguments only, so the special token ids fall back to the class defaults, which are `None`, while the generation config and the tokenizer come from the real model. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 200002, 'bos_token_id': 199998, 'pad_token_id': 199999}.
```

### Solution

Mirror the reference values:

- `vocab_size=201088` (reference padded embedding size; previously `len(tokenizer.vocab) = 200019`)
- `eos_token_id=200002`, `pad_token_id=199999` (reference values; previously `None`)

Unlike the Qwen models, `rope_theta` and `max_position_embeddings` need no change: the `GptOssConfig` defaults already match the reference at 150000 and 131072.

`bos_token_id` is left unset, because the reference leaves it unset too. The tokenizer does define one (199998), so the realignment message keeps that single key after this change. That disagreement lives in the reference model, not here.

The tiny architecture is untouched: `hidden_size`, `num_hidden_layers`, `num_attention_heads`, `num_key_value_heads`, `intermediate_size`, `num_local_experts` and `num_experts_per_tok` stay as they are.

Three groups of differences are deliberately left in place:

- `quantization_config`: the reference ships mxfp4-quantized, the tiny model is plain bfloat16. Copying that key would change how the fixture loads.
- `experts_per_token`, `initial_context_length`, `swiglu_limit`: fields the reference repo carries that `GptOssConfig` does not model. `experts_per_token` in particular would contradict the deliberately reduced `num_experts_per_tok`.
- `num_experts_per_tok` and `num_local_experts`: routing over 2 of 4 experts instead of 4 of 32, which is part of the size reduction.

### Before

```
[config_diff] openai/gpt-oss-20b vs tiny (16 differences)
  eos_token_id                                     200002                             → None
  experts_per_token                                4                                  → <missing>
  hidden_size                                      2880                               → 8
  initial_context_length                           4096                               → <missing>
  intermediate_size                                2880                               → 32
  layer_types                                      ['sliding_attention', 'full_attent → ['sliding_attention', 'full_attent
  num_attention_heads                              64                                 → 4
  num_experts_per_tok                              4                                  → 2
  num_hidden_layers                                24                                 → 2
  num_key_value_heads                              8                                  → 2
  num_local_experts                                32                                 → 4
  pad_token_id                                     199999                             → None
  quantization_config.modules_to_not_convert       ['model.layers.*.self_attn', 'mode → <missing>
  quantization_config.quant_method                 mxfp4                              → <missing>
  swiglu_limit                                     7.0                                → <missing>
  vocab_size                                       201088                             → 200019
```

### After

```
[config_diff] openai/gpt-oss-20b vs tiny (13 differences)
  experts_per_token                                4                                  → <missing>
  hidden_size                                      2880                               → 8
  initial_context_length                           4096                               → <missing>
  intermediate_size                                2880                               → 32
  layer_types                                      ['sliding_attention', 'full_attent → ['sliding_attention', 'full_attent
  num_attention_heads                              64                                 → 4
  num_experts_per_tok                              4                                  → 2
  num_hidden_layers                                24                                 → 2
  num_key_value_heads                              8                                  → 2
  num_local_experts                                32                                 → 4
  quantization_config.modules_to_not_convert       ['model.layers.*.self_attn', 'mode → <missing>
  quantization_config.quant_method                 mxfp4                              → <missing>
  swiglu_limit                                     7.0                                → <missing>
```

Once the fixture is regenerated the message drops from three keys to one, `{'bos_token_id': 199998}`.

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo still needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 201088
- Set `eos_token_id` and `pad_token_id` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only fixture generation change with no runtime training or inference logic modified.
> 
> **Overview**
> Updates the **tiny `GptOssForCausalLM` generator** so `GptOssConfig` matches `openai/gpt-oss-20b` on vocabulary and special tokens, instead of deriving `vocab_size` from `len(tokenizer.vocab)` and leaving pad/eos unset.
> 
> **`vocab_size`** is pinned to **201088** (reference padded embedding size). **`eos_token_id=200002`** and **`pad_token_id=199999`** are set explicitly so config, tokenizer, and `GenerationConfig` stay aligned and `Trainer` no longer rewrites those fields at train time. Tiny architecture dimensions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b968065600c3dc7851ac26fa4fca290ef9e40f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->