### PR TITLE
Section the auto-generated release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Sections for the auto-generated release notes draft.
+# A PR lands in the first category whose labels match, so "*" must stay last.
+changelog:
+  categories:
+    - title: Breaking
+      labels:
+        - 💥 breaking
+    - title: Features
+      labels:
+        - ✨ enhancement
+    - title: Fixes
+      labels:
+        - 🐛 bug
+    - title: Documentation
+      labels:
+        - 📚 documentation
+    - title: CI and maintenance
+      labels:
+        - 🔧 maintenance
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
This PR adds `.github/release.yml` so the release notes GitHub drafts come out already split into sections, instead of one flat list.

### Motivation

Every release so far has been written by hand on top of a flat "What's Changed" list, and the resulting notes have used the same sections since v1.9: Breaking, Features, Fixes, Documentation, CI. GitHub can produce that split itself from a label to section mapping.

### Solution

The section titles match the ones the recent releases already use, so the draft lands shaped like the final notes and the remaining work is promoting entries into hand-written subsections rather than sorting them.

Three of the labels already exist (`✨ enhancement`, `🐛 bug`, `📚 documentation`), and Dependabot already applies `dependencies` to all of its PRs, so that section works with no extra effort. Two labels do not exist yet and are listed below as a blocker.

An unlabelled PR falls into `Other`, which is what the flat list gives today, so nothing regresses while labelling ramps up.

Priority labels such as `🩹 for patch` are deliberately left out: they mark a different axis, and since a PR lands in the first matching category they would pull PRs out of the section that describes what actually changed.

### Changes

- Add `.github/release.yml` mapping labels to release notes sections
- `Other` is the catch-all and stays last, since a PR lands in the first category whose labels match

### Before merging

- [x] Create the `💥 breaking` label: breaking change, removal, or deprecation
- [x] Create the `🔧 maintenance` label: CI, tooling, tests, or repo upkeep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds GitHub release-notes configuration only; no runtime or application code changes.
> 
> **Overview**
> Adds **`.github/release.yml`** so GitHub’s auto-generated release notes draft is grouped into sections (**Breaking**, **Features**, **Fixes**, **Documentation**, **CI and maintenance**, **Dependencies**, **Other**) instead of a single flat list.
> 
> Each section maps to existing or planned PR labels (e.g. `✨ enhancement`, `🐛 bug`, `dependencies`); unlabeled PRs land in **Other** via the catch-all `*` label, which must remain last because GitHub assigns each PR to the **first** matching category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95db9a5d2e44c4251add39b31957e6d56a966ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->