### PR TITLE
Require deepspeed>=0.18.6 and drop the 0.16.4 guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ bco = [
     "joblib"
 ]
 deepspeed = [
-    "deepspeed>=0.14.4",
+    "deepspeed>=0.18.6",
     "transformers!=5.1.0",  # see transformers#43780
 ]
 kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
@@ -105,7 +105,7 @@ dev = [
     "scikit-learn",
     "joblib",
     # deepspeed
-    "deepspeed>=0.14.4",
+    "deepspeed>=0.18.6",
     # kernels: transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
@@ -192,16 +192,6 @@ filterwarnings = [
     "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
-
-    # PyTorch JIT deprecations (upstream, not actionable in TRL)
-    # Upstream issue: https://github.com/deepspeedai/DeepSpeed/issues/7835
-    # Upstream PR: https://github.com/deepspeedai/DeepSpeed/pull/7840
-    # Upstream fix released in deepspeed v0.18.6: https://github.com/deepspeedai/DeepSpeed/releases/tag/v0.18.6
-    # Remove once: deepspeed >= 0.18.6 is required
-    "ignore:`torch.jit.script_method` is deprecated:DeprecationWarning",
-    "ignore:`torch.jit.script` is deprecated:DeprecationWarning",
-    # On Python 3.14+ the same deprecation is reworded to "is not supported in Python 3.14+ and may break"
-    "ignore:`torch.jit.script_method` is not supported:DeprecationWarning",
 
     # PyTorch DataLoader pin_memory device argument deprecations
     # Triggered internally by torch.utils.data, not by our code

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -77,8 +77,6 @@ def iter_params(module, recurse=False):
 
 def add_hooks(model: "DeepSpeedEngine") -> None:
     """Adds the optimizer hooks from a DeepSpeed ZeRO-3 model."""
-    import deepspeed
-
     if not hasattr(model, "optimizer"):  # before the first training step, the model has no optimizer
         return
     if model.optimizer is not None and hasattr(model.optimizer, "parameter_offload"):
@@ -96,11 +94,7 @@ def add_hooks(model: "DeepSpeedEngine") -> None:
         if not coordinator.is_invalid_trace():
             coordinator._invalidate_trace()
 
-    if Version(deepspeed.__version__) >= Version("0.16.4"):
-        # Account for renaming in https://github.com/deepspeedai/DeepSpeed/pull/6847
-        optimizer_offload._register_deepspeed_module(optimizer_offload.module)
-    else:
-        optimizer_offload._register_hooks_recursively(optimizer_offload.module)
+    optimizer_offload._register_deepspeed_module(optimizer_offload.module)
 
 
 @contextmanager


### PR DESCRIPTION
This PR raises the deepspeed floor from 0.14.4 (June 2024) to 0.18.6 (February 2026) and removes the two things that floor was holding in place.

### Motivation

The rationale is not new here. #7102, opened by TRL's main maintainer and approved, raises the peft floor on the grounds that a floor should not be older than two years. This applies that same reasoning to the oldest floor we have: `deepspeed>=0.14.4` is 26 months old, and it is the only floor already past that window.

Two things go with it:

- The `Version(deepspeed.__version__) >= Version("0.16.4")` branch in `add_hooks`, which chooses between `_register_deepspeed_module` and the pre-rename `_register_hooks_recursively` (deepspeed#6847). The local `import deepspeed` in that function existed only to read `__version__`, so it goes too.
- The `filterwarnings` block for the `torch.jit.script` and `torch.jit.script_method` deprecations deepspeed emits. Its comment already records the exit condition: "Remove once: deepspeed >= 0.18.6 is required" (deepspeed#7835, fixed by deepspeed#7840, released in v0.18.6).

The general criterion is under discussion in #7116.

### Verification

`_register_deepspeed_module` is present at the v0.18.6 tag, so the retained call is valid across the whole supported range.

Importing deepspeed 0.18.9 with `warnings.simplefilter("always")` produces 0 `torch.jit.script` deprecation warnings, so the removed filter entries match nothing at the new floor. The other side of that check is upstream's record rather than a local run: the filter was added because deepspeed#7835 fired, and deepspeed#7840 fixed it in v0.18.6.

deepspeed is an optional extra, so a default `pip install trl` is unaffected.

### Changes

- Raise `deepspeed>=0.14.4` to `>=0.18.6` in the `deepspeed` extra and in `dev`
- Collapse the 0.16.4 branch in `add_hooks` and drop the now-unused local `import deepspeed`
- Remove the deepspeed `torch.jit` `filterwarnings` block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the minimum DeepSpeed version and ZeRO-3 hook registration path for users of the deepspeed extra; impact is limited to optional installs but affects distributed training compatibility.
> 
> **Overview**
> Raises the **deepspeed** optional/dev floor from `>=0.14.4` to **`>=0.18.6`**, aligning supported DeepSpeed with a newer minimum and upstream fixes (including resolved `torch.jit` deprecation noise).
> 
> In **`add_hooks`**, drops the `0.16.4` version branch and always calls **`_register_deepspeed_module`** instead of the legacy **`_register_hooks_recursively`** path; the function-local `import deepspeed` used only for version checks is removed.
> 
> Removes the pytest **`filterwarnings`** entries that suppressed DeepSpeed’s **`torch.jit.script`** / **`torch.jit.script_method`** deprecations, since those were documented to go away once `deepspeed >= 0.18.6` is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16846478c7df7e9c6778b67bf70f7fb329930af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->