### PR TITLE
Fix three broken doc links

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -60,7 +60,6 @@ Below is an overview of TRL trainers, organized by maturity and method type.
 - [GSPO-token](gspo_token)
 - [`NashMDTrainer`](nash_md_trainer)
 - [`OnlineDPOTrainer`](online_dpo_trainer)
-- [`PPOTrainer`](ppo_trainer)
 - [`XPOTrainer`](xpo_trainer)
 
 #### Reward modeling

--- a/docs/source/kernels_hub.md
+++ b/docs/source/kernels_hub.md
@@ -116,4 +116,4 @@ training_args = SFTConfig(
 )
 ```
 
-Learn more about the [Liger Kernel Integration](./liger_kernel_integration).
+Learn more about the [Liger Kernel Integration](liger_kernel_integration).

--- a/examples/grpo_harbor/harnesses/bash/README.md
+++ b/examples/grpo_harbor/harnesses/bash/README.md
@@ -1,6 +1,6 @@
 # `bash` harness
 
-The minimal harness: a single shell tool. This is the **built-in** [`HarborBashEnv`](../../../../../trl/experimental/harbor/_env.py) (`trl.experimental.harbor.HarborBashEnv`); this folder just documents it and re-exports it as `BashEnv`.
+The minimal harness: a single shell tool. This is the **built-in** [`HarborBashEnv`](../../../../trl/experimental/harbor/_env.py) (`trl.experimental.harbor.HarborBashEnv`); this folder just documents it and re-exports it as `BashEnv`.
 
 ## Tools
 


### PR DESCRIPTION
`index.md` still linked `ppo_trainer`, whose page and toc entry are gone; the kernels-hub link carried a `./` prefix; the bash harness README was one `../` too deep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and path corrections with no runtime or API impact.
> 
> **Overview**
> Fixes **three broken documentation links** so navigation matches the current docs layout.
> 
> The experimental trainers index **drops** the stale [`PPOTrainer`](ppo_trainer) entry after that page was removed. **kernels_hub** now points to Liger integration with the same relative link style as other docs (`liger_kernel_integration` instead of `./liger_kernel_integration`). The **bash harness** README corrects the relative path to `HarborBashEnv` in `trl/experimental/harbor/_env.py` (one fewer `../`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2223177c7e255b716d162e190669404d8b6ac1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->