### PR TITLE
Use the canonical id for the tiny GPTNeoX sequence classification model

### DIFF
--- a/tests/test_chat_template_utils.py
+++ b/tests/test_chat_template_utils.py
@@ -103,9 +103,9 @@ class TestCloneChatTemplate(TrlTestCase):
 
     def test_clone_with_sequence_classification_model(self):
         # This tokenizer doesn't have a chat_template by default
-        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GptNeoXForSequenceClassification")
+        tokenizer = AutoTokenizer.from_pretrained("trl-internal-testing/tiny-GPTNeoXForSequenceClassification")
         model = AutoModelForSequenceClassification.from_pretrained(
-            "trl-internal-testing/tiny-GptNeoXForSequenceClassification"
+            "trl-internal-testing/tiny-GPTNeoXForSequenceClassification"
         )
         # This one has a chat_template by default
         source = "trl-internal-testing/tiny-Qwen3ForCausalLM"
@@ -401,7 +401,7 @@ class TestSupportsToolCalling:
             pytest.param("trl-internal-testing/tiny-BloomForCausalLM", id="bloom"),
             pytest.param("trl-internal-testing/tiny-GPT2LMHeadModel", id="gpt2"),
             pytest.param("trl-internal-testing/tiny-GPTNeoXForCausalLM", id="gptneox"),
-            pytest.param("trl-internal-testing/tiny-GptNeoXForSequenceClassification", id="gptneox-seq"),
+            pytest.param("trl-internal-testing/tiny-GPTNeoXForSequenceClassification", id="gptneox-seq"),
             pytest.param("trl-internal-testing/tiny-OPTForCausalLM", id="opt"),
             pytest.param("trl-internal-testing/tiny-T5ForConditionalGeneration", id="t5"),
             # TemplateError: rejects tool role sequence


### PR DESCRIPTION
`tests/test_chat_template_utils.py` refers to the tiny model as `trl-internal-testing/tiny-GptNeoXForSequenceClassification`, but the repository is `trl-internal-testing/tiny-GPTNeoXForSequenceClassification`. The Hub resolves the misspelt id with a 307 redirect, so the tests pass either way and nothing has ever failed because of it.

### Why it matters

`apply_model_revisions` in `tests/conftest.py` injects the revision only on an exact match:

```python
if pretrained_model_name_or_path in MODEL_REVISIONS:
```

So a `MODEL_REVISIONS` entry written with the canonical id would not match these three call sites. The tests would quietly load the default branch instead of `refs/pr/N`, pass, and report a tiny model PR as tested when it was not. One of the three call sites loads the model as well as the tokenizer, so this covers config and weights, not just the chat template.

Nothing is affected retroactively: `MODEL_REVISIONS` has never carried an entry for this model, and the Hub repo has no PRs.

Found while checking which tiny models the revision override can actually reach.

### Changes

- Spell the model id as `tiny-GPTNeoXForSequenceClassification` at its three occurrences

It also matches the line directly above it in the tool-calling list, which already uses `tiny-GPTNeoXForCausalLM`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only string fixes with no runtime or production code changes.
> 
> **Overview**
> Updates three references in `tests/test_chat_template_utils.py` from `trl-internal-testing/tiny-GptNeoXForSequenceClassification` to the canonical Hub id `tiny-GPTNeoXForSequenceClassification` (tokenizer/model load in `test_clone_with_sequence_classification_model`, plus the `gptneox-seq` param in the tool-calling negative test).
> 
> Tests still pass today because the Hub redirects the old spelling; the fix matters so `apply_model_revisions`’ exact `MODEL_REVISIONS` lookup would apply `refs/pr/N` to these call sites instead of silently loading the default branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d3b467eb812e95fd946a9540a65d0f662d9967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->