### PR TITLE
Align tiny GPTNeoX config with EleutherAI/pythia-14m

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/gpt_neox_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/gpt_neox_for_causal_lm.py
@@ -32,12 +32,13 @@ MODEL_ID = "EleutherAI/pythia-14m"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = GPTNeoXConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=50304,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    eos_token_id=0,
 )
 model = GPTNeoXForCausalLM(config).to(dtype=torch.float16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-GPTNeoXForCausalLM` generator config with its reference model, `EleutherAI/pythia-14m`.

Part of #7093. Follows #7098 (Qwen2.5), #7106 (Qwen3), #7107 (Qwen3 Instruct-2507) and #7108 (GptOss).

### Motivation

The script builds `GPTNeoXConfig` from architecture arguments only, so `eos_token_id` falls back to the class default of `2` while the real model uses `0`. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 0}.
```

### Solution

Mirror the reference values:

- `vocab_size=50304` (reference padded embedding size; previously `len(tokenizer.vocab) = 50277`)
- `eos_token_id=0` (reference value; class default is `2`)

`bos_token_id` needs no entry: the reference sets it to `0` and the `GPTNeoXConfig` default already is `0`. `pad_token_id` is left unset because the reference does not set it either.

This is the first fixture in the series that ends up **completely** clean. The tokenizer has no pad token, so the trainer falls back to the eos token, and since #7097 it mirrors that onto the model configs, which covers the one remaining key. Simulating the alignment against the fixture's own tokenizer and generation config confirms it:

```
fixture generation_config: bos/eos/pad = 0 0 None
fixture tokenizer        : bos/eos/pad = 0 0 None
warning after regeneration, with #7097 in place: NO WARNING
```

### Before

```
[config_diff] EleutherAI/pythia-14m vs tiny (6 differences)
  eos_token_id                                     0                                  → 2
  hidden_size                                      128                                → 8
  intermediate_size                                512                                → 32
  num_hidden_layers                                6                                  → 2
  num_key_value_heads                              <missing>                          → 2
  vocab_size                                       50304                              → 50277
```

### After

```
[config_diff] EleutherAI/pythia-14m vs tiny (4 differences)
  hidden_size                                      128                                → 8
  intermediate_size                                512                                → 32
  num_hidden_layers                                6                                  → 2
  num_key_value_heads                              <missing>                          → 2
```

The four remaining rows are the deliberate size reduction. `num_key_value_heads` is part of that: the reference config predates the field and runs plain multi-head attention, while the tiny model uses 2 kv heads against 4 attention heads to shrink the kv projections.

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo still needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 50304
- Set `eos_token_id` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to tiny test model generation; no runtime training or production paths.
> 
> **Overview**
> Updates the **tiny GPTNeoX** generator so its `GPTNeoXConfig` matches **EleutherAI/pythia-14m** for embedding and EOS handling, not just the shrunk layer sizes.
> 
> **`vocab_size`** is pinned to **50304** (reference padded size) instead of **`len(tokenizer.vocab)`** (50277). **`eos_token_id=0`** is set explicitly so it no longer falls back to the class default of **2**.
> 
> Together this removes trainer warnings about tokenizer vs model config drift and drops two spurious rows from **`print_config_diff`** against the reference; only the intentional tiny-architecture diffs remain until the Hub fixture is regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472365d6784c63fde41af51225143e82eb024b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->