### PR TITLE
Fix docstring content drift

### DIFF
--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -400,9 +400,9 @@ class WeaveCallback(TrainerCallback):
             have signature: `scorer(prompt: str, completion: str) -> float | int`
         generation_config ([`~transformers.GenerationConfig`], *optional*):
             Generation config to use for generating completions.
-        num_prompts (`int` or `None`, *optional*):
-            Number of prompts to generate completions for. If not provided, defaults to the number of examples in the
-            evaluation dataset.
+        num_prompts (`int`, *optional*):
+            The number of prompts to generate completions for. If not provided, defaults to the number of examples in
+            the evaluation dataset.
         dataset_name (`str`, *optional*, defaults to `"eval_dataset"`):
             Name for the dataset metadata in Weave.
         model_name (`str`, *optional*):

--- a/trl/trainer/callbacks.py
+++ b/trl/trainer/callbacks.py
@@ -144,7 +144,7 @@ class SyncRefModelCallback(TrainerCallback):
 
 class RichProgressCallback(TrainerCallback):
     """
-    A [`TrainerCallback`] that displays the progress of training or evaluation using Rich.
+    A [`~transformers.TrainerCallback`] that displays the progress of training or evaluation using Rich.
     """
 
     def __init__(self):

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -109,8 +109,8 @@ class DPOConfig(_BaseConfig):
             reference model. For the IPO loss (`loss_type='ipo'`), this value is the regularization parameter denoted
             by τ in the [paper](https://huggingface.co/papers/2310.12036).
         use_weighting (`bool`, *optional*, defaults to `False`):
-            Whether to apply WPO-style weighting (https://huggingface.co/papers/2406.11827) to preference pairs using
-            the policy's length-normalized sequence probabilities.
+            Whether to apply [WPO](https://huggingface.co/papers/2406.11827)-style weighting to preference pairs
+            using the policy's length-normalized sequence probabilities.
         discopop_tau (`float`, *optional*, defaults to `0.05`):
             τ/temperature parameter from the DiscoPOP paper, which controls the shape of the log-ratio modulated loss
             when using `loss_type='discopop'`. The paper recommends the default value `discopop_tau=0.05`.
@@ -301,7 +301,7 @@ class DPOConfig(_BaseConfig):
     use_weighting: bool = field(
         default=False,
         metadata={
-            "help": "Whether to apply WPO-style weighting (https://huggingface.co/papers/2406.11827) to preference "
+            "help": "Whether to apply [WPO](https://huggingface.co/papers/2406.11827)-style weighting to preference "
             "pairs using the policy's length-normalized sequence probabilities."
         },
     )

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -126,8 +126,9 @@ class DPOConfig(_BaseConfig):
             reference policy during updates. The reference policy is updated according to the equation: `π_ref = α *
             π_θ + (1 - α) * π_ref_prev`. To use this parameter, you must set `sync_ref_model=True`.
         ref_model_sync_steps (`int`, *optional*, defaults to `512`):
-            τ parameter from the TR-DPO paper, which determines how frequently the current policy is synchronized with
-            the reference policy. To use this parameter, you must set `sync_ref_model=True`.
+            τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
+            frequently the current policy is synchronized with the reference policy. To use this parameter, you must
+            set `sync_ref_model=True`.
 
         > Deprecated parameters
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -398,7 +398,7 @@ class GRPOConfig(_BaseConfig):
 
             <Deprecated version="1.6.0">
 
-            Parameter `vllm_importance_sampling_cap` is deprecated and will be removed in v2.0.0. Use
+            Parameter `vllm_importance_sampling_cap` is deprecated and will be removed in version v2.0.0. Use
             `vllm_importance_sampling_clip_max` instead.
 
             </Deprecated>

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -96,6 +96,7 @@ class KTOConfig(_BaseConfig):
         ref_model_sync_steps (`int`, *optional*, defaults to `512`):
             τ parameter from the TR-DPO paper, which determines how frequently the current policy is synchronized with
             the reference policy. To use this parameter, you must set `sync_ref_model=True`.
+
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:
     > - `logging_steps`: Defaults to `10` instead of `500`.

--- a/trl/trainer/kto_config.py
+++ b/trl/trainer/kto_config.py
@@ -94,8 +94,9 @@ class KTOConfig(_BaseConfig):
             reference policy during updates. The reference policy is updated according to the equation: `π_ref = α *
             π_θ + (1 - α) * π_ref_prev`. To use this parameter, you must set `sync_ref_model=True`.
         ref_model_sync_steps (`int`, *optional*, defaults to `512`):
-            τ parameter from the TR-DPO paper, which determines how frequently the current policy is synchronized with
-            the reference policy. To use this parameter, you must set `sync_ref_model=True`.
+            τ parameter from the [TR-DPO](https://huggingface.co/papers/2404.09656) paper, which determines how
+            frequently the current policy is synchronized with the reference policy. To use this parameter, you must
+            set `sync_ref_model=True`.
 
     > [!NOTE]
     > These parameters have default values different from [`~transformers.TrainingArguments`]:

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -68,7 +68,7 @@ class RewardConfig(_BaseConfig):
 
         center_rewards_coefficient (`float`, *optional*):
             Coefficient to incentivize the reward model to output mean-zero rewards (proposed by
-            https://huggingface.co/papers/2312.09244, Eq. 2). Recommended value: `0.01`.
+            [this paper](https://huggingface.co/papers/2312.09244), Eq. 2). Recommended value: `0.01`.
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
 
@@ -157,7 +157,7 @@ class RewardConfig(_BaseConfig):
         default=None,
         metadata={
             "help": "Coefficient to incentivize the reward model to output mean-zero rewards (proposed by "
-            "https://huggingface.co/papers/2312.09244, Eq. 2). Recommended value: `0.01`."
+            "[this paper](https://huggingface.co/papers/2312.09244), Eq. 2). Recommended value: `0.01`."
         },
     )
     activation_offloading: bool = field(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -874,7 +874,7 @@ class SFTTrainer(_BaseTrainer):
             A function that accepts the raw model outputs, labels, and the number of items in the entire accumulated
             batch (batch_size * gradient_accumulation_steps) and returns the loss. For example, see the default [loss
             function](https://github.com/huggingface/transformers/blob/052e652d6d53c2b26ffde87e039b723949a53493/src/transformers/trainer.py#L3618)
-            used by [`Trainer`].
+            used by [`~transformers.Trainer`].
         compute_metrics (`Callable[[EvalPrediction], dict]`, *optional*):
             The function that will be used to compute metrics at evaluation. Must take a
             [`~transformers.EvalPrediction`] and return a dictionary string to metric values. When passing

--- a/trl/trainer/utils.py
+++ b/trl/trainer/utils.py
@@ -316,18 +316,18 @@ def generate_model_card(
             Weights & Biases run URL.
         trackio_url (`str` or `None`):
             Trackio Space URL.
-        comet_url (`str` or `None`):
-            Comet experiment URL.
         trainer_name (`str`):
             Trainer name.
-        trainer_citation (`str` or `None`, defaults to `None`):
+        trainer_citation (`str`, *optional*):
             Trainer citation as a BibTeX entry.
-        template_file (`str` *optional*):
+        template_file (`str`, *optional*):
             Template file name located in the `trl/templates` directory. Defaults to `lm_model_card.md`.
-        paper_title (`str` or `None`, defaults to `None`):
+        paper_title (`str`, *optional*):
             Paper title.
-        paper_id (`str` or `None`, defaults to `None`):
+        paper_id (`str`, *optional*):
             ArXiv paper ID as `YYMM.NNNNN`.
+        comet_url (`str`, *optional*):
+            Comet experiment URL.
 
     Returns:
         [`~huggingface_hub.ModelCard`]:


### PR DESCRIPTION
TR-DPO link missing from the DPO and KTO `ref_model_sync_steps` entries, two bare paper URLs, two bare `[Trainer]` refs, `comet_url` documented out of signature order, and a missing blank line before the KTOConfig note block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to docstrings and field help strings; no training logic or public API changes.
> 
> **Overview**
> This PR **aligns trainer docstrings and config help text** with the project’s documentation conventions—no runtime or API behavior changes.
> 
> Updates include **Hugging Face–style cross-references** (e.g. `TrainerCallback` and `Trainer` → `~transformers.*`), **markdown paper links** where URLs were bare or missing (TR-DPO on `ref_model_sync_steps` in DPO/KTO, WPO on `use_weighting`, reward-centering citation), and **small formatting fixes** (`num_prompts` wording, GRPO deprecation “in version v2.0.0”, blank line before KTO’s NOTE block). In `utils.py`, **`comet_url` is moved** in the Args section and optional-parameter descriptions are normalized (`*optional*` instead of `or None, defaults to None`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7441031556208aebbfc9695c4857a2b18deb7750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->