### PR TITLE
fix: validate ngram_size in get_repetition_penalty_reward

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -161,6 +161,11 @@ class TestRepetitionPenaltyReward:
         with pytest.raises(ValueError):
             get_repetition_penalty_reward(ngram_size=2, max_penalty=0.5)
 
+    @pytest.mark.parametrize("ngram_size", [0, -1])
+    def test_non_positive_ngram_size_raises(self, ngram_size):
+        with pytest.raises(ValueError):
+            get_repetition_penalty_reward(ngram_size=ngram_size, max_penalty=-1.0)
+
     def test_extra_kwargs_are_ignored(self):
         """Trainers pass prompts/completions/etc. as kwargs; the reward must accept and ignore them."""
         reward_fn = get_repetition_penalty_reward(ngram_size=2, max_penalty=-1.0)

--- a/trl/rewards/other_rewards.py
+++ b/trl/rewards/other_rewards.py
@@ -56,6 +56,8 @@ def get_repetition_penalty_reward(ngram_size: int = 3, max_penalty: float = -1.0
     """
     if max_penalty > 0:
         raise ValueError(f"max_penalty {max_penalty} should not be positive")
+    if ngram_size <= 0:
+        raise ValueError(f"ngram_size {ngram_size} should be greater than 0")
     return _RepetitionPenalty(ngram_size, max_penalty)
 
 


### PR DESCRIPTION
# What does this PR do?

Adds construction-time validation for `ngram_size` in `get_repetition_penalty_reward`. Zero or negative values were accepted at construction time but caused a `ZeroDivisionError` (or silently produced empty n-grams) during reward computation, as reported in #7015.

The fix adds a check consistent with the existing `max_penalty` validation:

```python
if ngram_size <= 0:
    raise ValueError(f"ngram_size {ngram_size} should be greater than 0")
```

Also adds a parametrized regression test covering `ngram_size=0` and `ngram_size=-1`.

Fixes #7015

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. (#7015)
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small input-validation change in a reward helper with regression tests; no auth, data, or training-path behavior changes beyond failing fast on invalid config.
> 
> **Overview**
> **`get_repetition_penalty_reward`** now rejects non-positive **`ngram_size`** at construction with a **`ValueError`**, matching the existing **`max_penalty`** guard. Previously, **`0`** or negative values could slip through and fail during scoring (e.g. **`ZeroDivisionError`** when **`ngram_size=0`**).
> 
> A parametrized test in **`tests/test_rewards.py`** asserts that **`ngram_size`** **`0`** and **`-1`** raise **`ValueError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eec16b3473ef7d8141bf81861b2ade6f78e2eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->