### PR TITLE
Guard target_parameters use for peft<0.17.0

### DIFF
--- a/tests/test_dpo_trainer.py
+++ b/tests/test_dpo_trainer.py
@@ -31,6 +31,7 @@ from .testing_utils import (
     require_kernels,
     require_liger_kernel,
     require_peft,
+    require_peft_target_parameters,
     require_vision,
 )
 
@@ -732,7 +733,7 @@ class TestDPOTrainer(TrlTestCase):
             elif "base_layer" not in n:  # We expect the peft params to be different (except for the base layer)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")
@@ -800,7 +801,7 @@ class TestDPOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -45,6 +45,7 @@ from .testing_utils import (
     require_bitsandbytes,
     require_liger_kernel,
     require_peft,
+    require_peft_target_parameters,
     require_response_parsing,
     require_torch_accelerator,
     require_vision,
@@ -1042,7 +1043,7 @@ class TestGRPOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_kto_trainer.py
+++ b/tests/test_kto_trainer.py
@@ -24,7 +24,14 @@ from transformers.utils import is_peft_available
 from trl import KTOConfig, KTOTrainer
 from trl.trainer.kto_trainer import DataCollatorForUnpairedPreference, DataCollatorForVisionUnpairedPreference
 
-from .testing_utils import TrlTestCase, require_bitsandbytes, require_liger_kernel, require_peft, require_vision
+from .testing_utils import (
+    TrlTestCase,
+    require_bitsandbytes,
+    require_liger_kernel,
+    require_peft,
+    require_peft_target_parameters,
+    require_vision,
+)
 
 
 if is_peft_available():
@@ -812,7 +819,7 @@ class TestKTOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_rloo_trainer.py
+++ b/tests/test_rloo_trainer.py
@@ -30,7 +30,14 @@ from transformers.utils import is_peft_available
 
 from trl import RLOOConfig, RLOOTrainer
 
-from .testing_utils import TrlTestCase, require_bitsandbytes, require_peft, require_vision, require_vllm
+from .testing_utils import (
+    TrlTestCase,
+    require_bitsandbytes,
+    require_peft,
+    require_peft_target_parameters,
+    require_vision,
+    require_vllm,
+)
 
 
 if is_peft_available():
@@ -605,7 +612,7 @@ class TestRLOOTrainer(TrlTestCase):
             elif "base_layer" not in n and "ref" not in n:  # and the peft params to be different (except base and ref)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_peft_model(self):
         # Regression test for https://github.com/huggingface/trl/issues/5222. Before PEFT 0.20.0, only one adapter per
         # model was supported when the LoRA config uses `target_parameters` (see peft#3340, fixed in peft#3350), so no

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -52,6 +52,7 @@ from .testing_utils import (
     require_kernels,
     require_liger_kernel,
     require_peft,
+    require_peft_target_parameters,
     require_torch_accelerator,
     require_torch_multi_accelerator,
     require_vision,
@@ -752,7 +753,7 @@ class TestSFTTrainer(TrlTestCase):
             else:  # We expect the peft params to be different
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
 
-    @require_peft
+    @require_peft_target_parameters
     def test_train_moe_with_peft_config(self):
         model_id = "trl-internal-testing/tiny-GptOssForCausalLM"
         model = AutoModelForCausalLM.from_pretrained(model_id, dtype="float32")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -22,6 +22,7 @@ import psutil
 import pytest
 import torch
 import torch.nn as nn
+from packaging.version import Version
 from transformers import is_bitsandbytes_available, is_comet_available, is_sklearn_available, is_wandb_available
 from transformers.testing_utils import backend_device_count, torch_device
 from transformers.utils import (
@@ -47,6 +48,10 @@ from trl.import_utils import (
 )
 
 
+if is_peft_available():
+    import peft
+
+
 require_bitsandbytes = pytest.mark.skipif(not is_bitsandbytes_available(), reason="test requires bitsandbytes")
 require_comet = pytest.mark.skipif(not is_comet_available(), reason="test requires comet_ml")
 require_harbor = pytest.mark.skipif(not is_harbor_available(), reason="test requires harbor")
@@ -56,6 +61,11 @@ require_math_latex = pytest.mark.skipif(not is_math_verify_available(), reason="
 require_mergekit = pytest.mark.skipif(not is_mergekit_available(), reason="test requires mergekit")
 require_openreward = pytest.mark.skipif(not is_openreward_available(), reason="test requires openreward")
 require_peft = pytest.mark.skipif(not is_peft_available(), reason="test requires peft")
+# `LoraConfig.target_parameters` was added in peft 0.17.0; on older versions the field doesn't exist at all.
+require_peft_target_parameters = pytest.mark.skipif(
+    not is_peft_available() or Version(peft.__version__) < Version("0.17.0"),
+    reason="test requires peft>=0.17.0 for `LoraConfig.target_parameters`",
+)
 # Response parsing needs jmespath only on transformers < 5.13, which ships the legacy `response_schema` parser; the
 # new-style `response_template` parser doesn't use it. See `_SUPPORTS_RESPONSE_TEMPLATE`.
 require_response_parsing = pytest.mark.skipif(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -639,12 +639,13 @@ class DPOTrainer(_BaseTrainer):
             # 0.20.0, only one adapter per model was supported when the LoRA config uses `target_parameters` (see
             # peft#3340, fixed in peft#3350), so in that case we skip the "ref" adapter and compute the reference log
             # probs with adapters disabled, i.e. with the base model. The fix only allows adapters targeting the same
-            # parameters, which holds here since the "ref" adapter reuses the "default" config.
+            # parameters, which holds here since the "ref" adapter reuses the "default" config. `target_parameters`
+            # itself was only added in PEFT 0.17.0, so the version check is bounded on both sides.
             default_config = model.peft_config["default"]
             if (
                 isinstance(default_config, LoraConfig)
+                and Version("0.17.0") <= Version(peft.__version__) < Version("0.20.0")
                 and default_config.target_parameters
-                and Version(peft.__version__) < Version("0.20.0")
             ):
                 logger.warning(
                     "PEFT<0.20.0 can't add a frozen reference adapter alongside one that uses `target_parameters` "

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -443,12 +443,13 @@ class GRPOTrainer(_BaseTrainer):
             # 0.20.0, only one adapter per model was supported when the LoRA config uses `target_parameters` (see
             # peft#3340, fixed in peft#3350), so in that case we skip the "ref" adapter and compute the reference log
             # probs with adapters disabled, i.e. with the base model. The fix only allows adapters targeting the same
-            # parameters, which holds here since the "ref" adapter reuses the "default" config.
+            # parameters, which holds here since the "ref" adapter reuses the "default" config. `target_parameters`
+            # itself was only added in PEFT 0.17.0, so the version check is bounded on both sides.
             default_config = model.peft_config["default"]
             if (
                 isinstance(default_config, LoraConfig)
+                and Version("0.17.0") <= Version(peft.__version__) < Version("0.20.0")
                 and default_config.target_parameters
-                and Version(peft.__version__) < Version("0.20.0")
             ):
                 logger.warning(
                     "PEFT<0.20.0 can't add a frozen reference adapter alongside one that uses `target_parameters` "

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -696,12 +696,13 @@ class KTOTrainer(_BaseTrainer):
             # 0.20.0, only one adapter per model was supported when the LoRA config uses `target_parameters` (see
             # peft#3340, fixed in peft#3350), so in that case we skip the "ref" adapter and compute the reference log
             # probs with adapters disabled, i.e. with the base model. The fix only allows adapters targeting the same
-            # parameters, which holds here since the "ref" adapter reuses the "default" config.
+            # parameters, which holds here since the "ref" adapter reuses the "default" config. `target_parameters`
+            # itself was only added in PEFT 0.17.0, so the version check is bounded on both sides.
             default_config = model.peft_config["default"]
             if (
                 isinstance(default_config, LoraConfig)
+                and Version("0.17.0") <= Version(peft.__version__) < Version("0.20.0")
                 and default_config.target_parameters
-                and Version(peft.__version__) < Version("0.20.0")
             ):
                 logger.warning(
                     "PEFT<0.20.0 can't add a frozen reference adapter alongside one that uses `target_parameters` "

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -359,12 +359,13 @@ class RLOOTrainer(_BaseTrainer):
             # 0.20.0, only one adapter per model was supported when the LoRA config uses `target_parameters` (see
             # peft#3340, fixed in peft#3350), so in that case we skip the "ref" adapter and compute the reference log
             # probs with adapters disabled, i.e. with the base model. The fix only allows adapters targeting the same
-            # parameters, which holds here since the "ref" adapter reuses the "default" config.
+            # parameters, which holds here since the "ref" adapter reuses the "default" config. `target_parameters`
+            # itself was only added in PEFT 0.17.0, so the version check is bounded on both sides.
             default_config = model.peft_config["default"]
             if (
                 isinstance(default_config, LoraConfig)
+                and Version("0.17.0") <= Version(peft.__version__) < Version("0.20.0")
                 and default_config.target_parameters
-                and Version(peft.__version__) < Version("0.20.0")
             ):
                 logger.warning(
                     "PEFT<0.20.0 can't add a frozen reference adapter alongside one that uses `target_parameters` "

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -262,17 +262,22 @@ def get_peft_config(model_args: ModelConfig) -> "PeftConfig | None":
             "Make sure to run `pip install -U peft`."
         )
 
+    # `target_parameters` was added in PEFT 0.17.0, so only pass it when the user asked for it
+    lora_config_kwargs = {}
+    if model_args.lora_target_parameters is not None:
+        lora_config_kwargs["target_parameters"] = model_args.lora_target_parameters
+
     peft_config = LoraConfig(
         task_type=model_args.lora_task_type,
         r=model_args.lora_r,
         target_modules=model_args.lora_target_modules,
-        target_parameters=model_args.lora_target_parameters,
         lora_alpha=model_args.lora_alpha,
         lora_dropout=model_args.lora_dropout,
         bias="none",
         use_rslora=model_args.use_rslora,
         use_dora=model_args.use_dora,
         modules_to_save=model_args.lora_modules_to_save,
+        **lora_config_kwargs,
     )
 
     return peft_config


### PR DESCRIPTION
`LoraConfig.target_parameters` only exists from peft 0.17.0, but TRL uses it unconditionally in three places. With the floor at `peft>=0.13.0` (#7102), 0.13 to 0.16 are supported versions on which those paths raise.

### Motivation

- `get_peft_config` in `trl/trainer/utils.py` passes `target_parameters=` to `LoraConfig` on every call, so **`trl <cmd> --use_peft` raises `TypeError: LoraConfig.__init__() got an unexpected keyword argument 'target_parameters'`** on peft below 0.17. This hits all seven CLI scripts (`sft`, `dpo`, `grpo`, `rloo`, `kto`, `reward`, `distillation`), whether or not the user asked for `--lora_target_parameters`.
- DPO, GRPO, KTO and RLOO read `default_config.target_parameters` *before* testing the peft version, so passing a pre-wrapped LoRA `PeftModel` raises `AttributeError: 'LoraConfig' object has no attribute 'target_parameters'`. Reordering alone does not fix it: the existing `< 0.20.0` test is true on 0.13 to 0.16, so the attribute access still runs. The check needs a lower bound as well.
- Six tests construct `LoraConfig(target_parameters=[...])` under a bare `@require_peft`, so they error at construction instead of skipping.

### Changes

- `get_peft_config` passes `target_parameters` only when the user set `--lora_target_parameters`. No version comparison is needed: the field defaults to `None` in peft, so omitting it is behaviour-identical on 0.17+.
- The four trainer guards become two-sided, `Version("0.17.0") <= Version(peft.__version__) < Version("0.20.0")`, with the field read last. Applied identically in all four copies, comment included.
- New `require_peft_target_parameters` in `tests/testing_utils.py`, following the existing `require_response_parsing` pattern, replaces `@require_peft` on the six affected tests. The `not is_peft_available() or ...` ordering matters, since `peft` is imported under `if is_peft_available():` and a skipif condition is evaluated at import time.

The `< 0.20.0` upper bound is unchanged and stays: it encodes peft#3340, fixed by peft#3350 in 0.20.0, where a second adapter alongside `target_parameters` became possible. Only the lower bound is new, and it exists solely because the floor sits below 0.17.

### Verification

The introducing version is counted at the release tags rather than inferred from dates. Occurrences of `target_parameters` in `src/peft/tuners/lora/config.py`:

| tag | occurrences |
|---|---|
| v0.15.0 | 0 |
| v0.16.0 | 0 |
| v0.17.0 | 10 |
| v0.18.0 | 10 |

Run against a peft 0.16.0 install, each failure reproduced before the change and gone after:

| | peft 0.16.0 | peft 0.20.1 |
|---|---|---|
| old `get_peft_config` construction | `TypeError: unexpected keyword argument 'target_parameters'` | ok |
| new `get_peft_config` | builds, `LoraConfig` identical to the old output | builds, identical to the old output |
| old trainer condition | `AttributeError: 'LoraConfig' object has no attribute 'target_parameters'` | ok |
| new trainer condition | `False`, so the ref adapter is added as before | unchanged |
| `require_peft_target_parameters` | skips | runs |

`get_peft_config` equivalence was checked field by field on the resulting `LoraConfig` for the default case, for `--lora_target_parameters` set, and for `--lora_target_modules` set. The four affected tests that do not need vLLM pass at peft 0.20.1, confirming the decorator swap did not silently disable them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compatibility guards and test skips only; behavior on peft ≥ 0.17 without `lora_target_parameters` stays the same.
> 
> **Overview**
> Fixes crashes on **peft 0.13–0.16** where `LoraConfig.target_parameters` does not exist, while keeping the existing **0.17 ≤ peft < 0.20** reference-adapter workaround.
> 
> **`get_peft_config`** now passes `target_parameters` to `LoraConfig` only when `--lora_target_parameters` is set, so default CLI `--use_peft` no longer raises `TypeError` on older PEFT.
> 
> **DPO, GRPO, KTO, and RLOO** tighten the ref-adapter guard to `0.17.0 <= peft < 0.20.0` before reading `default_config.target_parameters`, avoiding `AttributeError` when a pre-wrapped `PeftModel` is passed on peft &lt; 0.17.
> 
> **Tests** add `require_peft_target_parameters` (peft ≥ 0.17) and apply it to the six MoE tests that construct `LoraConfig(target_parameters=...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2b9f740043fcfc985777e45c8a5d645b427046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->