### PR TITLE
Align tie_word_embeddings with the reference models

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_2.py
+++ b/scripts/generate_tiny_models/for_causal_lm/llama_for_causal_lm_3_2.py
@@ -38,6 +38,7 @@ config = LlamaConfig(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=True,
     max_position_embeddings=131072,
     rope_theta=500000.0,
     rope_scaling={

--- a/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm_instruct_2507.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen3_for_causal_lm_instruct_2507.py
@@ -40,6 +40,7 @@ config = Qwen3Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=True,
     max_position_embeddings=262144,
     rope_theta=5000000,
     max_window_layers=36,

--- a/scripts/generate_tiny_models/for_causal_lm/remote_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/remote_for_causal_lm.py
@@ -49,6 +49,7 @@ config = RemoteConfig(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=True,
     max_position_embeddings=131072,
     rope_theta=500000.0,
     rope_scaling={

--- a/scripts/generate_tiny_models/for_causal_lm/small_qwen3_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/small_qwen3_for_causal_lm.py
@@ -33,6 +33,7 @@ config = Qwen3Config(
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=True,
     max_position_embeddings=40960,
     rope_theta=1000000,
     max_window_layers=36,


### PR DESCRIPTION
This PR mirrors `tie_word_embeddings` from the reference models onto the four tiny models where it diverges.

Part of #7137. Closes the last non-size difference left by #7106, #7107 and #7110, where it was deliberately deferred as a decision worth taking once rather than three times.

### Motivation

Four tiny models declare `tie_word_embeddings: False` while the model they stand in for ties:

| tiny model | reference | tiny model | reference value |
|---|---|---|---|
| `small-Qwen3ForCausalLM` | `Qwen/Qwen3-4B` | `False` | `True` |
| `tiny-Qwen3ForCausalLM-Instruct-2507` | `Qwen/Qwen3-4B-Instruct-2507` | `False` | `True` |
| `tiny-LlamaForCausalLM-3.2` | `meta-llama/Llama-3.2-1B-Instruct` | `False` | `True` |
| `tiny-RemoteForCausalLM` | `meta-llama/Llama-3.2-1B-Instruct` | `False` | `True` |

`False` is not a deliberate choice here, it is the class default that survived because the scripts never passed the field. The other tiny models in the series are already correct: `Qwen/Qwen3-8B` and `Qwen/Qwen2.5-32B-Instruct` genuinely untie, and `tiny-Qwen3ForCausalLM` and the Qwen2.5 pair match them.

Unlike the metadata mirrored so far, tying is a real behavioural difference. With weights tied, the embedding matrix receives gradient from the output projection as well as the input lookup, and `lm_head` stops being an independent parameter. Anything that touches embeddings or the head, embedding resizing, PEFT `modules_to_save`, chunked cross-entropy, activation offloading, behaves differently. Right now no test exercises the tied path for these four models even though every real user of them does.

### Effect on the artefacts

This one changes the weights, not just the config. Measured on the `small-Qwen3ForCausalLM` geometry:

```
tie=False params=39,314,560 shared_storage=False lm_head_in_file=True  file=78.6MB
tie=True  params=19,866,752 shared_storage=True  lm_head_in_file=False file=39.7MB
```

`save_pretrained` correctly omits the tied `lm_head.weight`, so the tiny model halves in size, and a forward pass runs clean with no NaNs.

### Result

Each of the four goes from seven differences against its reference to six, and every remaining row is the deliberate size reduction:

```
before  small-Qwen3               7: hidden_size, intermediate_size, layer_types, num_attention_heads, num_hidden_layers, num_key_value_heads, tie_word_embeddings
after   small-Qwen3               6: hidden_size, intermediate_size, layer_types, num_attention_heads, num_hidden_layers, num_key_value_heads

before  tiny-Qwen3-Instruct-2507  7: hidden_size, intermediate_size, layer_types, num_attention_heads, num_hidden_layers, num_key_value_heads, tie_word_embeddings
after   tiny-Qwen3-Instruct-2507  6: hidden_size, intermediate_size, layer_types, num_attention_heads, num_hidden_layers, num_key_value_heads

before  tiny-Llama-3.2 / Remote   7: head_dim, hidden_size, intermediate_size, num_attention_heads, num_hidden_layers, num_key_value_heads, tie_word_embeddings
after   tiny-Llama-3.2 / Remote   6: head_dim, hidden_size, intermediate_size, num_attention_heads, num_hidden_layers, num_key_value_heads
```

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. This does not change the realignment warning either way, since tying does not touch the token ids. The Hub repos need regenerating for it to take effect.

### Changes

- Set `tie_word_embeddings` from the reference config in the four generator scripts where it diverges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tying changes tiny model parameter layout and training/inference behavior once Hub models are regenerated; scope is limited to tiny-model generators, not runtime library code.
> 
> **Overview**
> Sets **`tie_word_embeddings=True`** in the four tiny causal-LM generator scripts (Llama 3.2, Qwen3 Instruct-2507, small Qwen3, and remote Llama) so tiny model configs match their reference checkpoints instead of inheriting the class default `False`.
> 
> Regenerating Hub artefacts will **tie input embeddings to `lm_head`**, roughly halving saved weight size and changing how gradients and tooling (resize, PEFT, etc.) interact with the head—aligning tests with production models that already use tying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5844e952c40b5aafe3d395c9d15276fba8b7ca3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
