### PR TITLE
Add support for vLLM 0.29.0

### DIFF
--- a/docs/source/vllm_integration.md
+++ b/docs/source/vllm_integration.md
@@ -3,7 +3,7 @@
 This document will guide you through the process of using vLLM with TRL for faster generation in online methods like GRPO and Online DPO. We first summarize a tl;dr on how to use vLLM with TRL, and then we will go into the details of how it works under the hood.
 
 > [!WARNING]
-> TRL currently only supports vLLM versions from `0.19.1` to `0.28.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
+> TRL currently only supports vLLM versions from `0.19.1` to `0.29.0`. Please ensure you have a version in this range installed to avoid compatibility issues.
 
 > [!TIP]
 > The following trainers currently support generation with vLLM:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ test = [
     "tabulate"  # test report rendering in scripts/log_reports.py
 ]
 vllm = [
-    "vllm>=0.19.1,<=0.28.0",
+    "vllm>=0.19.1,<=0.29.0",
     "aiohttp>=3.13.3",
     "requests",
 ]

--- a/trl/import_utils.py
+++ b/trl/import_utils.py
@@ -104,9 +104,9 @@ def is_vllm_available(min_version: str | None = None) -> bool:
         # Use base_version to drop any local segment (e.g. the "+cu129" in "0.24.0+cu129"), which PEP 440 orders
         # above the plain release and would otherwise fail the upper-bound check.
         _vllm_base_version = Version(Version(_vllm_version).base_version)
-        if not (Version("0.19.1") <= _vllm_base_version <= Version("0.28.0")):
+        if not (Version("0.19.1") <= _vllm_base_version <= Version("0.29.0")):
             warnings.warn(
-                f"TRL currently supports vLLM versions from 0.19.1 to 0.28.0. You have version {_vllm_version} "
+                f"TRL currently supports vLLM versions from 0.19.1 to 0.29.0. You have version {_vllm_version} "
                 "installed. We recommend installing a supported version to avoid compatibility issues.",
                 stacklevel=2,
             )


### PR DESCRIPTION
Checked the v0.29.0 release notes against what TRL uses: **no breaking change for TRL.** vLLM 0.29.0 rides the same `>= 0.28.0` weight-transfer branch added in #7001, so this is a cap-only bump in the usual three places.

### Relevant, no change needed

* **Weight transfer**: `nccl_common.trainer_init` and `packed_tensor.packed_nccl_broadcast_producer` are unchanged at v0.29.0 (identical signatures), and the packed-stream reuse fix (vllm-project/vllm#52951) is internal. The new RL backends (`sharded_rdt` vllm-project/vllm#43375, rank-local IPC vllm-project/vllm#52497, sparse checkpoint vllm-project/vllm#50723) are additive.
* **Model Runner V2 now default for all models (vllm-project/vllm#53183)**: colocate mode's `driver_worker.model_runner.model.load_weights` chain still resolves; MRV2 also fixes memory release on sleep (vllm-project/vllm#53508 etc.), which colocate sleep mode benefits from.
* **`python -m vllm.entrypoints.openai.api_server` deprecated (vllm-project/vllm#52131)**: TRL launches `vllm.entrypoints.cli.main serve`, unaffected. All 9 dev-mode RLHF routes TRL calls are still registered.
* Every other imported symbol resolves; no torch change when upgrading from 0.28.0 (still 2.13.0+cu130).

## Support window

<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/6b2edec2-08bd-4d72-b791-1b8ae1108afa" />

0.29.0 released 9 Sep 2026, ages out ~9 Feb 2027. Next drop: 0.19.1 on **18 Sep 2026**.

### Tests

4×H100, torch 2.13.0+cu130. `tests/test_vllm_client_server.py`: **39 passed, 1 xfailed** (the 14 warnings are one `torch.jit.script_method` deprecation from inside torch, pulled in by the new flashinfer dependency). Async GRPO 3-step smoke against `vllm serve` 0.29.0: 4 weight syncs, 21/21 routes 200, `weight_sync_s` 0.1252.

<details><summary>pytest, vLLM 0.29.0</summary>

```
$ pytest -v tests/test_vllm_client_server.py
========== test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /fsx/qgallouedec/miniconda3/envs/trl/bin/python
cachedir: .pytest_cache
rootdir: /fsx/qgallouedec/trl-wt-vllm029
configfile: pyproject.toml
plugins: transformers-ci-0.1.0, anyio-4.14.2, xdist-3.8.0
collecting ... collected 40 items

tests/test_vllm_client_server.py::TestParseLogprobs::test_completion_logprobs_sorted_by_probability PASSED [  2%]
tests/test_vllm_client_server.py::TestParseLogprobs::test_chat_logprobs PASSED [  5%]
tests/test_vllm_client_server.py::TestParseLogprobs::test_returns_none_when_logprobs_missing PASSED [  7%]
tests/test_vllm_client_server.py::TestExtractLogprobs::test_extract_logprobs_sorts_by_rank_and_replaces_nan PASSED [ 10%]
tests/test_vllm_client_server.py::TestExtractLogprobs::test_extract_logprobs_returns_none_token_ids_when_logprobs_missing PASSED [ 12%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate PASSED [ 15%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_logprobs_none PASSED [ 17%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat PASSED [ 20%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat_with_logprobs_none PASSED [ 22%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_chat_with_tools PASSED [ 25%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_token_ids PASSED [ 27%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_generate_with_params PASSED [ 30%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_update_model_params PASSED [ 32%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_reset_prefix_cache PASSED [ 35%]
tests/test_vllm_client_server.py::TestVLLMClientServer::test_logprobs_match_with_non_default_sampling XFAIL [ 37%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate PASSED [ 40%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_logprobs_none PASSED [ 42%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat PASSED [ 45%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat_with_logprobs_none PASSED [ 47%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_chat_with_tools PASSED [ 50%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_token_ids PASSED [ 52%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_generate_with_params PASSED [ 55%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_update_model_params PASSED [ 57%]
tests/test_vllm_client_server.py::TestVLLMClientServerBaseURL::test_reset_prefix_cache PASSED [ 60%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate PASSED [ 62%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_logprobs_none PASSED [ 65%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat PASSED [ 67%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat_with_logprobs_none PASSED [ 70%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_chat_with_tools PASSED [ 72%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_token_ids PASSED [ 75%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_generate_with_params PASSED [ 77%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_update_model_params PASSED [ 80%]
tests/test_vllm_client_server.py::TestVLLMClientServerTP::test_reset_prefix_cache PASSED [ 82%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_int PASSED [ 85%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_device_string PASSED [ 87%]
tests/test_vllm_client_server.py::TestVLLMClientServerDeviceParameter::test_init_communicator_with_torch_device PASSED [ 90%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_from_token_ids_and_images PASSED [ 92%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_generate_from_token_ids_without_images PASSED [ 95%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_chat_with_images PASSED [ 97%]
tests/test_vllm_client_server.py::TestVLLMClientServerVLM::test_chat_with_mixed_images PASSED [100%]

=============================== warnings summary ===============================
../miniconda3/envs/trl/lib/python3.13/site-packages/torch/jit/_script.py:365: 14 warnings
  /fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 39 passed, 1 xfailed, 14 warnings in 1376.09s (0:22:56) ============
```
</details>

<details><summary>async GRPO smoke, vLLM 0.29.0</summary>

```
# server log, first sync round (3 more identical rounds follow, one per step)
127.0.0.1:58130 - "POST /init_weight_transfer_engine HTTP/1.1" 200 OK
127.0.0.1:52422 - "POST /pause?mode=keep HTTP/1.1" 200 OK
127.0.0.1:52436 - "POST /start_weight_update HTTP/1.1" 200 OK
127.0.0.1:52444 - "POST /update_weights HTTP/1.1" 200 OK
127.0.0.1:52454 - "POST /finish_weight_update HTTP/1.1" 200 OK
127.0.0.1:52460 - "POST /resume HTTP/1.1" 200 OK

# trainer
{'loss': '0', 'grad_norm': '0', 'learning_rate': '1e-06', 'perf/weight_sync_s': '0.1252', 'perf/weight_sync_pause_s': '0.02959', 'perf/weight_sync_barrier_s': '1.872e-05', 'perf/weight_sync_transfer_s': '0.09342', 'sample/rollout_queue_size': '1.552', 'sample/time_in_queue_s': '0.0002892', 'sample/staleness_mean': '0', 'sample/staleness_max': '0', 'sample/forwarded_tokens_mean': '133.9', 'sample/f
...
{'train_runtime': '49.83', 'train_samples_per_second': '0.241', 'train_steps_per_second': '0.06', 'train_loss': '0', 'epoch': '1'}
ASYNC_SMOKE_OK
```
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-cap and docs-only changes with no behavioral logic beyond allowing 0.29.0 installs and suppressing the unsupported-version warning in-range.
> 
> **Overview**
> Extends TRL’s supported vLLM window to **0.29.0** by raising the upper bound from `0.28.0` in three places: the `trl[vllm]` extra in `pyproject.toml`, the runtime range check and warning in `is_vllm_available()` in `import_utils.py`, and the integration docs warning.
> 
> No integration or trainer code changes—only dependency pinning and documentation aligned with the new cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e934806f85a5934407b1bce39d4d3b51ff245dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->