### PR TITLE
fix: normalize RLOO VLM prompt content

### DIFF
--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -39,6 +39,35 @@ if is_peft_available():
 
 
 class TestRLOOTrainer(TrlTestCase):
+    def test_tokenize_prompts_normalizes_string_content_for_vlm(self):
+        class DummyProcessor:
+            def apply_chat_template(self, conversation, **kwargs):
+                assert kwargs["add_generation_prompt"] is True
+                assert kwargs["tokenize"] is True
+                assert kwargs["return_dict"] is True
+                assert conversation == [
+                    [
+                        {
+                            "role": "user",
+                            "content": [{"type": "text", "text": "What is in this image?"}],
+                        }
+                    ]
+                ]
+                return {"input_ids": [[1, 2, 3]], "attention_mask": [[1, 1, 1]]}
+
+        trainer = RLOOTrainer.__new__(RLOOTrainer)
+        trainer._is_vlm = True
+        trainer.processing_class = DummyProcessor()
+        trainer.chat_template_kwargs = {}
+
+        prompt_ids, images, multimodal_fields = trainer._tokenize_prompts(
+            [[{"role": "user", "content": "What is in this image?"}]]
+        )
+
+        assert prompt_ids == [[1, 2, 3]]
+        assert images is None
+        assert multimodal_fields == {}
+
     def test_init_minimal(self):
         # Test that RLOOTrainer can be instantiated with only model, reward_model and train_dataset
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -1171,6 +1171,10 @@ class RLOOTrainer(_BaseTrainer):
     def _tokenize_prompts(self, prompts: list):
         """Tokenize prompts and extract images/multimodal fields for generation."""
         if is_conversational({"prompt": prompts[0]}):
+            # Normalize string content to content blocks for VLM processors that don't handle plain strings.
+            if self._is_vlm:
+                prompts = [prepare_multimodal_messages(prompt) for prompt in prompts]
+
             # Extract images from messages for VLM support
             images = []
             has_images = False


### PR DESCRIPTION
# What does this PR do?

Fixes #7049.

`RLOOTrainer._tokenize_prompts` already has the VLM image-extraction path used by
`examples/rloo_visual_math`, and it imports `prepare_multimodal_messages`, but it did not normalize
conversational string content before calling `apply_chat_template`.

`GRPOTrainer` and `DistillationTrainer` both do this normalization first:

```python
# Normalize string content to content blocks for VLM processors that don't handle plain strings.
if self._is_vlm:
    prompts = [prepare_multimodal_messages(prompt) for prompt in prompts]
```

This PR applies the same VLM prompt normalization to RLOO so processors that expect structured
content blocks receive the same prompt shape across GRPO, Distillation, and RLOO.

Added a lightweight regression test that calls `_tokenize_prompts` with a dummy processor, so it
does not download a model or require vision dependencies.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

Tested with:

```bash
python -m pytest tests/test_rloo_trainer.py::TestRLOOTrainer::test_tokenize_prompts_normalizes_string_content_for_vlm --basetemp .pytest-tmp
git diff --check
```

`python -m ruff check trl/trainer/rloo_trainer.py tests/test_rloo_trainer.py` could not be run in my
local environment because `ruff` is not installed there.

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone familiar with RLOO/VLM prompt tokenization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow VLM tokenization fix aligned with existing trainers; only affects conversational prompts when `_is_vlm` is true.
> 
> **Overview**
> **RLOO VLM prompts with plain string `content` are now normalized to structured content blocks before `apply_chat_template`, matching GRPO and Distillation trainers.**
> 
> When `_is_vlm` is set and prompts are conversational, `RLOOTrainer._tokenize_prompts` runs `prepare_multimodal_messages` on each prompt so processors that expect `[{"type": "text", "text": "..."}]` instead of a raw string get the right shape (fixes #7049).
> 
> A lightweight unit test uses a dummy processor to assert string user content is converted before chat templating, without downloading models or requiring vision deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfac29b4a3569ad9ec8c7cf0e9de1cd2055d7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->