### PR TITLE
Fix two stream races in OffloadActivations

### DIFF
--- a/trl/models/activation_offloading.py
+++ b/trl/models/activation_offloading.py
@@ -151,13 +151,6 @@ class OffloadActivations(saved_tensors_hooks):
         self.accelerator_type = (
             torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
         )
-        # NOTE: xpu doesn't have `default_stream` API, use `current_stream` instead
-        if self.accelerator_type == "xpu":  # comp stream
-            self.s0 = torch.xpu.current_stream()
-        elif is_torch_npu_available() and self.accelerator_type == "npu":
-            self.s0 = torch.npu.current_stream()
-        else:
-            self.s0 = torch.cuda.default_stream()
 
         # For streaming
         if self.use_streams:
@@ -270,6 +263,21 @@ class OffloadActivations(saved_tensors_hooks):
                 pass
 
             # Tensor qualifies for offloading
+            # Check if tensor has broadcast dimensions (stride == 0)
+            # If so, copy the underlying storage directly instead of materializing the broadcast
+            has_broadcast = 0 in activation.stride()
+
+            # No broadcast - use normal contiguous copy
+            # .contiguous() can be a no-op for contiguous views with
+            # non-zero storage_offset. Force a clone for those views
+            # so later as_strided reconstruction stays in bounds.
+            # Done on the compute stream, before `wait_stream` below, so that wait also covers this clone.
+            if not has_broadcast and (not activation.is_contiguous() or activation.storage_offset() != 0):
+                if activation.storage_offset() != 0:
+                    activation = activation.clone(memory_format=torch.contiguous_format)
+                else:
+                    activation = activation.contiguous()
+
             if self.use_streams:
                 # First, sync back and dereference previously offloaded tensors
                 # as the offloading should be done sufficiently long ago.
@@ -285,6 +293,11 @@ class OffloadActivations(saved_tensors_hooks):
                 # Sync in, offload, and add an event to sync back later
                 self.s1.wait_stream(self.s0)
 
+            # Save original stride and shape information
+            original_stride = activation.stride()
+            original_storage_offset = activation.storage_offset()
+            original_shape = activation.size()
+
             stream = self.s1 if self.use_streams else self.s0
             if self.accelerator_type == "xpu":
                 stream_ctx = torch.xpu.stream(stream)
@@ -293,15 +306,6 @@ class OffloadActivations(saved_tensors_hooks):
             else:
                 stream_ctx = torch.cuda.stream(stream)
             with stream_ctx:
-                # Save original stride and shape information
-                original_stride = activation.stride()
-                original_storage_offset = activation.storage_offset()
-                original_shape = activation.size()
-
-                # Check if tensor has broadcast dimensions (stride == 0)
-                # If so, copy the underlying storage directly instead of materializing the broadcast
-                has_broadcast = 0 in original_stride
-
                 if has_broadcast:
                     # Copy only the actual underlying storage, not the materialized broadcast
                     # Create CPU tensor with same storage size as original
@@ -319,17 +323,6 @@ class OffloadActivations(saved_tensors_hooks):
                     cpu_storage.copy_(cpu_storage_view, non_blocking=True)
                     cpu_tensor = cpu_storage
                 else:
-                    # No broadcast - use normal contiguous copy
-                    # .contiguous() can be a no-op for contiguous views with
-                    # non-zero storage_offset. Force a clone for those views
-                    # so later as_strided reconstruction stays in bounds.
-                    if not activation.is_contiguous() or activation.storage_offset() != 0:
-                        if activation.storage_offset() != 0:
-                            activation = activation.clone(memory_format=torch.contiguous_format)
-                        else:
-                            activation = activation.contiguous()
-                        original_stride = activation.stride()
-                        original_storage_offset = activation.storage_offset()
                     cpu_tensor = torch.empty_like(activation, pin_memory=self.use_pin_memory, device="cpu")
                     cpu_tensor.copy_(activation, non_blocking=True)
 
@@ -555,6 +548,16 @@ class OffloadActivations(saved_tensors_hooks):
 
         unpack_tensor = unpack_tensor_with_streams if self.use_streams else unpack_tensor_single_stream
         super().__init__(pack_tensor, unpack_tensor)
+
+    @property
+    def s0(self) -> torch.Stream:
+        # Compute stream. Queried live, not cached: under FSDP2, checkpoint recompute, or a custom autograd
+        # Function, the current stream when packing/unpacking may differ from the one at construction time.
+        if self.accelerator_type == "xpu":
+            return torch.xpu.current_stream()
+        elif is_torch_npu_available() and self.accelerator_type == "npu":
+            return torch.npu.current_stream()
+        return torch.cuda.current_stream()
 
     def update_model_params(self, model: nn.Module):
         """


### PR DESCRIPTION
# What does this PR do?

Fixes two stream races in `OffloadActivations` that axolotl found and works around with monkeypatches on their end (`activation_checkpointing.py`), rather than upstream:

1. `self.s0` was cached once at construction as the default/current stream. Under FSDP2, checkpoint recompute, or a custom autograd Function launching kernels on its own stream, the actual current stream at pack/unpack time can differ from the one cached at init, so syncs against `self.s0` target the wrong stream. Made `s0` a property queried live instead.
2. `pack_tensor` cloned offset/non-contiguous saved tensors (e.g. cross-entropy's shifted `shift_labels`) on the transfer stream, after already taking the `wait_stream` snapshot that's supposed to order the transfer stream's copy against the compute stream. The clone was enqueued too late to be covered by that wait, so the transfer stream's copy could race it. Moved the clone before the `wait_stream` call so it's covered.

Both are real, rare, timing-dependent races and hard to pin with a deterministic unit test; `tests/test_activation_offloading.py::test_real_hf_model` caught fix #2 being wrong on a first pass (it produced a gradient mismatch), so I'm relying on the existing suite plus repeated runs rather than adding a new flaky one.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## AI writing disclosure

We welcome the use of AI tools to help with contributions. For transparency and to help us improve our review process, please indicate the level of AI involvement in this PR.

- [ ] No AI usage: the PR was written entirely by a human.
- [ ] AI-assisted: some parts were suggested or improved by AI, but the PR was written and reviewed by a human.
- [x] AI-generated: the PR was mostly or fully generated by an AI tool.

## Who can review?

cc @qgallouedec @winglian

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level GPU stream ordering in activation offload used during training; incorrect sync could cause rare nondeterministic wrong gradients, though the fix aligns with established stream semantics.
> 
> **Overview**
> Fixes two timing-dependent CUDA/XPU/NPU stream races in **`OffloadActivations`** that could corrupt offloaded activations or break gradient correctness (e.g. under FSDP2, checkpoint recompute, or custom autograd).
> 
> **Compute stream (`s0`)** is no longer pinned at construction (`default_stream` / cached `current_stream`). It is now a **live `current_stream()` property** at pack/unpack time so `wait_stream`, `wait_event`, and `record_stream` target the stream that actually produced the saved tensor.
> 
> In **`pack_tensor`**, contiguous **`clone`/`contiguous`** for non-broadcast views (e.g. shifted labels with non-zero storage offset) runs on the **compute stream before** `s1.wait_stream(s0)`, so the transfer stream’s CPU copy cannot race ahead of that materialization. Stride/shape metadata is captured after that prep, still before the async offload on `s1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3eb5ffb1bd43a7322773f115bab20f5b8c65ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->