### PR TITLE
Remove outdated "under construction" banners from docs

### DIFF
--- a/docs/source/deepspeed_integration.md
+++ b/docs/source/deepspeed_integration.md
@@ -1,8 +1,5 @@
 # DeepSpeed Integration
 
-> [!WARNING]
-> Section under construction. Feel free to contribute!
-
 TRL supports training with DeepSpeed, a library that implements advanced training optimization techniques. These include optimizer state partitioning, offloading, gradient partitioning, and more.
 
 DeepSpeed integrates the [Zero Redundancy Optimizer (ZeRO)](https://huggingface.co/papers/1910.02054), which allows to scale the model size proportional to the number of devices with sustained high efficiency.

--- a/docs/source/distributing_training.md
+++ b/docs/source/distributing_training.md
@@ -1,8 +1,5 @@
 # Distributing Training
 
-> [!WARNING]
-> Section under construction. Feel free to contribute!
-
 ## Multi-GPU Training with TRL
 
 The trainers in TRL use [🤗 Accelerate](https://github.com/huggingface/accelerate) to enable distributed training across multiple GPUs or nodes. To do so, first create an [🤗 Accelerate](https://github.com/huggingface/accelerate) config file by running


### PR DESCRIPTION
The DeepSpeed integration and distributing training pages were the last two still flagged as under construction. Both have been complete for a while (multi-GPU, multi-node, SLURM, ZeRO configs), the banners date from the 2025 stubs (#2956, #2993).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only removal of warning callouts with no behavioral or API impact.
> 
> **Overview**
> Removes the stale **“Section under construction”** GitHub warning callouts from the **DeepSpeed Integration** and **Distributing Training** docs pages. No other content on those pages is changed—the banners were left over from early stubs while the guides already document installation, Accelerate launch, multi-GPU/multi-node, SLURM, and ZeRO configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ce02969c753a27f6c1d734854eed339635fd67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->