### PR TITLE
Only dedupe offloaded activation storages in streams mode

### DIFF
--- a/tests/test_activation_offloading.py
+++ b/tests/test_activation_offloading.py
@@ -283,3 +283,32 @@ class TestActivationOffloading(TrlTestCase):
 
         param_ptrs = {p.data.untyped_storage().data_ptr() for p in model.parameters()}
         assert offload_ctx.param_storages == param_ptrs, "Tracked storages should match parameter storages"
+
+    @require_torch_accelerator
+    def test_tensor_deduplication_only_happens_in_streams_mode(self):
+        """Two saved views of the same storage are deduplicated (one re-offload skipped) only when use_streams=True."""
+
+        class SaveTensor(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tensor):
+                ctx.save_for_backward(tensor)
+                return tensor.sum()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (tensor,) = ctx.saved_tensors
+                return torch.ones_like(tensor) * grad_output
+
+        def offload_two_views(use_streams: bool) -> list[bool]:
+            base = torch.randn(64, 64, device=torch_device, requires_grad=True)
+            view1 = base.view(-1)
+            view2 = base.transpose(0, 1)
+            offload_ctx = OffloadActivations(use_streams=use_streams, min_offload_size=1)
+            with offload_ctx:
+                loss = SaveTensor.apply(view1) + SaveTensor.apply(view2)
+            modified_flags = [modified for _, modified, _, _, _ in offload_ctx.tracker.values()]
+            loss.backward()
+            return modified_flags
+
+        assert offload_two_views(use_streams=False) == [True, True]
+        assert offload_two_views(use_streams=True) == [True, False]

--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -222,11 +222,11 @@ class OffloadActivations(saved_tensors_hooks):
             num_bytes = get_num_bytes_tensor(activation)
             tensor_id = get_tensor_id()
 
-            # Check for tensor deduplication using storage pointer
+            # Check for tensor deduplication using storage pointer in streams mode.
             # If this storage is already being tracked, we still create a new tensor_id
-            # but don't offload again (just keep the tensor in GPU)
+            # but don't offload again (just keep the tensor in GPU).
             storage_key = _get_unique_tensor_key(activation)
-            if storage_key in self.storage_to_tensor_id:
+            if self.use_streams and storage_key in self.storage_to_tensor_id:
                 # Storage already offloaded - don't offload again, just track the reference
                 self.tracker[tensor_id] = (activation, False, None, None, None)  # Keep on GPU, don't offload
                 track_storage_key(storage_key, tensor_id)


### PR DESCRIPTION
# What does this PR do?

Makes the activation-offload storage dedup check explicitly streams-only. `fwd_stash` gives streams mode a clear point to release a deduped reference; single-stream mode has none, so reusing the same dedup path there was unintentional.

Split out of #6280 per review, with a test added to show what changes: two saved views of the same storage now get deduplicated only when `use_streams=True`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

cc @qgallouedec @winglian

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offloading behavior for `use_streams=False` (more CPU offloads for shared-storage views), which affects memory and correctness paths in activation offloading during training.
> 
> **Overview**
> **Restricts activation storage deduplication to `use_streams=True`** in `OffloadActivations.pack_tensor`: shared-storage views are only skipped for a second offload when streams mode is on, because `fwd_stash` can release dedup tracking; single-stream mode no longer takes that path and offloads each saved tensor independently.
> 
> Adds **`test_tensor_deduplication_only_happens_in_streams_mode`**, which saves two views of the same storage via a custom autograd function and asserts tracker `modified` flags are `[True, True]` without streams vs `[True, False]` with streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a9ee355aa8cbf70953559c29588297d48361bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->