### PR TITLE
Fix typos in help strings and error messages

### DIFF
--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -923,7 +923,7 @@ def pack_dataset(
     elif strategy == "wrapped":
         dataset = dataset.map(_pack_wrapped, batched=True, fn_kwargs={"seq_length": seq_length}, **map_kwargs)
     else:
-        raise ValueError(f"Invalid packing strategy: '{strategy}', must be one of {valid_strategies}.")
+        raise ValueError(f"Invalid packing strategy '{strategy}', must be one of {valid_strategies}.")
 
     if strategy in {"bfd", "bfd_split"} and "columns" in format:
         format["columns"] = format["columns"] + ["seq_lengths"]

--- a/trl/data_utils.py
+++ b/trl/data_utils.py
@@ -191,7 +191,7 @@ def is_conversational(example: dict[str, Any]) -> bool:
         # It must be a list of messages
         if isinstance(maybe_messages, list):
             maybe_message = maybe_messages[0]
-            # Each message must a list of dictionaries with keys "role" and "content"
+            # Each message must be a list of dictionaries with keys "role" and "content"
             if isinstance(maybe_message, dict) and "role" in maybe_message:
                 return True
 
@@ -965,7 +965,7 @@ def is_conversational_from_value(example: dict[str, Any]) -> bool:
     # It must be a list of messages
     if isinstance(maybe_messages, list):
         maybe_message = maybe_messages[0]
-        # Each message must a list of dictionaries with keys "from" and "value"
+        # Each message must be a list of dictionaries with keys "from" and "value"
         if isinstance(maybe_message, dict) and "from" in maybe_message and "value" in maybe_message:
             return True
 

--- a/trl/scripts/grpo.py
+++ b/trl/scripts/grpo.py
@@ -44,8 +44,8 @@ class GRPOScriptArguments(ScriptArguments):
                 - `"accuracy_reward"`
                 - `"reasoning_accuracy_reward"`
                 - `"think_format_reward"`
-                - `"get_soft_overlong_punishment"` (used value are `max_completion_len=1280`, `soft_punish_cache=256`)
-                - any dotted import path " (e.g., `'my_lib.rewards.custom_reward'`).
+                - `"get_soft_overlong_punishment"` (used values are `max_completion_len=1280`, `soft_punish_cache=256`)
+                - any dotted import path (e.g., `'my_lib.rewards.custom_reward'`).
     """
 
     reward_model_name_or_path: str | None = field(
@@ -58,7 +58,7 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] | None = field(
         default=None,
         metadata={
-            "help": "Reward functions to use. Supported values are: `accuracy_reward`,  `reasoning_accuracy_reward`, `think_format_reward`, "
+            "help": "Reward functions to use. Supported values are: `accuracy_reward`, `reasoning_accuracy_reward`, `think_format_reward`, "
             "`get_soft_overlong_punishment` (used values are `max_completion_len=1280`, `soft_punish_cache=256`), or "
             "any dotted import path (e.g., `'my_lib.rewards.custom_reward'`)."
         },

--- a/trl/scripts/rloo.py
+++ b/trl/scripts/rloo.py
@@ -44,8 +44,8 @@ class RLOOScriptArguments(ScriptArguments):
                 - `"accuracy_reward"`
                 - `"reasoning_accuracy_reward"`
                 - `"think_format_reward"`
-                - `"get_soft_overlong_punishment"` (used value are `max_completion_len=1280`, `soft_punish_cache=256`)
-                - any dotted import path " (e.g., `'my_lib.rewards.custom_reward'`).
+                - `"get_soft_overlong_punishment"` (used values are `max_completion_len=1280`, `soft_punish_cache=256`)
+                - any dotted import path (e.g., `'my_lib.rewards.custom_reward'`).
     """
 
     reward_model_name_or_path: str | None = field(
@@ -58,7 +58,7 @@ class RLOOScriptArguments(ScriptArguments):
     reward_funcs: list[str] | None = field(
         default=None,
         metadata={
-            "help": "Reward functions to use. Supported values are: `accuracy_reward`,  `reasoning_accuracy_reward`, `think_format_reward`, "
+            "help": "Reward functions to use. Supported values are: `accuracy_reward`, `reasoning_accuracy_reward`, `think_format_reward`, "
             "`get_soft_overlong_punishment` (used values are `max_completion_len=1280`, `soft_punish_cache=256`), or "
             "any dotted import path (e.g., `'my_lib.rewards.custom_reward'`)."
         },

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -756,7 +756,7 @@ class GRPOConfig(_BaseConfig):
         default="token",
         metadata={
             "help": "Controls whether importance sampling ratios are computed at the `'token'` or `'sequence'` level. "
-            "`'token'` keeps the raw per-token log-probability ratios (one weight per token).  `'sequence'` averages "
+            "`'token'` keeps the raw per-token log-probability ratios (one weight per token). `'sequence'` averages "
             "the log-probability ratios across valid tokens to produce a single ratio per sequence. The GSPO paper "
             "shows that sequence-level sampling often yields more stable training and better alignment with "
             "sequence-level rewards."
@@ -1129,7 +1129,7 @@ class GRPOConfig(_BaseConfig):
 
         if self.vllm_importance_sampling_cap is not None:
             warnings.warn(
-                "The `vllm_importance_sampling_cap` argument is deprecated and will be removed in v2.0.0.  "
+                "The `vllm_importance_sampling_cap` argument is deprecated and will be removed in v2.0.0. "
                 "Use `vllm_importance_sampling_clip_max` instead.",
                 FutureWarning,
                 stacklevel=2,

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -459,7 +459,7 @@ class GRPOConfig(_BaseConfig):
     cast_lm_head_to_fp32: bool = field(
         default=False,
         metadata={
-            "help": "Whether to cast the language modeling head of the policy and reference, models to float32."
+            "help": "Whether to cast the language modeling head of the policy and reference models to float32. "
             "As recommended by the [ScaleRL](https://huggingface.co/papers/2510.13786) recipe. This flag is only "
             "supported when the model has untied word embedding and language modeling head layers i.e. "
             "`tie_word_embeddings` in the model config is False."

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -381,7 +381,7 @@ class GRPOConfig(_BaseConfig):
             Hugging Face Hub repository to save the completions. Should be a complete repository name like
             `'username/reponame'` or `'orgname/reponame'`, or just `'reponame'` in which case the repository will be
             created in the currently-logged-in Hugging Face user's namespace. Note that this repository will be public
-            unless you set `hub_private_repo=True` or your organization's default is to create private repositories."
+            unless you set `hub_private_repo=True` or your organization's default is to create private repositories.
 
         > Deprecated parameters
 


### PR DESCRIPTION
`cast_lm_head_to_fp32` rendered as "policy and reference, models to float32.As recommended", plus a stray quote in a docstring, two double spaces, "used value are" and "must a list".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and string-only edits with no changes to training, data, or configuration logic.
> 
> **Overview**
> This PR cleans up **typos and punctuation** in user-facing strings only—comments, CLI/doc help text, and one `ValueError` message. No runtime behavior changes.
> 
> In **`trl/data_utils.py`**, inline comments now say messages **must be** (not “must a”) dictionaries; the invalid packing strategy error drops the colon after the strategy name for consistent wording with the earlier check.
> 
> **`trl/scripts/grpo.py`** and **`trl/scripts/rloo.py`** align reward-function docs: **“used values are”**, remove a stray quote on the dotted import-path line, and fix double spaces in `reward_funcs` help metadata.
> 
> **`trl/trainer/grpo_config.py`** fixes `cast_lm_head_to_fp32` help (“policy and reference models”), removes a trailing stray quote on `log_completions_hub_repo` docs, trims extra spaces in `importance_sampling_level` help and the `vllm_importance_sampling_cap` deprecation warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4473839d298f24c38c2db3732877e7f129d7d382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->