### PR TITLE
Fix two messages that describe the wrong behaviour

### DIFF
--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -811,8 +811,8 @@ class DistillationTrainer(_BaseTrainer):
         if self.use_vllm:
             if not is_vllm_available():
                 raise ImportError(
-                    "vLLM is not available and use_vllm is set to True. Please install vLLM with "
-                    "`pip install vllm` to use it."
+                    "vLLM is not available and `use_vllm` is set to True. Please install vLLM with "
+                    "`pip install trl[vllm]` to use it."
                 )
             self.vllm_generation = VLLMGeneration(
                 model=self.model,

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -143,8 +143,8 @@ class RewardConfig(_BaseConfig):
     max_length: int | None = field(
         default=1024,
         metadata={
-            "help": "Maximum length of the tokenized sequence. Sequences longer than `max_length` are truncated from "
-            "the right. If `None`, no truncation is applied."
+            "help": "Maximum length of the tokenized sequence. Samples are filtered out if either chosen or rejected "
+            "sequence exceeds this value. If `None`, no filtering is applied."
         },
     )
     pad_to_multiple_of: int | None = field(


### PR DESCRIPTION
The RewardConfig `max_length` help says sequences are truncated, but the trainer filters them out. DistillationTrainer points at `pip install vllm` instead of `trl[vllm]`, which is what pins the supported range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to config help and an error message; no runtime logic is modified.
> 
> **Overview**
> Corrects two user-facing strings that described the wrong behavior.
> 
> **`RewardConfig.max_length`** help now states that samples are **filtered out** when either the chosen or rejected sequence exceeds the limit (and that `None` disables filtering), instead of claiming right-side truncation.
> 
> **`DistillationTrainer`** vLLM `ImportError` now recommends **`pip install trl[vllm]`** (aligned with TRL’s pinned optional extra) and formats **`use_vllm`** in backticks in the message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6f18c7ec128305086dcc250758e7736c8204c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->