### PR TITLE
docs: guide users through agentic GRPO examples

### DIFF
--- a/docs/source/example_overview.md
+++ b/docs/source/example_overview.md
@@ -19,6 +19,27 @@ pip install --upgrade trl[quantization]
 
 Check for additional optional dependencies [here](https://github.com/huggingface/trl/blob/main/pyproject.toml). Notebook-based examples are self-contained and can run on **free Colab**; script-based examples run on single-GPU, multi-GPU, or DeepSpeed setups (see [Distributed Training](#distributed-training) below).
 
+## Choosing an agentic RL example
+
+Several examples train models that interact with tools or environments. Pick the one that matches
+who owns the interaction loop:
+
+- Use [`grpo_echo`](https://github.com/huggingface/trl/tree/main/examples/grpo_echo) for the smallest
+  end-to-end `environment_factory` example.
+- Use [`grpo_wordle`](https://github.com/huggingface/trl/tree/main/examples/grpo_wordle),
+  [`grpo_sudoku`](https://github.com/huggingface/trl/tree/main/examples/grpo_sudoku), or
+  [`grpo_catch`](https://github.com/huggingface/trl/tree/main/examples/grpo_catch) when TRL should
+  drive each turn and the environment exposes stateful tools.
+- Use [`grpo_multi_env`](https://github.com/huggingface/trl/tree/main/examples/grpo_multi_env) when a
+  single training run mixes tasks that need different tool sets or environment classes.
+- Use [`grpo_sql_agent`](https://github.com/huggingface/trl/tree/main/examples/grpo_sql_agent) when
+  reward comes from a verifiable business-like workflow, such as answering by querying a database.
+- Use [`grpo_harbor`](https://github.com/huggingface/trl/tree/main/examples/grpo_harbor) when each
+  task is packaged as a sandbox plus verifier.
+- Use [`async_grpo_opencode`](https://github.com/huggingface/trl/tree/main/examples/async_grpo_opencode)
+  when the agent owns its own loop and TRL should train from captured proxy traces instead of driving
+  every tool call directly.
+
 ## Index
 
 | Example | Description | Open in Colab |

--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -986,6 +986,16 @@ All environments plug into the same `environment_factory` slot, so they are inte
 | [OpenReward](openreward) | An integration with ORS-speaking environments (the [openreward.ai](https://openreward.ai) catalog or your own ORS server); tasks **and** rewards are served over HTTP. | You want to train against an ORS environment: the catalog (e.g. `Eigent/SETA`), one you self-host on your own infra, or a local server you're developing. |
 | [Harbor](harbor) | An integration with Harbor task suites: each task is an instruction, a real sandbox image (`docker`, `e2b`, ...), and an in-sandbox verifier. | You want to train against a Harbor task suite: a tree of tasks, each a self-contained sandbox plus verifier (e.g. a data-analysis agent that explores files in a sandbox and writes an answer a grader checks). |
 
+Choosing between the built-in paths depends on who owns the rollout loop:
+
+| Need | Recommended path |
+|---|---|
+| Stateless helper calls, such as a calculator or retriever, with no per-episode state. | Pass functions through `tools`. |
+| TRL should generate every turn, execute tools, and feed observations back to the model. | Use `environment_factory` with an environment class. |
+| One run mixes tasks with different tool sets or state machines. | Pass `environment_factory` as a dictionary and route examples with an `environment` column. |
+| Tasks are packaged as sandbox images with held-out verifiers. | Use the [Harbor](harbor) integration. |
+| An external agent already owns planning, context management, and the tool loop. | Use the experimental loop-owning harness path described in [OpenEnv](openenv#training-on-harnesses-training-a-real-coding-agent-opencode). |
+
 ## Vision-Language Model (VLM) Training
 
 GRPO supports training Vision-Language Models (VLMs) on multimodal datasets containing both text and images.


### PR DESCRIPTION
# What does this PR do?

Adds a short navigation section for agentic RL examples and a matching decision table in the
`GRPOTrainer` guide.

TRL now has several examples that involve tools, stateful environments, sandboxed verifiers, and
loop-owning agents. For new users, the hard part is often choosing the right integration before they
write the first trainer call:

- plain `tools`
- `environment_factory`
- multiple environments
- Harbor sandbox suites
- OpenEnv loop-owning harnesses such as `async_grpo_opencode`

This PR adds:

- `docs/source/example_overview.md`: a "Choosing an agentic RL example" section that points users to
  the smallest relevant example for each rollout/state-ownership pattern.
- `docs/source/grpo_trainer.md`: a compact decision table under "Environment Integrations" describing
  which built-in path to use for common agent-training needs.

No code paths are changed.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

Tested with:

```bash
python -m pytest tests/test_examples_index.py
git diff --check HEAD~1..HEAD
```

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone familiar with the GRPO/OpenEnv/Harbor examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or training behavior impact.
> 
> **Overview**
> Adds **documentation-only** navigation so newcomers can pick the right agentic GRPO pattern before wiring a trainer.
> 
> In **`example_overview.md`**, a new **“Choosing an agentic RL example”** section frames choices around **who owns the interaction loop**, with bullets pointing to `grpo_echo`, stateful OpenEnv examples (`grpo_wordle` / `sudoku` / `catch`), `grpo_multi_env`, `grpo_sql_agent`, `grpo_harbor`, and loop-owning `async_grpo_opencode`.
> 
> In **`grpo_trainer.md`**, under **Environment Integrations**, a **“Need → Recommended path”** table maps common setups to `tools`, `environment_factory`, multi-env routing via an `environment` column, Harbor, and the OpenEnv loop-owning harness path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02db9d57e759f2ffd984480913558955afbf773d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->