### PR TITLE
Fix the example commands in the script docstrings

### DIFF
--- a/trl/scripts/distillation.py
+++ b/trl/scripts/distillation.py
@@ -23,7 +23,7 @@
 
 """
 # Full training
-```
+```bash
 python trl/scripts/distillation.py \
     --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
     --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
@@ -34,7 +34,7 @@ python trl/scripts/distillation.py \
 ```
 
 # LoRA
-```
+```bash
 python trl/scripts/distillation.py \
     --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
     --teacher_model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \

--- a/trl/scripts/kto.py
+++ b/trl/scripts/kto.py
@@ -43,7 +43,6 @@ python trl/scripts/kto.py \
 
 # QLoRA:
 ```bash
-# QLoRA:
 python trl/scripts/kto.py \
     --dataset_name trl-lib/kto-mix-14k \
     --model_name_or_path=trl-lib/qwen1.5-1.8b-sft \

--- a/trl/scripts/sft.py
+++ b/trl/scripts/sft.py
@@ -23,7 +23,7 @@
 
 """
 # Full training
-```
+```bash
 python trl/scripts/sft.py \
     --model_name_or_path Qwen/Qwen2-0.5B \
     --dataset_name trl-lib/Capybara \
@@ -40,7 +40,7 @@ python trl/scripts/sft.py \
 ```
 
 # LoRA
-```
+```bash
 python trl/scripts/sft.py \
     --model_name_or_path Qwen/Qwen2-0.5B \
     --dataset_name trl-lib/Capybara \


### PR DESCRIPTION
SFT and Distillation opened their example fences without the bash language tag, and the KTO QLoRA block repeated its heading inside the shell snippet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only markdown fixes with no runtime or API impact.
> 
> **Overview**
> Fixes **markdown docstrings** in `trl/scripts/distillation.py`, `trl/scripts/sft.py`, and `trl/scripts/kto.py` so embedded example commands render correctly.
> 
> In **distillation** and **sft**, the Full training and LoRA/PEFT snippets now open with ` ```bash ` instead of bare fences, matching other scripts like `dpo.py`. In **kto**, the duplicate `# QLoRA:` line inside the QLoRA shell block was removed so the heading appears only once above the fence.
> 
> No training logic, CLI behavior, or dependencies change—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b4d0e9542694c1a7b231697b23edbbf5dcf776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->