### PR TITLE
Cover the three generation config eos token shapes in the sync test

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -2308,21 +2308,32 @@ class TestSFTTrainer(TrlTestCase):
         assert trainer.model.config.pad_token_id == pad_token_id
         assert trainer.model.generation_config.pad_token_id == pad_token_id
 
-    def test_eos_token_id_synced_with_model_config(self):
+    @pytest.mark.parametrize(
+        "generation_eos_token_id, expected_eos_token_ids",
+        [
+            ([151645, 151643], [151644, 151645, 151643]),  # a list of ids, as Qwen and Llama ship
+            (151645, [151644, 151645]),  # a single id, as Mistral and GPT-2 ship
+            (None, [151644]),  # no id at all
+            ([151644, 151645], [151644, 151645]),  # a list that already holds the requested token
+        ],
+    )
+    def test_eos_token_id_synced_with_model_config(self, generation_eos_token_id, expected_eos_token_ids):
         # The trainer sets the requested eos token on the tokenizer. The model configs must follow: otherwise
-        # `Trainer` realigns them at train time and reports it as a change the user did not make.
+        # `Trainer` realigns them at train time and reports it as a change the user did not make. The generation
+        # config holds the eos token as a list, as a single id, or not at all, so cover the three shapes.
+        model = AutoModelForCausalLM.from_pretrained("trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", dtype="float32")
+        model.generation_config.eos_token_id = generation_eos_token_id
+
         dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
 
         training_args = SFTConfig(output_dir=self.tmp_dir, eos_token="<|im_start|>", report_to="none")
-        trainer = SFTTrainer(
-            model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
-        )
+        trainer = SFTTrainer(model=model, args=training_args, train_dataset=dataset)
 
         eos_token_id = trainer.processing_class.eos_token_id
         assert eos_token_id == 151644  # <|im_start|>
         assert trainer.model.config.eos_token_id == eos_token_id
         # The model's own eos tokens are kept, since any of them halts generation
-        assert trainer.model.generation_config.eos_token_id == [151644, 151645, 151643]
+        assert trainer.model.generation_config.eos_token_id == expected_eos_token_ids
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This PR extends the eos token sync test added in #7127 to every shape `generation_config.eos_token_id` takes, following the review there.

### Motivation

`SFTTrainer` branches on three shapes when it mirrors the eos token onto the generation config, because that is what checkpoints ship:

| Shape | Example |
|---|---|
| a list of ids | `Qwen2.5` ships `[151645, 151643]`, `Llama-3.1-8B-Instruct` ships `[128001, 128008, 128009]` |
| a single id | `Mistral-7B-v0.2` ships `2`, `gpt2` ships `50256` |
| nothing at all | some checkpoints leave it unset |

Only the list shape was covered. The single id is the most common one in the wild, and it is the branch where a wrong normalisation would produce a bare id instead of a list, or drop the model's other stop tokens. Any of the ids in that list halts generation, so getting it wrong changes when a model stops.

### Solution

Parametrise the test over the three shapes, plus the case where the list already holds the requested token, which is the one place the trainer deliberately differs from `align_special_tokens` by not appending a duplicate.

The shape is set explicitly on a loaded model rather than picked up from a fixture that happens to have it. Fixture generation configs are regenerated from their reference models and have changed before, so a test that reads its input shape from a fixture silently stops covering the branch it was written for.

### Changes

- Parametrise `test_eos_token_id_synced_with_model_config` over the list, single id, unset and already-present cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code modified.
> 
> **Overview**
> **Expands regression coverage** for how `SFTTrainer` mirrors a user-requested EOS token onto `generation_config.eos_token_id` without surprising `Trainer` realignments at train time.
> 
> `test_eos_token_id_synced_with_model_config` is now **parametrized** over four setups: EOS as a **list** (Qwen/Llama-style), a **single int** (Mistral/GPT-2-style), **unset** (`None`), and a list that **already includes** the requested token (no duplicate append). Each case loads a tiny Qwen model, **sets** `model.generation_config.eos_token_id` explicitly, builds the trainer with `eos_token="<|im_start|>"`, and asserts tokenizer/config sync plus the expected **merged** generation EOS list.
> 
> The test no longer relies on a fixture’s default generation config shape, so fixture regeneration cannot silently drop coverage of a branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4da19d8ffcf3004ee557f37661be52d6d12fe5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->