### PR TITLE
Reword the token sync comments to say what the line does

### DIFF
--- a/trl/experimental/async_distillation/async_distillation_trainer.py
+++ b/trl/experimental/async_distillation/async_distillation_trainer.py
@@ -990,8 +990,8 @@ class AsyncDistillationTrainer(_BaseTrainer):
             )
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = processing_class.pad_token_id
         model.generation_config.pad_token_id = processing_class.pad_token_id
 

--- a/trl/experimental/async_grpo/async_grpo_trainer.py
+++ b/trl/experimental/async_grpo/async_grpo_trainer.py
@@ -858,8 +858,8 @@ class AsyncGRPOTrainer(_BaseTrainer):
             )
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = processing_class.pad_token_id
         model.generation_config.pad_token_id = processing_class.pad_token_id
 

--- a/trl/experimental/cpo/cpo_trainer.py
+++ b/trl/experimental/cpo/cpo_trainer.py
@@ -331,8 +331,8 @@ class CPOTrainer(_BaseTrainer):
 
         if processing_class.pad_token is None:
             processing_class.pad_token = processing_class.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = processing_class.pad_token_id
         model.generation_config.pad_token_id = processing_class.pad_token_id
         self.pad_token_id = processing_class.pad_token_id

--- a/trl/experimental/iw_opd/iw_opd_trainer.py
+++ b/trl/experimental/iw_opd/iw_opd_trainer.py
@@ -438,8 +438,8 @@ class IWOPDTrainer(_BaseTrainer):
         if processing_class is not None:
             if getattr(processing_class, "pad_token", None) is None:
                 processing_class.pad_token = processing_class.eos_token
-            # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+            # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+            # configs.
             model.config.pad_token_id = processing_class.pad_token_id
             model.generation_config.pad_token_id = processing_class.pad_token_id
 

--- a/trl/experimental/online_dpo/online_dpo_trainer.py
+++ b/trl/experimental/online_dpo/online_dpo_trainer.py
@@ -387,8 +387,8 @@ class OnlineDPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/experimental/sdft/sdft_trainer.py
+++ b/trl/experimental/sdft/sdft_trainer.py
@@ -313,8 +313,8 @@ class SDFTTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/experimental/sdpo/sdpo_trainer.py
+++ b/trl/experimental/sdpo/sdpo_trainer.py
@@ -430,8 +430,8 @@ class SDPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/experimental/ssd/ssd_trainer.py
+++ b/trl/experimental/ssd/ssd_trainer.py
@@ -176,8 +176,8 @@ class SSDTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/experimental/tpo/tpo_trainer.py
+++ b/trl/experimental/tpo/tpo_trainer.py
@@ -349,8 +349,8 @@ class TPOTrainer(_BaseTrainer):
 
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/trainer/distillation_trainer.py
+++ b/trl/trainer/distillation_trainer.py
@@ -479,8 +479,8 @@ class DistillationTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -602,8 +602,8 @@ class DPOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 
@@ -745,8 +745,8 @@ class DPOTrainer(_BaseTrainer):
                     "in the vocabulary before using it as a padding token."
                 )
             self._tokenizer.pad_token = pad_token
-            # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+            # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+            # configs.
             model.config.pad_token_id = self._tokenizer.pad_token_id
             model.generation_config.pad_token_id = self._tokenizer.pad_token_id
             data_collator = DataCollatorForPreference(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -392,8 +392,8 @@ class GRPOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/trainer/kto_trainer.py
+++ b/trl/trainer/kto_trainer.py
@@ -659,8 +659,8 @@ class KTOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/trainer/reward_trainer.py
+++ b/trl/trainer/reward_trainer.py
@@ -428,9 +428,8 @@ class RewardTrainer(_BaseTrainer):
                     "in the vocabulary before using it as an EOS token."
                 )
             processing_class.eos_token = args.eos_token
-            # Mirror the eos token onto the model config: `Trainer` runs the same alignment at train time, so the end
-            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built. A
-            # sequence classification model has no generation config, so there is nothing else to align.
+            # The model must agree with the tokenizer on the eos token from construction, so mirror it onto the model
+            # config (a sequence classification model has no generation config).
             model.config.eos_token_id = processing_class.eos_token_id
 
         if args.chat_template_path is not None:

--- a/trl/trainer/rloo_trainer.py
+++ b/trl/trainer/rloo_trainer.py
@@ -322,8 +322,8 @@ class RLOOTrainer(_BaseTrainer):
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
 
-        # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-        # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+        # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+        # configs.
         model.config.pad_token_id = self._tokenizer.pad_token_id
         model.generation_config.pad_token_id = self._tokenizer.pad_token_id
 

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -1023,10 +1023,9 @@ class SFTTrainer(_BaseTrainer):
                     "in the vocabulary before using it as an EOS token."
                 )
             self._tokenizer.eos_token = args.eos_token
-            # Mirror the eos token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built. The
-            # generation config may hold several eos tokens, any of which halts generation, so the new one is added to
-            # the existing ones instead of replacing them.
+            # The model must agree with the tokenizer on the eos token from construction, so mirror it onto the model
+            # configs. The generation config may hold several eos tokens, any of which halts generation, so the new
+            # one is added to the existing ones instead of replacing them.
             model.config.eos_token_id = self._tokenizer.eos_token_id
             eos_token_ids = model.generation_config.eos_token_id
             if eos_token_ids is None:
@@ -1227,8 +1226,8 @@ class SFTTrainer(_BaseTrainer):
                     "in the vocabulary before using it as a padding token."
                 )
             self._tokenizer.pad_token = pad_token
-            # Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
-            # state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
+            # The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
+            # configs.
             model.config.pad_token_id = self._tokenizer.pad_token_id
             model.generation_config.pad_token_id = self._tokenizer.pad_token_id
             data_collator = DataCollatorForLanguageModeling(


### PR DESCRIPTION
This PR rewords the comment that accompanies the token sync added in #7097, #7128 and #7127, following the review on https://github.com/huggingface/trl/pull/7127#issuecomment-5603967168.

### Motivation

The comment argues why the line is safe rather than saying what it does:

```python
# Mirror the pad token onto the model configs: `Trainer` runs the same alignment at train time, so the end
# state is unchanged, but the model stays consistent with the tokenizer from the moment it is built.
```

"The end state is unchanged" is a claim about what `Trainer` does elsewhere, and it reads oddly next to a line whose whole purpose is that the state before `train()` is *not* the same. A reader of the trainer wants to know why the assignment is there, not why it is harmless.

### Solution

Say what the line does, and keep the parts that carry information a reader cannot get from the code:

```python
# The model must agree with the tokenizer on the pad token from construction, so mirror it onto the model
# configs.
```

The eos variants keep their second half, since the append semantics and the absent generation config on sequence classification models are both non-obvious:

```python
# The model must agree with the tokenizer on the eos token from construction, so mirror it onto the model
# configs. The generation config may hold several eos tokens, any of which halts generation, so the new
# one is added to the existing ones instead of replacing them.
```

```python
# The model must agree with the tokenizer on the eos token from construction, so mirror it onto the model
# config (a sequence classification model has no generation config).
```

Comments only. No code changes, no behavior changes.

### Changes

- Reword all 18 occurrences: 16 pad token ones across the SFT, DPO (x2), KTO, GRPO, RLOO and Distillation trainers and the nine experimental trainers, plus the two eos token ones in the SFT and Reward trainers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or training behavior impact.
> 
> **Overview**
> This PR **only rewords comments** next to the existing tokenizer→model token ID assignments (`model.config.pad_token_id`, `generation_config`, and eos variants). **No executable code changes.**
> 
> Across **SFT, DPO, KTO, GRPO, RLOO, Distillation, Reward**, and **nine experimental trainers**, the old text that argued the assignments were redundant with Hugging Face `Trainer` at train time is replaced with wording that states the **purpose**: keep **model config aligned with the tokenizer from construction**.
> 
> **Pad-token** sites use a shorter two-line comment. **EOS** paths in **SFT** and **Reward** keep extra notes (append-to-`eos_token_id` list behavior; no `generation_config` on sequence-classification models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae22e28ac0f25c3e8b0f97db814a8399928fe43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->