### PR TITLE
Cancel superseded PR runs in the test workflows

### DIFF
--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -14,6 +14,10 @@ env:
   PYTORCH_ALLOC_CONF: "expandable_segments:True"
   TRL_EXPERIMENTAL_SILENCE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_code_quality:
     name: Check code quality

--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -15,7 +15,7 @@ env:
   TRL_EXPERIMENTAL_SILENCE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ env:
   PYTORCH_ALLOC_CONF: "expandable_segments:True"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,10 @@ env:
   PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   PYTORCH_ALLOC_CONF: "expandable_segments:True"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_code_quality:
     name: Check code quality


### PR DESCRIPTION
## What does this PR do?

`build_pr_documentation.yml` cancels a PR's in-flight run when a new commit is pushed to the same branch. `tests.yml` and `tests-experimental.yml` do not, so every push to an open PR leaves the previous run occupying runners until it finishes on its own, testing a commit nobody will merge.

Over 2026-08-26 to 2026-09-10, 341 PR runs of `tests.yml` were superseded by a newer commit on the same branch and kept running anyway. **64 GPU-hours** of that was spent after the superseding run had already been created. That capacity is shared, so those runs also sit ahead of other PRs in the queue.

`tests.yml` books five GPU jobs per run (four on `aws-g6e-4xlarge`, one on `aws-g5-12xlarge-cache`), around 77 runner-minutes per full matrix.

This adds the same `concurrency` block the doc workflow already uses, keyed on the pull request number. `github.event.pull_request.number` is empty for `push` events, so the group falls back to the unique `github.run_id` and pushes to `main` and to `ci-*` branches are never cancelled. Only PR runs superseded by a newer commit on the same PR are.

The doc workflow keys on `github.head_ref`, which is only the branch name and is shared across forks, so two PRs that both use a branch called `patch-1` would cancel each other. Bugbot caught that on the first version of this PR. No two open PRs share a head branch name today, but 130 of the 182 open ones come from forks, so the collision is reachable and the PR number costs nothing. `build_pr_documentation.yml` still carries the `head_ref` form and could be aligned separately.

The 64 hours is the reclaimable part, not the full 352 hours those runs consumed, and it counts `tests.yml` only, so the estimate is conservative.

Part of #7169.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow configuration; no application or test logic changes, only earlier termination of obsolete PR runs.
> 
> **Overview**
> Adds GitHub Actions **concurrency** to `tests.yml` and `tests-experimental.yml` so an older workflow run is cancelled when a newer commit triggers another run for the same PR.
> 
> Each workflow uses `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}` with `cancel-in-progress: true`, matching the pattern already used for PR doc builds. PRs share one group per workflow via the PR number; non–pull-request triggers fall back to `run_id`, so pushes to `main` and `ci-*` are not cancelled by each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dca50d6a7c34ea70c5414e574325506a2e187de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->