### PR TITLE
Skip the tests on pushes that change no tested file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - main
       - ci-*
+    paths:
+      # Run only when relevant files are modified
+      - ".github/**.yml"
+      - ".pre-commit-config.yaml"
+      - "examples/**.py"
+      - "scripts/**.py"
+      - "tests/**.py"
+      - "trl/**.py"
+      - "pyproject.toml"
+      # Exclude if only experimental code/tests
+      - "!trl/experimental/**"
+      - "!tests/experimental/**"
   pull_request:
     paths:
       # Run only when relevant files are modified

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ on:
       # Exclude if only experimental code/tests
       - "!trl/experimental/**"
       - "!tests/experimental/**"
+  workflow_dispatch:
 
 env:
   TQDM_DISABLE: 1


### PR DESCRIPTION
## What does this PR do?

`tests.yml` filters `pull_request` events by path, so a docs-only PR correctly shows no GPU jobs. The `push:` trigger carries no filter, so the same change runs the full matrix once it lands on `main`.

Over 2026-08-26 to 2026-09-10, **27 of the 114 commits** that landed on `main` would not have matched the `pull_request` filter, 10 of them touching nothing but `.md` files. At around 77 GPU runner-minutes per matrix that is roughly **35 GPU-hours** in 15 days, spent testing commits the PR-side filter had already judged irrelevant.

Item 2 of #7169.

## Implementation, and the part worth discussing

`on.push` takes a single `paths` list for all of its branches, so the filter cannot apply to `main` alone. It also applies to `ci-*`, which is how a run is forced on demand today. A `ci-*` push whose diff does not match would now run nothing, which is a capability we would silently lose.

The second commit is the proposed answer: add `workflow_dispatch` so a run can be forced on any ref regardless of what the diff touches. That makes the force path explicit rather than a side effect of the branch name, and it is the piece I am least attached to. Alternatives if you prefer:

- Keep `ci-*` unfiltered by moving it to its own workflow, at the cost of a second file to keep in sync.
- Gate the jobs on a `changed-files` step instead of the trigger, which keeps one list but starts a runner to decide it does not need one.
- Drop the second commit and accept that forcing a run requires a diff that matches.

Note the two `paths` lists are now duplicated: GitHub Actions does not expand YAML anchors, so this cannot be factored out. They have to be kept in sync by hand.

## Behaviour change to be aware of

A docs-only merge produces no `main` run at all for that SHA, so `main` will have commits with no test result attached. That is the intent, and it matches the judgement the PR-side filter already makes, but it does change what a green `main` history looks like.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions trigger configuration changes; no application or security logic, though main may show commits without attached test runs for path-skipped pushes.
> 
> **Overview**
> Aligns **`push`** on `main` and `ci-*` with the existing **`pull_request`** path filters so the full GPU test matrix no longer runs when a merge only touches docs or other out-of-scope paths (same include/exclude rules for `trl/**`, tests, workflows, etc.).
> 
> Adds **`workflow_dispatch`** so tests can still be triggered manually on any ref without relying on a `ci-*` push that might no longer match the new push filter.
> 
> **Note:** `push` and `pull_request` now duplicate the same `paths` list; both must be updated together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10e8d903112d1b87203a7cf0d7aab35ea83f08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->