### PR TITLE
Point the tiny FalconMamba generator at a FalconMamba reference

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/falcon_mamba_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/falcon_mamba_for_causal_lm.py
@@ -27,7 +27,7 @@ from .._common import (
 
 check_transformers_version()
 
-MODEL_ID = "tiiuae/falcon-7b-instruct"
+MODEL_ID = "tiiuae/falcon-mamba-7b-instruct"
 
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)


### PR DESCRIPTION
`tiny-FalconMambaForCausalLM` is generated against `tiiuae/falcon-7b-instruct`, a Falcon attention model, while the tiny model itself is `FalconMambaForCausalLM`, a Mamba SSM. This PR points it at `tiiuae/falcon-mamba-7b-instruct`.

It is deliberately a one-line change. Regenerating the tiny model on top of it picks up the tokenizer, chat template and generation config from the right model family, which is the substance of the fix. Aligning the config values follows in #7139, so the tokenizer change and the config change can be reviewed and regenerated separately.

Part of #7137.

@qgallouedec you introduced this entry in #2287, so I would value your opinion on the choice of reference, and on whether the mismatch was intentional for some reason I have missed.

### How it got here

The pairing has been wrong since the entry was first written. `453db5cd` (2024-11-25, #2287) created the single-file generator with:

```python
("tiiuae/falcon-7b-instruct", FalconMambaConfig, FalconMambaForCausalLM, None),
```

The list is `(model_id, config_class, model_class, suffix)`, so a Falcon repo id was paired with the FalconMamba classes from the start. That entry then survived unchanged, including through the split into per-model scripts in #5637, which carried it over faithfully. `tiiuae/falcon-mamba` has never appeared anywhere in the repository: `git log --all -S "falcon-mamba"` returns nothing.

It is an understandable choice rather than a random one. `tiiuae/falcon-7b-instruct` supplies a working tokenizer with a chat template and the right 65024 vocabulary, so the generated model loads and passes its smoke test, and nothing downstream cared which config the numbers came from. `print_config_diff` only arrived with #5637, and a 46-row diff scrolls past exactly like a 6-row one.

### Why the instruct variant

Both FalconMamba releases were candidates:

```
tiiuae/falcon-mamba-7b            chat_template=NO   bos=0 eos=11 pad=11
tiiuae/falcon-mamba-7b-instruct   chat_template=yes  bos=8 eos=11 pad=0
```

The tiny model has a chat template today, inherited from `falcon-7b-instruct`, and it is used where that matters: it appears in `tests/test_chat_template_utils.py` as `id="falconmamba"`, and in `test_sft_trainer.py` and `test_data_utils.py`. Pointing at the base variant would remove a capability the tiny model currently has.

This also matches the rest of the series. Of the 35 tiny causal-LM models, 32 have a chat template; the three without are `tiny-GPT2LMHeadModel`, `tiny-GPTNeoXForCausalLM` and `tiny-OPTForCausalLM`, whose families have no chat release. The naming is not the guide here: only five references carry "Instruct" in the name, yet `Qwen/Qwen3-8B`, `zai-org/GLM-4.5`, `deepseek-ai/DeepSeek-R1` and the Nemotrons all ship chat templates.

Checked that the assertion in the tool-calling suite still holds, since a different template could have changed it:

```
trl-internal-testing/tiny-FalconMambaForCausalLM  supports_tool_calling=False
tiiuae/falcon-mamba-7b-instruct                   supports_tool_calling=False
```

### Effect on the diff

The row count against the old reference was meaningless, since the two config schemas are unrelated: `alibi`, `multi_query`, `parallel_attn` and `ffn_hidden_size` on one side against `state_size`, `conv_kernel`, `expand` and `time_step_rank` on the other.

```
[config_diff] tiiuae/falcon-7b-instruct        vs tiny  46 differences
[config_diff] tiiuae/falcon-mamba-7b-instruct  vs tiny  11 differences
```

The correction alone accounts for 35 of them. The remaining 11 are what #7139 addresses, taking it to 6, all of them the deliberate size reduction.

### Note on regeneration

Unlike the other models in this series, this one changes the tokenizer as well: the two repos ship different `tokenizer.json`, `tokenizer_config.json` and `special_tokens_map.json`. That is unavoidable once the reference is corrected, and it is the reason this is a PR of its own rather than being bundled with the config alignment.
