### PR TITLE
Fix the IW-OPD self-distillation loss assertion in tests

### DIFF
--- a/tests/experimental/test_iw_opd_trainer.py
+++ b/tests/experimental/test_iw_opd_trainer.py
@@ -524,7 +524,8 @@ class TestIWOPDTrainer(TrlTestCase):
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
         assert trainer.state.log_history[0]["eval_loss"] is not None
-        assert train_result.metrics["train_loss"] >= 0.0
+        # Student and teacher are the same model, so the JSD is exactly zero up to float32 rounding.
+        assert train_result.metrics["train_loss"] == pytest.approx(0.0, abs=1e-6)
         assert "model.safetensors" in os.listdir(self.tmp_dir + "/checkpoint-2")
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes the IW-OPD local-teacher training test, which asserted the sign of a value that is only floating-point rounding.

Fix #7122.

### Motivation

The test passes the same checkpoint as student and as teacher, so the JSD loss is mathematically exactly zero and `train_loss` is zero up to float32 rounding, with an arbitrary sign. The previous assertion `train_loss >= 0.0` passed only by luck of that sign, and it started failing once the tiny Qwen2.5 checkpoint was updated in #7098.

### Solution

Assert that the loss is approximately zero, which is the property that actually holds for self-distillation and would still catch a broken JSD path, and document why.

### Changes

- Replace the non-negativity assertion on `train_loss` with an approximate-zero assertion
- Add a comment explaining that student and teacher are the same model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or training behavior is modified.
> 
> **Overview**
> Fixes a flaky assertion in **`test_distillation_trainer_train_runs_with_local_teacher`**, where student and teacher share the same checkpoint so JSD loss should be ~0, not merely non-negative.
> 
> Replaces `train_loss >= 0.0` with `pytest.approx(0.0, abs=1e-6)` and adds a short comment that the old check could pass on float32 rounding sign alone (e.g. after the tiny Qwen checkpoint update in #7098).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982a9783c3939e7ed43469cafd958e3f226c44bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->