### PR TITLE
Align tiny Llama 3.2 and Remote configs with meta-llama/Llama-3.2-1B-Instruct

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_2.py
+++ b/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_2.py
@@ -32,12 +32,24 @@ MODEL_ID = "meta-llama/Llama-3.2-1B-Instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = LlamaConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=128256,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=131072,
+    rope_theta=500000.0,
+    rope_scaling={
+        "factor": 32.0,
+        "high_freq_factor": 4.0,
+        "low_freq_factor": 1.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3",
+    },
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=[128001, 128008, 128009],
 )
 model = LlamaForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)

--- a/scripts/generate_tiny_models/for_causal_lm/remote_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/remote_for_causal_lm.py
@@ -19,7 +19,13 @@
 import torch
 from transformers import AutoTokenizer, GenerationConfig
 
-from .._common import check_transformers_version, init_weights_tiny_model, push_to_hub, smoke_test
+from .._common import (
+    check_transformers_version,
+    init_weights_tiny_model,
+    print_config_diff,
+    push_to_hub,
+    smoke_test,
+)
 from ._remote_code.configuration_remote import RemoteConfig
 from ._remote_code.modeling_remote import RemoteForCausalLM, RemoteForSequenceClassification, RemoteModel
 
@@ -37,12 +43,24 @@ RemoteForCausalLM.register_for_auto_class("AutoModelForCausalLM")
 RemoteForSequenceClassification.register_for_auto_class("AutoModelForSequenceClassification")
 
 config = RemoteConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=128256,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=131072,
+    rope_theta=500000.0,
+    rope_scaling={
+        "factor": 32.0,
+        "high_freq_factor": 4.0,
+        "low_freq_factor": 1.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3",
+    },
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=[128001, 128008, 128009],
 )
 # `model.save_pretrained` only records auto-map entries for the saved class's own auto-classes.
 # Seed the AutoModel and SeqCls entries on the config so the Hub repo can also be loaded as
@@ -55,4 +73,5 @@ config.auto_map = {
 model = RemoteForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)
 smoke_test(model, tokenizer)
+print_config_diff(MODEL_ID, model)
 push_to_hub(model, tokenizer, generation_config, "tiny")


### PR DESCRIPTION
This PR aligns the `tiny-LlamaForCausalLM-3.2` and `tiny-RemoteForCausalLM` generator configs with their reference model, `meta-llama/Llama-3.2-1B-Instruct`.

Part of #7093. Follows #7098 (Qwen2.5), #7106 (Qwen3), #7107 (Qwen3 Instruct-2507), #7108 (GptOss) and #7109 (GPTNeoX).

### Motivation

Both scripts build their config from architecture arguments only, so the special token ids fall back to the class defaults (`bos=1`, `eos=2`) instead of the Llama 3 values, and the RoPE settings stay at the generic defaults. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 128009, 'bos_token_id': 128000}.
```

The two fixtures share one reference and are the same model reached two ways: `RemoteConfig` is `class RemoteConfig(LlamaConfig)` with `model_type = "remote"`, and `tiny-RemoteForCausalLM` exists so the `trust_remote_code` path can be tested. They are aligned together so the remote-code tests keep exercising the same shape as their normal-path counterparts.

### Solution

Mirror the reference values:

- `vocab_size=128256` (matches `len(tokenizer.vocab)` today, so this is a no-op in value; pinned so the config no longer depends on the reference tokenizer files at generation time)
- `bos_token_id=128000` (reference value; class default is `1`)
- `eos_token_id=[128001, 128008, 128009]` (reference value; class default is `2`)
- `rope_theta=500000.0` (reference override; class default is `10000.0`)
- `rope_scaling={...}` with `rope_type: llama3` (reference override; class default is `None`)
- `max_position_embeddings=131072` (reference override; class default is `2048`)
- `rms_norm_eps=1e-05` (reference override; class default is `1e-06`)

This is the first fixture in the series where the mirrored `eos_token_id` is a list and where the reference carries a nested `rope_scaling` block. `Trainer` handles the list correctly, testing membership rather than equality. The `llama3` rope scaling was checked against the tiny geometry before being adopted: with `head_dim=2` there is a single rotation pair, and the model builds, runs a forward pass without NaNs, and keeps an identical parameter count.

`head_dim` is deliberately left at 2 rather than mirrored to the reference's 64. It is derived from `hidden_size // num_attention_heads`, so pinning it would grow the attention projections by 32x and undo the size reduction.

`tie_word_embeddings` is deliberately left alone, same call as in #7106 and #7107: tying changes the model structure rather than its metadata.

`pad_token_id` is left unset because the reference does not set it either.

The `remote_for_causal_lm.py` script had no drift check at all, so `print_config_diff` is added there. That is what produces the second pair of tables below.

Once the fixtures are regenerated, **both go completely clean**. Their tokenizers have no pad token, so the trainer falls back to eos and, since #7097, mirrors it onto the model configs, which covers the last key:

```
tiny-LlamaForCausalLM-3.2: gen bos/eos/pad = 128000 [128001, 128008, 128009] None
  warning after regeneration: NO WARNING
tiny-RemoteForCausalLM:    gen bos/eos/pad = 128000 [128001, 128008, 128009] None
  warning after regeneration: NO WARNING
```

## Before

```
[config_diff] meta-llama/Llama-3.2-1B-Instruct vs tiny (18 differences)
  bos_token_id                                     128000                             → 1
  eos_token_id                                     [128001, 128008, 128009]           → 2
  head_dim                                         64                                 → 2
  hidden_size                                      2048                               → 8
  intermediate_size                                8192                               → 32
  max_position_embeddings                          131072                             → 2048
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                16                                 → 2
  num_key_value_heads                              8                                  → 2
  rms_norm_eps                                     1e-05                              → 1e-06
  rope_scaling                                     <missing>                          → None
  rope_scaling.factor                              32.0                               → <missing>
  rope_scaling.high_freq_factor                    4.0                                → <missing>
  rope_scaling.low_freq_factor                     1.0                                → <missing>
  rope_scaling.original_max_position_embeddings    8192                               → <missing>
  rope_scaling.rope_type                           llama3                             → <missing>
  rope_theta                                       500000.0                           → 10000.0
  tie_word_embeddings                              True                               → False
```

## After

```
[config_diff] meta-llama/Llama-3.2-1B-Instruct vs tiny (7 differences)
  head_dim                                         64                                 → 2
  hidden_size                                      2048                               → 8
  intermediate_size                                8192                               → 32
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                16                                 → 2
  num_key_value_heads                              8                                  → 2
  tie_word_embeddings                              True                               → False
```

Both scripts produce the same tables, since `RemoteConfig` inherits `LlamaConfig`'s defaults and they share the reference.

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repos still need regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 128256 in both scripts
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta`, `rope_scaling`, `max_position_embeddings` and `rms_norm_eps` from the reference config
- Add the missing `print_config_diff` call to the remote-code generator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only tiny-model generation scripts and test fixture metadata; no runtime training or production model paths.
> 
> **Overview**
> Updates the **tiny Llama 3.2** and **tiny Remote** causal-LM generator scripts so their `LlamaConfig` / `RemoteConfig` metadata matches `meta-llama/Llama-3.2-1B-Instruct`, not generic class defaults.
> 
> Both scripts now pin **`vocab_size=128256`**, set **BOS/EOS token ids** to the Llama 3 values (including a **list** of EOS ids), and copy **RoPE-related fields** (`max_position_embeddings`, `rope_theta`, `rope_scaling` with `rope_type: llama3`) plus **`rms_norm_eps`**. Tiny geometry (small `hidden_size`, layers, etc.) is unchanged on purpose.
> 
> The remote-code generator also imports and runs **`print_config_diff`** before push, matching the standard Llama 3.2 script so drift vs the reference is visible at generation time. Regenerating the Hub fixtures should stop `Trainer` from rewriting configs when tokenizer and model special tokens disagree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657791bbd034636f0b51bd0cd38957fea2d340bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->