### PR TITLE
Align tiny Llama 3 config with meta-llama/Meta-Llama-3-8B-Instruct

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3.py
+++ b/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3.py
@@ -32,12 +32,17 @@ MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = LlamaConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=128256,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=8192,
+    rope_theta=500000.0,
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=128009,
 )
 model = LlamaForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-LlamaForCausalLM-3` generator config with its reference model, `meta-llama/Meta-Llama-3-8B-Instruct`.

Part of #7093. Follows #7098, #7106, #7107, #7108, #7109 and #7110.

### Motivation

The script builds `LlamaConfig` from architecture arguments only, so the special token ids fall back to the class defaults (`bos=1`, `eos=2`) instead of the Llama 3 values. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 128009, 'bos_token_id': 128000}.
```

### Solution

Mirror the reference values:

- `vocab_size=128256` (matches `len(tokenizer.vocab)` today, so this is a no-op in value; pinned so the config no longer depends on the reference tokenizer files at generation time)
- `bos_token_id=128000` (reference value; class default is `1`)
- `eos_token_id=128009` (reference value; class default is `2`)
- `rope_theta=500000.0` (reference override; class default is `10000.0`)
- `max_position_embeddings=8192` (reference override; class default is `2048`)
- `rms_norm_eps=1e-05` (reference override; class default is `1e-06`)

Unlike Llama 3.2 in #7110, this reference has no `rope_scaling` block, which arrived with 3.1, and its `eos_token_id` is a plain scalar rather than a list. It also sets `tie_word_embeddings` to `False`, matching the class default, so this fixture carries none of the tying residual that #7106, #7107 and #7110 do.

`head_dim` is deliberately left at 2 rather than mirrored to the reference's 128. It derives from `hidden_size // num_attention_heads`, so pinning it would grow the attention projections and undo the size reduction.

`pad_token_id` is left unset because the reference does not set it either.

Once the fixture is regenerated it goes **completely clean**. The tokenizer has no pad token, so the trainer falls back to eos and, since #7097, mirrors it onto the model configs, which covers the last key:

```
fixture generation: bos/eos/pad = 128000 [128001, 128009] None
fixture tokenizer : bos/eos/pad = 128000 128009 None
warning after regeneration: NO WARNING
```

The scalar `eos_token_id=128009` sits inside the generation config's `[128001, 128009]`, which is what the alignment checks.

## Before

```
[config_diff] meta-llama/Meta-Llama-3-8B-Instruct vs tiny (11 differences)
  bos_token_id                                     128000                             → 1
  eos_token_id                                     128009                             → 2
  head_dim                                         128                                → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                14336                              → 32
  max_position_embeddings                          8192                               → 2048
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                32                                 → 2
  num_key_value_heads                              8                                  → 2
  rms_norm_eps                                     1e-05                              → 1e-06
  rope_theta                                       500000.0                           → 10000.0
```

## After

```
[config_diff] meta-llama/Meta-Llama-3-8B-Instruct vs tiny (6 differences)
  head_dim                                         128                                → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                14336                              → 32
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                32                                 → 2
  num_key_value_heads                              8                                  → 2
```

Every remaining row is the deliberate size reduction. The Hub repo still needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 128256
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta`, `max_position_embeddings` and `rms_norm_eps` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only fixture generation change with no runtime library or auth/data-path impact.
> 
> **Overview**
> Updates the **tiny Llama 3** causal-LM fixture script so `LlamaConfig` matches **meta-llama/Meta-Llama-3-8B-Instruct** on tokenizer and RoPE-related fields, not just the shrunk architecture dims.
> 
> `vocab_size` is pinned to **128256** instead of `len(tokenizer.vocab)`, and the config now sets **bos/eos** (`128000` / `128009`), **max_position_embeddings** `8192`, **rope_theta** `500000.0`, and **rms_norm_eps** `1e-05`. That removes the trainer warning about BOS/EOS drifting from class defaults and cuts `print_config_diff` noise to only the intentional tiny dimensions (e.g. `head_dim` stays small via `hidden_size // num_attention_heads`).
> 
> The Hub tiny model still needs regenerating for the published artifact to pick this up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b764503b966f311b4a66e33045bf7f494a2313c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->