### PR TITLE
Train the tiny DeepSeek-R1-Distill model in the SFT test

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -321,6 +321,7 @@ class TestSFTTrainer(TrlTestCase):
             ),
             "trl-internal-testing/tiny-GptOssForCausalLM",
             "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+            "trl-internal-testing/tiny-Qwen2ForCausalLM-R1-Distill",
             "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
             pytest.param(
                 "trl-internal-testing/tiny-NemotronHForCausalLM-nano",


### PR DESCRIPTION
`trl-internal-testing/tiny-Qwen2ForCausalLM-R1-Distill` is used in three places, all in `tests/test_chat_template_utils.py`, and all through `AutoTokenizer`. Nothing in the suite loads its config or weights.

That is how #7135 came to align this model's `vocab_size`, `bos_token_id`, `eos_token_id`, `max_position_embeddings` and `max_window_layers` against fields no test reads. The `MODEL_REVISIONS` run before that merge did fire, since the tokenizer loads are patched too, but it could only confirm the tokenizer and chat template, never the config the PR actually changed.

Adding the model to `test_train` closes that: `SFTTrainer` loads it from the id, so config and weights are read, and a training step runs. It is the same coverage that made the FalconMamba check in #7139 meaningful.

### Changes

- Add `tiny-Qwen2ForCausalLM-R1-Distill` to the `test_train` model list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code paths modified.
> 
> **Overview**
> Adds **`trl-internal-testing/tiny-Qwen2ForCausalLM-R1-Distill`** to the parametrized `test_train` model list in `test_sft_trainer.py`, so CI runs the same **SFTTrainer** smoke test (load config/weights, train one step, assert loss and updated params) for that checkpoint.
> 
> This closes a coverage gap: the tiny R1-Distill model was only exercised via **`AutoTokenizer`** in chat-template tests, so changes to model config fields were not validated during training.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025787f4bf82c285ff4cb247a4852cd88923156c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->