### PR TITLE
Align tiny DeepSeek-R1-Distill config with deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_r1_distill.py
+++ b/scripts/generate_tiny_models/for_causal_lm/qwen2_for_causal_lm_r1_distill.py
@@ -32,12 +32,16 @@ MODEL_ID = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = Qwen2Config(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=151936,
     hidden_size=8,
     num_attention_heads=4,
     num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    max_position_embeddings=131072,
+    max_window_layers=21,
+    bos_token_id=151643,
+    eos_token_id=151643,
 )
 model = Qwen2ForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-Qwen2ForCausalLM-R1-Distill` generator config with its reference model, `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`.

Part of #7137.

Same treatment as the earlier tiny models in the series, for one that emits no warning in the current job and so was left to a second pass.

### Motivation

The script builds `Qwen2Config` from architecture arguments only, so the special token ids fall back to the class defaults, which are `None`. `Trainer.train()` finds the divergence and rewrites the model config, logging:

```
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 151643, 'bos_token_id': 151646, 'pad_token_id': 151643}.
```

### Solution

Mirror the reference values:

- `vocab_size=151936` (reference padded embedding size; previously `len(tokenizer.vocab) = 151665`)
- `bos_token_id=151643`, `eos_token_id=151643` (reference values; previously `None`)
- `max_position_embeddings=131072` (reference override; class default is `32768`)
- `max_window_layers=21` (reference override; class default is `28`)

Unlike its Qwen siblings this reference keeps `rope_theta` at the class default of `10000.0` and sets `tie_word_embeddings` to `False`, so neither needs an entry. `pad_token_id` is left unset because the reference does not set it either.

Once the tiny model is regenerated the message drops from three keys to one, `{'bos_token_id': 151646}`. That one is the reference disagreeing with its own tokenizer: the config points at `151643` while the tokenizer's bos is `<｜begin▁of▁sentence｜>` at `151646`. Not fixable here, and mirroring the tokenizer's value instead would make the tiny model less faithful than the model it stands in for.

`use_mrope` stays as a difference: the reference repo carries it but `Qwen2Config` does not model it.

### Before

```
[config_diff] deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B vs tiny (11 differences)
  bos_token_id                                     151643                             → None
  eos_token_id                                     151643                             → None
  hidden_size                                      1536                               → 8
  intermediate_size                                8960                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  max_position_embeddings                          131072                             → 32768
  max_window_layers                                21                                 → 28
  num_attention_heads                              12                                 → 4
  num_hidden_layers                                28                                 → 2
  use_mrope                                        False                              → <missing>
  vocab_size                                       151936                             → 151665
```

### After

```
[config_diff] deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B vs tiny (6 differences)
  hidden_size                                      1536                               → 8
  intermediate_size                                8960                               → 32
  layer_types                                      ['full_attention', 'full_attention → ['full_attention', 'full_attention
  num_attention_heads                              12                                 → 4
  num_hidden_layers                                28                                 → 2
  use_mrope                                        False                              → <missing>
```

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to the reference's 151936
- Set `bos_token_id`, `eos_token_id`, `max_position_embeddings` and `max_window_layers` from the reference config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to tiny test tiny model generation; no runtime library or production model behavior.
> 
> **Overview**
> Updates the **tiny DeepSeek-R1-Distill Qwen2** generator so `Qwen2Config` matches `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` on metadata fields, not just the shrunk architecture dims.
> 
> **Pinned `vocab_size` to 151936** instead of `len(tokenizer.vocab)`, and **set `bos_token_id` / `eos_token_id` to 151643**, **`max_position_embeddings` to 131072**, and **`max_window_layers` to 21** from the reference config. That cuts tokenizer–config drift during training (fewer Trainer alignment warnings) and shrinks `print_config_diff` vs the Hub model to the intentional tiny-architecture gaps only.
> 
> Regenerating and pushing the Hub tiny model is required for the change to land in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36abc56f41374e424d963e0719f3919186180904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

