### PR TITLE
Add selective activation checkpointing (SAC) to SFT

### DIFF
--- a/docs/source/paper_index.md
+++ b/docs/source/paper_index.md
@@ -1331,6 +1331,21 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml
     --output_dir diffusiongemma-26B-A4B-it-gsm8k-lora
 ```
 
+### Reducing Activation Recomputation in Large Transformer Models
+
+**📜 Paper**: https://huggingface.co/papers/2205.05198
+
+Full activation checkpointing recomputes every op in a checkpointed region during backward, including attention, even though only a few ops (attention among them) account for most of the recomputation cost relative to the memory they'd cost to keep. The paper's selective activation recomputation checkpoints only those expensive ops instead of the whole region. TRL implements this as selective activation checkpointing (SAC) for [`SFTTrainer`], saving the attention output during the forward pass so backward does not recompute it:
+
+```python
+from trl import SFTConfig
+
+training_args = SFTConfig(
+    gradient_checkpointing=True,
+    selective_activation_checkpointing=True,
+)
+```
+
 ## Parameter-Efficient Fine-Tuning (PEFT)
 
 For general details on using PEFT with TRL, please refer to the [PEFT Integration](peft_integration) guide.

--- a/tests/test_selective_activation_checkpointing.py
+++ b/tests/test_selective_activation_checkpointing.py
@@ -1,0 +1,79 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch.utils.checkpoint import CheckpointPolicy
+from transformers import AutoModelForCausalLM
+from transformers.testing_utils import torch_device
+
+from trl.models.selective_activation_checkpointing import (
+    _aten_attention_ops,
+    _build_policy_fn,
+    enable_selective_activation_checkpointing,
+)
+
+from .testing_utils import TrlTestCase, require_torch_accelerator
+
+
+class TestSelectiveActivationCheckpointingPolicy(TrlTestCase):
+    """Exercises the SAC policy directly, against real and fake ops, so it needs no accelerator or model."""
+
+    def test_saves_aten_sdpa_ops(self):
+        aten_attention_ops = _aten_attention_ops()
+        assert aten_attention_ops, "At least one SDPA backend should be registered under torch.ops.aten"
+        policy_fn = _build_policy_fn(aten_attention_ops)
+        for op in aten_attention_ops:
+            assert policy_fn(None, op) == CheckpointPolicy.MUST_SAVE
+
+    def test_saves_flash_attn_ops_by_name(self):
+        # flash-attn's custom kernels live under hashed namespaces (e.g. `_flash_attn2_cuda_f12afc9::varlen_fwd`),
+        # so they can only be recognized by substring, not by identity like the aten ops above.
+        policy_fn = _build_policy_fn(set())
+        assert policy_fn(None, "flash_attn2_cuda::varlen_fwd") == CheckpointPolicy.MUST_SAVE
+
+    def test_recomputes_everything_else(self):
+        policy_fn = _build_policy_fn(_aten_attention_ops())
+        assert policy_fn(None, torch.ops.aten.mm.default) == CheckpointPolicy.PREFER_RECOMPUTE
+
+
+@require_torch_accelerator
+class TestSelectiveActivationCheckpointing(TrlTestCase):
+    model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+
+    def test_matches_full_checkpointing(self):
+        """SAC must produce the same gradients as full checkpointing."""
+        model_full = AutoModelForCausalLM.from_pretrained(self.model_id, attn_implementation="sdpa").to(torch_device)
+        model_full.train()
+        model_full.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+
+        model_sac = AutoModelForCausalLM.from_pretrained(self.model_id, attn_implementation="sdpa").to(torch_device)
+        model_sac.train()
+        enable_selective_activation_checkpointing(model_sac)
+        model_sac.gradient_checkpointing_enable()
+
+        torch.manual_seed(42)
+        inp = torch.randint(0, model_full.config.vocab_size, (2, 32), device=torch_device)
+        model_full(input_ids=inp, labels=inp).loss.backward()
+        model_sac(input_ids=inp, labels=inp).loss.backward()
+
+        for p_full, p_sac in zip(model_full.parameters(), model_sac.parameters(), strict=True):
+            torch.testing.assert_close(p_sac.grad, p_full.grad, rtol=1e-4, atol=1e-5)
+
+    def test_idempotent(self):
+        """Enabling SAC twice on the same model must not stack wrappers."""
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, attn_implementation="sdpa").to(torch_device)
+        enable_selective_activation_checkpointing(model)
+        once_wrapped = model.gradient_checkpointing_enable
+        enable_selective_activation_checkpointing(model)
+        assert model.gradient_checkpointing_enable is once_wrapped

--- a/trl/models/__init__.py
+++ b/trl/models/__init__.py
@@ -19,12 +19,14 @@ from .._lazy_module import _LazyModule
 
 _import_structure = {
     "activation_offloading": ["get_act_offloading_ctx_manager"],
+    "selective_activation_checkpointing": ["enable_selective_activation_checkpointing"],
     "utils": ["create_reference_model", "prepare_deepspeed", "prepare_fsdp", "unwrap_model_for_generation"],
 }
 
 
 if TYPE_CHECKING:
     from .activation_offloading import get_act_offloading_ctx_manager
+    from .selective_activation_checkpointing import enable_selective_activation_checkpointing
     from .utils import create_reference_model, prepare_deepspeed, prepare_fsdp, unwrap_model_for_generation
 else:
     import sys

--- a/trl/models/selective_activation_checkpointing.py
+++ b/trl/models/selective_activation_checkpointing.py
@@ -1,0 +1,93 @@
+# Copyright 2020-2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+
+import torch
+from torch import nn
+from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
+
+
+# Exact aten overloads for the SDPA backends (flash, memory-efficient, cuDNN, and the CPU fallback). Matched by
+# identity, as recommended in https://pytorch.org/blog/activation-checkpointing-techniques (not every name exists in
+# every torch build, hence the `getattr` default). Flash-attn's custom kernels are a separate case: they register
+# under hashed namespaces (e.g. `_flash_attn2_cuda_f12afc9::varlen_fwd`) and so can only be matched by substring.
+_ATEN_ATTENTION_PACKET_NAMES = (
+    "_scaled_dot_product_flash_attention",
+    "_scaled_dot_product_efficient_attention",
+    "_scaled_dot_product_cudnn_attention",
+    "_scaled_dot_product_flash_attention_for_cpu",
+)
+
+
+def _aten_attention_ops() -> set:
+    return {
+        packet.default
+        for name in _ATEN_ATTENTION_PACKET_NAMES
+        if (packet := getattr(torch.ops.aten, name, None)) is not None
+    }
+
+
+def _build_policy_fn(aten_attention_ops: set):
+    def policy_fn(ctx, op, *args, **kwargs):
+        if op in aten_attention_ops or "flash_attn" in str(op):
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return policy_fn
+
+
+def enable_selective_activation_checkpointing(model: nn.Module) -> None:
+    """
+    Enable eager selective activation checkpointing (SAC) on the model.
+
+    Plain (full) activation checkpointing recomputes every op in the checkpointed region during the backward pass,
+    including attention. Attention *backward* is irreducible, but its recompute is not: at long context, saving the
+    attention output during the forward pass instead of recomputing it recovers most of the checkpointing slowdown for
+    one extra hidden-state-sized tensor per layer.
+
+    This wraps the model's `gradient_checkpointing_enable` so that, whenever gradient checkpointing is turned on (by
+    the trainer, PEFT preparation, etc.), a policy-based [SAC context
+    function](https://pytorch.org/docs/main/checkpoint.html#torch.utils.checkpoint.create_selective_checkpoint_contexts)
+    is injected. The policy saves the attention op and recomputes everything else. Matching happens at the dispatcher
+    level, so custom kernels that are not registered as torch ops are simply recomputed as usual. It runs fully eager
+    (no `torch.compile` required) and forces non-reentrant checkpointing, which SAC relies on.
+
+    Wrapping the model instance's method (rather than passing a `context_fn` through the config) keeps the
+    non-serializable callable out of [`~transformers.TrainingArguments`] and covers every enable call site. The
+    wrapper is idempotent, so calling this twice on the same model (e.g. across repeated `Trainer` inits in tests) is
+    a no-op the second time.
+
+    Args:
+        model (`nn.Module`):
+            Model on which to enable selective activation checkpointing. Must support `gradient_checkpointing_enable`.
+    """
+    if getattr(model.gradient_checkpointing_enable, "_is_sac_wrapped", False):
+        return
+
+    policy_fn = _build_policy_fn(_aten_attention_ops())
+    context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+    original_gradient_checkpointing_enable = model.gradient_checkpointing_enable
+
+    def gradient_checkpointing_enable(gradient_checkpointing_kwargs: dict | None = None, **kwargs):
+        gradient_checkpointing_kwargs = dict(gradient_checkpointing_kwargs or {})
+        # SAC intercepts saved tensors, which only happens under non-reentrant checkpointing.
+        gradient_checkpointing_kwargs["use_reentrant"] = False
+        gradient_checkpointing_kwargs["context_fn"] = context_fn
+        return original_gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs=gradient_checkpointing_kwargs, **kwargs
+        )
+
+    gradient_checkpointing_enable._is_sac_wrapped = True
+    model.gradient_checkpointing_enable = gradient_checkpointing_enable

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -115,6 +115,11 @@ class SFTConfig(_BaseConfig):
 
         activation_offloading (`bool`, *optional*, defaults to `False`):
             Whether to offload the activations to the CPU.
+        selective_activation_checkpointing (`bool`, *optional*, defaults to `False`):
+            Whether to use selective activation checkpointing (SAC). When `gradient_checkpointing` is enabled, the
+            attention output is saved during the forward pass instead of being recomputed in the backward pass,
+            recovering most of the checkpointing slowdown at long context for one extra hidden-state-sized tensor per
+            layer. Requires `gradient_checkpointing=True` and forces non-reentrant checkpointing.
 
         > Deprecated parameters
 
@@ -294,6 +299,15 @@ class SFTConfig(_BaseConfig):
     activation_offloading: bool = field(
         default=False,
         metadata={"help": "Whether to offload the activations to the CPU."},
+    )
+    selective_activation_checkpointing: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to use selective activation checkpointing (SAC). When gradient checkpointing is enabled, "
+            "the attention output is saved during the forward pass instead of being recomputed in the backward pass, "
+            "recovering most of the checkpointing slowdown at long context for one extra hidden-state-sized tensor per "
+            "layer. Requires `gradient_checkpointing=True` and forces non-reentrant checkpointing."
+        },
     )
 
     # Deprecated parameters

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -66,7 +66,7 @@ from ..data_utils import (
     pack_dataset,
     prepare_multimodal_messages,
 )
-from ..models import get_act_offloading_ctx_manager
+from ..models import enable_selective_activation_checkpointing, get_act_offloading_ctx_manager
 from .base_trainer import _BaseTrainer
 from .sft_config import SFTConfig
 from .utils import (
@@ -1142,6 +1142,11 @@ class SFTTrainer(_BaseTrainer):
             and args.deepspeed_plugin.zero_stage == 3
             and args.gradient_checkpointing
         ):
+            if args.selective_activation_checkpointing:
+                raise ValueError(
+                    "`selective_activation_checkpointing=True` is not supported with PEFT + DeepSpeed ZeRO-3, which "
+                    "requires reentrant gradient checkpointing while SAC requires non-reentrant checkpointing."
+                )
             args.gradient_checkpointing_kwargs = args.gradient_checkpointing_kwargs or {}
             use_reentrant = args.gradient_checkpointing_kwargs.get("use_reentrant")
             if use_reentrant is False:
@@ -1368,6 +1373,17 @@ class SFTTrainer(_BaseTrainer):
         if args.gradient_checkpointing and Version(transformers.__version__) < Version("5.0.0"):
             args.gradient_checkpointing_kwargs = args.gradient_checkpointing_kwargs or {}
             args.gradient_checkpointing_kwargs.setdefault("use_reentrant", False)
+
+        if args.selective_activation_checkpointing:
+            if not args.gradient_checkpointing:
+                raise ValueError("`selective_activation_checkpointing=True` requires `gradient_checkpointing=True`.")
+            if (args.gradient_checkpointing_kwargs or {}).get("use_reentrant"):
+                raise ValueError(
+                    "`selective_activation_checkpointing=True` requires non-reentrant gradient checkpointing. Set "
+                    "`use_reentrant` to `False` in `gradient_checkpointing_kwargs`, or leave it unset."
+                )
+            # Wrap before `super().__init__()` so the context function is set when the Trainer enables checkpointing.
+            enable_selective_activation_checkpointing(model)
 
         super().__init__(
             model=model,


### PR DESCRIPTION
# What does this PR do?

Adds selective activation checkpointing (SAC) to SFT. With gradient checkpointing on, the attention output is saved during forward instead of being recomputed in backward, recovering most of the checkpointing slowdown at long context for one extra hidden-state-sized tensor per layer. Same eager SAC approach torchtitan uses under FSDP2, no `torch.compile` needed.

Turn it on with `selective_activation_checkpointing=True` on `SFTConfig` (needs `gradient_checkpointing=True`). PEFT + DeepSpeed ZeRO-3 is rejected since that combo needs reentrant checkpointing, which SAC can't use.

Split out of #6280, addressing review: `enable_selective_activation_checkpointing` now lives in its own module instead of `activation_offloading.py`, the op-matching policy is unit-tested directly instead of by counting SDPA calls in an actual forward/backward, and the test class requires an accelerator.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

cc @qgallouedec @winglian

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gradient checkpointing behavior on the training path and can affect memory/performance; incompatible distributed configs are rejected explicitly, but wrong flag combinations could surprise users until they hit validation errors.
> 
> **Overview**
> Adds **selective activation checkpointing (SAC)** for [`SFTTrainer`], opt-in via `SFTConfig(selective_activation_checkpointing=True)` with `gradient_checkpointing=True`. A new `enable_selective_activation_checkpointing` helper wraps the model’s `gradient_checkpointing_enable` so PyTorch’s selective checkpoint policy **saves attention outputs** (SDPA `aten` ops and `flash_attn` kernels) while **recomputing other ops**, using non-reentrant checkpointing only.
> 
> `SFTTrainer` validates SAC prerequisites, applies the wrapper before `Trainer` init, and **errors** on incompatible setups (SAC without gradient checkpointing, `use_reentrant=True`, or **PEFT + DeepSpeed ZeRO-3**). Tests cover the op policy and gradient parity vs full checkpointing; the paper index documents the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf7043f8a2f9fa6a5edf08bbf81629be2826968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->