### PR TITLE
Cancel superseded runs on main

### DIFF
--- a/.github/workflows/tests-experimental.yml
+++ b/.github/workflows/tests-experimental.yml
@@ -15,7 +15,7 @@ env:
   TRL_EXPERIMENTAL_SILENCE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
+        if: github.ref == 'refs/heads/main' && !cancelled()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
@@ -151,7 +151,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
+        if: github.ref == 'refs/heads/main' && !cancelled()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
@@ -201,7 +201,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
+        if: github.ref == 'refs/heads/main' && !cancelled()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
@@ -255,7 +255,7 @@ jobs:
           make test
 
       - name: Post to Slack
-        if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
+        if: github.ref == 'refs/heads/main' && !cancelled()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
@@ -307,7 +307,7 @@ jobs:
           pytest -v tests/distributed/test_distributed.py
 
       - name: Post to Slack
-        if: github.ref == 'refs/heads/main' && always()  # Check if the branch is main
+        if: github.ref == 'refs/heads/main' && !cancelled()  # Check if the branch is main
         uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ env:
   PYTORCH_ALLOC_CONF: "expandable_segments:True"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Stacked on #7170, which adds the `concurrency` block this PR changes. Item 3 of #7169.

#7170 cancels superseded runs on pull requests only: its `github.event.pull_request.number || github.run_id` fallback gives every push event a unique group, so pushes are never cancelled. This changes the fallback to `github.ref`, which groups push runs by the branch they are on, so a newer push to `main` cancels the run started by the previous merge.

Over 2026-08-26 to 2026-09-10, 113 runs were started by pushes to `main`, consuming 145 GPU-hours. **71 of them, 63%, were superseded by the next merge before they finished**, and **77 GPU-hours** were spent on them after the next merge had already landed. Each of those runs was answering a question about a `main` that no longer existed.

## The decision this asks you to make

`main` runs can mean one of two things, and they point at different implementations:

- **A current-state check**: is `main` green right now. Then all but the newest run are redundant and this PR is the right shape.
- **A per-commit record**: every SHA on `main` carries its own result, for bisection. Then cancelling loses information, and the alternative is the GitHub merge queue, which tests batches before they land rather than after.

Worth noting that with squash merges every commit on `main` arrives from a PR that has already run the full matrix, so the per-commit record is a second opinion on an already tested tree rather than the only signal.

## Why the Slack change is in the same PR

The five `Post to Slack` steps are conditioned on `always()`, and the local action already renders a `cancelled` state with its own emoji. Enabling cancellation without touching them would have posted five "cancelled" messages for every superseded run, which over the measured window would have been around 355 extra messages in the channel. `!cancelled()` keeps success and failure reporting and drops only the cancelled ones.

## Note on `tests-experimental.yml`

Its `push` trigger covers `ci-*` only, not `main`, so this changes nothing about how it behaves on merges. The group expression is updated there too so the two workflows do not drift apart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; the main tradeoff is losing completed per-SHA results on `main` when runs are cancelled, which the team is explicitly choosing over redundant GPU time.
> 
> **Overview**
> Updates GitHub Actions **concurrency** so push workflows group by branch, not per-run ID. In `tests.yml` and `tests-experimental.yml`, the group expression changes from `github.event.pull_request.number || github.run_id` to `github.event.pull_request.number || github.ref`, so a newer push to the same branch (especially **`main`**) cancels an in-progress run from an earlier commit while PR runs still key off the PR number.
> 
> In **`tests.yml`**, all five **Post to Slack** steps on `main` switch from `always()` to `!cancelled()`, so superseded runs that get cancelled no longer flood the CI channel with cancelled notifications.
> 
> The experimental workflow gets the same group string so it stays aligned with the main test workflow; its push trigger does not include `main`, so merge behavior there is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52805819e1a9e2e131271d015ea97baf3344ac31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->