### PR TITLE
Move the latest release tests from T4 to L40S

### DIFF
--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -16,9 +16,7 @@ jobs:
   tests:
     name: Tests latest TRL release with dev dependencies
     runs-on:
-      # TODO: move to aws-g6e-4xlarge (L40S) once v1.11 ships; v1.10-release predates the flash-attn2 xfails and
-      # would fail on Ada hardware
-      group: aws-g4dn-2xlarge
+      group: aws-g6e-4xlarge
     container:
       image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
       options: --gpus all


### PR DESCRIPTION
This PR runs the daily latest-release tests on the same GPU runner as the rest of the GPU CI.

### Motivation

`tests_latest.yml` stayed on `aws-g4dn-2xlarge` (T4) when the other GPU workflows moved to `aws-g6e-4xlarge` (L40S) in #6741: the release branch in use at the time (`v1.10-release`) predated the flash-attn2 xfail markers and would have failed on Ada hardware. It is now the only GPU workflow left on T4.

Both halves of that reason are gone. The workflow runs against `v1.13-release`, and the xfail markers were removed in #7057 once the padding-free tests passed.

### Solution

On T4, `is_ampere_or_newer()` skips the two padding-free tests, so the move makes them run: `tests/test_dpo_trainer.py::TestDPOTrainer::test_train_padding_free` and `tests/test_sft_trainer.py::TestSFTTrainer::test_train_padding_free`. Both are identical on `v1.13-release` and `main`, and both pass on L40S in the `Tests with dev dependencies` job of `tests.yml`, which uses the same container, runner and dependency set as this workflow.

The other tests gated on `is_ampere_or_newer()` are unaffected: the GRPO continuous batching test is marked slow, and the experimental ones are excluded from collection by `norecursedirs`.

### Changes

- Run the job on `aws-g6e-4xlarge` instead of `aws-g4dn-2xlarge`
- Remove the obsolete TODO about the runner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner change with no application code touched; expanded test execution matches the existing dev-dependencies GPU job that already passes on the same hardware.
> 
> **Overview**
> Aligns the daily **Tests latest TRL release with dev dependencies** workflow with the rest of GPU CI by switching the runner from `aws-g4dn-2xlarge` (T4) to `aws-g6e-4xlarge` (L40S) and dropping the outdated TODO that blocked the move.
> 
> On L40S, `is_ampere_or_newer()` is true, so the job will **execute** the padding-free DPO and SFT trainer tests that were previously skipped on T4; other Ampere-gated tests stay unchanged (slow GRPO batching, experimental paths excluded from collection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b547b235aa21d0e5a0694e8edcb262412a9ff362. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->