### PR TITLE
Key the doc build concurrency group on the pull request number

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -7,7 +7,7 @@ env:
   TRL_EXPERIMENTAL_SILENCE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

`build_pr_documentation.yml` keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks that both use a branch called `patch-1` therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

`github.event.pull_request.number` is unique per pull request. This workflow only triggers on `pull_request`, so the `github.run_id` fallback is never reached, but it is kept so the block stays identical to the one in `tests.yml` and `tests-experimental.yml`. Happy to drop it if you would rather the expression say only what this workflow needs.

Bugbot found the same pattern on https://github.com/huggingface/trl/pull/7170#discussion_r3979963943, where it had been copied from here. No two of the 182 currently open PRs share a head branch name, but 130 of them come from forks, so the collision is reachable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow concurrency expression change with no runtime or application impact.
> 
> **Overview**
> **Fixes cross-PR doc build cancellations** when multiple forks use the same branch name (e.g. `patch-1`).
> 
> The **Build PR Documentation** workflow’s `concurrency.group` now uses `github.event.pull_request.number` instead of `github.head_ref`, so each PR gets its own group and pushes on one PR no longer cancel in-flight doc builds on another. The `github.run_id` fallback is unchanged for parity with other workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5adea5af0436da0b54983913bd1145c9c109143c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->