### PR TITLE
Tidy pyproject, Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.bak
 .gitattributes
 .last_checked
-.gitconfig
-*.bak
 *.log
 *~
 ~*
@@ -63,7 +61,6 @@ coverage.xml
 *.pot
 
 # Django stuff:
-*.log
 local_settings.py
 
 # Flask stuff:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-.PHONY: test precommit common_tests slow_tests tests_gpu test_experimental claude clean-ai
-
-check_dirs := examples tests trl
-
-ACCELERATE_CONFIG_PATH = `pwd`/examples/accelerate_configs
+.PHONY: test precommit slow_tests test_experimental claude clean-ai
 
 # Transient infrastructure errors that are worth retrying, matched against "<ExceptionType>: <message>":
 #  - OSError, Timeout, HTTPError 502/504: Hub flakiness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,21 @@ deepspeed = [
     "deepspeed>=0.18.6",
     "transformers!=5.1.0",  # see transformers#43780
 ]
+harbor = [
+    "harbor>=0.13.0; python_version >= '3.12'",  # harbor requires Python 3.12+ (pulls its sandbox backends)
+]
 kernels = [  # transformers renamed the "hub-kernels" extra to "kernels" in 5.1.0
     "transformers[kernels]",  # transformers >= 5.1.0
     "transformers[hub-kernels]",  # transformers < 5.1.0
 ]
 liger = [
     "liger-kernel>=0.8.2"
+]
+math_verify = [
+    "math-verify>=0.5.2",
+]
+openreward = [
+    "openreward>=0.1.109; python_version >= '3.11'",  # openreward requires Python 3.11+
 ]
 peft = [
     "peft>=0.13.0"
@@ -90,15 +99,6 @@ vlm = [
     "Pillow",
     "torchvision",
     "num2words==0.5.14"
-]
-math_verify = [
-    "math-verify>=0.5.2",
-]
-openreward = [
-    "openreward>=0.1.109; python_version >= '3.11'",  # openreward requires Python 3.11+
-]
-harbor = [
-    "harbor>=0.13.0; python_version >= '3.12'",  # harbor requires Python 3.12+ (pulls its sandbox backends)
 ]
 dev = [
     # bco


### PR DESCRIPTION
Three extras appended out of alphabetical order, two phony Makefile targets and two variables that no longer exist, and three duplicated .gitignore entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only deduplication and ordering; no application logic or install extra definitions changed beyond file layout.
> 
> **Overview**
> Housekeeping-only cleanup across repo config files with **no runtime or dependency behavior changes**.
> 
> **`.gitignore`** drops duplicate patterns (`*.bak`, `*.log`, and an early `.gitignore` entry) so each ignore rule appears once.
> 
> **`Makefile`** trims stale `.PHONY` targets (`common_tests`, `tests_gpu`) and unused variables (`check_dirs`, `ACCELERATE_CONFIG_PATH`), and restores a trailing newline on the file.
> 
> **`pyproject.toml`** reorders the `harbor`, `math_verify`, and `openreward` optional extras into alphabetical order in `[project.optional-dependencies]` (same pins and Python version markers as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d961deefc34be39ad2fbcc3fff86795696d4ff98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->