### PR TITLE
Publish to PyPI on tag push and guard VERSION against the tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # Publishing is triggered by the release tag, not by a change to VERSION. A tag push is a deliberate act, while a
 # VERSION change is a side effect of an ordinary PR: v1.12.0 was published to PyPI because a post-release bump set
-# VERSION to "1.12.0" instead of "1.12.0.dev0".
+# VERSION to "1.12.0" instead of "1.12.0.dev0". The job refuses to upload unless VERSION agrees with the tag.
 name: Publish to PyPI
 
 on:
@@ -14,12 +14,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Read version
-        id: get_version
-        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Debug - Show version.txt content
-        run: echo "Version is ${{ steps.get_version.outputs.version }}"
+      - name: Check VERSION matches the tag
+        run: |
+          version=$(cat VERSION)
+          echo "VERSION is $version, tag is $GITHUB_REF_NAME"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::VERSION ($version) is not a release version. Expected {major}.{minor}.{patch}, see RELEASE.md."
+            exit 1
+          fi
+          if [[ "v$version" != "$GITHUB_REF_NAME" ]]; then
+            echo "::error::VERSION ($version) does not match the tag ($GITHUB_REF_NAME). Tag the release commit, expected tag v$version."
+            exit 1
+          fi
 
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -35,7 +41,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        if: ${{ !contains(steps.get_version.outputs.version, 'dev') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,12 @@
+# Publishing is triggered by the release tag, not by a change to VERSION. A tag push is a deliberate act, while a
+# VERSION change is a side effect of an ordinary PR: v1.12.0 was published to PyPI because a post-release bump set
+# VERSION to "1.12.0" instead of "1.12.0.dev0".
 name: Publish to PyPI
 
 on:
   push:
-    branches:
-      - main
-      - v*-release
-    paths:
-      - "VERSION"
+    tags:
+      - "v*"
 
 jobs:
   publish:

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,37 @@
+# Checks the VERSION file on pull requests to main:
+#   1. VERSION is either a release version ({major}.{minor}.{patch}) or a dev version ({major}.{minor}.{patch}.dev{n}).
+#   2. A release version can only be followed by a dev version. On main, VERSION is a release version only between the
+#      release PR and the post-release bump, so the bump must set a ".dev" version. Missing it is what turned the
+#      v1.11.0 bump into a v1.12.0 release.
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "VERSION"
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check VERSION bump
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base=$(git show "$BASE_SHA":VERSION)
+          new=$(cat VERSION)
+          echo "VERSION: $base -> $new"
+          if [[ ! "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$ ]]; then
+            echo "::error::VERSION ($new) must be {major}.{minor}.{patch} or {major}.{minor}.{patch}.dev{n}, see RELEASE.md."
+            exit 1
+          fi
+          if [[ "$base" != *dev* && "$new" != *dev* ]]; then
+            echo "::error::VERSION goes from one release version ($base) to another ($new). The PR that follows a release is the dev bump, it must set a .dev version, see RELEASE.md."
+            exit 1
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,7 @@ from `release-v{major}.{minor}` to `main`, named `Release: v{major}.{minor}`, wa
 
 ### 6. Once the pull request is approved, merge it into `main`
 
-It will automatically publish the new version of the package on PyPI.
+Merging does not publish anything. The package is published by the tag pushed in the next step.
 
 ### 7. Add a tag in git to mark the release
 
@@ -68,6 +68,8 @@ git pull origin main
 git tag -a v{major}.{minor}.0 -m 'Adds tag v{major}.{minor}.0 for PyPI'
 git push origin v{major}.{minor}.0
 ```
+
+Pushing the tag triggers the publish workflow, which uploads the package to PyPI. Tag the release commit: do this before the dev bump of step 10.
 
 ### 8. Create a branch `v{major}.{minor}-release` for future patch releases
 
@@ -150,21 +152,19 @@ git commit -m 'Release: {major}.{minor}.{patch}'
 git push origin v{major}.{minor}-release
 ```
 
-### 5. Wait for the CI to pass
-
-The CI will automatically publish the new version of the package on PyPI.
-
-### 6. Add a tag in git to mark the release
+### 5. Add a tag in git to mark the release
 
 ```shell
 git tag -a v{major}.{minor}.{patch} -m 'Adds tag v{major}.{minor}.{patch} for PyPI'
 git push origin v{major}.{minor}.{patch}
 ```
 
-### 7. Create a GitHub Release
+Pushing the tag triggers the publish workflow, which uploads the package to PyPI.
+
+### 6. Create a GitHub Release
 
 1. Go to the repo’s [releases section](https://github.com/huggingface/trl/releases) on GitHub.
 2. Click **Draft a new release**.
-3. Select the `v{major}.{minor}.{patch}` tag you just created in step 6.
+3. Select the `v{major}.{minor}.{patch}` tag you just created in step 5.
 4. Add a title (`v{major}.{minor}.{patch}`) and a short description of what’s new.
 5. Click **Publish Release**.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,6 +105,8 @@ This ensures that future patch releases (`v{major}.{minor}.1`, `v{major}.{minor}
    + {major}.{minor+1}.0.dev0
    ```
 
+   The `.dev0` suffix is mandatory. CI rejects a pull request that replaces a release version with another release version: dropping the suffix here is what published the empty `v1.12.0` to PyPI.
+
 3. Commit and push these changes
 
    ```shell

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,7 +69,7 @@ git tag -a v{major}.{minor}.0 -m 'Adds tag v{major}.{minor}.0 for PyPI'
 git push origin v{major}.{minor}.0
 ```
 
-Pushing the tag triggers the publish workflow, which uploads the package to PyPI. Tag the release commit: do this before the dev bump of step 10.
+Pushing the tag triggers the publish workflow, which uploads the package to PyPI. It refuses to upload unless `VERSION` in the tagged commit is exactly `{major}.{minor}.0`, so tag the release commit: do this before the dev bump of step 10.
 
 ### 8. Create a branch `v{major}.{minor}-release` for future patch releases
 
@@ -159,7 +159,7 @@ git tag -a v{major}.{minor}.{patch} -m 'Adds tag v{major}.{minor}.{patch} for Py
 git push origin v{major}.{minor}.{patch}
 ```
 
-Pushing the tag triggers the publish workflow, which uploads the package to PyPI.
+Pushing the tag triggers the publish workflow, which uploads the package to PyPI. It refuses to upload unless `VERSION` in the tagged commit is exactly `{major}.{minor}.{patch}`.
 
 ### 6. Create a GitHub Release
 


### PR DESCRIPTION
This PR makes it impossible to publish a version of TRL that was never tagged as a release, and rejects a post-release version bump that is not a dev version.

### Motivation

`v1.12.0` on PyPI is an accidental duplicate of `v1.11.0`. The publish workflow fired on any push to `main` touching `VERSION` and skipped the upload only when the version contained `"dev"`, so a post-release bump that set `VERSION` to `1.12.0` instead of `1.12.0.dev0` uploaded a release 90 seconds after `1.11.0`, with identical code. The version number is burned, since PyPI does not allow re-uploading it.

Two things went wrong: publishing was a side effect of editing a file rather than a deliberate act, and nothing checked that the published version corresponded to a release.

### Solution

Publishing is now triggered by the release tag, and the job refuses to upload unless `VERSION` in the tagged commit is a release version equal to the tag. A separate check runs on pull requests that touch `VERSION`, and rejects a change from one release version to another: on `main`, `VERSION` is a release version only between the release pull request and the post-release bump, so that bump must carry a `.dev` suffix.

Applied to the history, the bump that produced `1.12.0` fails the pull request check, and even if it were merged, no upload would follow.

### Changes

- Trigger `Publish to PyPI` on `v*` tag pushes instead of pushes touching `VERSION`
- Refuse to publish unless `VERSION` is `{major}.{minor}.{patch}` and equals the tag, replacing the `"dev"` substring check
- Add a `Version Check` workflow on pull requests to `main` touching `VERSION`, validating the version format and requiring a dev version after a release version
- Update `RELEASE.md`: merging the release pull request no longer publishes, pushing the tag does, and the `.dev0` suffix in the bump step is mandatory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how packages reach PyPI; mis-tagging or workflow mistakes could block releases, but runtime library code is unaffected.
> 
> **Overview**
> PyPI publishing is no longer tied to merging or pushing `VERSION` on `main`. The **Publish to PyPI** workflow now runs only on `v*` tag pushes and **fails the job** unless `VERSION` is a strict `{major}.{minor}.{patch}` release and matches the tag (`v$version`), replacing the old `"dev"` substring gate.
> 
> A new **Version Check** workflow runs on PRs to `main` that change `VERSION`, enforcing valid release or `.dev{n}` formats and **blocking** a bump from one release version to another (post-release bumps must use `.dev`).
> 
> **RELEASE.md** is updated so merge no longer implies publish, tag push does, tagging must happen before the dev bump, and the `.dev0` suffix on the post-release bump is documented as required by CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a528085f9ff5a8091a4a298069d7e52d413deb4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->