### PR TITLE
Restore generation unwrap state if generate() raises

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -19,7 +19,7 @@ import pytest
 from transformers import AutoModelForCausalLM
 
 from trl.import_utils import is_deepspeed_available
-from trl.models.utils import disable_gradient_checkpointing, prepare_deepspeed
+from trl.models.utils import _unwrap_model_for_generation, disable_gradient_checkpointing, prepare_deepspeed
 
 
 @pytest.mark.skipif(not is_deepspeed_available(), reason="deepspeed is not installed")
@@ -73,3 +73,35 @@ class TestDisableGradientCheckpointing:
         with disable_gradient_checkpointing(model):
             assert model.is_gradient_checkpointing is False
         assert model.is_gradient_checkpointing is True
+
+
+class TestUnwrapModelForGeneration:
+    def test_restores_gradient_checkpointing_on_error(self):
+        class DummyModel:
+            def __init__(self):
+                self.is_gradient_checkpointing = True
+                self.enable_calls = 0
+
+            def gradient_checkpointing_disable(self):
+                self.is_gradient_checkpointing = False
+
+            def gradient_checkpointing_enable(self):
+                self.is_gradient_checkpointing = True
+                self.enable_calls += 1
+
+        class FakeDistributedBackend:
+            def __init__(self, accelerator):
+                self.is_zero3 = False
+
+        unwrapped = DummyModel()
+        accelerator = types.SimpleNamespace(unwrap_model=lambda model: unwrapped)
+
+        with (
+            patch("trl.distributed.DistributedBackend", FakeDistributedBackend),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            with _unwrap_model_for_generation(unwrapped, accelerator):
+                raise RuntimeError("boom")
+
+        assert unwrapped.enable_calls == 1
+        assert unwrapped.is_gradient_checkpointing is True

--- a/trl/models/utils.py
+++ b/trl/models/utils.py
@@ -130,20 +130,24 @@ def _unwrap_model_for_generation(
         unwrapped_model.gradient_checkpointing_disable()
     from ..distributed import DistributedBackend
 
-    if DistributedBackend(accelerator).is_zero3:
-        if not gather_deepspeed3_params:
-            yield accelerator.unwrap_model(model)
-        else:
-            import deepspeed
-
-            with deepspeed.zero.GatheredParameters(model.parameters()):
-                remove_hooks(model)
+    try:
+        if DistributedBackend(accelerator).is_zero3:
+            if not gather_deepspeed3_params:
                 yield accelerator.unwrap_model(model)
-                add_hooks(model)
-    else:
-        yield unwrapped_model
-    if is_gradient_checkpointing:
-        unwrapped_model.gradient_checkpointing_enable()
+            else:
+                import deepspeed
+
+                with deepspeed.zero.GatheredParameters(model.parameters()):
+                    remove_hooks(model)
+                    try:
+                        yield accelerator.unwrap_model(model)
+                    finally:
+                        add_hooks(model)
+        else:
+            yield unwrapped_model
+    finally:
+        if is_gradient_checkpointing:
+            unwrapped_model.gradient_checkpointing_enable()
 
 
 @contextmanager


### PR DESCRIPTION
# What does this PR do?

`_unwrap_model_for_generation` disables gradient checkpointing and, on ZeRO-3, removes DeepSpeed hooks, then restores them only after a successful `yield`. If `generate()` raises, checkpointing stays off and the hooks stay removed.

This wraps the yield in `try`/`finally`, matching `_override_model_generation_config` in the same file. ZeRO-3 `add_hooks` is also in an inner `finally` so it runs even when generation fails inside `GatheredParameters`.

Adds `test_restores_gradient_checkpointing_on_error`.

Fixes #6659

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bugfix to generation context cleanup; behavior on success is unchanged and failures now restore training state instead of leaving the model misconfigured.
> 
> **Overview**
> Fixes a cleanup gap in **`_unwrap_model_for_generation`**: when `generate()` (or other code inside the context) raises, gradient checkpointing could stay disabled and, on DeepSpeed ZeRO-3 with gathered params, optimizer hooks might not be reattached.
> 
> The yield path is now wrapped in **`try`/`finally`** so gradient checkpointing is re-enabled on exit, mirroring **`_override_model_generation_config`**. For ZeRO-3 with **`GatheredParameters`**, **`add_hooks`** runs in an inner **`finally`** so hooks are restored even if generation fails mid-context.
> 
> Adds **`test_restores_gradient_checkpointing_on_error`** to assert checkpointing is turned back on after a **`RuntimeError`** inside the context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0139109ca116d57344a77ebb6912c6387c56f327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->