### PR TITLE
Align tiny Qwen2.5-Coder config with Qwen/Qwen2.5-Coder-0.5B

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5_coder.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_2_5_coder.py
@@ -32,12 +32,17 @@ MODEL_ID = "Qwen/Qwen2.5-Coder-0.5B"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen2Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=151936,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=True,
+    rope_theta=1000000.0,
+    max_window_layers=24,
+    bos_token_id=151643,
+    eos_token_id=151643,
 )
 model = Qwen2ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-Qwen2ForCausalLM-2.5-Coder` generator config with its reference model, `Qwen/Qwen2.5-Coder-0.5B`.

Part of #7137.

Same treatment as #7098, #7106, #7107, #7108, #7109, #7110, #7112 and #7113, for one of the tiny models that emits no warning in the current job and so was left to a second pass.

### Motivation

The script builds `Qwen2Config` from architecture arguments only, so the special token ids fall back to the class defaults, which are `None`. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151643, 'bos_token_id': None, 'pad_token_id': 151643}.
```

### Solution

Mirror the reference values:

- `vocab_size=151936` (reference padded embedding size; previously `len(tokenizer.vocab) = 151665`)
- `bos_token_id=151643`, `eos_token_id=151643` (reference values; previously `None`)
- `rope_theta=1000000.0` (reference override; class default is `10000.0`)
- `max_window_layers=24` (reference override; class default is `28`)
- `tie_word_embeddings=True` (reference value; class default is `False`)

`tie_word_embeddings` is included here rather than deferred, on the same reasoning as #7130: it is the class default surviving rather than a deliberate choice, and mirroring it now avoids regenerating this tiny model twice. As there, it changes the artefact and not only the config, since `save_pretrained` omits the tied `lm_head.weight`.

`pad_token_id` is left unset because the reference does not set it either.

Once the tiny model is regenerated the message drops from three keys to one, `{'bos_token_id': None}`, which is the reference disagreeing with its own tokenizer and is not fixable here.

### Before

```
[config_diff] Qwen/Qwen2.5-Coder-0.5B vs tiny (11 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151643                             → None
  hidden_size                                      896                                → 8
  intermediate_size                                4864                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_window_layers                                24                                 → 28
  num_attention_heads                              14                                 → 4
  num_hidden_layers                                24                                 → 2
  rope_theta                                       1000000.0                          → 10000.0
  tie_word_embeddings                              True                               → False
  vocab_size                                       151936                             → 151665
```

### After

```
[config_diff] Qwen/Qwen2.5-Coder-0.5B vs tiny (5 differences)
  hidden_size                                      896                                → 8
  intermediate_size                                4864                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              14                                 → 4
  num_hidden_layers                                24                                 → 2
```

Every remaining row is the deliberate size reduction. Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 151936
- Set `bos_token_id`, `eos_token_id`, `rope_theta`, `max_window_layers` and `tie_word_embeddings` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a tiny-model generation script and test tiny models; no production training or inference paths.
> 
> **Overview**
> Updates the **tiny Qwen2.5-Coder** generator so `Qwen2Config` matches `Qwen/Qwen2.5-Coder-0.5B` on non-size fields, cutting spurious diffs and reducing `Trainer` tokenizer/config alignment warnings.
> 
> **Config changes:** fixed `vocab_size=151936` instead of `len(tokenizer.vocab)`; sets `bos_token_id` / `eos_token_id`, `rope_theta`, `max_window_layers`, and `tie_word_embeddings` from the reference. Deliberate tiny dimensions (`hidden_size`, layer counts, etc.) are unchanged. Regenerating the Hub tiny model is required for the saved weights/config to pick up `tie_word_embeddings` (tied `lm_head` omitted on save).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba716cc18ed6e33a1096bcd4c3ded2c3fcbe17d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

