### PR TITLE
Drop the Slack action checkout workaround from the latest release tests

### DIFF
--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -61,19 +61,9 @@ jobs:
           source .venv/bin/activate
           make test
 
-      # This job checks out the release branch, which predates the local Slack action, so check
-      # the action out from the branch running the workflow. Keep this step on `always()`: it must
-      # never be skipped while the Slack step below runs, or the action cannot be resolved.
-      - name: Check out the Slack action
-        if: always()
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          path: slack-action
-          sparse-checkout: .github/actions
-
       - name: Post to Slack
         if: always()
-        uses: ./slack-action/.github/actions/post-slack
+        uses: ./.github/actions/post-slack
         with:
           slack_channel: ${{ env.CI_SLACK_CHANNEL }}
           title: Tests latest TRL release with dev dependencies


### PR DESCRIPTION
This PR removes the extra checkout that the daily latest-release test workflow needed to resolve the local Slack action.

### Motivation

`tests_latest.yml` checks out a release branch instead of the branch running the workflow. When the local `post-slack` composite action was introduced, the release branch in use at the time (`v1.10-release`) predated it, so `./.github/actions/post-slack` could not be resolved and the action had to be checked out separately.

That is no longer the case: the workflow now runs against `v1.13-release`, which ships the action, and its copy is identical to the one on `main`, so the inputs passed by the Slack step still match.

### Solution

Resolve the action from the workspace, as every other workflow in the repository already does.

### Changes

- Remove the `Check out the Slack action` step and its comment
- Point the `Post to Slack` step at `./.github/actions/post-slack`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the Slack notification action is resolved; no application or runtime behavior changes.
> 
> **Overview**
> Simplifies the daily **tests latest release** workflow now that `v1.13-release` includes the local Slack composite action.
> 
> Removes the extra `actions/checkout` step that sparse-checked out `.github/actions` from the triggering branch, and points **Post to Slack** at `./.github/actions/post-slack` like the rest of the repo’s workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c27d3d602084ad595caf35a503a2627341b839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->