### PR TITLE
Align tiny Llama 3.1 config with meta-llama/Llama-3.1-8B-Instruct

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_1.py
+++ b/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_1.py
@@ -32,12 +32,24 @@ MODEL_ID = "meta-llama/Llama-3.1-8B-Instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = LlamaConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=128256,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=131072,
+    rope_theta=500000.0,
+    rope_scaling={
+        "factor": 8.0,
+        "high_freq_factor": 4.0,
+        "low_freq_factor": 1.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3",
+    },
+    rms_norm_eps=1e-05,
+    bos_token_id=128000,
+    eos_token_id=[128001, 128008, 128009],
 )
 model = LlamaForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-LlamaForCausalLM-3.1` generator config with its reference model, `meta-llama/Llama-3.1-8B-Instruct`.

Part of #7093. Follows #7098, #7106, #7107, #7108, #7109, #7110 and #7112. This is the last model in the first batch.

### Motivation

The script builds `LlamaConfig` from architecture arguments only, so the special token ids fall back to the class defaults (`bos=1`, `eos=2`) instead of the Llama 3.1 values, and the RoPE settings stay at the generic defaults. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 128009, 'bos_token_id': 128000}.
```

### Solution

Mirror the reference values:

- `vocab_size=128256` (matches `len(tokenizer.vocab)` today, so this is a no-op in value; pinned so the config no longer depends on the reference tokenizer files at generation time)
- `bos_token_id=128000` (reference value; class default is `1`)
- `eos_token_id=[128001, 128008, 128009]` (reference value; class default is `2`)
- `rope_theta=500000.0` (reference override; class default is `10000.0`)
- `rope_scaling={...}` with `rope_type: llama3` and `factor: 8.0` (reference override; class default is `None`)
- `max_position_embeddings=131072` (reference override; class default is `2048`)
- `rms_norm_eps=1e-05` (reference override; class default is `1e-06`)

The `rope_scaling` block matches the shape used for Llama 3.2 in #7110 but **not** its values: 3.1 scales by `factor: 8.0` where 3.2 uses `32.0`. Verified against the tiny geometry before adopting it: with `head_dim=2` there is a single rotation pair, and the model builds and runs a forward pass without NaNs at an unchanged parameter count.

Like Llama 3 in #7112 and unlike 3.2, the reference sets `tie_word_embeddings` to `False`, matching the class default, so this fixture carries none of the tying residual.

`head_dim` is deliberately left at 2 rather than mirrored to the reference's 128. It derives from `hidden_size // num_attention_heads`, so pinning it would grow the attention projections and undo the size reduction.

`pad_token_id` is left unset because the reference does not set it either.

Once the fixture is regenerated it goes **completely clean**. The tokenizer has no pad token, so the trainer falls back to eos and, since #7097, mirrors it onto the model configs, which covers the last key:

```
fixture generation: bos/eos/pad = 128000 [128001, 128008, 128009] None
fixture tokenizer : bos/eos/pad = 128000 128009 None
warning after regeneration: NO WARNING
```

## Before

```
[config_diff] meta-llama/Llama-3.1-8B-Instruct vs tiny (17 differences)
  bos_token_id                                     128000                             → 1
  eos_token_id                                     [128001, 128008, 128009]           → 2
  head_dim                                         128                                → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                14336                              → 32
  max_position_embeddings                          131072                             → 2048
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                32                                 → 2
  num_key_value_heads                              8                                  → 2
  rms_norm_eps                                     1e-05                              → 1e-06
  rope_scaling                                     <missing>                          → None
  rope_scaling.factor                              8.0                                → <missing>
  rope_scaling.high_freq_factor                    4.0                                → <missing>
  rope_scaling.low_freq_factor                     1.0                                → <missing>
  rope_scaling.original_max_position_embeddings    8192                               → <missing>
  rope_scaling.rope_type                           llama3                             → <missing>
  rope_theta                                       500000.0                           → 10000.0
```

## After

```
[config_diff] meta-llama/Llama-3.1-8B-Instruct vs tiny (6 differences)
  head_dim                                         128                                → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                14336                              → 32
  num_attention_heads                              32                                 → 4
  num_hidden_layers                                32                                 → 2
  num_key_value_heads                              8                                  → 2
```

Every remaining row is the deliberate size reduction. The Hub repo still needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 128256
- Set `bos_token_id` and `eos_token_id` from the reference config
- Set `rope_theta`, `rope_scaling`, `max_position_embeddings` and `rms_norm_eps` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to tiny test fixture generation; no production training or inference paths affected until the Hub model is regenerated.
> 
> **Overview**
> Updates `llama_for_causal_lm_3_1.py` so the tiny **Llama 3.1** fixture’s `LlamaConfig` matches `meta-llama/Llama-3.1-8B-Instruct` for tokenizer and RoPE-related fields, not just the shrunk architecture dims.
> 
> **Pinned / set from reference:** `vocab_size=128256` (replacing `len(tokenizer.vocab)`), `bos_token_id=128000`, `eos_token_id=[128001, 128008, 128009]`, `max_position_embeddings=131072`, `rope_theta=500000.0`, Llama 3.1 `rope_scaling` (`rope_type: llama3`, `factor: 8.0`, etc.), and `rms_norm_eps=1e-05`. Tiny geometry (`hidden_size`, layers, heads, etc.) stays unchanged.
> 
> **Why:** avoids Trainer rewriting model/generation config when tokenizer BOS/EOS differ from class defaults, and cuts `print_config_diff` noise so only intentional size reductions remain after regenerating the Hub fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a039070514a896409424668abc78210bab895a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->