### PR TITLE
Reflow two docstrings to the doc-builder width

### DIFF
--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -109,8 +109,8 @@ class DPOConfig(_BaseConfig):
             reference model. For the IPO loss (`loss_type='ipo'`), this value is the regularization parameter denoted
             by τ in the [paper](https://huggingface.co/papers/2310.12036).
         use_weighting (`bool`, *optional*, defaults to `False`):
-            Whether to apply [WPO](https://huggingface.co/papers/2406.11827)-style weighting to preference pairs
-            using the policy's length-normalized sequence probabilities.
+            Whether to apply [WPO](https://huggingface.co/papers/2406.11827)-style weighting to preference pairs using
+            the policy's length-normalized sequence probabilities.
         discopop_tau (`float`, *optional*, defaults to `0.05`):
             τ/temperature parameter from the DiscoPOP paper, which controls the shape of the log-ratio modulated loss
             when using `loss_type='discopop'`. The paper recommends the default value `discopop_tau=0.05`.

--- a/trl/trainer/reward_config.py
+++ b/trl/trainer/reward_config.py
@@ -67,8 +67,8 @@ class RewardConfig(_BaseConfig):
         > Parameters that control the training
 
         center_rewards_coefficient (`float`, *optional*):
-            Coefficient to incentivize the reward model to output mean-zero rewards (proposed by
-            [this paper](https://huggingface.co/papers/2312.09244), Eq. 2). Recommended value: `0.01`.
+            Coefficient to incentivize the reward model to output mean-zero rewards (proposed by [this
+            paper](https://huggingface.co/papers/2312.09244), Eq. 2). Recommended value: `0.01`.
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only line wrapping in config docstrings; no runtime or API impact.
> 
> **Overview**
> Reformats two class docstring parameter descriptions so they match **doc-builder** line-width conventions, with no wording or behavior changes.
> 
> In `DPOConfig`, the `use_weighting` entry is reflowed so the WPO sentence wraps across two lines differently. In `RewardConfig`, the `center_rewards_coefficient` entry reflows the citation link so `[this paper](...)` is not split awkwardly across lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb0b86b9e6a613cfed7fee998883e9dd013bdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->