### PR TITLE
Qualify doc references to experimental classes

### DIFF
--- a/docs/source/async_distillation_trainer.md
+++ b/docs/source/async_distillation_trainer.md
@@ -12,8 +12,8 @@
 
 ## Overview
 
-[`AsyncDistillationTrainer`] is the async counterpart to [`~trl.experimental.distillation.DistillationTrainer`],
-architected like [`AsyncGRPOTrainer`]: a background rollout worker generates the student's own on-policy
+[`experimental.async_distillation.AsyncDistillationTrainer`] is the async counterpart to [`~trl.experimental.distillation.DistillationTrainer`],
+architected like [`experimental.async_grpo.AsyncGRPOTrainer`]: a background rollout worker generates the student's own on-policy
 completions and scores them against a teacher, while training proceeds concurrently instead of alternating between
 generation and gradient updates. Unlike the synchronous trainer, the teacher is never loaded locally — only a vLLM
 server URL is needed, so the teacher can run on entirely separate hardware from the student and trainer, or even be
@@ -58,7 +58,7 @@ example.
 
 In [`~trl.experimental.distillation.DistillationTrainer`], the teacher is a locally loaded model: generation,
 teacher forward pass, and the gradient update all happen sequentially in the same process.
-[`AsyncDistillationTrainer`] separates these concerns the same way [`AsyncGRPOTrainer`] separates GRPO's rollout
+[`experimental.async_distillation.AsyncDistillationTrainer`] separates these concerns the same way [`experimental.async_grpo.AsyncGRPOTrainer`] separates GRPO's rollout
 from its update:
 
 - **Rollout worker** (background process) — generates completions from the student's vLLM server, sends the full
@@ -68,12 +68,12 @@ from its update:
   the student's weights.
 
 Because the teacher is scored over HTTP rather than a local forward pass, only a sparse, top-k slice of its
-distribution is ever transmitted (`teacher_top_k`), not the full vocabulary — see [`AsyncDistillationConfig`]'s
+distribution is ever transmitted (`teacher_top_k`), not the full vocabulary — see [`experimental.async_distillation.AsyncDistillationConfig`]'s
 `beta` and `teacher_top_k` documentation for exactly which candidates the wire protocol guarantees a teacher
 logprob for at each `beta` regime.
 
 After every `weight_sync_steps` training steps, the updated student weights are transferred to its vLLM server via
-NCCL. As with [`AsyncGRPOTrainer`], generation runs ahead of training, so samples may reflect a slightly stale
+NCCL. As with [`experimental.async_grpo.AsyncGRPOTrainer`], generation runs ahead of training, so samples may reflect a slightly stale
 policy; `max_staleness` controls how many weight updates a sample can lag behind before being discarded.
 
 ## Quick start

--- a/docs/source/async_grpo_trainer.md
+++ b/docs/source/async_grpo_trainer.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-[`AsyncGRPOTrainer`] implements the same [GRPO](grpo_trainer) algorithm but decouples rollout generation from training. A background worker continuously streams completions from a vLLM server while the training loop consumes them, so generation and gradient updates overlap instead of alternating. The API mirrors [`GRPOTrainer`] — for full details on the GRPO method itself (advantage computation, KL estimation, loss formulation, reward functions, etc.), see the [GRPO Trainer](grpo_trainer) documentation. Not all features from [`GRPOTrainer`] are available; refer to [`AsyncGRPOConfig`] for the supported parameters.
+[`experimental.async_grpo.AsyncGRPOTrainer`] implements the same [GRPO](grpo_trainer) algorithm but decouples rollout generation from training. A background worker continuously streams completions from a vLLM server while the training loop consumes them, so generation and gradient updates overlap instead of alternating. The API mirrors [`GRPOTrainer`] — for full details on the GRPO method itself (advantage computation, KL estimation, loss formulation, reward functions, etc.), see the [GRPO Trainer](grpo_trainer) documentation. Not all features from [`GRPOTrainer`] are available; refer to [`experimental.async_grpo.AsyncGRPOConfig`] for the supported parameters.
 
 This trainer was contributed by [Quentin Gallouédec](https://huggingface.co/qgallouedec) and [Amine Dirhoussi](https://huggingface.co/aminediroHF).
 
@@ -20,7 +20,7 @@ This trainer was contributed by [Quentin Gallouédec](https://huggingface.co/qga
 
 In the standard [`GRPOTrainer`], generation and training are sequential: generate a batch, compute the loss, update weights, repeat. Even in [vLLM colocate mode](grpo_trainer#speed-up-training-with-vllm-powered-generation), where generation runs on the same GPUs, one phase must finish before the other begins.
 
-[`AsyncGRPOTrainer`] separates these two concerns:
+[`experimental.async_grpo.AsyncGRPOTrainer`] separates these two concerns:
 
 - **Rollout worker** (background process) — sends prompts to a vLLM server, scores completions with reward functions, computes advantages, and pushes ready-to-train samples into a queue.
 - **Training loop** (main process) — pulls samples from the queue, computes the clipped surrogate loss, and updates the model weights.

--- a/docs/source/gmpo.md
+++ b/docs/source/gmpo.md
@@ -2,7 +2,7 @@
 
 In the paper [Geometric-Mean Policy Optimization](https://huggingface.co/papers/2507.20673), the authors propose a GRPO variant that maximizes the *geometric* mean of the token-level importance ratios instead of the arithmetic mean. Because the geometric mean is far less sensitive to outlier ratios, the policy update is more stable and tolerates a much wider clipping range. Clipping is applied per token, in log space, and one-sided per the advantage sign (the standard PPO trust region) — crucially, *before* the geometric mean is taken.
 
-To use GMPO, you can use the [`GMPOTrainer`] class in `trl.experimental.gmpo`.
+To use GMPO, you can use the [`experimental.gmpo.GMPOTrainer`] class in `trl.experimental.gmpo`.
 
 ## Usage
 

--- a/docs/source/gold_trainer.md
+++ b/docs/source/gold_trainer.md
@@ -20,8 +20,8 @@ Key capabilities:
 
 ## Usage tips
 
-The [`GOLDTrainer`] subclasses [`SFTTrainer`] and accepts the same datasets as other TRL trainers (lists of ChatML style
-messages). Important configuration flags on [`GOLDConfig`] include:
+The [`experimental.gold.GOLDTrainer`] subclasses [`SFTTrainer`] and accepts the same datasets as other TRL trainers (lists of ChatML style
+messages). Important configuration flags on [`experimental.gold.GOLDConfig`] include:
 
 * `use_uld_loss` – toggles Universal Logit Distillation. Set this to `True` for cross-tokenizer setups.
 * `teacher_tokenizer_name_or_path` – required when `use_uld_loss=True`; GOLD uses the teacher tokenizer to align tokens.
@@ -178,7 +178,7 @@ python examples/gold_chatbot_arena/gold_chatbot_arena.py \
 
 ## Training Vision Language Models
 
-[`GOLDTrainer`] supports VLM-to-VLM distillation. Both student and teacher must be vision-language models. To train a VLM, provide a dataset with either an `image` column (single image per sample) or an `images` column (list of images per sample). For more information on the expected dataset structure, see the [Dataset Format — Vision datasets](dataset_formats#vision-datasets) section.
+[`experimental.gold.GOLDTrainer`] supports VLM-to-VLM distillation. Both student and teacher must be vision-language models. To train a VLM, provide a dataset with either an `image` column (single image per sample) or an `images` column (list of images per sample). For more information on the expected dataset structure, see the [Dataset Format — Vision datasets](dataset_formats#vision-datasets) section.
 
 When the student and teacher share the same architecture and tokenizer (e.g. Qwen3-VL-8B to Qwen3-VL-2B), the standard generalized JSD loss applies directly. When they have different `model_type` (e.g. Qwen3-VL to LFM2.5-VL), set `use_uld_loss=True` to enable cross-tokenizer alignment via Universal Logit Distillation. Images are processed separately through each model's processor.
 
@@ -231,7 +231,7 @@ accelerate launch examples/gold_qwen3_vl/gold_qwen3_vl.py \
 ```
 
 > [!TIP]
-> For VLMs, `truncation_mode='keep_end'` is not supported because image tokens reside in the prompt portion of the sequence and may be silently dropped. Use `truncation_mode='keep_start'` (the default) or set `max_length=None` in the [`GOLDConfig`]. This allows the model to process the full sequence length without truncating image tokens.
+> For VLMs, `truncation_mode='keep_end'` is not supported because image tokens reside in the prompt portion of the sequence and may be silently dropped. Use `truncation_mode='keep_start'` (the default) or set `max_length=None` in the [`experimental.gold.GOLDConfig`]. This allows the model to process the full sequence length without truncating image tokens.
 >
 > ```python
 > GOLDConfig(max_length=None, ...)

--- a/docs/source/iw_opd_trainer.md
+++ b/docs/source/iw_opd_trainer.md
@@ -2,7 +2,7 @@
 
 In the paper [On the Position Bias of On-Policy Distillation](https://huggingface.co/papers/2606.22600), the authors introduce Importance-Weighted On-Policy Distillation (IW-OPD). IW-OPD addresses position bias in on-policy distillation by reweighting sampled-token updates according to accumulated teacher-student prefix discrepancy. Early tokens keep larger weights, while later tokens after high drift are downweighted.
 
-To use IW-OPD, you can use the [`IWOPDTrainer`] class in `trl.experimental.iw_opd`.
+To use IW-OPD, you can use the [`experimental.iw_opd.IWOPDTrainer`] class in `trl.experimental.iw_opd`.
 
 > [!NOTE]
 > IW-OPD is currently part of the `trl.experimental` namespace. APIs may change without notice while the feature is iterated on.

--- a/docs/source/sdft_trainer.md
+++ b/docs/source/sdft_trainer.md
@@ -45,7 +45,7 @@ trainer.train()
 ```
 
 To generate from the teacher-conditioned prompt instead of the student prompt, set `generate_from_teacher=True`.
-To customize how the teacher prompt is built, set `teacher_prompt_template` on [`SDFTConfig`].
+To customize how the teacher prompt is built, set `teacher_prompt_template` on [`experimental.sdft.SDFTConfig`].
 
 ## Serving the teacher from the vLLM server
 

--- a/trl/experimental/a2po/a2po_config.py
+++ b/trl/experimental/a2po/a2po_config.py
@@ -20,7 +20,7 @@ from trl.trainer.base_config import _BaseConfig
 @dataclass
 class A2POConfig(_BaseConfig):
     r"""
-    Configuration class for the [`A2POTrainer`].
+    Configuration class for the [`experimental.a2po.A2POTrainer`].
 
     This class includes only the parameters that are specific to A2PO training. For a full list of training arguments,
     please refer to the [`~transformers.TrainingArguments`] documentation. Note that default values in this class may
@@ -31,8 +31,8 @@ class A2POConfig(_BaseConfig):
 
         model_init_kwargs (`dict[str, Any]`, *optional*):
             Keyword arguments for [`~transformers.AutoModelForCausalLM.from_pretrained`], used when the `model`
-            argument of the [`A2POTrainer`] is provided as a string. The `revision` value is also used when loading the
-            processing class.
+            argument of the [`experimental.a2po.A2POTrainer`] is provided as a string. The `revision` value is also
+            used when loading the processing class.
         trust_remote_code (`bool`, *optional*, defaults to `False`):
             Whether to allow loading models and tokenizers that ship custom Python code from the Hub. Forwarded to
             [`~transformers.AutoModelForCausalLM.from_pretrained`] and [`~transformers.AutoTokenizer.from_pretrained`].

--- a/trl/experimental/a2po/a2po_trainer.py
+++ b/trl/experimental/a2po/a2po_trainer.py
@@ -67,7 +67,7 @@ class A2POTrainer(_BaseTrainer):
             Reward function(s). Each takes `prompts` and `completions` (plus dataset columns as keyword arguments) and
             returns a list of float rewards. When multiple are provided, their weighted sum (see
             [`A2POConfig.reward_weights`]) is the scalar reward `r`, which A*-PO assumes to be binary (in `{0, 1}`).
-        args ([`A2POConfig`], *optional*):
+        args ([`experimental.a2po.A2POConfig`], *optional*):
             Configuration for this trainer. If `None`, a default configuration is used.
         train_dataset ([`~datasets.Dataset`], *optional*):
             Training dataset. Must contain a `"prompt"` column.

--- a/trl/experimental/async_distillation/async_distillation_config.py
+++ b/trl/experimental/async_distillation/async_distillation_config.py
@@ -21,7 +21,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class AsyncDistillationConfig(_BaseConfig):
     r"""
-    Configuration class for the [`AsyncDistillationTrainer`].
+    Configuration class for the [`experimental.async_distillation.AsyncDistillationTrainer`].
 
     This class includes only the parameters that are specific to asynchronous on-policy distillation. For a full list
     of training arguments, please refer to the [`~transformers.TrainingArguments`] documentation. Note that default

--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -427,7 +427,8 @@ class TokenBudgetBatcher(torch.utils.data.IterableDataset):
 
 
 class RolloutWorkerProtocol(Protocol):
-    """Interface a rollout worker must implement to be passed as `rollout_worker` to [`AsyncDistillationTrainer`].
+    """Interface a rollout worker must implement to be passed as `rollout_worker` to
+    [`experimental.async_distillation.AsyncDistillationTrainer`].
 
     Same contract as [`~trl.experimental.async_grpo.async_grpo_trainer.RolloutWorkerProtocol`].
 
@@ -454,7 +455,7 @@ class RolloutWorkerProtocol(Protocol):
 
 class WeightTransferProtocol(Protocol):
     """Interface a weight-sync backend must implement to be passed as `weight_transfer` to
-    [`AsyncDistillationTrainer`].
+    [`experimental.async_distillation.AsyncDistillationTrainer`].
 
     Same contract as [`~trl.experimental.async_grpo.async_grpo_trainer.WeightTransferProtocol`]. The default
     [`WeightTransferClient`] streams the student's weights into its vLLM server over NCCL; pass a no-op implementation
@@ -904,7 +905,7 @@ class AsyncDistillationTrainer(_BaseTrainer):
             [`~transformers.PreTrainedModel.save_pretrained`]. Loaded with
             [`~transformers.AutoModelForCausalLM.from_pretrained`]. The model name is also used to identify the student
             model on its vLLM server.
-        args ([`AsyncDistillationConfig`], *optional*):
+        args ([`experimental.async_distillation.AsyncDistillationConfig`], *optional*):
             Configuration for this trainer. If `None`, a default configuration is used.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`]):
             Dataset to use for training. Must include a `"prompt"` column

--- a/trl/experimental/async_grpo/async_grpo_config.py
+++ b/trl/experimental/async_grpo/async_grpo_config.py
@@ -21,7 +21,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class AsyncGRPOConfig(_BaseConfig):
     r"""
-    Configuration class for the [`AsyncGRPOTrainer`].
+    Configuration class for the [`experimental.async_grpo.AsyncGRPOTrainer`].
 
     This class includes only the parameters that are specific to asynchronous GRPO training. For a full list of
     training arguments, please refer to the [`~transformers.TrainingArguments`] documentation. Note that default values

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -105,7 +105,8 @@ EnvironmentFactory = Callable[[], _SupportsReset]
 
 
 class RolloutWorkerProtocol(Protocol):
-    """Interface a rollout worker must implement to be passed as `rollout_worker` to [`AsyncGRPOTrainer`].
+    """Interface a rollout worker must implement to be passed as `rollout_worker` to
+    [`experimental.async_grpo.AsyncGRPOTrainer`].
 
     The default [`AsyncRolloutWorker`] spawns a CUDA-free child process and scores completions with the trainer's
     `reward_funcs`. Implement this protocol to plug in a custom rollout/scoring backend instead — for example, one that
@@ -144,7 +145,8 @@ class RolloutWorkerProtocol(Protocol):
 
 
 class WeightTransferProtocol(Protocol):
-    """Interface a weight-sync backend must implement to be passed as `weight_transfer` to [`AsyncGRPOTrainer`].
+    """Interface a weight-sync backend must implement to be passed as `weight_transfer` to
+    [`experimental.async_grpo.AsyncGRPOTrainer`].
 
     The default [`WeightTransferClient`] streams the trainer's weights into the vLLM server over NCCL. Implement this
     protocol to plug in a different sync mechanism, or pass a no-op implementation to disable trainer-side weight sync
@@ -701,7 +703,7 @@ class AsyncGRPOTrainer(_BaseTrainer):
             `functools.partial`, or a callable class instance — lambdas and closures will fail at startup. The child
             process also runs with `CUDA_VISIBLE_DEVICES=""`, so a GPU-backed reward model runs on CPU (slow), not the
             trainer's GPU.
-        args ([`AsyncGRPOConfig`], *optional*):
+        args ([`experimental.async_grpo.AsyncGRPOConfig`], *optional*):
             Configuration for this trainer. If `None`, a default configuration is used.
         train_dataset ([`~datasets.Dataset`] or [`~datasets.IterableDataset`], *optional*):
             Dataset to use for training. It must include a column `"prompt"`. Any additional columns in the dataset are

--- a/trl/experimental/gmpo/gmpo_config.py
+++ b/trl/experimental/gmpo/gmpo_config.py
@@ -20,13 +20,14 @@ from ...trainer.grpo_config import GRPOConfig
 @dataclass
 class GMPOConfig(GRPOConfig):
     r"""
-    Configuration class for the [`GMPOTrainer`].
+    Configuration class for the [`experimental.gmpo.GMPOTrainer`].
 
-    [`GMPOConfig`] inherits every parameter from [`GRPOConfig`]; it only changes the meaning and default of the
-    clipping range. In GMPO, clipping is applied to the per-token *log*-importance ratios (i.e. in log space) before
-    the geometric mean is taken, so `epsilon` and `epsilon_high` are expressed in log space: the effective ratio
-    clipping range is `(exp(-epsilon), exp(epsilon_high))`. The [GMPO paper](https://huggingface.co/papers/2507.20673)
-    recommends a markedly wider range than GRPO/DAPO, `(exp(-0.4), exp(0.4))`, to encourage exploration.
+    [`experimental.gmpo.GMPOConfig`] inherits every parameter from [`GRPOConfig`]; it only changes the meaning and
+    default of the clipping range. In GMPO, clipping is applied to the per-token *log*-importance ratios (i.e. in log
+    space) before the geometric mean is taken, so `epsilon` and `epsilon_high` are expressed in log space: the
+    effective ratio clipping range is `(exp(-epsilon), exp(epsilon_high))`. The [GMPO
+    paper](https://huggingface.co/papers/2507.20673) recommends a markedly wider range than GRPO/DAPO, `(exp(-0.4),
+    exp(0.4))`, to encourage exploration.
 
     Parameters:
         epsilon (`float`, *optional*, defaults to `0.4`):

--- a/trl/experimental/gold/gold_config.py
+++ b/trl/experimental/gold/gold_config.py
@@ -22,7 +22,7 @@ from ...trainer.sft_config import SFTConfig
 @dataclass
 class GOLDConfig(SFTConfig):
     r"""
-    Configuration class for [`GOLDTrainer`].
+    Configuration class for [`experimental.gold.GOLDTrainer`].
 
     This class includes only the parameters that are specific to GOLD training. For a full list of training arguments,
     please refer to the [`~transformers.TrainingArguments`] and [`SFTConfig`] documentation.

--- a/trl/experimental/iw_opd/iw_opd_config.py
+++ b/trl/experimental/iw_opd/iw_opd_config.py
@@ -22,7 +22,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class IWOPDConfig(_BaseConfig):
     r"""
-    Configuration class for the [`IWOPDTrainer`].
+    Configuration class for the [`experimental.iw_opd.IWOPDTrainer`].
 
     Extends [`~transformers.TrainingArguments`] with parameters specific to knowledge distillation. This config is
     independent of [`SFTConfig`] — all necessary fields are declared here.

--- a/trl/experimental/minillm/minillm_config.py
+++ b/trl/experimental/minillm/minillm_config.py
@@ -22,7 +22,7 @@ from ...trainer.grpo_config import GRPOConfig
 @dataclass
 class MiniLLMConfig(GRPOConfig):
     """
-    Configuration class for [`MiniLLMTrainer`].
+    Configuration class for [`experimental.minillm.MiniLLMTrainer`].
 
     This class includes only the parameters that are specific to MiniLLM training. For a full list of training
     arguments, please refer to the [`~transformers.TrainingArguments`] and [`GRPOConfig`] documentation.

--- a/trl/experimental/sdft/sdft_config.py
+++ b/trl/experimental/sdft/sdft_config.py
@@ -23,7 +23,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class SDFTConfig(_BaseConfig):
     r"""
-    Configuration class for the [`SDFTTrainer`].
+    Configuration class for the [`experimental.sdft.SDFTTrainer`].
 
     Parameters:
         > Parameters that control the SDFT loss

--- a/trl/experimental/sdpo/sdpo_config.py
+++ b/trl/experimental/sdpo/sdpo_config.py
@@ -23,7 +23,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class SDPOConfig(_BaseConfig):
     r"""
-    Configuration class for the [`SDPOTrainer`].
+    Configuration class for the [`experimental.sdpo.SDPOTrainer`].
 
     Parameters:
         > Parameters that control the online policy objective

--- a/trl/experimental/server_distillation/server_distillation_config.py
+++ b/trl/experimental/server_distillation/server_distillation_config.py
@@ -20,7 +20,7 @@ from ...trainer.distillation_config import DistillationConfig
 @dataclass
 class ServerDistillationConfig(DistillationConfig):
     r"""
-    Configuration class for the [`ServerDistillationTrainer`].
+    Configuration class for the [`experimental.server_distillation.ServerDistillationTrainer`].
 
     Extends [`DistillationConfig`] with the address of an external vLLM server that scores the student's completions.
     The teacher is never held locally: instead of a local forward pass, per-token teacher logprobs are fetched from the

--- a/trl/experimental/ssd/ssd_config.py
+++ b/trl/experimental/ssd/ssd_config.py
@@ -23,7 +23,7 @@ from ...trainer.base_config import _BaseConfig
 @dataclass
 class SSDConfig(_BaseConfig):
     r"""
-    Configuration class for [`SSDTrainer`].
+    Configuration class for [`experimental.ssd.SSDTrainer`].
 
     Implements Simple Self-Distillation (SSD) from [*Embarrassingly Simple Self-Distillation Improves Code
     Generation*](https://huggingface.co/papers/2604.01193). SSD samples completions from the model at a training-time


### PR DESCRIPTION
Experimental trainers and configs are not exported at the top level of `trl`, so a bare `[`SSDTrainer`]` does not resolve; the autodoc key is the dotted path, e.g. `[[autodoc]] experimental.ssd.SSDTrainer`. Half the experimental configs already used the qualified form, the other half did not.

36 references across 20 files. Markdown links of the form `[`X`](page)` are untouched, and so are references to top-level exports such as `[`SFTTrainer`]` and `[`GRPOConfig`]`. A few docstring lines are rewrapped to stay under 119 columns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring link text only; no runtime, API, or training behavior changes.
> 
> **Overview**
> Updates **36 Sphinx-style cross-references** across **20 files** so experimental trainers and configs link correctly in the docs. Bare refs like ``[`AsyncGRPOTrainer`]`` are replaced with **qualified autodoc keys** such as ``[`experimental.async_grpo.AsyncGRPOTrainer`]`` (and the matching ``*Config`` classes), because those symbols live under ``trl.experimental`` and are not re-exported at the top level.
> 
> **Docs** touched include async distillation/GRPO, GMPO, GOLD, IW-OPD, and SDFT. **Python docstrings** in the corresponding ``trl/experimental/*/`` config and trainer modules get the same link fixes. Top-level exports (e.g. ``[`GRPOTrainer`]``, ``[`SFTTrainer`]``) and normal markdown page links are unchanged. A few long docstring lines are rewrapped to stay within the column limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56379aca3b2c78bd00d2403c632a610858b5cf8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->