### PR TITLE
docs: fix the clip explanation in the GRPO trainer page

### DIFF
--- a/docs/source/grpo_trainer.md
+++ b/docs/source/grpo_trainer.md
@@ -107,7 +107,7 @@ $$
 \mathcal{L}_{\text{GRPO}}(\theta) = - \frac{1}{\sum_{i=1}^G |o_i|} \sum_{i=1}^G \sum_{t=1}^{|o_i|} \left[ \min \left( \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_{\text{old}}}(o_{i,t} \mid q, o_{i,< t})} \hat{A}_{i,t}, \, \text{clip}\left( \frac{\pi_\theta(o_{i,t} \mid q, o_{i,< t})}{\pi_{\theta_{\text{old}}}(o_{i,t} \mid q, o_{i,< t})}, 1 - \epsilon, 1 + \epsilon \right) \hat{A}_{i,t} \right) - \beta \mathbb{D}_{\text{KL}}\left[\pi_\theta \| \pi_{\text{ref}}\right] \right],
 $$
 
-where  \\(\text{clip}(\cdot, 1 - \epsilon, 1 + \epsilon) \\) ensures that updates do not deviate excessively from the reference policy by bounding the policy ratio between  \\( 1 - \epsilon \\) and  \\( 1 + \epsilon \\).
+where  \\(\text{clip}(\cdot, 1 - \epsilon, 1 + \epsilon) \\) ensures that updates do not deviate excessively from the old policy  \\( \pi_{\theta_{\text{old}}} \\) by bounding the policy ratio between  \\( 1 - \epsilon \\) and  \\( 1 + \epsilon \\).
 When  \\( \mu = 1 \\) (default in TRL), the clipped surrogate objective simplifies to the original objective.
 
 #### Loss Types


### PR DESCRIPTION
# What does this PR do?

The GRPO trainer page explains the clip term with this sentence:

> where clip(·, 1−ε, 1+ε) ensures that updates do not deviate excessively from the reference policy by bounding the policy ratio between 1−ε and 1+ε.

The ratio inside the clip is π_θ / π_θ_old. So the clip term limits how far the update moves from the old policy, not from the reference policy. The reference policy is a separate model in this loss. It appears only in the KL penalty, which the page covers one section above.

I changed "reference policy" to "old policy" and added the symbol. One line, docs only.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [x] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [ ] AI-generated: the PR was mostly or fully generated by an AI tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or API impact.
> 
> **Overview**
> Corrects a **terminology mistake** in the GRPO trainer docs for the clipped surrogate objective: the explanation of `clip(·, 1−ε, 1+ε)` now says it limits how far updates move from the **old policy** \( \pi_{\theta_{\text{old}}} \), not the reference policy.
> 
> That matches the ratio \( \pi_\theta / \pi_{\theta_{\text{old}}} \) in the displayed loss; the reference policy remains only in the separate KL term above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5b6b0f797a0f555e920e787a1c139529e2edf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->