### PR TITLE
Reformat five docstrings to the repo style

### DIFF
--- a/trl/_compat.py
+++ b/trl/_compat.py
@@ -32,8 +32,10 @@ def _is_package_version_below(package_name: str, version_threshold: str) -> bool
     Check if installed package version is below the given threshold.
 
     Args:
-        package_name (str): Package name.
-        version_threshold (str): Maximum version threshold.
+        package_name (`str`):
+            Package name.
+        version_threshold (`str`):
+            Maximum version threshold.
 
     Returns:
         - True if package is installed and version < version_threshold.
@@ -56,8 +58,10 @@ def _is_package_version_at_least(package_name: str, version_threshold: str) -> b
     Check if installed package version is at least the given threshold.
 
     Args:
-        package_name (str): Package name.
-        version_threshold (str): Minimum version threshold.
+        package_name (`str`):
+            Package name.
+        version_threshold (`str`):
+            Minimum version threshold.
 
     Returns:
         - True if package is installed and version >= version_threshold.

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -161,8 +161,10 @@ def _override_model_generation_config(model, generation_kwargs=None):
     their intended inference behavior.
 
     Args:
-        model: The model (typically unwrapped_model) whose generation_config to temporarily override.
-        generation_kwargs (dict): Generation kwargs to be used to override model's generation config.
+        model ([`~transformers.PreTrainedModel`]):
+            The model (typically unwrapped_model) whose generation_config to temporarily override.
+        generation_kwargs (`dict`):
+            Generation kwargs to be used to override model's generation config.
     """
     if (
         # Issue fixed in transformers v5 by PR transformers#42702
@@ -210,7 +212,7 @@ def unwrap_model_for_generation(
         gather_deepspeed3_params (`bool`, *optional*, defaults to `True`):
             Whether to gather weights for DeepSpeed ZeRO Stage 3 models. If `False`, skips parameter gathering, which
             can be more memory-efficient but may lead to slower generation times.
-        generation_kwargs (dict, *optional*):
+        generation_kwargs (`dict`, *optional*):
             If provided, temporarily overrides the model's generation_config during generation. The original config is
             automatically restored when exiting the context. This is useful for using different generation parameters
             during training vs. inference.

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -73,15 +73,22 @@ def _generate_completions(
     Generates completions for a list of pre-formatted prompts from the given model.
 
     Args:
-        prompts (list[str]): A list of input prompts for which completions are to be generated.
-        model (PreTrainedModel): The pre-trained model to be used for generation.
-        tokenizer (PreTrainedTokenizerBase): The tokenizer to be used for encoding and decoding.
-        accelerator (Accelerator): The accelerator to be used for model execution.
-        generation_config (GenerationConfig): Configuration for text generation.
-        batch_size (int, *optional*): The number of prompts to process in each batch. Default is 1.
+        prompts (`list[str]`):
+            A list of input prompts for which completions are to be generated.
+        model ([`~transformers.PreTrainedModel`]):
+            The pre-trained model to be used for generation.
+        tokenizer ([`~transformers.PreTrainedTokenizerBase`]):
+            The tokenizer to be used for encoding and decoding.
+        accelerator ([`~accelerate.Accelerator`]):
+            The accelerator to be used for model execution.
+        generation_config ([`~transformers.GenerationConfig`]):
+            Configuration for text generation.
+        batch_size (`int`, *optional*, defaults to `1`):
+            The number of prompts to process in each batch.
 
     Returns:
-        list[str]: A list of generated text completions corresponding to the input prompts.
+        `list[str]`:
+            A list of generated text completions corresponding to the input prompts.
     """
     completions = []
     # TODO: Override model.generation_config with generation_kwargs

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -533,7 +533,7 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
             batch_seq_lengths (`list[list[int]]`):
                 A list of lists containing the lengths of each individual document in the packed batch.
 
-        Return:
+        Returns:
             `list[torch.Tensor]`:
                 A list of tensors containing the position IDs for each packed sequence.
         """

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -969,10 +969,12 @@ def nanmin(tensor: torch.Tensor) -> torch.Tensor:
     Compute the minimum value of a tensor, ignoring NaNs. This function only supports 1D tensors.
 
     Args:
-        tensor (`torch.Tensor`): Input tensor of shape `(N,)`.
+        tensor (`torch.Tensor`):
+            Input tensor of shape `(N,)`.
 
     Returns:
-        `torch.Tensor`: Minimum value of the tensor, ignoring NaNs. Returns NaN if all values are NaN.
+        `torch.Tensor`:
+            Minimum value of the tensor, ignoring NaNs. Returns NaN if all values are NaN.
     """
     if torch.isnan(tensor).all():
         return torch.tensor(float("nan"), dtype=tensor.dtype, device=tensor.device)
@@ -984,10 +986,12 @@ def nanmax(tensor: torch.Tensor) -> torch.Tensor:
     Compute the maximum value of a tensor, ignoring NaNs. This function only supports 1D tensors.
 
     Args:
-        tensor (`torch.Tensor`): Input tensor of shape `(N,)`.
+        tensor (`torch.Tensor`):
+            Input tensor of shape `(N,)`.
 
     Returns:
-        `torch.Tensor`: Maximum value of the tensor, ignoring NaNs. Returns NaN if all values are NaN.
+        `torch.Tensor`:
+            Maximum value of the tensor, ignoring NaNs. Returns NaN if all values are NaN.
     """
     if torch.isnan(tensor).all():
         return torch.tensor(float("nan"), dtype=tensor.dtype, device=tensor.device)


### PR DESCRIPTION
Inline `name (type): desc` entries, unbackticked types, and one `Return:` heading, in `_generate_completions`, `_compat`, `models/utils`, `nanmin`/`nanmax` and the packed position-ids helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> Aligns **docstrings only** with the repo’s HuggingFace-style format across five areas: `_is_package_version_below` / `_is_package_version_at_least` in `_compat.py`, generation helpers in `models/utils.py`, `_generate_completions` in `callbacks.py`, `get_position_ids_from_packed_seq_lengths` in `sft_trainer.py`, and `nanmin` / `nanmax` in `trainer/utils.py`.
> 
> **Args** move from inline `name (type): description` to backticked types (including cross-ref links like ``[`~transformers.PreTrainedModel`]`` where applicable), optional/default phrasing (`*optional*, defaults to \`1\``), and descriptions on the following line. **Returns** use the same multi-line layout instead of one-line `type: desc` forms. The packed position-ids helper’s section heading is corrected from `Return:` to `Returns:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e9e0c4cc5b777ad164d4ee766119006360075d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->