### PR TITLE
fix: score think_format_reward when <think> is prefilled in the prompt

### DIFF
--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -37,9 +37,16 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>\nThis is\nmy reasoning.\n</think>\nThis is my answer.",  # Multiline reasoning
             "<think>\nThis is <some tag> my reasoning.</think>\nThis is my answer.",  # Reasoning including other tags
             "<think></think>\nThis is my answer.",  # Empty reasoning
+            # GRPO keeps generated tokens only; some templates already opened <think> in the prompt.
+            "This is my reasoning.</think>\nThis is my answer.",
+            "This is my reasoning.</think>This is my answer.",
+            "First, 2 plus 2.\n</think>\nThe answer is 4.",
+            # Accepted deliberately: a bare or mentioned </think> also scores 1.0.
+            "</think>",
+            "An answer that merely mentions </think>.",
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
+        expected_rewards = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]  # All should be valid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 
@@ -49,14 +56,12 @@ class TestThinkFormatReward(TrlTestCase):
             "<think>This is my reasoning.\nThis is my answer.",  # No closing </think>
             "This is my reasoning. This is my answer.",  # No <think> tags
             "This is my reasoning.\nThis is my answer.",  # No <think> tags
-            "This is my reasoning.</think>\nThis is my answer.",  # No opening <think>
-            "This is my reasoning.</think>This is my answer.",  # No opening <think>
             "This<think>is my reasoning.</think>\nThis is my answer.",  # <think> tag in the middle
             "<think>This is<think>my reasoning.</think></think>This is my answer.",  # Nested <think> tags
             "<think>This is</think>\nmy\n<think>reasoning.</think>\nThis is my answer.",  # Multiline <think>
         ]
         completions = [[{"content": completion}] for completion in completions]
-        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
+        expected_rewards = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # All should be invalid
         rewards = think_format_reward(completions)
         assert rewards == expected_rewards
 

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -17,8 +17,15 @@ import re
 
 def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> list[float]:
     r"""
-    Reward function that checks if the reasoning process is enclosed within `"<think>"` and `"</think>"` tags. The
-    function returns a reward of 1.0 if the format is correct, otherwise 0.0.
+    Reward function that checks if the completion contains a `"</think>"` tag, with at most one optional leading
+    `"<think>"` tag. The function returns a reward of 1.0 if the format is correct, otherwise 0.0.
+
+    The opening `"<think>"` tag is optional so that GRPO-style trainers still score well-formed completions when the
+    chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the
+    trainer only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
+
+    The relaxation is unconditional: completions that omit the opening tag also score 1.0 under templates that do not
+    prefill `"<think>"`.
 
     Args:
         completions (`list[list[dict[str, str]]]`):
@@ -38,13 +45,16 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
 
     >>> completions = [
     ...     [{"content": "<think>\nThis is my reasoning.\n</think>\nThis is my answer."}],
+    ...     [{"content": "This is my reasoning.\n</think>\nThis is my answer."}],
     ...     [{"content": "<think>\nThis is my reasoning.\nThis is my answer."}],
     ... ]
     >>> think_format_reward(completions)
-    [1.0, 0.0]
+    [1.0, 1.0, 0.0]
     ```
     """
-    pattern = r"^<think>(?!.*<think>)(.*?)</think>.*$"
+    # Opening <think> is optional: GRPO decodes generated tokens only, and some chat templates already
+    # emit that tag in the prompt.
+    pattern = r"^(?:<think>)?(?!.*<think>)(.*?)</think>.*$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]

--- a/trl/rewards/format_rewards.py
+++ b/trl/rewards/format_rewards.py
@@ -21,8 +21,8 @@ def think_format_reward(completions: list[list[dict[str, str]]], **kwargs) -> li
     `"<think>"` tag. The function returns a reward of 1.0 if the format is correct, otherwise 0.0.
 
     The opening `"<think>"` tag is optional so that GRPO-style trainers still score well-formed completions when the
-    chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the
-    trainer only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
+    chat template already prefills that tag into the prompt (for example DeepSeek-R1 distill). In that case the trainer
+    only decodes generated tokens, so the completion starts mid-reasoning and only `"</think>"` is present.
 
     The relaxation is unconditional: completions that omit the opening tag also score 1.0 under templates that do not
     prefill `"<think>"`.


### PR DESCRIPTION
`think_format_reward` rejected valid completions when the chat template had already placed the opening thinking tag in the prompt. I made the opening tag optional while keeping the closing tag required and rejecting nested opening tags. The reward test suite passes apart from skipped tests, and lint and format checks pass on both files.
Fixes #6966.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RL reward criteria for format shaping; broader acceptance (any completion with `</think>`) may shift GRPO training signal versus the old strict opening-tag rule.
> 
> **Overview**
> **`think_format_reward` no longer requires a leading `<think>` tag** so GRPO runs that decode only generated tokens (with the opening tag prefilled in the chat template) can earn 1.0 on well-formed reasoning. The matcher still requires `</think>`, forbids nested `<think>`, and uses an optional `(?:<think>)?` prefix on the existing regex.
> 
> Docs and doctest examples describe this GRPO/prefill behavior. **Tests** add prefilled-prompt-style completions as valid, drop “closing tag without opening” from the invalid set, and document that a bare or text-mention `</think>` also scores 1.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66dbb557e06619152d02bea3eb42d540cadb4ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->