### PR TITLE
Sync the model config eos token id with the tokenizer in the trainers

### DIFF
--- a/tests/test_reward_trainer.py
+++ b/tests/test_reward_trainer.py
@@ -1014,3 +1014,19 @@ class TestRewardTrainer(TrlTestCase):
         for n, param in previous_trainable_params.items():
             new_param = trainer.model.get_parameter(n)
             assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_eos_token_id_synced_with_model_config(self):
+        # The trainer sets the requested eos token on the tokenizer. The model config must follow: otherwise
+        # `Trainer` realigns it at train time and reports it as a change the user did not make.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_implicit_prompt_preference", split="train")
+
+        training_args = RewardConfig(output_dir=self.tmp_dir, eos_token="<|im_start|>", report_to="none")
+        trainer = RewardTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        eos_token_id = trainer.processing_class.eos_token_id
+        assert eos_token_id == 151644  # <|im_start|>
+        assert trainer.model.config.eos_token_id == eos_token_id

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2292,6 +2292,22 @@ class TestSFTTrainer(TrlTestCase):
         assert trainer.model.config.pad_token_id == pad_token_id
         assert trainer.model.generation_config.pad_token_id == pad_token_id
 
+    def test_eos_token_id_synced_with_model_config(self):
+        # The trainer sets the requested eos token on the tokenizer. The model configs must follow: otherwise
+        # `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+
+        training_args = SFTConfig(output_dir=self.tmp_dir, eos_token="<|im_start|>", report_to="none")
+        trainer = SFTTrainer(
+            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+        )
+
+        eos_token_id = trainer.processing_class.eos_token_id
+        assert eos_token_id == 151644  # <|im_start|>
+        assert trainer.model.config.eos_token_id == eos_token_id
+        # The model's own eos tokens are kept, since any of them halts generation
+        assert trainer.model.generation_config.eos_token_id == [151644, 151645, 151643]
+
 
 @pytest.mark.slow
 @require_torch_accelerator

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -425,6 +425,10 @@ class RewardTrainer(_BaseTrainer):
                     "in the vocabulary before using it as an EOS token."
                 )
             processing_class.eos_token = args.eos_token
+            # Mirror the eos token onto the model config: `Trainer` runs the same alignment at train time, so the end
+            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built. A
+            # sequence classification model has no generation config, so there is nothing else to align.
+            model.config.eos_token_id = processing_class.eos_token_id
 
         if args.chat_template_path is not None:
             if os.path.isfile(args.chat_template_path) and args.chat_template_path.endswith((".jinja", ".j2")):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1021,6 +1021,18 @@ class SFTTrainer(_BaseTrainer):
                     "in the vocabulary before using it as an EOS token."
                 )
             self._tokenizer.eos_token = args.eos_token
+            # Mirror the eos token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built. The
+            # generation config may hold several eos tokens, any of which halts generation, so the new one is added to
+            # the existing ones instead of replacing them.
+            model.config.eos_token_id = self._tokenizer.eos_token_id
+            eos_token_ids = model.generation_config.eos_token_id
+            if eos_token_ids is None:
+                eos_token_ids = []
+            elif isinstance(eos_token_ids, int):
+                eos_token_ids = [eos_token_ids]
+            if self._tokenizer.eos_token_id not in eos_token_ids:
+                model.generation_config.eos_token_id = [self._tokenizer.eos_token_id, *eos_token_ids]
 
         if args.chat_template_path is not None:
             if os.path.isfile(args.chat_template_path) and args.chat_template_path.endswith((".jinja", ".j2")):


### PR DESCRIPTION
This PR keeps `model.config` and `model.generation_config` in agreement with the tokenizer's eos token in the SFT and Reward trainers, as #7097 did for the pad token.

### Motivation

`SFTConfig.eos_token` and `RewardConfig.eos_token` let the user pick the token that marks the end of a turn or sequence. The trainers set it on the tokenizer and leave the model configs untouched. `Trainer.train()` then finds the divergence, rewrites both configs itself, and logs it as a change the user did not make:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151644}.
```

Part of #7093.

### Solution

Mirror the eos token onto the model configs right where the trainers set it on the tokenizer. The alignment that `Trainer` performs at train time then finds nothing to change, so the end state is identical, while the model stays consistent with the tokenizer from the moment the trainer is built and for any code reading the configs before `train()`.

The generation config may hold several eos tokens, and any of them halts generation, so the new id is added to the ones already there instead of replacing them. `align_special_tokens` preserves them the same way. The only divergence from it is that an id the list already contains is not appended a second time.

`RewardTrainer` needs the model config only: a sequence classification model has no `generation_config` attribute at all, which is what `align_special_tokens` guards on.

No other trainer is affected, since `eos_token` is exposed by `SFTConfig` and `RewardConfig` only.

### Changes

- Mirror the tokenizer's eos token onto the model config, and onto the generation config where there is one, wherever the SFT and Reward trainers assign it
- Add a regression test to each, covering the causal LM path where the existing eos tokens are preserved and the sequence classification path where there is no generation config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time config alignment only; behavior at train time was already corrected by Trainer, with tests locking in tokenizer/config consistency.
> 
> **Overview**
> When **`SFTConfig.eos_token`** or **`RewardConfig.eos_token`** is set, the trainers already update the tokenizer; this PR **also aligns model configs at init** so Hugging Face **`Trainer`** does not log a spurious “tokenizer vs model config” realignment at **`train()`** time.
> 
> **`RewardTrainer`** copies the tokenizer’s **`eos_token_id`** onto **`model.config`** only (sequence-classification models have no generation config). **`SFTTrainer`** sets **`model.config.eos_token_id`** and **prepends** the new id to **`generation_config.eos_token_id`** when it is not already present, keeping any existing EOS ids for generation.
> 
> Regression tests assert config sync for a custom **`<|im_start|>`** EOS token on both trainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88511b21fb05036ac53f2f4c22ffffc17841b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->