### PR TITLE
Align tiny FalconMamba config with tiiuae/falcon-mamba-7b-instruct

### DIFF
--- a/scripts/generate_tiny_models/for_causal_lm/falcon_mamba_for_causal_lm.py
+++ b/scripts/generate_tiny_models/for_causal_lm/falcon_mamba_for_causal_lm.py
@@ -32,12 +32,14 @@ MODEL_ID = "tiiuae/falcon-mamba-7b-instruct"
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 generation_config = GenerationConfig.from_pretrained(MODEL_ID)
 config = FalconMambaConfig(
-    vocab_size=len(tokenizer.vocab),
+    vocab_size=65024,
     hidden_size=8,
-    num_attention_heads=4,
-    num_key_value_heads=2,
     num_hidden_layers=2,
     intermediate_size=32,
+    tie_word_embeddings=False,
+    bos_token_id=8,
+    eos_token_id=11,
+    pad_token_id=0,
 )
 model = FalconMambaForCausalLM(config).to(dtype=torch.bfloat16)
 init_weights_tiny_model(model)


### PR DESCRIPTION
This PR aligns the `tiny-FalconMambaForCausalLM` generator config with `tiiuae/falcon-mamba-7b-instruct`.

Part of #7137. Depends on #7138, which corrects the reference; this PR is branched off it and only the last commit belongs here.

### Motivation

With the reference corrected in #7138, the config diff becomes meaningful for the first time, and it shows the tiny model carrying `FalconMambaConfig` defaults where the real model uses its own values.

### Solution

Mirror the reference values:

- `vocab_size=65024`, matching `len(tokenizer.vocab)` today and pinned so the config no longer depends on the tokenizer files at generation time
- `bos_token_id=8`, `eos_token_id=11`, `pad_token_id=0` (reference values; class defaults are `0`, `0` and `None`)
- `tie_word_embeddings=False` (reference value; the `FalconMambaConfig` default is `True`, so this goes the opposite way from #7130)

`num_attention_heads` and `num_key_value_heads` are removed. The reference has neither, and a Mamba SSM has no attention heads, so the script was forwarding two meaningless fields into the config.

`use_mambapy` stays as a difference: the reference repo carries it but `FalconMambaConfig` does not model it at our floor version.

### Before, with the reference already corrected by #7138

```
[config_diff] tiiuae/falcon-mamba-7b-instruct vs tiny (11 differences)
  bos_token_id                                     8                                  → 0
  eos_token_id                                     11                                 → 0
  expand                                           16                                 → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                8192                               → 32
  num_attention_heads                              <missing>                          → 4
  num_hidden_layers                                64                                 → 2
  num_key_value_heads                              <missing>                          → 2
  tie_word_embeddings                              False                              → True
  time_step_rank                                   256                                → 1
  use_mambapy                                      False                              → <missing>
```

### After

```
[config_diff] tiiuae/falcon-mamba-7b-instruct vs tiny (6 differences)
  expand                                           16                                 → 2
  hidden_size                                      4096                               → 8
  intermediate_size                                8192                               → 32
  num_hidden_layers                                64                                 → 2
  time_step_rank                                   256                                → 1
  use_mambapy                                      False                              → <missing>
```

`expand` and `time_step_rank` are the Mamba equivalents of the size reduction, so they stay reduced.

Produced with `print_config_diff` at `transformers==4.56.2`, the version `check_transformers_version()` pins. The Hub repo needs regenerating for this to take effect.

### Changes

- Pin `vocab_size` to 65024
- Set `bos_token_id`, `eos_token_id`, `pad_token_id` and `tie_word_embeddings` from the reference config
- Drop `num_attention_heads` and `num_key_value_heads`, which the reference does not have

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the tiny-model generation script and Hub config metadata; no runtime library or auth paths affected.
> 
> **Overview**
> Updates the **tiny Falcon Mamba** causal-LM generator so `FalconMambaConfig` matches `tiiuae/falcon-mamba-7b-instruct` on metadata fields, not just shrunk dimensions.
> 
> **`vocab_size`** is pinned to **65024** instead of `len(tokenizer.vocab)`, so generation no longer depends on tokenizer files at build time. **Special tokens** and **`tie_word_embeddings=False`** are set from the reference (`bos_token_id=8`, `eos_token_id=11`, `pad_token_id=0`), replacing class defaults that showed up in `print_config_diff`.
> 
> **`num_attention_heads`** and **`num_key_value_heads`** are dropped from the config—they are not on the reference and are irrelevant for a Mamba SSM. After regeneration, config diff vs the full model should only show intentional tiny-size fields (e.g. `hidden_size`, `expand`, `time_step_rank`) plus `use_mambapy`, which the local config type does not model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e192d36f6e3d0862494c3cd0e655d23c551495c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->