### PR TITLE
Fail fast when GRPO combines Liger with the MoE auxiliary loss

### DIFF
--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -1006,6 +1006,25 @@ class TestGRPOTrainer(TrlTestCase):
                 peft_config=PromptTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=8),
             )
 
+    @require_liger_kernel
+    def test_init_fails_with_moe_aux_loss_and_liger(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")
+
+        # The MoE auxiliary loss is on by default; it is incompatible with the Liger fused loss.
+        training_args = GRPOConfig(
+            output_dir=self.tmp_dir,
+            use_liger_kernel=True,
+            report_to="none",
+        )
+
+        with pytest.raises(ValueError, match="does not support the Mixture-of-Experts load-balancing auxiliary loss"):
+            GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
     @require_peft
     def test_train_peft_model(self):
         model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -792,6 +792,12 @@ class GRPOTrainer(_BaseTrainer):
         is_moe = getattr(text_config, "output_router_logits", None) is not None
         self.aux_loss_enabled = is_moe and args.router_aux_loss_coef != 0.0
         self.router_aux_loss_coef = args.router_aux_loss_coef
+        if self.aux_loss_enabled and self.use_liger_kernel:
+            raise ValueError(
+                "Liger GRPO loss does not support the Mixture-of-Experts load-balancing auxiliary loss, because it "
+                "fuses the loss without materializing the router logits. Either set `router_aux_loss_coef` to `0.0` "
+                "to disable the auxiliary loss, or set `use_liger_kernel` to False."
+            )
         self.scale_rewards = args.scale_rewards
         self.importance_sampling_level = args.importance_sampling_level
         self.off_policy_mask_threshold = args.off_policy_mask_threshold


### PR DESCRIPTION
# What does this PR do?

`GRPOTrainer` already sets `aux_loss_enabled` for Mixture-of-Experts models, but `use_liger_kernel=True` routes `compute_loss` through `compute_liger_loss`, which never sees router logits. The load-balancing term was dropped with no error.

DPO and KTO already raise in this combination. This copies that fail-fast into GRPO (`Liger GRPO loss does not support...`) and adds `test_init_fails_with_moe_aux_loss_and_liger` on `tiny-Qwen3MoeForCausalLM`.

Fixes #7009

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Init-time validation only; no change to training paths except blocking an already-unsupported silent misconfiguration.
> 
> **Overview**
> **GRPO now rejects Liger + MoE aux loss at init**, matching DPO/KTO behavior. When a MoE model has load-balancing enabled (`router_aux_loss_coef` non-zero) and `use_liger_kernel=True`, `GRPOTrainer` raises a `ValueError` explaining that the fused Liger path cannot use router logits, with guidance to disable the aux loss or turn off Liger.
> 
> Adds **`test_init_fails_with_moe_aux_loss_and_liger`** (Liger-gated) using `tiny-Qwen3MoeForCausalLM` to assert that error on construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7566981b079c7fffe7f684873461f90b867c65c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->