### PR TITLE
Sync the model config pad token id with the tokenizer in the experimental trainers

### DIFF
--- a/tests/experimental/test_cpo_trainer.py
+++ b/tests/experimental/test_cpo_trainer.py
@@ -296,3 +296,18 @@ class TestCPOTrainer(TrlTestCase):
             new_param = trainer.model.get_parameter(n)
             if param.sum() != 0:
                 assert not torch.equal(param, new_param)
+
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+
+        training_args = CPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = CPOTrainer(
+            model="trl-internal-testing/tiny-MistralForCausalLM-0.2", args=training_args, train_dataset=dataset
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id

--- a/tests/experimental/test_iw_opd_trainer.py
+++ b/tests/experimental/test_iw_opd_trainer.py
@@ -825,6 +825,24 @@ class TestIWOPDTrainer(TrlTestCase):
         assert torch.isfinite(loss)
         assert teacher_client.calls[0]["top_logprobs"] == 1
 
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        model_id = "trl-internal-testing/tiny-MistralForCausalLM-0.2"
+        dataset = load_dataset("trl-internal-testing/zen", "conversational_language_modeling", split="train")
+
+        trainer = IWOPDTrainer(
+            model=model_id,
+            teacher_model=model_id,
+            args=IWOPDConfig(output_dir=self.tmp_dir, report_to="none"),
+            train_dataset=dataset,
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id
+
 
 class TestIWOPDTrainerServerPath(TrlTestCase):
     @classmethod

--- a/tests/experimental/test_online_dpo_trainer.py
+++ b/tests/experimental/test_online_dpo_trainer.py
@@ -440,6 +440,27 @@ class TestOnlineDPOTrainer(TrlTestCase):
         assert round(abs(trainer.reward_weights[0].item() - 0.7), 5) == 0
         assert round(abs(trainer.reward_weights[1].item() - 0.3), 5) == 0
 
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        model_id = "trl-internal-testing/tiny-MistralForCausalLM-0.2"
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = OnlineDPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = OnlineDPOTrainer(
+            model=model_id,
+            reward_funcs=self.reward_model,
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=AutoTokenizer.from_pretrained(model_id),
+            reward_processing_classes=self.reward_tokenizer,
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id
+
 
 @require_vision
 class TestOnlineDPOVisionTrainer(TrlTestCase):

--- a/tests/experimental/test_sdft_trainer.py
+++ b/tests/experimental/test_sdft_trainer.py
@@ -565,3 +565,23 @@ class TestSDFTTrainer(TrlTestCase):
         loss.backward()
         assert all(torch.isfinite(p.grad).all() for p in trainer.model.parameters() if p.grad is not None)
         assert trainer.teacher_client.calls[0]["top_logprobs"] == 2
+
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = Dataset.from_dict(
+            {
+                "prompt": ["Solve 2+2.", "Name the capital of France."],
+                "privileged_context": ["Example answer: 4.", "Example answer: Paris."],
+            }
+        )
+
+        training_args = SDFTConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SDFTTrainer(
+            model="trl-internal-testing/tiny-MistralForCausalLM-0.2", args=training_args, train_dataset=dataset
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id

--- a/tests/experimental/test_sdpo_trainer.py
+++ b/tests/experimental/test_sdpo_trainer.py
@@ -655,3 +655,26 @@ class TestSDPOTrainer(TrlTestCase):
         loss.backward()
         assert all(torch.isfinite(p.grad).all() for p in trainer.model.parameters() if p.grad is not None)
         assert trainer.teacher_client.calls[0]["top_logprobs"] == 2
+
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = Dataset.from_dict(
+            {
+                "prompt": ["Solve 2+2.", "Name the capital of France."],
+                "privileged_context": ["Example answer: 4.", "Example answer: Paris."],
+            }
+        )
+
+        training_args = SDPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SDPOTrainer(
+            model="trl-internal-testing/tiny-MistralForCausalLM-0.2",
+            reward_funcs=lambda **kwargs: [0.0] * len(kwargs["prompts"]),
+            args=training_args,
+            train_dataset=dataset,
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id

--- a/tests/experimental/test_ssd_trainer.py
+++ b/tests/experimental/test_ssd_trainer.py
@@ -265,3 +265,18 @@ class TestSSDTrainer(TrlTestCase):
         trainer.train()
 
         assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        training_args = SSDConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = SSDTrainer(
+            model="trl-internal-testing/tiny-MistralForCausalLM-0.2", args=training_args, train_dataset=dataset
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id

--- a/tests/experimental/test_tpo_trainer.py
+++ b/tests/experimental/test_tpo_trainer.py
@@ -395,3 +395,19 @@ class TestTPOTrainer(TrlTestCase):
             if "lora" in n:
                 new_param = trainer.model.get_parameter(n)
                 assert not torch.equal(param, new_param), f"Parameter {n} has not changed."
+
+    def test_pad_token_id_synced_with_model_config(self):
+        # This model's tokenizer has no pad token, so the trainer falls back to the eos token. The model configs must
+        # follow: otherwise `Trainer` realigns them at train time and reports it as a change the user did not make.
+        dataset = load_dataset("trl-internal-testing/zen", "standard_preference", split="train")
+        dataset = dataset.map(_add_reference_column)
+
+        training_args = TPOConfig(output_dir=self.tmp_dir, report_to="none")
+        trainer = TPOTrainer(
+            model="trl-internal-testing/tiny-MistralForCausalLM-0.2", args=training_args, train_dataset=dataset
+        )
+
+        pad_token_id = trainer.processing_class.pad_token_id
+        assert pad_token_id is not None
+        assert trainer.model.config.pad_token_id == pad_token_id
+        assert trainer.model.generation_config.pad_token_id == pad_token_id

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -986,6 +986,10 @@ class AsyncDistillationTrainer(_BaseTrainer):
             processing_class = AutoTokenizer.from_pretrained(model_name, trust_remote_code=args.trust_remote_code)
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = processing_class.pad_token_id
+        model.generation_config.pad_token_id = processing_class.pad_token_id
 
         # Initialize the Trainer
         super().__init__(

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -855,6 +855,10 @@ class AsyncGRPOTrainer(_BaseTrainer):
             )
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = processing_class.pad_token_id
+        model.generation_config.pad_token_id = processing_class.pad_token_id
 
         # Reward functions
         if reward_funcs is None:

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -330,6 +330,10 @@ class CPOTrainer(_BaseTrainer):
 
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = processing_class.pad_token_id
+        model.generation_config.pad_token_id = processing_class.pad_token_id
         self.pad_token_id = processing_class.pad_token_id
 
         if args.loss_type in ["hinge", "ipo"] and args.label_smoothing > 0:

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -436,6 +436,10 @@ class IWOPDTrainer(_BaseTrainer):
         if processing_class is not None:
             if getattr(processing_class, "pad_token", None) is None:
                 processing_class.pad_token = processing_class.eos_token
+            # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+            model.config.pad_token_id = processing_class.pad_token_id
+            model.generation_config.pad_token_id = processing_class.pad_token_id
 
         # ── PEFT ──
         if peft_config is not None:

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -381,6 +381,10 @@ class OnlineDPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = self._tokenizer.pad_token_id
+        model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
         # Vision tokens for VLM support
         self.image_token_id = getattr(processing_class, "image_token_id", None)

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -310,6 +310,10 @@ class SDFTTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = self._tokenizer.pad_token_id
+        model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -427,6 +427,10 @@ class SDPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = self._tokenizer.pad_token_id
+        model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -173,6 +173,10 @@ class SSDTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = self._tokenizer.pad_token_id
+        model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
         self.max_prompt_length = args.max_prompt_length
         self.max_completion_length = args.max_completion_length

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -346,6 +346,10 @@ class TPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
+        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        model.config.pad_token_id = self._tokenizer.pad_token_id
+        model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
         # PEFT
         if peft_config is not None:


### PR DESCRIPTION
This PR extends #7097 to the experimental trainers that set the tokenizer's pad token themselves.

### Motivation

When the tokenizer has no pad token, these trainers fall back to the eos token and set it on the tokenizer, but leave the model configs untouched. `Trainer.train()` then finds the divergence, rewrites both configs itself, and logs it as a change the user did not make:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'pad_token_id': 2}.
```

#7097 closed this in the main trainers. The same block is duplicated in the experimental ones, and `AGENTS.md` asks the copies to stay aligned.

Part of #7093.

### Solution

Mirror the pad token onto the model config and generation config right where the trainer assigns it on the tokenizer, exactly as the main trainers now do. The alignment that `Trainer` performs at train time then finds nothing to change, so the end state is identical, while the model stays consistent with the tokenizer from the moment the trainer is built.

Applied to Online DPO, SDPO, TPO, SDFT, SSD, CPO, IW-OPD, Async GRPO and Async Distillation.

GOLD needs no change: it delegates to `SFTTrainer`, which #7097 already covers. ORPO never assigns a pad token to the processing class, so there is no divergence to mirror.

Teacher and reward models are untouched, consistent with #7097: `Trainer` aligns its own model only, and the reward paths already set `config.pad_token_id`.

### Changes

- Mirror the tokenizer's pad token onto the model config and generation config wherever these nine trainers assign it
- Add the same regression test as #7097 to the seven trainers that can be constructed without an accelerator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time config alignment only; training behavior should match the previous end state after Trainer’s automatic fix, with no auth or data-path changes.
> 
> **Overview**
> Experimental trainers that assign the tokenizer’s pad token (typically **EOS** when none exists) now also set **`model.config.pad_token_id`** and **`model.generation_config.pad_token_id`** at init, matching the fix from #7097 in the main trainers.
> 
> This avoids Hugging Face **`Trainer`** realigning configs at **`train()`** and logging a misleading “tokenizer tokens differ from model config” warning. **CPO**, **Online DPO**, **SDPO**, **SDFT**, **SSD**, **TPO**, **IW-OPD**, **Async GRPO**, and **Async Distillation** are updated; regression tests **`test_pad_token_id_synced_with_model_config`** were added for seven of them (Mistral tiny model, no pad token).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455cd227177a6646915210f410464ac8ac62ed9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->